### PR TITLE
Fix resource leak when using GStreamer

### DIFF
--- a/content/media/gstreamer/GStreamerFormatHelper.cpp
+++ b/content/media/gstreamer/GStreamerFormatHelper.cpp
@@ -239,7 +239,11 @@ static bool SupportsCaps(GstElementFactory *aFactory, GstCaps *aCaps)
       continue;
     }
 
-    if (gst_caps_can_intersect(gst_static_caps_get(&templ->static_caps), aCaps)) {
+    bool supported = gst_caps_can_intersect(caps, aCaps);
+
+    gst_caps_unref(caps);
+
+    if (supported) {
       return true;
     }
   }
@@ -267,11 +271,11 @@ bool GStreamerFormatHelper::HaveElementsToProcessCaps(GstCaps* aCaps) {
       }
     }
 
+    gst_caps_unref(caps);
+
     if (!found) {
       return false;
     }
-
-    gst_caps_unref(caps);
   }
 
   return true;


### PR DESCRIPTION
Confirmed builds and works as intended Linux x64.

With this patch, Pale Moon's memory usage is around 50-70MB less on my system when watching 720p YouTube videos with GStreamer enabled compared to a current trunk build.