### PR TITLE
Apply three patches from the BMO, and one user patch. 

### DIFF
--- a/content/svg/content/src/SVGFETurbulenceElement.cpp
+++ b/content/svg/content/src/SVGFETurbulenceElement.cpp
@@ -332,7 +332,7 @@ SVGFETurbulenceElement::Turbulence(int aColorChannel, double* aPoint,
     if (aBaseFreqX != 0.0) {
       double loFreq = double (floor(aTileWidth * aBaseFreqX)) / aTileWidth;
       double hiFreq = double (ceil(aTileWidth * aBaseFreqX)) / aTileWidth;
-      if (aBaseFreqX / loFreq < hiFreq / aBaseFreqX)
+      if (aBaseFreqX * aBaseFreqX < hiFreq * loFreq)
         aBaseFreqX = loFreq;
       else
         aBaseFreqX = hiFreq;
@@ -340,7 +340,7 @@ SVGFETurbulenceElement::Turbulence(int aColorChannel, double* aPoint,
     if (aBaseFreqY != 0.0) {
       double loFreq = double (floor(aTileHeight * aBaseFreqY)) / aTileHeight;
       double hiFreq = double (ceil(aTileHeight * aBaseFreqY)) / aTileHeight;
-      if (aBaseFreqY / loFreq < hiFreq / aBaseFreqY)
+      if (aBaseFreqY * aBaseFreqY < loFreq * hiFreq)
         aBaseFreqY = loFreq;
       else
         aBaseFreqY = hiFreq;

--- a/js/src/frontend/SyntaxParseHandler.h
+++ b/js/src/frontend/SyntaxParseHandler.h
@@ -178,7 +178,7 @@ class SyntaxParseHandler
     Node setInParens(Node pn) {
         // String literals enclosed by parentheses are ignored during
         // strict mode parsing.
-        return NodeGeneric;
+        return (pn == NodeString) ? NodeGeneric : pn;
     }
     void setPrologue(Node pn) {}
 

--- a/layout/base/nsPresContext.cpp
+++ b/layout/base/nsPresContext.cpp
@@ -2315,6 +2315,11 @@ nsPresContext::NotifyDidPaintForSubtree(uint32_t aFlags)
       return;
     }
   }
+  
+  if (!PresShell()->IsVisible() && !mFireAfterPaintEvents) {
+    return;
+  }
+  
   // Non-root prescontexts fire MozAfterPaint to all their descendants
   // unconditionally, even if no invalidations have been collected. This is
   // because we don't want to eat the cost of collecting invalidations for

--- a/netwerk/sctp/src/netinet/sctp_usrreq.c
+++ b/netwerk/sctp/src/netinet/sctp_usrreq.c
@@ -4726,7 +4726,6 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 		sctp_hmaclist_t *hmaclist;
 		uint16_t hmacid;
 		uint32_t i;
-		size_t found;
 
 		SCTP_CHECK_AND_CAST(shmac, optval, struct sctp_hmacalgo, optsize);
 		if (optsize < sizeof(struct sctp_hmacalgo) + shmac->shmac_number_of_idents * sizeof(uint16_t)) {
@@ -4751,14 +4750,14 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 				goto sctp_set_hmac_done;
 			}
 		}
-		found = 0;
 		for (i = 0; i < hmaclist->num_algo; i++) {
 			if (hmaclist->hmac[i] == SCTP_AUTH_HMAC_ID_SHA1) {
 				/* already in list */
-				found = 1;
+				break;
 			}
 		}
-		if (!found) {
+		if (i == hmaclist->num_algo) {
+			/* not found in list */
 			sctp_free_hmaclist(hmaclist);
 			SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_USRREQ, EINVAL);
 			error = EINVAL;


### PR DESCRIPTION
The three bug patches, and their BMO IDs:
[Bug 898234](https://bugzilla.mozilla.org/show_bug.cgi?id=898234) - Wasted work in sctp_setopt()
[Bug 1078005](https://bugzilla.mozilla.org/show_bug.cgi?id=1078005) - Firefox window with lots of tabs becomes sluggish due to floods of afterpaint events.
[Bug 1084959](https://bugzilla.mozilla.org/show_bug.cgi?id=1084959) - (a) = ...; aborts syntax parsing.