### PR TITLE
Use default locale as fallback for add-on metadata

### DIFF
--- a/toolkit/mozapps/extensions/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/XPIProvider.jsm
@@ -6173,8 +6173,12 @@ function AddonWrapper(aAddon) {
         }
       }
 
-      if (result == null)
-        [result, ] = chooseValue(aAddon.selectedLocale, aProp);
+      if (result == null) {
+        if (typeof aAddon.selectedLocale[aProp] == "string" && aAddon.selectedLocale[aProp].length)
+          [result, ] = chooseValue(aAddon.selectedLocale, aProp);
+        else
+          [result, ] = chooseValue(aAddon.defaultLocale, aProp);
+      }
 
       if (aProp == "creator")
         return result ? new AddonManagerPrivate.AddonAuthor(result) : null;
@@ -6204,8 +6208,12 @@ function AddonWrapper(aAddon) {
         }
       }
 
-      if (results == null)
-        [results, usedRepository] = chooseValue(aAddon.selectedLocale, aProp);
+      if (results == null) {
+        if (aAddon.selectedLocale[aProp] instanceof Array && aAddon.selectedLocale[aProp].length)
+          [results, usedRepository] = chooseValue(aAddon.selectedLocale, aProp);
+        else
+          [results, usedRepository] = chooseValue(aAddon.defaultLocale, aProp);
+      }
 
       if (results && !usedRepository) {
         results = results.map(function mapResult(aResult) {


### PR DESCRIPTION
Tested and confirmed working (x64 Linux) by Antonius32.

Forum topic: https://forum.palemoon.org/viewtopic.php?f=29&t=8915