### PR TITLE
Restore the library scope bar

### DIFF
--- a/browser/components/places/content/places.js
+++ b/browser/components/places/content/places.js
@@ -204,8 +204,20 @@ var PlacesOrganizer = {
     // and update the back/forward buttons by setting location.
     if (ContentArea.currentPlace != placeURI || !resetSearchBox) {
       ContentArea.currentPlace = placeURI;
+      PlacesSearchBox.hideSearchUI();
       this.location = node.uri;
     }
+
+    // Update the selected folder title where it appears in the UI: the folder
+    // scope button, and the search box emptytext.
+    // They must be updated even if the selection hasn't changed --
+    // specifically when node's title changes.  In that case a selection event
+    // is generated, this method is called, but the selection does not change.
+    var folderButton = document.getElementById("scopeBarFolder");
+    var folderTitle = node.title || folderButton.getAttribute("emptytitle");
+    folderButton.setAttribute("label", folderTitle);
+    if (PlacesSearchBox.filterCollection == "collection")
+      PlacesSearchBox.updateCollectionTitle(folderTitle);
 
     // When we invalidate a container we use suppressSelectionEvent, when it is
     // unset a select event is fired, in many cases the selection did not really
@@ -233,17 +245,30 @@ var PlacesOrganizer = {
   _setSearchScopeForNode: function PO__setScopeForNode(aNode) {
     let itemId = aNode.itemId;
 
+    // Set default buttons status.
+    let bookmarksButton = document.getElementById("scopeBarAll");
+    bookmarksButton.hidden = false;
+    let downloadsButton = document.getElementById("scopeBarDownloads");
+    downloadsButton.hidden = true;
+
     if (PlacesUtils.nodeIsHistoryContainer(aNode) ||
         itemId == PlacesUIUtils.leftPaneQueries["History"]) {
       PlacesQueryBuilder.setScope("history");
     }
     else if (itemId == PlacesUIUtils.leftPaneQueries["Downloads"]) {
+      downloadsButton.hidden = false;
+      bookmarksButton.hidden = true;
       PlacesQueryBuilder.setScope("downloads");
     }
     else {
       // Default to All Bookmarks for all other nodes, per bug 469437.
       PlacesQueryBuilder.setScope("bookmarks");
     }
+
+    // Enable or disable the folder scope button.
+    let folderButton = document.getElementById("scopeBarFolder");
+    folderButton.hidden = !PlacesUtils.nodeIsFolder(aNode) ||
+                          itemId == PlacesUIUtils.allBookmarksFolderId;
   },
 
   /**
@@ -717,6 +742,50 @@ var PlacesOrganizer = {
       additionalInfoBroadcaster.setAttribute("hidden", "true");
     }
   },
+
+  /**
+   * Save the current search (or advanced query) to the bookmarks root.
+   */
+  saveSearch: function PO_saveSearch() {
+    // Get the place: uri for the query.
+    // If the advanced query builder is showing, use that.
+    var options = this.getCurrentOptions();
+    var queries = this.getCurrentQueries();
+
+    var placeSpec = PlacesUtils.history.queriesToQueryString(queries,
+                                                             queries.length,
+                                                             options);
+    var placeURI = Cc["@mozilla.org/network/io-service;1"].
+                   getService(Ci.nsIIOService).
+                   newURI(placeSpec, null, null);
+
+    // Prompt the user for a name for the query.
+    // XXX - using prompt service for now; will need to make
+    // a real dialog and localize when we're sure this is the UI we want.
+    var title = PlacesUIUtils.getString("saveSearch.title");
+    var inputLabel = PlacesUIUtils.getString("saveSearch.inputLabel");
+    var defaultText = PlacesUIUtils.getString("saveSearch.inputDefaultText");
+
+    var prompts = Cc["@mozilla.org/embedcomp/prompt-service;1"].
+                  getService(Ci.nsIPromptService);
+    var check = {value: false};
+    var input = {value: defaultText};
+    var save = prompts.prompt(null, title, inputLabel, input, null, check);
+
+    // Don't add the query if the user cancels or clears the seach name.
+    if (!save || input.value == "")
+      return;
+
+    // Add the place: uri as a bookmark under the bookmarks root.
+    var txn = new PlacesCreateBookmarkTransaction(placeURI,
+                                                  PlacesUtils.bookmarksMenuFolderId,
+                                                  PlacesUtils.bookmarks.DEFAULT_INDEX,
+                                                  input.value);
+    PlacesUtils.transactionManager.doTransaction(txn);
+
+    // select and load the new query
+    this._places.selectPlaceURI(placeSpec);
+  }
 };
 
 /**
@@ -769,9 +838,12 @@ var PlacesSearchBox = {
     let currentView = ContentArea.currentView;
     let currentOptions = PO.getCurrentOptions();
 
-    // Search according to the current scope, which was set by
+    // Search according to the current scope and folders, which were set by
     // PQB_setScope()
     switch (PlacesSearchBox.filterCollection) {
+      case "collection":
+        currentView.applyFilter(filterString, this.folders);
+        break;
       case "bookmarks":
         currentView.applyFilter(filterString, this.folders);
         break;
@@ -811,6 +883,8 @@ var PlacesSearchBox = {
         throw "Invalid filterCollection on search";
     }
 
+    PlacesSearchBox.showSearchUI();
+
     // Update the details panel
     PlacesOrganizer.updateDetailsPane();
   },
@@ -840,15 +914,24 @@ var PlacesSearchBox = {
    */
   updateCollectionTitle: function PSB_updateCollectionTitle(aTitle) {
     let title = "";
-    switch (this.filterCollection) {
-      case "history":
-        title = PlacesUIUtils.getString("searchHistory");
-        break;
-      case "downloads":
-        title = PlacesUIUtils.getString("searchDownloads");
-        break;
-      default:
-        title = PlacesUIUtils.getString("searchBookmarks");                                    
+    // This is needed when a user performs a folder-specific search
+    // using the scope bar, removes the search-string, and unfocuses
+    // the search box, at least until the removal of the scope bar.
+    if (aTitle) {
+      title = PlacesUIUtils.getFormattedString("searchCurrentDefault",
+                                               [aTitle]);
+    }
+    else {
+      switch (this.filterCollection) {
+        case "history":
+          title = PlacesUIUtils.getString("searchHistory");
+          break;
+        case "downloads":
+          title = PlacesUIUtils.getString("searchDownloads");
+          break;
+        default:
+          title = PlacesUIUtils.getString("searchBookmarks");
+      }
     }
     this.searchFilter.placeholder = title;
   },
@@ -864,8 +947,14 @@ var PlacesSearchBox = {
       return collectionName;
 
     this.searchFilter.setAttribute("collection", collectionName);
-    this.updateCollectionTitle();
 
+    var newGrayText = null;
+    if (collectionName == "collection") {
+      newGrayText = PlacesOrganizer._places.selectedNode.title ||
+                    document.getElementById("scopeBarFolder").
+                      getAttribute("emptytitle");
+    }
+    this.updateCollectionTitle(newGrayText);
     return collectionName;
   },
 
@@ -892,6 +981,17 @@ var PlacesSearchBox = {
   set value(value) {
     return this.searchFilter.value = value;
   },
+
+  showSearchUI: function PSB_showSearchUI() {
+    // Hide the advanced search controls when the user hasn't searched
+    var searchModifiers = document.getElementById("searchModifiers");
+    searchModifiers.hidden = false;
+  },
+
+  hideSearchUI: function PSB_hideSearchUI() {
+    var searchModifiers = document.getElementById("searchModifiers");
+    searchModifiers.hidden = true;
+  }
 };
 
 /**
@@ -901,6 +1001,31 @@ var PlacesQueryBuilder = {
 
   queries: [],
   queryOptions: null,
+
+  /**
+   * Called when a scope button in the scope bar is clicked.
+   * @param   aButton
+   *          the scope button that was selected
+   */
+  onScopeSelected: function PQB_onScopeSelected(aButton) {
+    switch (aButton.id) {
+      case "scopeBarHistory":
+        this.setScope("history");
+        break;
+      case "scopeBarFolder":
+        this.setScope("collection");
+        break;
+      case "scopeBarDownloads":
+        this.setScope("downloads");
+        break;
+      case "scopeBarAll":
+        this.setScope("bookmarks");
+        break;
+      default:
+        throw "Invalid search scope button ID";
+        break;
+    }
+  },
 
   /**
    * Sets the search scope.  This can be called when no search is active, and
@@ -915,23 +1040,43 @@ var PlacesQueryBuilder = {
     // Determine filterCollection, folders, and scopeButtonId based on aScope.
     var filterCollection;
     var folders = [];
+    var scopeButtonId;
     switch (aScope) {
       case "history":
         filterCollection = "history";
+        scopeButtonId = "scopeBarHistory";
         break;
+      case "collection":
+        // The folder scope button can only become hidden upon selecting a new
+        // folder in the left pane, and the disabled state will remain unchanged
+        // until a new folder is selected.  See PO__setScopeForNode().
+        if (!document.getElementById("scopeBarFolder").hidden) {
+          filterCollection = "collection";
+          scopeButtonId = "scopeBarFolder";
+          folders.push(PlacesUtils.getConcreteItemId(
+                         PlacesOrganizer._places.selectedNode));
+          break;
+        }
+        // Fall through.  If collection scope doesn't make sense for the
+        // selected node, choose bookmarks scope.
       case "bookmarks":
         filterCollection = "bookmarks";
+        scopeButtonId = "scopeBarAll";
         folders.push(PlacesUtils.bookmarksMenuFolderId,
                      PlacesUtils.toolbarFolderId,
                      PlacesUtils.unfiledBookmarksFolderId);
         break;
       case "downloads":
         filterCollection = "downloads";
+        scopeButtonId = "scopeBarDownloads";
         break;
       default:
         throw "Invalid search scope";
         break;
     }
+
+    // Check the appropriate scope button in the scope bar.
+    document.getElementById(scopeButtonId).checked = true;
 
     // Update the search box.  Re-search if there's an active search.
     PlacesSearchBox.filterCollection = filterCollection;

--- a/browser/components/places/content/places.xul
+++ b/browser/components/places/content/places.xul
@@ -358,41 +358,41 @@
     </tree>
     <splitter collapse="none" persist="state"></splitter>
     <vbox id="contentView" flex="4">
+      <toolbox id="searchModifiers" hidden="true">
+        <toolbar id="organizerScopeBar" class="chromeclass-toolbar" align="center">
+          <label id="scopeBarTitle" value="&search.in.label;"/>
+          <toolbarbutton id="scopeBarAll" class="small-margin"
+                         type="radio" group="scopeBar"
+                         oncommand="PlacesQueryBuilder.onScopeSelected(this);"
+                         label="&search.scopeBookmarks.label;"
+                         accesskey="&search.scopeBookmarks.accesskey;"/>
+          <toolbarbutton id="scopeBarHistory" class="small-margin"
+                         type="radio" group="scopeBar"
+                         oncommand="PlacesQueryBuilder.onScopeSelected(this);"
+                         label="&search.scopeHistory.label;"
+                         accesskey="&search.scopeHistory.accesskey;"/>
+          <toolbarbutton id="scopeBarDownloads" class="small-margin"
+                         type="radio" group="scopeBar"
+                         oncommand="PlacesQueryBuilder.onScopeSelected(this);"
+                         label="&search.scopeDownloads.label;"
+                         accesskey="&search.scopeDownloads.accesskey;"/>
+          <toolbarbutton id="scopeBarFolder" class="small-margin"
+                         type="radio" group="scopeBar"
+                         oncommand="PlacesQueryBuilder.onScopeSelected(this);"
+                         accesskey="&search.scopeFolder.accesskey;"
+                         emptytitle="&search.scopeFolder.label;" flex="1"/>
+          <!-- The folder scope button should flex but not take up more room
+                than its label needs.  The only simple way to do that is to
+                set a really big flex on the spacer, e.g., 2^31 - 1. -->
+          <spacer flex="2147483647"/>
+          <button id="saveSearch" class="small-margin"
+                  label="&saveSearch.label;" accesskey="&saveSearch.accesskey;"
+                  command="OrganizerCommand_search:save"/>
+        </toolbar>
+      </toolbox>
       <deck id="placesViewsDeck"
             selectedIndex="0"
             flex="1">
-        <toolbox id="searchModifiers" hidden="true">
-          <toolbar id="organizerScopeBar" class="chromeclass-toolbar" align="center">
-            <label id="scopeBarTitle" value="&search.in.label;"/>
-            <toolbarbutton id="scopeBarAll" class="small-margin"
-                           type="radio" group="scopeBar"
-                           oncommand="PlacesQueryBuilder.onScopeSelected(this);"
-                           label="&search.scopeBookmarks.label;"
-                           accesskey="&search.scopeBookmarks.accesskey;"/>
-            <toolbarbutton id="scopeBarHistory" class="small-margin"
-                           type="radio" group="scopeBar"
-                           oncommand="PlacesQueryBuilder.onScopeSelected(this);"
-                           label="&search.scopeHistory.label;"
-                           accesskey="&search.scopeHistory.accesskey;"/>
-            <toolbarbutton id="scopeBarDownloads" class="small-margin"
-                           type="radio" group="scopeBar"
-                           oncommand="PlacesQueryBuilder.onScopeSelected(this);"
-                           label="&search.scopeDownloads.label;"
-                           accesskey="&search.scopeDownloads.accesskey;"/>
-            <toolbarbutton id="scopeBarFolder" class="small-margin"
-                           type="radio" group="scopeBar"
-                           oncommand="PlacesQueryBuilder.onScopeSelected(this);"
-                           accesskey="&search.scopeFolder.accesskey;"
-                           emptytitle="&search.scopeFolder.label;" flex="1"/>
-            <!-- The folder scope button should flex but not take up more room
-                  than its label needs.  The only simple way to do that is to
-                  set a really big flex on the spacer, e.g., 2^31 - 1. -->
-            <spacer flex="2147483647"/>
-            <button id="saveSearch" class="small-margin"
-                    label="&saveSearch.label;" accesskey="&saveSearch.accesskey;"
-                    command="OrganizerCommand_search:save"/>
-          </toolbar>
-        </toolbox>
         <tree id="placeContent"
               class="plain placesTree"
               context="placesContext"

--- a/browser/components/places/content/places.xul
+++ b/browser/components/places/content/places.xul
@@ -361,6 +361,38 @@
       <deck id="placesViewsDeck"
             selectedIndex="0"
             flex="1">
+        <toolbox id="searchModifiers" hidden="true">
+          <toolbar id="organizerScopeBar" class="chromeclass-toolbar" align="center">
+            <label id="scopeBarTitle" value="&search.in.label;"/>
+            <toolbarbutton id="scopeBarAll" class="small-margin"
+                           type="radio" group="scopeBar"
+                           oncommand="PlacesQueryBuilder.onScopeSelected(this);"
+                           label="&search.scopeBookmarks.label;"
+                           accesskey="&search.scopeBookmarks.accesskey;"/>
+            <toolbarbutton id="scopeBarHistory" class="small-margin"
+                           type="radio" group="scopeBar"
+                           oncommand="PlacesQueryBuilder.onScopeSelected(this);"
+                           label="&search.scopeHistory.label;"
+                           accesskey="&search.scopeHistory.accesskey;"/>
+            <toolbarbutton id="scopeBarDownloads" class="small-margin"
+                           type="radio" group="scopeBar"
+                           oncommand="PlacesQueryBuilder.onScopeSelected(this);"
+                           label="&search.scopeDownloads.label;"
+                           accesskey="&search.scopeDownloads.accesskey;"/>
+            <toolbarbutton id="scopeBarFolder" class="small-margin"
+                           type="radio" group="scopeBar"
+                           oncommand="PlacesQueryBuilder.onScopeSelected(this);"
+                           accesskey="&search.scopeFolder.accesskey;"
+                           emptytitle="&search.scopeFolder.label;" flex="1"/>
+            <!-- The folder scope button should flex but not take up more room
+                  than its label needs.  The only simple way to do that is to
+                  set a really big flex on the spacer, e.g., 2^31 - 1. -->
+            <spacer flex="2147483647"/>
+            <button id="saveSearch" class="small-margin"
+                    label="&saveSearch.label;" accesskey="&saveSearch.accesskey;"
+                    command="OrganizerCommand_search:save"/>
+          </toolbar>
+        </toolbox>
         <tree id="placeContent"
               class="plain placesTree"
               context="placesContext"

--- a/browser/locales/en-US/chrome/browser/places/places.dtd
+++ b/browser/locales/en-US/chrome/browser/places/places.dtd
@@ -91,6 +91,18 @@
 <!ENTITY search.label                              "Search:">
 <!ENTITY search.accesskey                          "S">
 
+<!ENTITY search.in.label                           "Search in:">
+<!ENTITY search.scopeFolder.label                  "Selected Folder">
+<!ENTITY search.scopeFolder.accesskey              "r">
+<!ENTITY search.scopeBookmarks.label               "Bookmarks">
+<!ENTITY search.scopeBookmarks.accesskey           "k">
+<!ENTITY search.scopeDownloads.label               "Downloads">
+<!ENTITY search.scopeDownloads.accesskey           "D">
+<!ENTITY search.scopeHistory.label                 "History">
+<!ENTITY search.scopeHistory.accesskey             "H">
+<!ENTITY saveSearch.label                          "Save">
+<!ENTITY saveSearch.accesskey                      "S">
+
 <!ENTITY cmd.find.key  "f">
 
 <!ENTITY maintenance.label      "Import and Backup">

--- a/browser/locales/en-US/chrome/browser/places/places.properties
+++ b/browser/locales/en-US/chrome/browser/places/places.properties
@@ -47,6 +47,7 @@ view.sortBy.tags.accesskey=T
 searchBookmarks=Search Bookmarks
 searchHistory=Search History
 searchDownloads=Search Downloads
+searchCurrentDefault=Search in '%S'
 
 tabs.openWarningTitle=Confirm open
 tabs.openWarningMultipleBranded=You are about to open %S tabs.  This might slow down %S while the pages are loading.  Are you sure you want to continue?
@@ -55,6 +56,10 @@ tabs.openWarningPromptMeBranded=Warn me when opening multiple tabs might slow do
 
 SelectImport=Import Bookmarks File
 EnterExport=Export Bookmarks File
+
+saveSearch.title=Save Search
+saveSearch.inputLabel=Name:
+saveSearch.inputDefaultText=New Search
 
 detailsPane.noItems=No items
 # LOCALIZATION NOTE (detailsPane.itemsCountLabel): Semicolon-separated list of plural forms.

--- a/browser/themes/linux/places/organizer.css
+++ b/browser/themes/linux/places/organizer.css
@@ -77,6 +77,14 @@
   -moz-padding-start: 2px;
 }
 
+#searchModifiers {
+  padding-right: 3px;
+}
+
+#saveSearch {
+  list-style-image: url("moz-icon://stock/gtk-save?size=menu");
+}
+
 /**** menuitem stock icons ****/
 #orgClose {
   list-style-image: url("moz-icon://stock/gtk-close?size=menu");

--- a/browser/themes/windows/places/organizer-aero.css
+++ b/browser/themes/windows/places/organizer-aero.css
@@ -37,6 +37,7 @@
 
 @media (-moz-windows-default-theme) {
   #placesView,
+  #searchModifiers,
   #infoPane,
   #placesList,
   #placeContent {
@@ -56,6 +57,15 @@
     background-color: transparent;
     -moz-margin-start: -3px;
     position: relative;
+  }
+
+  #searchModifiers {
+    border-bottom: 1px solid #A9B7C9;
+  }
+
+  #organizerScopeBar {
+    -moz-appearance: none;
+    border: none;
   }
 
   #detailsDeck {

--- a/browser/themes/windows/places/organizer.css
+++ b/browser/themes/windows/places/organizer.css
@@ -124,6 +124,37 @@
   -moz-padding-start: 2px;
 }
 
+#organizerScopeBar {
+  padding: 2px 0;
+  -moz-padding-end: 3px;
+}
+
+#organizerScopeBar > toolbarbutton {
+  -moz-appearance: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  padding: 0 !important;
+  margin: 0 1px;
+}
+
+#organizerScopeBar > toolbarbutton > .toolbarbutton-icon {
+  padding: 0;
+  margin: 0;
+}
+
+#organizerScopeBar > toolbarbutton > .toolbarbutton-text {
+   margin: 0;
+   padding: 2px 5px;
+}
+
+#organizerScopeBar > toolbarbutton:not([disabled="true"]):not([checked="true"]):hover {
+  border-color: ThreeDShadow;
+}
+
+#organizerScopeBar > toolbarbutton[checked="true"] {
+  border-color: ThreeDDarkShadow !important;
+}
+
 #searchFilter {
   margin: 0;
 }


### PR DESCRIPTION
This patch was authored by Antonius32.

This PR resolves issue #135 (although some work on the stylesheet for Mac still needs done). Tested and confirmed working on Linux x64 by both Antonius32 & myself.

Forum thread: https://forum.palemoon.org/viewtopic.php?f=3&t=8896