### PR TITLE
Implement the backend for adding indicators when the website offers an opensearch description

### DIFF
--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -3015,8 +3015,32 @@ const BrowserSearch = {
 
     if (hidden)
       browser.hiddenEngines = engines;
-    else
+    else {
       browser.engines = engines;
+      if (browser == gBrowser.selectedBrowser)
+        this.updateSearchButton();
+    }
+  },
+
+  /**
+   * Update the browser UI to show whether or not additional engines are
+   * available when a page is loaded or the user switches tabs to a page that
+   * has search engines.
+   */
+  updateSearchButton: function() {
+    var searchBar = this.searchBar;
+
+    // The search bar binding might not be applied even though the element is
+    // in the document (e.g. when the navigation toolbar is hidden), so check
+    // for .searchButton specifically.
+    if (!searchBar || !searchBar.searchButton)
+      return;
+
+    var engines = gBrowser.selectedBrowser.engines;
+    if (engines && engines.length > 0)
+      searchBar.searchButton.setAttribute("addengines", "true");
+    else
+      searchBar.searchButton.removeAttribute("addengines");
   },
 
   /**
@@ -3951,6 +3975,7 @@ var XULBrowserWindow = {
 
   asyncUpdateUI: function () {
     FeedHandler.updateFeeds();
+    BrowserSearch.updateSearchButton();
   },
 
   hideChromeForLocation: function(aLocation) {

--- a/browser/components/search/content/search.xml
+++ b/browser/components/search/content/search.xml
@@ -244,6 +244,7 @@
               }
             }
           }
+          BrowserSearch.updateSearchButton();
         ]]></body>
       </method>
 
@@ -271,6 +272,7 @@
               }
             }
           }
+          BrowserSearch.updateSearchButton();
         ]]></body>
       </method>
 

--- a/browser/themes/linux/searchbar.css
+++ b/browser/themes/linux/searchbar.css
@@ -51,6 +51,12 @@
   height: 12px;
 }
 
+/* TODO implement indicator for availibility of search engines.
+.searchbar-engine-button[addengines="true"] > .button-box {
+  background: transparent url(chrome://browser/skin/Search-addengines.png) no-repeat right center;
+}
+*/
+
 /* Search go button */
 .search-go-container {
   -moz-box-align: center;

--- a/browser/themes/windows/searchbar.css
+++ b/browser/themes/windows/searchbar.css
@@ -51,6 +51,15 @@
   -moz-image-region: rect(0, 26px, 11px, 13px);
 }
 
+/* TODO implement indicator for availability of search engines.
+.searchbar-engine-button[addengines="true"] > .button-box {
+  background: transparent url(chrome://browser/skin/Search-addengines.png) no-repeat right center;
+}
+
+.searchbar-engine-button[addengines="true"]:-moz-locale-dir(rtl) > .button-box {
+  background-position: left center;
+}
+*/
 
 /* ::::: search-go-button ::::: */
 


### PR DESCRIPTION
Firefox >= 35.* provide an indicator in the search field when the website provides an opensearch description, making it easier for the user to tell if the website offers its own search engine.

This PR implements the backend code, but does not add the indicator. (My POS UX work needn't be showcased.)