### PR TITLE
fix Mac build issue due to removal of telemetry functionality

### DIFF
--- a/xpcom/build/mozPoisonWriteMac.cpp
+++ b/xpcom/build/mozPoisonWriteMac.cpp
@@ -11,6 +11,7 @@
 #include "mozilla/Assertions.h"
 #include "mozilla/Scoped.h"
 #include "mozilla/Mutex.h"
+#include "mozilla/DebugOnly.h"
 #include "mozilla/ProcessedStack.h"
 #include "nsStackWalk.h"
 #include "nsPrintfCString.h"


### PR DESCRIPTION
Removal of the telemetry functionality (specifically, mozilla/Telemetry.h) results in a build error on the Mac (use of undeclared identifier 'DebugOnly').  Inserting an include to mozilla/DebugOnly.h resolves the issue.