### PR TITLE
Unhighlight highlighted text when closing the findbar

### DIFF
--- a/toolkit/content/widgets/findbar.xml
+++ b/toolkit/content/widgets/findbar.xml
@@ -1479,6 +1479,9 @@
             this._quickFindTimeout = null;
           }
 
+          this.toggleHighlight(false);
+          this.getElement("highlight").checked = false;
+
           this._findFailedString = null;
         ]]></body>
       </method>


### PR DESCRIPTION
Here's another one! :)

Currently in Pale Moon if you search for text and click "Highlight All" and then close the findbar, the highlighted text remains highlighted. The only way to remove the highlight is to open the findbar again and reclick on "Highlight all" to remove the highlights. This PR automatically unhighlights the text on closing of the findbar.

Confirmed works as intended on top of current trunk (on Linux x64).