### PR TITLE
Revert "Disable screensaver when playing HTML5 video"

### DIFF
--- a/content/html/content/public/HTMLMediaElement.h
+++ b/content/html/content/public/HTMLMediaElement.h
@@ -1110,9 +1110,6 @@ protected:
   // True if the media has an audio track
   bool mHasAudio;
 
-  // True if the media has a video track
-  bool mHasVideo;
-
   // True if the media's channel's download has been suspended.
   bool mDownloadSuspendedByCache;
 

--- a/content/html/content/src/HTMLMediaElement.cpp
+++ b/content/html/content/src/HTMLMediaElement.cpp
@@ -1905,7 +1905,6 @@ HTMLMediaElement::HTMLMediaElement(already_AddRefed<nsINodeInfo> aNodeInfo)
     mMediaSecurityVerified(false),
     mCORSMode(CORS_NONE),
     mHasAudio(false),
-    mHasVideo(false),
     mDownloadSuspendedByCache(false),
     mAudioChannelType(AUDIO_CHANNEL_NORMAL),
     mPlayingThroughTheAudioChannel(false)
@@ -2711,7 +2710,6 @@ void HTMLMediaElement::MetadataLoaded(int aChannels,
   mChannels = aChannels;
   mRate = aRate;
   mHasAudio = aHasAudio;
-  mHasVideo = aHasVideo;
   mTags = aTags;
   ChangeReadyState(nsIDOMHTMLMediaElement::HAVE_METADATA);
   DispatchAsyncEvent(NS_LITERAL_STRING("durationchange"));
@@ -3086,6 +3084,9 @@ VideoFrameContainer* HTMLMediaElement::GetVideoFrameContainer()
     return nullptr;
   }
 
+  if (mVideoFrameContainer)
+    return mVideoFrameContainer;
+
   // If we have a print surface, this is just a static image so
   // no image container is required
   if (mPrintSurface)
@@ -3095,11 +3096,6 @@ VideoFrameContainer* HTMLMediaElement::GetVideoFrameContainer()
   nsCOMPtr<nsIDOMHTMLVideoElement> video = do_QueryObject(this);
   if (!video)
     return nullptr;
-
-  mHasVideo = true;
-
-  if (mVideoFrameContainer)
-    return mVideoFrameContainer;
 
   mVideoFrameContainer =
     new VideoFrameContainer(this, LayerManager::CreateAsynchronousImageContainer());

--- a/content/html/content/src/HTMLVideoElement.cpp
+++ b/content/html/content/src/HTMLVideoElement.cpp
@@ -271,7 +271,7 @@ HTMLVideoElement::WakeLockUpdate()
     return;
   }
 
-  if (!mScreenWakeLock && !mPaused && !hidden && mHasVideo) {
+  if (!mScreenWakeLock && !mPaused && !hidden) {
     nsCOMPtr<nsIPowerManagerService> pmService =
       do_GetService(POWERMANAGERSERVICE_CONTRACTID);
     NS_ENSURE_TRUE_VOID(pmService);

--- a/mobile/android/base/GeckoApp.java
+++ b/mobile/android/base/GeckoApp.java
@@ -2307,17 +2307,9 @@ abstract public class GeckoApp
         PowerManager.WakeLock wl = mWakeLocks.get(topic);
         if (state.equals("locked-foreground") && wl == null) {
             PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
-
-            if (CPU.equals(topic)) {
-              wl = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, topic);
-            } else if (SCREEN.equals(topic)) {
-              wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK, topic);
-            }
-
-            if (wl != null) {
-              wl.acquire();
-              mWakeLocks.put(topic, wl);
-            }
+            wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK, topic);
+            wl.acquire();
+            mWakeLocks.put(topic, wl);
         } else if (!state.equals("locked-foreground") && wl != null) {
             wl.release();
             mWakeLocks.remove(topic);

--- a/widget/cocoa/nsAppShell.mm
+++ b/widget/cocoa/nsAppShell.mm
@@ -35,68 +35,8 @@
 #include "GeckoProfiler.h"
 
 #include "npapi.h"
-#include <IOKit/pwr_mgt/IOPMLib.h>
-#include "nsIDOMWakeLockListener.h"
-#include "nsIPowerManagerService.h"
 
 using namespace mozilla::widget;
-
-// A wake lock listener that disables screen saver when requested by
-// Gecko. For example when we're playing video in a foreground tab we
-// don't want the screen saver to turn on.
-
-class MacWakeLockListener : public nsIDOMMozWakeLockListener {
-public:
-NS_DECL_ISUPPORTS;
-
-private:
-  IOPMAssertionID mAssertionID = kIOPMNullAssertionID;
-  NS_IMETHOD Callback(const nsAString& aTopic, const nsAString& aState) {
-    bool isLocked = mLockedTopics.Contains(aTopic);
-    bool shouldLock = aState.EqualsLiteral("locked-foreground");
-    if (isLocked == shouldLock) {
-      return NS_OK;
-    }
-    if (shouldLock) {
-      if (!mLockedTopics.Count()) {
-        // This is the first topic to request the screen saver be disabled.
-        // Prevent screen saver.
-        CFStringRef cf_topic =
-          ::CFStringCreateWithCharacters(kCFAllocatorDefault,
-                                         reinterpret_cast<const UniChar*>
-                                           (aTopic.Data()),
-                                         aTopic.Length());
-        IOReturn success =
-          ::IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep,
-                                        kIOPMAssertionLevelOn,
-                                        cf_topic,
-                                        &mAssertionID);
-        CFRelease(cf_topic);
-        if (success != kIOReturnSuccess) {
-          NS_WARNING("fail to disable screensaver");
-        }
-      }
-      mLockedTopics.PutEntry(aTopic);
-    } else {
-      mLockedTopics.RemoveEntry(aTopic);
-      if (!mLockedTopics.Count()) {
-        // No other outstanding topics have requested screen saver be disabled.
-        // Re-enable screen saver.
-        if (mAssertionID != kIOPMNullAssertionID) {
-          IOReturn result = ::IOPMAssertionRelease(mAssertionID);
-          if (result != kIOReturnSuccess) {
-            NS_WARNING("fail to release screensaver");
-          }
-        }
-      }
-    }
-    return NS_OK;
-  }
-  // Keep track of all the topics that have requested a wake lock. When the
-  // number of topics in the hashtable reaches zero, we can uninhibit the
-  // screensaver again.
-  nsTHashtable<nsStringHashKey> mLockedTopics;
-};
 
 // defined in nsCocoaWindow.mm
 extern int32_t             gXULModalLevel;
@@ -300,34 +240,6 @@ nsAppShell::~nsAppShell()
   [mDelegate release];
 
   NS_OBJC_END_TRY_ABORT_BLOCK
-}
-
-NS_IMPL_ISUPPORTS(MacWakeLockListener, nsIDOMMozWakeLockListener)
-mozilla::StaticRefPtr<MacWakeLockListener> sWakeLockListener;
-
-static void
-AddScreenWakeLockListener()
-{
-  nsCOMPtr<nsIPowerManagerService> sPowerManagerService = do_GetService(
-                                                          POWERMANAGERSERVICE_CONTRACTID);
-  if (sPowerManagerService) {
-    sWakeLockListener = new MacWakeLockListener();
-    sPowerManagerService->AddWakeLockListener(sWakeLockListener);
-  } else {
-    NS_WARNING("Failed to retrieve PowerManagerService, wakelocks will be broken!");
-  }
-}
-
-static void
-RemoveScreenWakeLockListener()
-{
-  nsCOMPtr<nsIPowerManagerService> sPowerManagerService = do_GetService(
-                                                          POWERMANAGERSERVICE_CONTRACTID);
-  if (sPowerManagerService) {
-    sPowerManagerService->RemoveWakeLockListener(sWakeLockListener);
-    sPowerManagerService = nullptr;
-    sWakeLockListener = nullptr;
-  }
 }
 
 // An undocumented CoreGraphics framework method, present in the same form
@@ -840,12 +752,7 @@ nsAppShell::Run(void)
     return NS_OK;
 
   mStarted = true;
-
-  AddScreenWakeLockListener();
-
   NS_OBJC_TRY_ABORT([NSApp run]);
-
-  RemoveScreenWakeLockListener();
 
   return NS_OK;
 }

--- a/widget/windows/nsAppShell.cpp
+++ b/widget/windows/nsAppShell.cpp
@@ -15,64 +15,8 @@
 #include "WinIMEHandler.h"
 #include "mozilla/widget/AudioSession.h"
 #include "mozilla/HangMonitor.h"
-#include "nsIDOMWakeLockListener.h"
-#include "nsIPowerManagerService.h"
-#include "mozilla/StaticPtr.h"
-#include "nsTHashtable.h"
-#include "nsHashKeys.h"
 
 using namespace mozilla::widget;
-
-// A wake lock listener that disables screen saver when requested by
-// Gecko. For example when we're playing video in a foreground tab we
-// don't want the screen saver to turn on.
-class WinWakeLockListener : public nsIDOMMozWakeLockListener {
-public:
-  NS_DECL_ISUPPORTS;
-
-private:
-  NS_IMETHOD Callback(const nsAString& aTopic, const nsAString& aState) {
-    if (!aTopic.EqualsASCII("screen")) {
-      return NS_OK;
-    }
-    // Note the wake lock code ensures that we're not sent duplicate
-    // "locked-foreground" notifications when multipe wake locks are held.
-    if (aState.EqualsASCII("locked-foreground")) {
-      // Prevent screen saver.
-      SetThreadExecutionState(ES_DISPLAY_REQUIRED|ES_CONTINUOUS);
-    } else {
-      // Re-enable screen saver.
-      SetThreadExecutionState(ES_CONTINUOUS);
-    }
-    return NS_OK;
-  }
-};
-
-NS_IMPL_ISUPPORTS1(WinWakeLockListener, nsIDOMMozWakeLockListener)
-StaticRefPtr<WinWakeLockListener> sWakeLockListener;
-
-static void
-AddScreenWakeLockListener()
-{
-  nsCOMPtr<nsIPowerManagerService> sPowerManagerService = do_GetService(POWERMANAGERSERVICE_CONTRACTID);
-  if (sPowerManagerService) {
-    sWakeLockListener = new WinWakeLockListener();
-    sPowerManagerService->AddWakeLockListener(sWakeLockListener);
-  } else {
-    NS_WARNING("Failed to retrieve PowerManagerService, wakelocks will be broken!");
-  }
-}
-
-static void
-RemoveScreenWakeLockListener()
-{
-  nsCOMPtr<nsIPowerManagerService> sPowerManagerService = do_GetService(POWERMANAGERSERVICE_CONTRACTID);
-  if (sPowerManagerService) {
-    sPowerManagerService->RemoveWakeLockListener(sWakeLockListener);
-    sPowerManagerService = nullptr;
-    sWakeLockListener = nullptr;
-  }
-}
 
 const PRUnichar* kAppShellEventId = L"nsAppShell:EventID";
 const PRUnichar* kTaskbarButtonEventId = L"TaskbarButtonCreated";
@@ -154,13 +98,7 @@ nsAppShell::Run(void)
   // appropriate response to failing to start an audio session.
   mozilla::widget::StartAudioSession();
 
-  // Add an observer that disables the screen saver when requested by Gecko.
-  // For example when we're playing video in the foreground tab.
-  AddScreenWakeLockListener();
-
   nsresult rv = nsBaseAppShell::Run();
-
-  RemoveScreenWakeLockListener();
 
   mozilla::widget::StopAudioSession();
 
@@ -192,7 +130,7 @@ nsAppShell::DoProcessMoreGeckoEvents()
   // always be true. ScheduleNativeEventCallback will be called on every
   // NativeEventCallback callback, and in a Windows modal dispatch loop, the
   // callback message will be processed first -> input gets starved, dead lock.
-
+  
   // To avoid, don't post native callback messages from NativeEventCallback
   // when we're in a modal loop. This gets us back into the Windows modal
   // dispatch loop dispatching input messages. Once we drop out of the modal
@@ -293,6 +231,6 @@ nsAppShell::ProcessNextNativeEvent(bool mayWait)
       nativeEventStarvationLimit) {
     ScheduleNativeEventCallback();
   }
-
+  
   return gotMessage;
 }


### PR DESCRIPTION
Reverts MoonchildProductions/Pale-Moon#95

This causes build errors on Windows.

```
51:11.66 nsAppShell.cpp
51:11.67
51:11.67 e:/mozdev/PaleMoon/widget/windows/nsAppShell.cpp(52) : error C2143: syntax error : missing
';' before '<'
51:11.67
51:11.67 e:/mozdev/PaleMoon/widget/windows/nsAppShell.cpp(52) : error C4430: missing type specifier
- int assumed. Note: C++ does not support default-int
51:11.67
51:11.67 e:/mozdev/PaleMoon/widget/windows/nsAppShell.cpp(59) : error C2065: 'sWakeLockListener' : u
ndeclared identifier
51:11.68
51:11.68 e:/mozdev/PaleMoon/widget/windows/nsAppShell.cpp(60) : error C2065: 'sWakeLockListener' : u
ndeclared identifier
51:11.68
51:11.68 e:/mozdev/PaleMoon/widget/windows/nsAppShell.cpp(71) : error C2065: 'sWakeLockListener' : u
ndeclared identifier
51:11.68
51:11.68 e:/mozdev/PaleMoon/widget/windows/nsAppShell.cpp(73) : error C2065: 'sWakeLockListener' : u
ndeclared identifier
51:11.68
51:11.68 e:\mozdev\PaleMoon\config\rules.mk:1106:0: command 'e:/mozdev/PaleMoon/build-x86/_virtualen
v/Scripts/python.exe -O e:/mozdev/PaleMoon/build/cl.py cl -FonsAppShell.obj -c -D_HAS_EXCEPTIONS=0 -
I../../dist/stl_wrappers  -D_IMPL_NS_WIDGET -DMOZ_UNICODE  -DMOZ_ENABLE_D3D9_LAYER -DMOZ_ENABLE_D3D1
0_LAYER -DXPCOM_TRANSLATE_NSGM_ENTRY_POINT=1 -DMOZILLA_INTERNAL_API -D_IMPL_NS_COM -DEXPORT_XPT_API
-DEXPORT_XPTC_API -D_IMPL_NS_GFX -D_IMPL_NS_WIDGET -DIMPL_XREAPI -DIMPL_NS_NET -DIMPL_THEBES  -DNO_N
SPR_10_SUPPORT -DUNICODE -D_UNICODE -DNOMINMAX -D_CRT_RAND_S -DCERT_CHAIN_PARA_HAS_EXTRA_FIELDS -D_S
ECURE_ATL -DCHROMIUM_BUILD -DU_STATIC_IMPLEMENTATION -DOS_WIN=1 -DWIN32 -D_WIN32 -D_WINDOWS -DWIN32_
LEAN_AND_MEAN  -DCOMPILER_MSVC -I. -Ie:/mozdev/PaleMoon/widget/windows/../xpwidgets -Ie:/mozdev/Pale
Moon/widget/windows/../shared -Ie:/mozdev/PaleMoon/widget/windows -Ie:/mozdev/PaleMoon/layout/generi
c -Ie:/mozdev/PaleMoon/layout/xul/base/src -Ie:/mozdev/PaleMoon/toolkit/xre -Ie:/mozdev/PaleMoon/xpc
om/base -Ie:/mozdev/PaleMoon/content/events/src  -Ie:/mozdev/PaleMoon/ipc/chromium/src -Ie:/mozdev/P
aleMoon/ipc/glue -I../../ipc/ipdl/_ipdlheaders  -Ie:/mozdev/PaleMoon/widget/windows -I. -I../../dist
/include  -Ie:/mozdev/PaleMoon/build-x86/dist/include/nspr -Ie:/mozdev/PaleMoon/build-x86/dist/inclu
de/nss        -wd4099 -TP -nologo -W3 -Gy -Fdgenerated.pdb -wd4251 -wd4244 -wd4345 -wd4351 -wd4482 -
wd4800 -wd4819 -wd4267 -we4553 -GR-  -DNDEBUG -DTRIMMED -Zi -UDEBUG -DNDEBUG -O2 -GFLs -GS- -Qfast_t
ranscendentals -Qpar -Oy -Ie:/mozdev/PaleMoon/build-x86/dist/include/cairo  -MD            -FI ../..
/dist/include/mozilla-config.h -DMOZILLA_CLIENT  e:/mozdev/PaleMoon/widget/windows/nsAppShell.cpp' f
ailed, return code 2
```