### PR TITLE
Fix Pale Moon issue with single word searches under proxies. 

### DIFF
--- a/docshell/base/nsDefaultURIFixup.cpp
+++ b/docshell/base/nsDefaultURIFixup.cpp
@@ -23,7 +23,6 @@
 #include "mozilla/Preferences.h"
 #include "nsIObserverService.h"
 
- 
 // Used to check if external protocol schemes are usable.
 #include "nsCExternalHandlerService.h"
 #include "nsIExternalProtocolService.h"

--- a/docshell/base/nsIURIFixup.idl
+++ b/docshell/base/nsIURIFixup.idl
@@ -12,7 +12,7 @@ interface nsIInputStream;
 /**
  * Interface implemented by objects capable of fixing up strings into URIs
  */
-[scriptable, uuid(552a23bb-c1b2-426e-a801-d346c6a98f1d)]
+[scriptable, uuid(5e81f628-c57b-44af-9488-9f3ff367cbf4)]
 interface nsIURIFixup : nsISupports
 {
     /** No fixup flags. */
@@ -35,6 +35,11 @@ interface nsIURIFixup : nsISupports
      * Use UTF-8 to encode the URI instead of platform charset.
      */
     const unsigned long FIXUP_FLAG_USE_UTF8 = 4;
+    
+    /**
+     * Fix common scheme typos.
+     */
+    const unsigned long FIXUP_FLAG_FIX_SCHEME_TYPOS = 5;
 
     /**
      * Converts an internal URI (e.g. a wyciwyg URI) into one which we can

--- a/modules/libpref/src/init/all.js
+++ b/modules/libpref/src/init/all.js
@@ -863,6 +863,14 @@ pref("network.protocol-handler.external.disks", false);
 pref("network.protocol-handler.external.afp", false);
 pref("network.protocol-handler.external.moz-icon", false);
 
+// Don't allow  external protocol handlers for common typos.
+pref("network.protocol-handler.external.ttp", false);  // http
+pref("network.protocol-handler.external.ttps", false); // https
+pref("network.protocol-handler.external.tps", false);  // https
+pref("network.protocol-handler.external.ps", false);   // https
+pref("network.protocol-handler.external.ile", false);  // file
+pref("network.protocol-handler.external.le", false);   // file
+
 // An exposed protocol handler is one that can be used in all contexts.  A
 // non-exposed protocol handler is one that can only be used internally by the
 // application.  For example, a non-exposed protocol would not be loaded by the


### PR DESCRIPTION
This stems from [here](https://forum.palemoon.org/viewtopic.php?f=37&t=8532&sid=3852a1c547313cf3f792828c669890d1), and this is the proper solution to the issue. This pull request also implements the URI typo fix. (e.g. ttp:// -> http://)

Compiles, and works on my machine. (Sorry for the messy commit log, hope it is not too bad.)