### PR TITLE
Linux: Fix build bustage when using jemalloc

### DIFF
--- a/xpcom/glue/standalone/nsXPCOMGlue.cpp
+++ b/xpcom/glue/standalone/nsXPCOMGlue.cpp
@@ -468,7 +468,6 @@ void XPCOMGlueEnablePreload()
 #endif
 
 #ifdef MOZ_GSLICE_INIT
-#include <glib.h>
 
 class GSliceInit {
 public:


### PR DESCRIPTION
Followup to commit 33708ea

Resolves issue #151 

Tested/confirmed works on CentOS 6