### PR TITLE
[!] Fix builds using --with-system-cairo.

### DIFF
--- a/gfx/2d/DrawTargetCairo.cpp
+++ b/gfx/2d/DrawTargetCairo.cpp
@@ -638,8 +638,10 @@ void
 DrawTargetCairo::SetPermitSubpixelAA(bool aPermitSubpixelAA)
 {
   DrawTarget::SetPermitSubpixelAA(aPermitSubpixelAA);
+#ifdef MOZ_TREE_CAIRO
   cairo_surface_set_subpixel_antialiasing(mSurface,
     aPermitSubpixelAA ? CAIRO_SUBPIXEL_ANTIALIASING_ENABLED : CAIRO_SUBPIXEL_ANTIALIASING_DISABLED);
+#endif
 }
 
 void


### PR DESCRIPTION
[!] This should be the last of the --with-system-x bugs.

Which should mean that Pale Moon should be able to build on (Free/Open)BSD like systems (unless Pale Moon Clang builds are broken again). However I still need to confirm such. (Note this bug fix is not *BSD specific, and pertains to Linux as well.) 