### PR TITLE
Prevent large images from overflowing in the feed subscription UI.

### DIFF
--- a/browser/themes/linux/feeds/subscribe.css
+++ b/browser/themes/linux/feeds/subscribe.css
@@ -66,6 +66,10 @@ html {
   padding-top: 0.2em;
 }
 
+img {
+  max-width: 100%;
+}
+
 /* Don't print subscription UI */
 @media print {
   #feedHeaderContainer {

--- a/browser/themes/windows/feeds/subscribe.css
+++ b/browser/themes/windows/feeds/subscribe.css
@@ -66,6 +66,10 @@ html {
   padding-top: 0.2em;
 }
 
+img {
+  max-width: 100%;
+}
+
 /* Don't print subscription UI */
 @media print {
   #feedHeaderContainer {


### PR DESCRIPTION
As shown in the image below, image elements larger than the content area in the feed subscription UI would overflow:
 
![2](https://cloud.githubusercontent.com/assets/11385622/10872834/8b38e7de-8130-11e5-8589-4f4dc192f45f.png)

This PR sets the `max-width` property for image elements to `100%` so that images do not overflow the content area. Image from a current Linux build from this branch:

![1](https://cloud.githubusercontent.com/assets/11385622/10872835/8b425210-8130-11e5-8f0f-3395106d106a.png)
