### PR TITLE
Partial fix for devtools UA sniffing insanity in the browser.

### DIFF
--- a/browser/devtools/sourceeditor/orion/orion.js
+++ b/browser/devtools/sourceeditor/orion/orion.js
@@ -3420,9 +3420,6 @@ define("orion/textview/textView", ['orion/textview/textModel', 'orion/textview/k
 	}
 	var userAgent = navigator.userAgent;
 	var isIE;
-	if (document.selection && window.ActiveXObject && /MSIE/.test(userAgent)) {
-		isIE = document.documentMode ? document.documentMode : 7;
-	}
 	var isFirefox = 24;
 	var isOpera = false;
 	var isChrome = false;

--- a/browser/devtools/sourceeditor/orion/orion.js
+++ b/browser/devtools/sourceeditor/orion/orion.js
@@ -3423,12 +3423,12 @@ define("orion/textview/textView", ['orion/textview/textModel', 'orion/textview/k
 	if (document.selection && window.ActiveXObject && /MSIE/.test(userAgent)) {
 		isIE = document.documentMode ? document.documentMode : 7;
 	}
-	var isFirefox = parseFloat(userAgent.split("Firefox/")[1] || userAgent.split("PaleMoon/")[1] || userAgent.split("NewMoon/")[1]) || undefined;
-	var isOpera = userAgent.indexOf("Opera") !== -1;
-	var isChrome = userAgent.indexOf("Chrome") !== -1;
-	var isSafari = userAgent.indexOf("Safari") !== -1 && !isChrome;
-	var isWebkit = userAgent.indexOf("WebKit") !== -1;
-	var isPad = userAgent.indexOf("iPad") !== -1;
+	var isFirefox = 24;
+	var isOpera = false;
+	var isChrome = false;
+	var isSafari = false;
+	var isWebkit = false;
+	var isPad = false;
 	var isMac = navigator.platform.indexOf("Mac") !== -1;
 	var isWindows = navigator.platform.indexOf("Win") !== -1;
 	var isLinux = navigator.platform.indexOf("Linux") !== -1;


### PR DESCRIPTION
Devtools uses UA sniffing for some of its functions, which (as expected) breaks when one changes the user agent to something else.

This PR provides a partial fix for this.

A more serious approach towards this (involving nsIXULRuntime) has to be done, but I don't have a good command of Mozilla XUL development. You may reject this PR if you're planning on improving above discussed aspect.