### PR TITLE
navigator.geolocation should never be null

### DIFF
--- a/dom/base/Navigator.cpp
+++ b/dom/base/Navigator.cpp
@@ -1067,12 +1067,8 @@ NS_IMETHODIMP Navigator::GetGeolocation(nsIDOMGeoGeolocation** _retval)
     return NS_ERROR_FAILURE;
   }
 
-  if (Preferences::GetBool("geo.enabled", true)) {
-    //Only Init when enabled, otherwise return empty
-    if (NS_FAILED(mGeolocation->Init(mWindow->GetOuterWindow()))) {
-      mGeolocation = nullptr;
-      return NS_ERROR_FAILURE;
-    }
+  if (NS_FAILED(mGeolocation->Init(mWindow->GetOuterWindow()))) {
+    return NS_ERROR_FAILURE;
   }
 
   NS_ADDREF(*_retval = mGeolocation);


### PR DESCRIPTION
A patch for the issue described here: https://forum.palemoon.org/viewtopic.php?f=29&t=8219

Tested using the Live Result box on the geolocation MDM page here: https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation

With geo.enabled set to true, test returns correct location.
When geo.enabled set to false, I receive a "Unable to retrieve your location" message (25.4.1 simply displays a never ending "loading..." message.