### PR TITLE
Continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ sudo: required
 
 before_install:
   - bash build/travis_ci/travis_ci.sh deps
+  - bash build/travis_ci/travis_ci.sh swap
 script:
   - bash build/travis_ci/travis_ci.sh build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: cpp
+sudo: required
+
+before_install:
+  - bash build/travis_ci/travis_ci.sh deps
+script:
+  - bash build/travis_ci/travis_ci.sh build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ sudo: required
 
 before_install:
   - bash build/travis_ci/travis_ci.sh deps
-  - bash build/travis_ci/travis_ci.sh swap
 script:
   - bash build/travis_ci/travis_ci.sh build

--- a/build/travis_ci/travis_ci.sh
+++ b/build/travis_ci/travis_ci.sh
@@ -8,16 +8,15 @@ logfile="$srcdir/travis.log"
 install_deps () {
 	set -e
 
-	sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 	sudo apt-get update -y --force-yes
-	sudo apt-get install -y --force-yes	zip unzip g++-4.7 gcc-4.7 make autoconf2.13 yasm libgtk2.0-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex
+	sudo apt-get install -y --force-yes clang
 }
 
 build_palemoon () {
 	set -e
 
-	export CC="gcc-4.7"
-	export CXX="g++-4.7"
+	export CC="clang"
+	export CXX="clang++"
 
 	case $(uname -m) in
 		i*86)

--- a/build/travis_ci/travis_ci.sh
+++ b/build/travis_ci/travis_ci.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Constants
+srcdir="$(readlink -e "$(dirname "$0")"/../..)"
+objdir="$(readlink -f "$srcdir/../pmbuild")"
+logfile="$srcdir/travis.log"
+
+install_deps () {
+	set -e
+
+	sudo apt-get update -y --force-yes
+	sudo apt-get install -y --force-yes	zip unzip g++ make autoconf2.13 yasm libgtk2.0-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex
+}
+
+build_palemoon () {
+	set -e
+
+	case $(uname -m) in
+		i*86)
+			optflags='-msse2 -mfpmath=sse'
+			;;
+		*)
+			optflags=''
+			;;
+	esac
+	echo \
+"
+mk_add_options MOZ_CO_PROJECT=browser
+ac_add_options --enable-application=browser
+
+mk_add_options MOZ_OBJDIR=\"$objdir\"
+
+ac_add_options --disable-installer
+ac_add_options --disable-updater
+
+ac_add_options --disable-tests
+ac_add_options --disable-mochitests
+
+ac_add_options --enable-jemalloc
+ac_add_options --enable-optimize='$optflags'
+
+ac_add_options --x-libraries=/usr/lib
+" > "$srcdir/.mozconfig"
+
+	make -f client.mk build
+	cd "$objdir"
+	make package
+}
+
+cd "$srcdir"
+
+if [[ -z "$1" ]]; then
+	echo "Action to be performed was not given."
+	exit 1
+fi
+
+if [[ -z $CONTINUOUS_INTEGRATION ]]; then
+	echo "This build is not running in a CI environment. To force the build, use CONTINUOUS_INTEGRATION=true $0"
+	exit 1
+fi
+
+if [[ -z $palemoon_ci_logging ]]; then
+	# Invoke a background process with the the variable defined.
+	palemoon_ci_logging=true "$srcdir/build/travis_ci/travis_ci.sh" "$1" &> "$logfile" &
+	ps_pid=$!
+	echo -n "Started job $1"
+
+	# Keep Travis-CI from killing the build process, by writing something to the screen.
+	while kill -0 $ps_pid &>/dev/null; do
+		echo -n ' .'
+		sleep 30
+	done
+
+	wait $ps_pid
+	exitstat=$?
+
+	echo -e "\n\nJob '$1' completed with exit status $exitstat"
+
+	if [[ "$(wc -l < "$logfile")" -ge 0 ]]; then
+		# There's a maximum logging limit too (4 MB at the time of this writing.)
+		echo "Last 200 lines of output from the log:"
+		tail -n 200 "$logfile"
+	fi
+	exit $exitstat
+fi
+
+case "$1" in
+	deps)
+		install_deps
+		;;
+	build)
+		build_palemoon
+		;;
+	*)
+		echo "Unknown job type: $1"
+		exit 2
+esac

--- a/build/travis_ci/travis_ci.sh
+++ b/build/travis_ci/travis_ci.sh
@@ -5,24 +5,18 @@ srcdir="$(readlink -e "$(dirname "$0")"/../..)"
 objdir="$(readlink -f "$srcdir/../pmbuild")"
 logfile="$srcdir/travis.log"
 
-make_swap () {
-	set -e
-
-	swap_img_file=$(mktemp --dry-run /tmp/swapXXXXXXXXX.img)
-	dd if=/dev/zero of="$swap_img_file" bs=1M count=6144
-	sudo mkswap "$swap_img_file"
-	sudo swapon "$swap_img_file"
-}	
-
 install_deps () {
 	set -e
 
 	sudo apt-get update -y --force-yes
-	sudo apt-get install -y --force-yes	zip unzip g++ make autoconf2.13 yasm libgtk2.0-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex
+	sudo apt-get install -y --force-yes	zip unzip g++-4.7 gcc-4.7 make autoconf2.13 yasm libgtk2.0-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex
 }
 
 build_palemoon () {
 	set -e
+
+	export CC="gcc-4.7"
+	export CXX="g++-4.7"
 
 	case $(uname -m) in
 		i*86)
@@ -99,9 +93,6 @@ case "$1" in
 		;;
 	build)
 		build_palemoon
-		;;
-	swap)
-		make_swap
 		;;
 	*)
 		echo "Unknown job type: $1"

--- a/build/travis_ci/travis_ci.sh
+++ b/build/travis_ci/travis_ci.sh
@@ -5,6 +5,15 @@ srcdir="$(readlink -e "$(dirname "$0")"/../..)"
 objdir="$(readlink -f "$srcdir/../pmbuild")"
 logfile="$srcdir/travis.log"
 
+make_swap () {
+	set -e
+
+	swap_img_file=$(mktemp --dry-run /tmp/swapXXXXXXXXX.img)
+	dd if=/dev/zero of="$swap_img_file" bs=1M count=6144
+	sudo mkswap "$swap_img_file"
+	sudo swapon "$swap_img_file"
+}	
+
 install_deps () {
 	set -e
 
@@ -90,6 +99,9 @@ case "$1" in
 		;;
 	build)
 		build_palemoon
+		;;
+	swap)
+		make_swap
 		;;
 	*)
 		echo "Unknown job type: $1"

--- a/build/travis_ci/travis_ci.sh
+++ b/build/travis_ci/travis_ci.sh
@@ -8,6 +8,7 @@ logfile="$srcdir/travis.log"
 install_deps () {
 	set -e
 
+	sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 	sudo apt-get update -y --force-yes
 	sudo apt-get install -y --force-yes	zip unzip g++-4.7 gcc-4.7 make autoconf2.13 yasm libgtk2.0-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex
 }

--- a/build/travis_ci/travis_ci.sh
+++ b/build/travis_ci/travis_ci.sh
@@ -9,7 +9,7 @@ install_deps () {
 	set -e
 
 	sudo apt-get update -y --force-yes
-	sudo apt-get install -y --force-yes clang
+	sudo apt-get install -y --force-yes	zip unzip clang make autoconf2.13 yasm libgtk2.0-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex
 }
 
 build_palemoon () {


### PR DESCRIPTION
Pale Moon currently does not have any system to check whether the commits/PRs made result in a "build-able" and stable trunk. As a result, any and all commits/PRs have to be checked manually.

This PR adds continuous integration support using Travis-CI. At present, it only solves the former problem ("build-able" state). I plan to look into downloadable "try-builds" (like Mozilla does) at some later point in time.

The build infrastructure uses:
- Ubuntu 12.04
- Clang instead of gcc-4.7 due to memory usage issues.

  I tried adding swap area to get around this problem, but (as I learned later) that does not work in OpenVZ containers.

The current build status may be reviewed here:
https://travis-ci.org/squarefractal/Pale-Moon
