### PR TITLE
Remove Mozilla specific parameters and pretend to be Firefox for suggestions.

### DIFF
--- a/browser/locales/en-US/searchplugins/google.xml
+++ b/browser/locales/en-US/searchplugins/google.xml
@@ -7,18 +7,11 @@
 <Description>Google Search</Description>
 <InputEncoding>UTF-8</InputEncoding>
 <Image width="16" height="16">data:image/x-icon;base64,AAABAAIAEBAAAAAAAAB9AQAAJgAAACAgAAAAAAAA8gIAAKMBAACJUE5HDQoaCgAAAA1JSERSAAAAEAAAABAIBgAAAB/z/2EAAAFESURBVDjLpZNJSwNBEIXnt4lE4kHxovgT9BDwJHqPy0HEEOJBiAuCRg+KUdC4QS4KrpC4gCBGE3NQ48JsnZ6eZ3UOM6gjaePhQU93v6+qq2q0pqgeJj2S8EdJT1hr0OxBtKCD5iEd8QxDYpvhvOBAuMDKURX9C9aPu4GA1GEVkzvMg10UBfYveWAWgYAP00V01fa+R9M2bA51wJvhIn3qR+ybt3D3JNQBE5sMjCIOLFpoHzOwdsLRO22qA6R6kiZiWwxUvy/PUQZIhYZ1vFM9cvcOOsYNdcBgysISdSJBnZjJMlR0Fw8vAp0xoz5gao/h+NZBy4i/10XGwrPA+hmvDyhVRG2Avu/LwcrkFADZa16L1h330w1RNgc3DiJzCpPYRm1bpveXX11clQR28xwblHpk1vq1iP/5mcoS0CoXDZiL0vsJ+dzfl+3T/VYAAAAASUVORK5CYIKJUE5HDQoaCgAAAA1JSERSAAAAIAAAACAIBgAAAHN6evQAAAK5SURBVFjDxVfrSxRRFJ9/Jta/oyWjF5XQm6D6EkHRgygIIgjUTcueVgqVWSRRkppEUQYWWB8ye1iGWilWlo/Ude489s7M6Zw7D9dlt53dmd29cFiWvXvO77x+51xpaaUsoSxBaUWZQ4ECy5xji2xKZDyCMlMEw6lCNiOSgwZKJK1SkcKeSealfP64t0mBjl4Ow39MkDUL0p2RSROOtqhZdeUEYM1pBl39XCg/fEeFtWcY7G9W4csvUxjlBkCsQ4Nt9QyWVfvT6RsAKXw3aoDGATZeYIt+W1kjw7cJG0RctWDTRebbKd8A6h5pwsDb70ba3w/eUr3wt/cmwgfw6Yft4TNMQaY7o1P2ncm4FT4ANQH/jQBJ2xv7kqIXEADDql8eS3+n8bku7oxNm+EDIM/dU92upb3T/NJGeaNbDx/AsbsLRUY5Xn92caWXY5d8RV6gWllxSg4fAEnTC90DQW13BLlgXR2D3dcUeDVkwOthA1bXspxILWcm3HdThcfvufB26LcJpkOEAz9NKI/lzqpSEC7feol5EWnpSeSlIxCALUkApmULdjUqxQVAQnl3D/X/yQda4QBEq2TYc12By091MQ17Bg3R88nHKlQbVmHvj89awNBLYrwT9zXY2aBAxTkGFdiSxP/Jp6FLDw+AS7GfsdJTJ2EqSO5khD43nGfBARy/ZxOQgZHe7GPM1jzUvChUtmnBAXQPcKGMJp3fdFGq6NByEhiAO4b/YptFfQJwNyQ/bZkVQGcf90Ja25ndIyrKBOa/f8wIpwi3X1G8UcxNu7ozUS7tiH0jBswwS3RIaF1w6LYKU/ML2+8sGnjygQswtKrVIy/Qd9qQP6LnO64q4fPAKpxyZIymHo1jWk6p1ag2BsdNwQMHcC+M5kHFJX+YlPxpVlbCx2mZ5DzPI04k4kUwHHdskU3pH76iftG8yWlkAAAAAElFTkSuQmCC</Image>
-<Url type="application/x-suggestions+json" method="GET" template="https://www.google.com/complete/search?client=palemoon&amp;q={searchTerms}"/>
+<Url type="application/x-suggestions+json" method="GET" template="https://suggestqueries.google.com/complete/search?output=firefox&amp;client=firefox&amp;q={searchTerms}"/>
 <Url type="text/html" method="GET" template="https://www.google.com/search">
   <Param name="q" value="{searchTerms}"/>
   <Param name="ie" value="utf-8"/>
   <Param name="oe" value="utf-8"/>
-  <Param name="aq" value="t"/>
-  <Param name="rls" value="{moz:distributionID}:{moz:locale}"/>
-  <MozParam name="client" condition="defaultEngine" trueValue="palemoon-a" falseValue="palemoon"/>
-  <MozParam name="channel" condition="purpose" purpose="contextmenu" value="rcs"/>
-  <MozParam name="channel" condition="purpose" purpose="keyword" value="fflb"/>
-  <MozParam name="channel" condition="purpose" purpose="homepage" value="np"/>
-  <MozParam name="source" condition="purpose" purpose="homepage" value="hp"/>
 </Url>
 <SearchForm>https://www.google.com/</SearchForm>
 </SearchPlugin>

--- a/mobile/locales/en-US/searchplugins/google.xml
+++ b/mobile/locales/en-US/searchplugins/google.xml
@@ -6,14 +6,11 @@
 <ShortName>Google</ShortName>
 <InputEncoding>UTF-8</InputEncoding>
 <Image width="16" height="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACv0lEQVR42sWX208TURDG958x8M+It5CoDxojGn0wPvCg8UljYhRjBCpqJBQbL6lgI5JyERpFRLAiF7GiqI0QbUCIlm1pQ6XM556z7dQNbTl1l/olkzTd0zO/THe+OUfbXk8ithnhM0I3Alscusxl5tRE8gojokagzBEVubUMDUqJ4x6CNwhMfQOiCSCVRl6tpYFHY8DeGwX38mkllF1u9OwDkEwB90cIZx4SrvQSpiNgEYC218DFLsKR1k33jGuqyfcZyWeXgPQ6UOu1PtvZSBj6BJaeBI7eVttXGWDkC4REorzPq5sIS3GwQt/hHMDpdkJWd4YLr3MPEv7WibsOAfgnwbo1UHjdwWYrwLWAQwDjc2D53hQv7fwyWC2DDgGMzYI1HSkKIFqTVdftEED7KFhEwGH35gCpNWD/TfsAbDxEYAXe56/CLheJFpTyDDnchg+CsKixf+Mab2ZN11ugqt5ZALGhdL+1dM7xhj+bIK4AYWIOUq0v+DeOAnDUuEmWd3AGCIaBnytgie/kOvsA6rEYA8vzksoPoCfBWtCBQy1lBuiZgkW/EsCptq0D4Ol3zEM495ik263TxnNAXbdzANzj9X3SlqXJrBoxM29Ox9538rNFAup8p0MAtV7p8Txmz3YIIOuaHQ3SByyGlViFOEfYApBl/m32vvy/qxqKr7/UxV6R8QUbANVN/JbLft/tUvu7rj4hZW/QVDd6/hEoxTUX9OwJygZA5wRYA6oAPBXZnP4ZQHp/VstJYI9LvQI/YuYBtsZtA+DkPQIhp76Q2pS73EOAeTy334Yd47BITD0BVsigrj8lpNLSG0RrKgHoxcspp58wH4siUfMN90+a8SoM2TFLcXEpUX5X4spXswPNJHt69CvkBEymcpeQ8CLQHwIu+NmgVIKvZpX/8XJamb2eV2QqEStD4pjMZebU/gD3oidE+JhxZwAAAABJRU5ErkJggg==</Image>
-<Url type="application/x-suggestions+json" method="GET" template="https://www.google.com/complete/search?client=palemoon&amp;q={searchTerms}"/>
+<Url type="application/x-suggestions+json" method="GET" template="https://suggestqueries.google.com/complete/search?output=firefox&amp;client=firefox&amp;q={searchTerms}"/>
 <Url type="text/html" method="GET" template="https://www.google.com/search">
   <Param name="q" value="{searchTerms}"/>
   <Param name="ie" value="utf-8"/>
   <Param name="oe" value="utf-8"/>
-  <Param name="aq" value="t"/>
-  <!-- Dynamic parameters -->
-  <Param name="rls" value="{moz:distributionID}:{moz:locale}:{moz:official}"/>
 </Url>
 <SearchForm>https://www.google.com</SearchForm>
 </SearchPlugin>


### PR DESCRIPTION
The search engine XML for google.com contains Mozilla specific parameters that do not make any sense for PM.

However, the suggestions can only be retrieved if `client=firefox` and `output=firefox` are set. The domain has switched to `https://suggestqueries.google.com/`

This commit fixes the two issues.