### PR TITLE
Bug 1131965 Crash during WebGL Conformance Tests - /conformance/glsl/…

### DIFF
--- a/gfx/angle/src/compiler/ParseHelper.cpp
+++ b/gfx/angle/src/compiler/ParseHelper.cpp
@@ -1460,9 +1460,11 @@ TIntermTyped* TParseContext::addIndexExpression(TIntermTyped *baseExpression, co
         recover();
     }
 
-    if (indexExpression->getQualifier() == EvqConst)
+    TIntermConstantUnion *indexConstantUnion = indexExpression->getAsConstantUnion();
+
+    if (indexExpression->getQualifier() == EvqConst && indexConstantUnion)
     {
-        int index = indexExpression->getAsConstantUnion()->getIConst(0);
+        int index = indexConstantUnion->getIConst(0);
         if (index < 0)
         {
             std::stringstream infoStream;
@@ -1523,7 +1525,7 @@ TIntermTyped* TParseContext::addIndexExpression(TIntermTyped *baseExpression, co
                 index = baseExpression->getType().getNominalSize() - 1;
             }
 
-            indexExpression->getAsConstantUnion()->getUnionArrayPointer()->setIConst(index);
+            indexConstantUnion->getUnionArrayPointer()->setIConst(index);
             indexedExpression = intermediate.addIndex(EOpIndexDirect, baseExpression, indexExpression, location);
         }
     }


### PR DESCRIPTION
…bugs/undefined-index-should-not-crash.html

Crash during WebGL conformance test.