### PR TITLE
Add support for element.matches.

### DIFF
--- a/content/base/public/Element.h
+++ b/content/base/public/Element.h
@@ -591,6 +591,8 @@ public:
   }
   bool HasAttributeNS(const nsAString& aNamespaceURI,
                       const nsAString& aLocalName) const;
+  bool Matches(const nsAString& aSelector,
+               ErrorResult& aError)
   already_AddRefed<nsIHTMLCollection>
     GetElementsByTagName(const nsAString& aQualifiedName);
   already_AddRefed<nsIHTMLCollection>
@@ -630,7 +632,10 @@ public:
     return Children()->Length();
   }
   bool MozMatchesSelector(const nsAString& aSelector,
-                          ErrorResult& aError);
+                          ErrorResult& aError)
+  {
+    return Matches(aSelector, aError);
+  }
   void SetCapture(bool aRetargetToElement)
   {
     // If there is already an active capture, ignore this request. This would

--- a/content/base/src/Element.cpp
+++ b/content/base/src/Element.cpp
@@ -2422,8 +2422,8 @@ ParseSelectorList(nsINode* aNode,
 
 
 bool
-Element::MozMatchesSelector(const nsAString& aSelector,
-                            ErrorResult& aError)
+Element::Matches(const nsAString& aSelector,
+				 ErrorResult& aError)
 {
   nsAutoPtr<nsCSSSelectorList> selectorList;
 

--- a/dom/webidl/Element.webidl
+++ b/dom/webidl/Element.webidl
@@ -49,7 +49,10 @@ interface Element : Node {
   void removeAttributeNS(DOMString? namespace, DOMString localName);
   boolean hasAttribute(DOMString name);
   boolean hasAttributeNS(DOMString? namespace, DOMString localName);
-
+  
+  [Throws, Pure]
+  boolean matches(DOMString selector);
+  
   HTMLCollection getElementsByTagName(DOMString localName);
   [Throws]
   HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);


### PR DESCRIPTION
Pale Moon had support for element.matches, however it was under
a non-standard name.
See: gorhill/ublock#546 as an example showing why adding support
under the standard name is good idea.

Side note, I have not verified this to be working, but I will get around to that at some point time (hopefully). On another note, not sure whether I should push this to Goanna, or the master branch. Sorry if I made a pull request to the wrong branch.