### PR TITLE
Add Places context menu to AppMenu's History submenu

### DIFF
--- a/browser/base/content/browser-appmenu.inc
+++ b/browser/base/content/browser-appmenu.inc
@@ -264,6 +264,7 @@
                  command="Browser:ShowAllHistory">
           <menupopup id="appmenu_historyMenupopup"
                      placespopup="true"
+                     context="placesContext"
                      oncommand="this.parentNode._placesView._onCommand(event);"
                      onclick="checkForMiddleClick(this, event);"
                      onpopupshowing="if (!this.parentNode._placesView)


### PR DESCRIPTION
This pull request adds the Places context menu to the AppMenu's History submenu, resolving issue #203.