### PR TITLE
Bug 1062355 - Crash in d3dcompiler, nested-functions-should-not-crash…

### DIFF
--- a/gfx/angle/src/libGLESv2/Shader.cpp
+++ b/gfx/angle/src/libGLESv2/Shader.cpp
@@ -356,7 +356,7 @@ void Shader::compileToHLSL(void *compiler)
     // ensure the compiler is loaded
     initializeCompiler();
 
-    int compileOptions = SH_OBJECT_CODE;
+    int compileOptions = SH_OBJECT_CODE | SH_LIMIT_CALL_STACK_DEPTH;
     std::string sourcePath;
     if (perfActive())
     {


### PR DESCRIPTION
….html test of WebGL Conformance Test

Crash during WebGL conformance test