### PR TITLE
Miscellaneous fixes for issues found while building for Alpine Linux

### DIFF
--- a/config/config.mk
+++ b/config/config.mk
@@ -380,6 +380,10 @@ JAVA_IFACES_PKG_NAME = org/mozilla/interfaces
 
 OS_INCLUDES += $(MOZ_JPEG_CFLAGS) $(MOZ_PNG_CFLAGS) $(MOZ_ZLIB_CFLAGS)
 
+ifndef MOZ_TREE_PIXMAN
+OS_INCLUDES += $(pkg-config --cflags pixman-1)
+endif
+
 # NSPR_CFLAGS and NSS_CFLAGS must appear ahead of OS_INCLUDES to avoid Linux
 # builds wrongly picking up system NSPR/NSS header files.
 INCLUDES = \

--- a/ipc/chromium/src/base/debug_util_posix.cc
+++ b/ipc/chromium/src/base/debug_util_posix.cc
@@ -5,7 +5,7 @@
 #include "build/build_config.h"
 #include "base/debug_util.h"
 
-#define MOZ_HAVE_EXECINFO_H (defined(OS_LINUX) && !defined(ANDROID))
+#define MOZ_HAVE_EXECINFO_H (defined(OS_LINUX) && defined(__GLIBC__))
 
 #include <errno.h>
 #include <fcntl.h>

--- a/js/src/config/config.mk
+++ b/js/src/config/config.mk
@@ -380,6 +380,10 @@ JAVA_IFACES_PKG_NAME = org/mozilla/interfaces
 
 OS_INCLUDES += $(MOZ_JPEG_CFLAGS) $(MOZ_PNG_CFLAGS) $(MOZ_ZLIB_CFLAGS)
 
+ifndef MOZ_TREE_PIXMAN
+OS_INCLUDES += $(pkg-config --cflags pixman-1)
+endif
+
 # NSPR_CFLAGS and NSS_CFLAGS must appear ahead of OS_INCLUDES to avoid Linux
 # builds wrongly picking up system NSPR/NSS header files.
 INCLUDES = \


### PR DESCRIPTION
Here are a couple small fixes for some build breaks I stumbled across while building for Alpine Linux.

1- commit 1f31aa51, fix --with-system-pixman builds: This is a non-platform-specific bug that I happen to have encountered. By default the pixman-1 include directory is not added to ${INCLUDES}.
I'm not sure how this would affect Windows builds, though.

2- commit c065b28caf, make execinfo.h glibc-specific.
There are numerous Linux libc versions; only glibc and some builds of uclibc (which also defines __GLIBC__) provide execinfo.h. Android's bionic libc, musl, and a number of more obscure versions do not.
So far, the only Linux systems Pale Moon is officially built for are glibc-based distros and Android, but Alpine Linux uses musl.

I'm using the system library versions for most packages for several reasons; the main ones are that some packages have only recently been updated to compile in the build environment Alpine has, and that I'm trying a build for the first time on an Atom N270 netbook with 1 gig of ram.
I have not gotten a complete build yet, but these will probably be needed for it.