### PR TITLE
Bug 973187 - typo in nsStyleGradient::HasCalc()

### DIFF
--- a/layout/style/nsStyleStruct.cpp
+++ b/layout/style/nsStyleStruct.cpp
@@ -1519,7 +1519,7 @@ nsStyleGradient::HasCalc()
       return true;
   }
   return mBgPosX.IsCalcUnit() || mBgPosY.IsCalcUnit() || mAngle.IsCalcUnit() ||
-         mRadiusX.IsCalcUnit() || mRadiusX.IsCalcUnit();
+         mRadiusX.IsCalcUnit() || mRadiusY.IsCalcUnit();
 }
 
 // --------------------


### PR DESCRIPTION
[Bug 973187](https://bugzilla.mozilla.org/show_bug.cgi?id=973187) typo causes checking mRadiusX twice, and not checking mRadiusY.

