### PR TITLE
Add more SSL/TLS connection information to "Page Info"

### DIFF
--- a/browser/base/content/pageinfo/security.js
+++ b/browser/base/content/pageinfo/security.js
@@ -52,17 +52,35 @@ var security = {
         cAName : issuerName,
         encryptionAlgorithm : undefined,
         encryptionStrength : undefined,
+        version: undefined,
         isBroken : isBroken,
         isEV : isEV,
         cert : cert,
         fullLocation : gWindow.location
       };
 
+      var version;
       try {
         retval.encryptionAlgorithm = status.cipherName;
         retval.encryptionStrength = status.secretKeyLength;
+        version = status.protocolVersion;
       }
       catch (e) {
+      }
+
+      switch (version) {
+        case nsISSLStatus.SSL_VERSION_3:
+          retval.version = "SSL 3";
+          break;
+        case nsISSLStatus.TLS_VERSION_1:
+          retval.version = "TLS 1.0";
+          break;
+        case nsISSLStatus.TLS_VERSION_1_1:
+          retval.version = "TLS 1.1";
+          break;
+        case nsISSLStatus.TLS_VERSION_1_2:
+          retval.version = "TLS 1.2"
+          break;
       }
 
       return retval;
@@ -72,6 +90,7 @@ var security = {
         cAName : "",
         encryptionAlgorithm : "",
         encryptionStrength : 0,
+        version: "",
         isBroken : isBroken,
         isEV : isEV,
         cert : null,
@@ -247,14 +266,18 @@ function securityOnLoad() {
   }
   else if (info.encryptionStrength >= 90) {
     hdr = pkiBundle.getFormattedString("pageInfo_StrongEncryptionWithBits",
-                                       [info.encryptionAlgorithm, info.encryptionStrength + ""]);
+                                       [info.encryptionAlgorithm,
+                                        info.encryptionStrength + "",
+                                        info.version]);
     msg1 = pkiBundle.getString("pageInfo_Privacy_Strong1");
     msg2 = pkiBundle.getString("pageInfo_Privacy_Strong2");
     security._cert = info.cert;
   }
   else if (info.encryptionStrength > 0) {
     hdr  = pkiBundle.getFormattedString("pageInfo_WeakEncryptionWithBits",
-                                        [info.encryptionAlgorithm, info.encryptionStrength + ""]);
+                                        [info.encryptionAlgorithm,
+                                         info.encryptionStrength + "",
+                                         info.version]);
     msg1 = pkiBundle.getFormattedString("pageInfo_Privacy_Weak1", [info.hostName]);
     msg2 = pkiBundle.getString("pageInfo_Privacy_Weak2");
   }

--- a/security/manager/locales/en-US/chrome/pippki/pippki.properties
+++ b/security/manager/locales/en-US/chrome/pippki/pippki.properties
@@ -76,12 +76,14 @@ pageInfo_Privacy_None2=Information sent over the Internet without encryption can
 pageInfo_Privacy_None3=The page you are viewing is not encrypted.
 # LOCALIZATION NOTE (pageInfo_StrongEncryptionWithBits): %1$S is the name of the encryption standard,
 # %2$S is the key size of the cipher.
-pageInfo_StrongEncryptionWithBits=Connection Encrypted: High-grade Encryption (%1$S, %2$S bit keys)
+# %3$S is protocol version like "SSL 3" or "TLS 1.2"
+pageInfo_StrongEncryptionWithBits=Connection Encrypted: High-grade Encryption (%1$S, %2$S bit keys, %3$S)
 pageInfo_Privacy_Strong1=The page you are viewing was encrypted before being transmitted over the Internet.
 pageInfo_Privacy_Strong2=Encryption makes it very difficult for unauthorized people to view information traveling between computers. It is therefore very unlikely that anyone read this page as it traveled across the network.
 # LOCALIZATION NOTE (pageInfo_WeakEncryptionWithBits): %1$S is the name of the encryption standard,
 # %2$S is the key size of the cipher.
-pageInfo_WeakEncryptionWithBits=Connection Encrypted: Low-grade Encryption (%1$S, %2$S bit keys)
+# %3$S is protocol version like "SSL 3" or "TLS 1.2"
+pageInfo_WeakEncryptionWithBits=Connection Encrypted: Low-grade Encryption (%1$S, %2$S bit keys, %3$S)
 pageInfo_Privacy_Weak1=The website %S is using low-grade encryption for the page you are viewing.
 pageInfo_Privacy_Weak2=Low-grade encryption may allow some unauthorized people to view this information.
 pageInfo_MixedContent=Connection Partially Encrypted

--- a/security/manager/ssl/public/nsISSLStatus.idl
+++ b/security/manager/ssl/public/nsISSLStatus.idl
@@ -8,13 +8,19 @@
 
 interface nsIX509Cert;
 
-[scriptable, uuid(3f1fcd83-c5a9-4cd1-a250-7676ca7c7e34)]
+[scriptable, uuid(fa9ba95b-ca3b-498a-b889-7c79cf28fee8)]
 interface nsISSLStatus : nsISupports {
   readonly attribute nsIX509Cert serverCert;
 
   readonly attribute string cipherName;
   readonly attribute unsigned long keyLength;
   readonly attribute unsigned long secretKeyLength;
+
+  const short SSL_VERSION_3   = 0;
+  const short TLS_VERSION_1   = 1;
+  const short TLS_VERSION_1_1 = 2;
+  const short TLS_VERSION_1_2 = 3;
+  readonly attribute unsigned long protocolVersion;
 
   readonly attribute boolean isDomainMismatch;
   readonly attribute boolean isNotValidAtThisTime;

--- a/security/manager/ssl/src/TransportSecurityInfo.cpp
+++ b/security/manager/ssl/src/TransportSecurityInfo.cpp
@@ -291,8 +291,8 @@ TransportSecurityInfo::GetInterface(const nsIID & uuid, void * *result)
 }
 
 static NS_DEFINE_CID(kNSSCertificateCID, NS_X509CERT_CID);
-#define TRANSPORTSECURITYINFOMAGIC { 0xa9863a23, 0x26b8, 0x4a9c, \
-  { 0x83, 0xf1, 0xe9, 0xda, 0xdb, 0x36, 0xb8, 0x30 } }
+#define TRANSPORTSECURITYINFOMAGIC { 0xa9863a23, 0x2429, 0x4866, \
+  { 0x92, 0x89, 0x45, 0x51, 0xc2, 0x01, 0xca, 0xf2 } }
 static NS_DEFINE_CID(kTransportSecurityInfoMagic, TRANSPORTSECURITYINFOMAGIC);
 
 NS_IMETHODIMP

--- a/security/manager/ssl/src/nsNSSCallbacks.cpp
+++ b/security/manager/ssl/src/nsNSSCallbacks.cpp
@@ -976,6 +976,7 @@ void HandshakeCallback(PRFileDesc* fd, void* client_data) {
       status->mSecretKeyLength = cipherInfo.effectiveKeyBits;
 //      status->mCipherName.Assign(cipherInfo.cipherSuiteName); //XXX: Fx Full Suite string
       status->mCipherName.Assign(cipherInfo.symCipherName);
+      status->mProtocolVersion = channelInfo.protocolVersion & 0xFF;
 
       // keyExchange null=0, rsa=1, dh=2, fortezza=3, ecdh=4
       Telemetry::Accumulate(Telemetry::SSL_KEY_EXCHANGE_ALGORITHM,

--- a/security/manager/ssl/src/nsNSSCallbacks.h
+++ b/security/manager/ssl/src/nsNSSCallbacks.h
@@ -222,6 +222,3 @@ public:
 };
 
 #endif // _NSNSSCALLBACKS_H_
-
-
-

--- a/security/manager/ssl/src/nsSSLStatus.cpp
+++ b/security/manager/ssl/src/nsSSLStatus.cpp
@@ -59,6 +59,18 @@ nsSSLStatus::GetCipherName(char** _result)
 }
 
 NS_IMETHODIMP
+nsSSLStatus::GetProtocolVersion(uint32_t* _result)
+{
+  NS_ASSERTION(_result, "non-NULL destination required");
+  if (!mHaveKeyLengthAndCipher) {
+    return NS_ERROR_NOT_AVAILABLE;
+  }
+
+  *_result = mProtocolVersion;
+  return NS_OK;
+}
+
+NS_IMETHODIMP
 nsSSLStatus::GetIsDomainMismatch(bool* _result)
 {
   NS_ASSERTION(_result, "non-NULL destination required");
@@ -106,6 +118,9 @@ nsSSLStatus::Read(nsIObjectInputStream* stream)
   rv = stream->ReadCString(mCipherName);
   NS_ENSURE_SUCCESS(rv, rv);
 
+  rv = stream->Read32(&mProtocolVersion);
+  NS_ENSURE_SUCCESS(rv, rv);
+
   rv = stream->ReadBoolean(&mIsDomainMismatch);
   NS_ENSURE_SUCCESS(rv, rv);
   rv = stream->ReadBoolean(&mIsNotValidAtThisTime);
@@ -134,6 +149,9 @@ nsSSLStatus::Write(nsIObjectOutputStream* stream)
   rv = stream->Write32(mSecretKeyLength);
   NS_ENSURE_SUCCESS(rv, rv);
   rv = stream->WriteStringZ(mCipherName.get());
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  rv = stream->Write32(mProtocolVersion);
   NS_ENSURE_SUCCESS(rv, rv);
 
   rv = stream->WriteBoolean(mIsDomainMismatch);
@@ -213,7 +231,9 @@ nsSSLStatus::GetClassIDNoAlloc(nsCID *aClassIDNoAlloc)
 }
 
 nsSSLStatus::nsSSLStatus()
-: mKeyLength(0), mSecretKeyLength(0)
+: mKeyLength(0)
+, mSecretKeyLength(0)
+, mProtocolVersion(0)
 , mIsDomainMismatch(false)
 , mIsNotValidAtThisTime(false)
 , mIsUntrusted(false)

--- a/security/manager/ssl/src/nsSSLStatus.h
+++ b/security/manager/ssl/src/nsSSLStatus.h
@@ -35,6 +35,8 @@ public:
   uint32_t mSecretKeyLength;
   nsXPIDLCString mCipherName;
 
+  uint32_t mProtocolVersion;
+
   bool mIsDomainMismatch;
   bool mIsNotValidAtThisTime;
   bool mIsUntrusted;
@@ -46,9 +48,8 @@ public:
   bool mHaveCertErrorBits;
 };
 
-// 2c3837af-8b85-4a68-b0d8-0aed88985b32
 #define NS_SSLSTATUS_CID \
-{ 0x2c3837af, 0x8b85, 0x4a68, \
-  { 0xb0, 0xd8, 0x0a, 0xed, 0x88, 0x98, 0x5b, 0x32 } }
+{ 0x4442f91b, 0x30c4, 0x46ce, \
+  { 0xbd, 0x6b, 0xc7, 0xd8, 0x92, 0x05, 0x72, 0x38 } }
 
 #endif


### PR DESCRIPTION
Original pull request: https://github.com/MoonchildProductions/Pale-Moon/pull/46

Forum thread: https://forum.palemoon.org/viewtopic.php?f=13&t=7843

Bug [886752] (https://bugzilla.mozilla.org/show_bug.cgi?id=886752)  

Pale Moon now displays the version of TLS in use in "Page Info". It still doesn't show as much info as Firefox does, but I'm going to attempt to incorporate some more of the patch from bugzilla. But for now, confirmed to show TLS version in x64 Linux trunk build. Note that the Cipherfox add-on (as mentioned in forum thread) still does not display any additional information.

Also note that unlike the first pull request, this one does not include the patch from bug 947149 (I will submit a new request for that later if this code looks good).

Screenshots:

Pale Moon 25.3.1:
![pm25 3 1](https://cloud.githubusercontent.com/assets/10595410/7152745/da77caf4-e306-11e4-8858-ae80812d7800.png)

Pale Moon Trunk with patch:
![pmtrunk](https://cloud.githubusercontent.com/assets/10595410/7152747/e730d7fe-e306-11e4-8409-c09e27de5010.png)

Firefox 37.0.1:
![ff37 0 1](https://cloud.githubusercontent.com/assets/10595410/7152751/ecd7154c-e306-11e4-93ad-1c7f9b83d8ae.png)

