### PR TITLE
[!] Support Link Time Optimization by newer GCC versions.

### DIFF
--- a/build/unix/elfhack/Makefile.in
+++ b/build/unix/elfhack/Makefile.in
@@ -25,6 +25,13 @@ HOST_CPPSRCS = \
 
 OS_CXXFLAGS := $(filter-out -fno-exceptions,$(OS_CXXFLAGS)) -fexceptions
 
+FNO_LTO_CFLAGS:=$(filter-out -flto, $(CFLAGS))
+test-array.c: test-array.c ...
+        $(CC) $(FNO_LTO_CFLAGS) -o $@ -c $<
+
+test-ctors.c: test-ctors.c ...
+        $(CC) $(FNO_LTO_CFLAGS) -o $@ -c $<
+
 ifneq (,$(filter %86,$(TARGET_CPU)))
 CPU := x86
 else

--- a/build/unix/elfhack/Makefile.in
+++ b/build/unix/elfhack/Makefile.in
@@ -25,13 +25,6 @@ HOST_CPPSRCS = \
 
 OS_CXXFLAGS := $(filter-out -fno-exceptions,$(OS_CXXFLAGS)) -fexceptions
 
-FNO_LTO_CFLAGS:=$(filter-out -flto, $(CFLAGS))
-test-array.c: test-array.c ...
-        $(CC) $(FNO_LTO_CFLAGS) -o $@ -c $<
-
-test-ctors.c: test-ctors.c ...
-        $(CC) $(FNO_LTO_CFLAGS) -o $@ -c $<
-
 ifneq (,$(filter %86,$(TARGET_CPU)))
 CPU := x86
 else

--- a/xpcom/reflect/xptcall/src/md/unix/xptc_gcc_x86_unix.h
+++ b/xpcom/reflect/xptcall/src/md/unix/xptc_gcc_x86_unix.h
@@ -14,6 +14,3 @@
 #else
 #define SYMBOL_UNDERSCORE
 #endif
-
-
-#define ATTRIBUTE_USED __attribute__ ((__used__))

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_alpha_openbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_alpha_openbsd.cpp
@@ -11,7 +11,7 @@
 /* Prototype specifies unmangled function name and disables unused warning */
 static nsresult
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint64_t* args)
-__asm__("PrepareAndDispatch") __attribute__((used));
+__asm__("PrepareAndDispatch") ATTRIBUTE_USED;
 
 static nsresult
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint64_t* args)

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_amd64_openbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_amd64_openbsd.cpp
@@ -28,7 +28,7 @@ const uint32_t FPR_COUNT            = 8;
 // The parameters are mapped into an array of type 'nsXPTCMiniVariant'
 // and then the method gets called.
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase * self, uint32_t methodIndex,
                    uint64_t * args, uint64_t * gpregs, double *fpregs)
 {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_arm.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_arm.cpp
@@ -12,21 +12,9 @@
 #error "This code is for Linux ARM only. Please check if it works for you, too.\nDepends strongly on gcc behaviour."
 #endif
 
-#ifdef __GNUC__
-/* This tells gcc3.4+ not to optimize away symbols.
- * @see http://gcc.gnu.org/gcc-3.4/changes.html
- */
-#define DONT_DROP_OR_WARN __attribute__((used))
-#else
-/* This tells older gccs not to warn about unused vairables.
- * @see http://docs.freebsd.org/info/gcc/gcc.info.Variable_Attributes.html
- */
-#define DONT_DROP_OR_WARN __attribute__((unused))
-#endif
-
 /* Specify explicitly a symbol for this function, don't try to guess the c++ mangled symbol.  */
 static nsresult PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args) asm("_PrepareAndDispatch")
-DONT_DROP_OR_WARN;
+ATTRIBUTE_USED;
 
 #ifdef __ARM_EABI__
 #define DOUBLEWORD_ALIGN(p) ((uint32_t *)((((uint32_t)(p)) + 7) & 0xfffffff8))

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_arm_netbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_arm_netbsd.cpp
@@ -7,7 +7,7 @@
 
 #include "xptcprivate.h"
 
-nsresult
+nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
 {
 #define PARAM_BUFFER_COUNT     16

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_arm_openbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_arm_openbsd.cpp
@@ -24,7 +24,7 @@
 static nsresult PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args) asm("_PrepareAndDispatch")
 DONT_DROP_OR_WARN;
 
-static nsresult
+static nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
 {
 #define PARAM_BUFFER_COUNT     16

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ipf32.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ipf32.cpp
@@ -16,7 +16,7 @@
 
 /* Implement shared vtbl methods. */
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex,
   uint64_t* intargs, uint64_t* floatargs, uint64_t* restargs)
 {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ipf64.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ipf64.cpp
@@ -17,7 +17,7 @@
 
 /* Implement shared vtbl methods. */
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex,
   uint64_t* intargs, uint64_t* floatargs, uint64_t* restargs)
 {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_linux_alpha.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_linux_alpha.cpp
@@ -11,7 +11,7 @@
 /* Prototype specifies unmangled function name and disables unused warning */
 static nsresult
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint64_t* args)
-__asm__("PrepareAndDispatch") __attribute__((used));
+__asm__("PrepareAndDispatch") ATTRIBUTE_USED;
 
 static nsresult
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint64_t* args)

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_linux_m68k.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_linux_m68k.cpp
@@ -9,7 +9,7 @@
 #include "xptiprivate.h"
 
 extern "C" {
-    nsresult
+    nsresult ATTRIBUTE_USED
     PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
     {
 #define PARAM_BUFFER_COUNT     16

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_linux_s390.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_linux_s390.cpp
@@ -9,7 +9,8 @@
 #include "xptcprivate.h"
 #include "xptiprivate.h"
 
-static nsresult
+static nsresult ATTRIBUTE_USED
+
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, 
                    uint32_t* a_gpr, uint64_t *a_fpr, uint32_t *a_ov)
 {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_linux_s390x.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_linux_s390x.cpp
@@ -9,7 +9,7 @@
 #include "xptcprivate.h"
 #include "xptiprivate.h"
 
-static nsresult
+static nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, 
                    uint64_t* a_gpr, uint64_t *a_fpr, uint64_t *a_ov)
 {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_mips.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_mips.cpp
@@ -15,7 +15,7 @@
  * Args contains a0-3 and then the stack.
  * Because a0 is 'this', we want to skip it
  */
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
 {
     args++; // always skip over a0

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_mips64.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_mips64.cpp
@@ -20,7 +20,7 @@
  * they are stored on the stack at address "args".
  *
  */
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint64_t* args,
                    uint64_t *gprData, double *fprData)
 {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_netbsd_m68k.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_netbsd_m68k.cpp
@@ -12,7 +12,7 @@
 #endif
 
 extern "C" {
-    static nsresult
+    static nsresult ATTRIBUTE_USED
     PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
     {
 #define PARAM_BUFFER_COUNT     16

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_pa32.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_pa32.cpp
@@ -14,7 +14,7 @@
 #error "This code is for HP-PA RISC 32 bit mode only"
 #endif
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex,
   uint32_t* args, uint32_t* floatargs)
 {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc64_linux.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc64_linux.cpp
@@ -32,7 +32,7 @@
 // The parameters are mapped into an array of type 'nsXPTCMiniVariant'
 // and then the method gets called.
 #include <stdio.h>
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self,
                    uint64_t methodIndex,
                    uint64_t* args,

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_aix.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_aix.cpp
@@ -16,7 +16,7 @@
         The args pointer has been set to the start of the parameters BEYOND the ones
         arriving in registers
 */
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args, uint32_t *gprData, double *fprData)
 {
     typedef struct {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_aix64.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_aix64.cpp
@@ -15,7 +15,7 @@
         The args pointer has been set to the start of the parameters BEYOND the ones
         arriving in registers
 */
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint64_t methodIndex, uint64_t* args, uint64_t *gprData, double *fprData)
 {
 

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_linux.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_linux.cpp
@@ -31,7 +31,7 @@
 // The parameters are mapped into an array of type 'nsXPTCMiniVariant'
 // and then the method gets called.
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self,
                    uint32_t methodIndex,
                    uint32_t* args,

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_netbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_netbsd.cpp
@@ -27,7 +27,7 @@
 // The parameters are mapped into an array of type 'nsXPTCMiniVariant'
 // and then the method gets called.
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self,
                    uint32_t methodIndex,
                    uint32_t* args,

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_openbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_openbsd.cpp
@@ -28,7 +28,7 @@
 // The parameters are mapped into an array of type 'nsXPTCMiniVariant'
 // and then the method gets called.
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self,
                    uint32_t methodIndex,
                    uint32_t* args,

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_rhapsody.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_ppc_rhapsody.cpp
@@ -35,7 +35,7 @@
  * http://developer.apple.com/documentation/DeveloperTools/Conceptual/
  *  MachORuntime/PowerPCConventions/chapter_3_section_1.html */
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(
   nsXPTCStubBase *self,
   uint32_t        methodIndex,

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparc64_openbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparc64_openbsd.cpp
@@ -11,7 +11,7 @@
 
 #if defined(sparc) || defined(__sparc__)
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint64_t methodIndex, uint64_t* args)
 {
 

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparc_netbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparc_netbsd.cpp
@@ -9,7 +9,7 @@
 
 #if defined(sparc) || defined(__sparc__)
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED 
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
 {
 

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparc_openbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparc_openbsd.cpp
@@ -9,7 +9,7 @@
 
 #if defined(sparc) || defined(__sparc__)
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
 {
 

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparc_solaris.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparc_solaris.cpp
@@ -10,7 +10,7 @@
 
 #if defined(sparc) || defined(__sparc__)
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
 {
 

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparcv9_solaris.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_sparcv9_solaris.cpp
@@ -11,7 +11,7 @@
 
 #if defined(sparc) || defined(__sparc__)
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint64_t methodIndex, uint64_t* args)
 {
 

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_x86_64_linux.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_x86_64_linux.cpp
@@ -30,7 +30,7 @@ const uint32_t FPR_COUNT            = 8;
 // The parameters are mapped into an array of type 'nsXPTCMiniVariant'
 // and then the method gets called.
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase * self, uint32_t methodIndex,
                    uint64_t * args, uint64_t * gpregs, double *fpregs)
 {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_x86_64_solaris.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_x86_64_solaris.cpp
@@ -30,7 +30,7 @@ const uint32_t FPR_COUNT            = 8;
 // The parameters are mapped into an array of type 'nsXPTCMiniVariant'
 // and then the method gets called.
 
-extern "C" nsresult
+extern "C" nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase * self, uint32_t methodIndex,
                    uint64_t * args, uint64_t * gpregs, double *fpregs)
 {

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_x86_solaris.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_x86_solaris.cpp
@@ -9,7 +9,7 @@
 #include "xptcprivate.h"
 #include "xptiprivate.h"
 
-nsresult
+nsresult ATTRIBUTE_USED
 PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
 {
 #define PARAM_BUFFER_COUNT     16

--- a/xpcom/reflect/xptcall/src/xptcprivate.h
+++ b/xpcom/reflect/xptcall/src/xptcprivate.h
@@ -58,4 +58,10 @@ public:
 #undef STUB_ENTRY
 #undef SENTINEL_ENTRY
 
+#if defined(__clang__) || defined(__GNUC__)
+#define ATTRIBUTE_USED __attribute__ ((__used__))
+#else
+#define ATTRIBUTE_USED
+#endif
+
 #endif /* xptcprivate_h___ */


### PR DESCRIPTION
I reverted the Makefile edit since it does not work, however it is not needed anyway if a person builds Pale Moon with the gold linker instead of the default GCC linker, the error on the elfhack tests do not appear. 