### PR TITLE
[!] Fix support for builds using newer freetype.

### DIFF
--- a/config/system-headers
+++ b/config/system-headers
@@ -411,6 +411,7 @@ freetype/ftlcdfil.h
 freetype/ftsizes.h
 freetype/ftadvanc.h
 freetype/ftbitmap.h
+freetype/ftfntfmt.h
 freetype/ftxf86.h
 freetype.h
 ftcache.h
@@ -424,6 +425,7 @@ ftlcdfil.h
 ftsizes.h
 ftadvanc.h
 ftbitmap.h
+ftfntfmt.h
 ftxf86.h
 fribidi/fribidi.h
 FSp_fopen.h

--- a/js/src/config/system-headers
+++ b/js/src/config/system-headers
@@ -411,6 +411,7 @@ freetype/ftlcdfil.h
 freetype/ftsizes.h
 freetype/ftadvanc.h
 freetype/ftbitmap.h
+freetype/ftfntfmt.h
 freetype/ftxf86.h
 freetype.h
 ftcache.h
@@ -424,6 +425,7 @@ ftlcdfil.h
 ftsizes.h
 ftadvanc.h
 ftbitmap.h
+ftfntfmt.h
 ftxf86.h
 fribidi/fribidi.h
 FSp_fopen.h


### PR DESCRIPTION
This commit fixes the undefined reference for me in issue #16, caused by a change by the freetype upstream. (I did not remove the older references so this should still allows for building with older freetype packages as well.) 