### PR TITLE
Set the G_SLICE environment variable to always-malloc

### DIFF
--- a/browser/app/nsBrowserApp.cpp
+++ b/browser/app/nsBrowserApp.cpp
@@ -55,18 +55,6 @@ using namespace mozilla;
 #ifdef XP_WIN
 #define kMetroTestFile "tests.ini"
 const char* kMetroConsoleIdParam = "testconsoleid=";
-#endif 	
-
-#if defined(MOZ_WIDGET_GTK) \
-  && (defined(MOZ_MEMORY) || defined(__FreeBSD__) \
-      || (defined(__NetBSD__) && __NetBSD_Version__ >= 500000000))
-  // Disable the slice allocator, since jemalloc already uses similar layout
-  // algorithms, and using a sub-allocator tends to increase fragmentation.
-  // This must be done before any g_slice_* functions are called.  That is
-  // before g_thread_init() for GLib versions prior to 2.32, before
-  // g_type_init() for later versions prior to 2.36, and before the library is
-  // loaded for later versions.
-#define SET_G_SLICE_ALWAYS_MALLOC 1
 #endif
 
 static void Output(const char *fmt, ... )
@@ -163,10 +151,6 @@ XRE_SetupDllBlocklistType XRE_SetupDllBlocklist;
 XRE_StartupTimelineRecordType XRE_StartupTimelineRecord;
 XRE_mainType XRE_main;
 XRE_DisableWritePoisoningType XRE_DisableWritePoisoning;
-#if SET_G_SLICE_ALWAYS_MALLOC
-void (*g_thread_init)(void*);
-void (*g_type_init)();
-#endif
 
 static const nsDynamicFunctionLoad kXULFuncs[] = {
     { "XRE_GetFileFromPath", (NSFuncPtr*) &XRE_GetFileFromPath },
@@ -178,10 +162,6 @@ static const nsDynamicFunctionLoad kXULFuncs[] = {
     { "XRE_StartupTimelineRecord", (NSFuncPtr*) &XRE_StartupTimelineRecord },
     { "XRE_main", (NSFuncPtr*) &XRE_main },
     { "XRE_DisableWritePoisoning", (NSFuncPtr*) &XRE_DisableWritePoisoning },
-#if SET_G_SLICE_ALWAYS_MALLOC
-    { "g_thread_init", (NSFuncPtr*) &g_thread_init },
-    { "g_type_init", (NSFuncPtr*) &g_type_init },
-#endif
     { nullptr, nullptr }
 };
 
@@ -570,14 +550,6 @@ InitXPCOMGlue(const char *argv0, nsIFile **xreDirectory)
     return NS_ERROR_FAILURE;
   }
 
-#if SET_G_SLICE_ALWAYS_MALLOC
-  char *g_slice = getenv("G_SLICE");
-  static char tmp_g_slice[] = "G_SLICE=always-malloc";
-  if (!g_slice) {
-    putenv(tmp_g_slice);
-  }
-#endif
-
   // We do this because of data in bug 771745
   XPCOMGlueEnablePreload();
 
@@ -592,16 +564,6 @@ InitXPCOMGlue(const char *argv0, nsIFile **xreDirectory)
     Output("Couldn't load XRE functions.\n");
     return rv;
   }
-
-#if SET_G_SLICE_ALWAYS_MALLOC
-  if (!g_slice) {
-    // Restore the environment for child processes after ensuring that GLib
-    // has read the variable.
-    g_thread_init(nullptr); // For GLib version < 2.32
-    g_type_init(); // For 2.32 <= GLib version < 2.36
-    unsetenv("G_SLICE");
-  }
-#endif
 
   NS_LogInit();
 

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -3447,6 +3447,13 @@ XREMain::XRE_main(int argc, char* argv[], const nsXREAppData* aAppData)
   ScopedLogging log;
 
 #if defined(MOZ_WIDGET_GTK)
+#if defined(MOZ_MEMORY) || defined(__FreeBSD__) \
+  || defined(__NetBSD__) && __NetBSD_Version__ >= 500000000
+  // Disable the slice allocator, since jemalloc already uses similar layout
+  // algorithms, and using a sub-allocator tends to increase fragmentation.
+  // This must be done before g_thread_init() is called.
+  g_slice_set_config(G_SLICE_CONFIG_ALWAYS_MALLOC, 1);
+#endif
   g_thread_init(NULL);
 #endif
 

--- a/toolkit/xre/nsEmbedFunctions.cpp
+++ b/toolkit/xre/nsEmbedFunctions.cpp
@@ -336,8 +336,8 @@ XRE_InitChildProcess(int aArgc,
   gArgv = aArgv;
   gArgc = aArgc;
 
-#if defined(MOZ_WIDGET_GTK)
-  g_thread_init(NULL);
+#if defined(MOZ_WIDGET_GTK2)
+  XRE_GlibInit();
 #endif
 
 #if defined(MOZ_WIDGET_QT)

--- a/xpcom/build/nsXULAppAPI.h
+++ b/xpcom/build/nsXULAppAPI.h
@@ -465,4 +465,9 @@ XRE_API(WindowsEnvironmentType,
         XRE_GetWindowsEnvironment, ())
 #endif // XP_WIN
 
+#if defined(MOZ_WIDGET_GTK2)
+XRE_API(void,
+         XRE_GlibInit, ())
+#endif
+
 #endif // _nsXULAppAPI_h__

--- a/xpcom/glue/standalone/nsXPCOMGlue.cpp
+++ b/xpcom/glue/standalone/nsXPCOMGlue.cpp
@@ -463,8 +463,53 @@ void XPCOMGlueEnablePreload()
     do_preload = true;
 }
 
+#if defined(MOZ_WIDGET_GTK) && (defined(MOZ_MEMORY) || defined(__FreeBSD__) || defined(__NetBSD__))
+#define MOZ_GSLICE_INIT
+#endif
+
+#ifdef MOZ_GSLICE_INIT
+#include <glib.h>
+
+class GSliceInit {
+public:
+  GSliceInit() {
+	mHadGSlice = bool(getenv("G_SLICE"));
+	if (!mHadGSlice) {
+	  // Disable the slice allocator , since jemalloc already uses similar layout
+	  // algorithms, and using a sub-allocator tends to increase fragmentation.
+	  // This must be done before g_thread_init() is called.
+	  // glib >= 2.36 initializes g_slice as a side effect of its various static
+	  // initializers, so this needs to happen before glib is loaded, which
+	  // this is hooked in XPCOMGlueStartup before libxul is loaded. This
+	  // relies on the main executable not depending on glib.
+	  setenv("G_SLICE", "always-malloc", 1);
+	}
+  }
+
+  ~GSliceInit() {
+#if defined(MOZ_WIDGET_GTK2)
+    if (sTop) {
+	  auto XRE_GlibInit = (void (*)(void)) GetSymbol(sTop->libHandle,
+	    "XRE_GlibInit");
+	  // Initialize glib enough for G_SLICE to have an effect before it is unset.
+	  // unset.
+	}
+#endif
+    if (!mHadGSlice) {
+	  unsetenv("G_SLICE");
+	}
+  }
+
+private:
+  bool mHadGSlice;
+};
+#endif
+
 nsresult XPCOMGlueStartup(const char* xpcomFile)
 {
+#ifdef MOZ_GSLICE_INIT
+  GSliceInit gSliceInit;
+#endif
     xpcomFunctions.version = XPCOM_GLUE_VERSION;
     xpcomFunctions.size    = sizeof(XPCOMFunctions);
 


### PR DESCRIPTION
This should(?) be a better solution than PR #41 was.

Confirmed builds and works as intended on both CentOS 6 with GCC 4.7.2 and Manjaro with GCC 5.2 (x64)