### PR TITLE
Add Places context menu to History menu pop-up

### DIFF
--- a/browser/base/content/browser-menubar.inc
+++ b/browser/base/content/browser-menubar.inc
@@ -322,6 +322,7 @@
 #ifndef XP_MACOSX
                          placespopup="true"
 #endif
+                         context="placesContext"
                          oncommand="this.parentNode._placesView._onCommand(event);"
                          onclick="checkForMiddleClick(this, event);"
                          onpopupshowing="if (!this.parentNode._placesView)


### PR DESCRIPTION
This pull request adds the Places context menu to the (main) Menu Bar's History menu pop-up, resolving issue #202.