### PR TITLE
Add "Parent Folder" columns to the Library

### DIFF
--- a/browser/components/places/content/places.xul
+++ b/browser/components/places/content/places.xul
@@ -433,6 +433,12 @@
             <splitter class="tree-splitter"/>
             <treecol label="&col.lastmodified.label;" id="placesContentLastModified" anonid="lastModified" flex="1" hidden="true"
                       persist="width hidden ordinal sortActive sortDirection"/>
+            <splitter class="tree-splitter"/>
+            <treecol label="&col.parentfolder.label;" id="placesContentParentFolder" anonid="parentFolder" flex="1" hidden="true"
+                      persist="width hidden ordinal"/>
+            <splitter class="tree-splitter"/>
+            <treecol label="&col.parentfolderpath.label;" id="placesContentParentFolderPath" anonid="parentFolderPath" flex="1" hidden="true"
+                      persist="width hidden ordinal"/>
           </treecols>
           <treechildren flex="1" onclick="ContentTree.onClick(event);"/>
         </tree>

--- a/browser/components/places/content/treeView.js
+++ b/browser/components/places/content/treeView.js
@@ -510,6 +510,8 @@ PlacesTreeView.prototype = {
   COLUMN_TYPE_DATEADDED: 7,
   COLUMN_TYPE_LASTMODIFIED: 8,
   COLUMN_TYPE_TAGS: 9,
+  COLUMN_TYPE_PARENTFOLDER: 10,
+  COLUMN_TYPE_PARENTFOLDERPATH: 11,
 
   _getColumnType: function PTV__getColumnType(aColumn) {
     let columnType = aColumn.element.getAttribute("anonid") || aColumn.id;
@@ -533,6 +535,10 @@ PlacesTreeView.prototype = {
         return this.COLUMN_TYPE_LASTMODIFIED;
       case "tags":
         return this.COLUMN_TYPE_TAGS;
+      case "parentFolder":
+        return this.COLUMN_TYPE_PARENTFOLDER;
+      case "parentFolderPath":
+        return this.COLUMN_TYPE_PARENTFOLDERPATH;
     }
     return this.COLUMN_TYPE_UNKNOWN;
   },
@@ -1462,6 +1468,47 @@ PlacesTreeView.prototype = {
         if (node.lastModified)
           return this._convertPRTimeToString(node.lastModified);
         return "";
+      case this.COLUMN_TYPE_PARENTFOLDER:
+        if (PlacesUtils.nodeIsQuery(node.parent) &&
+            PlacesUtils.asQuery(node.parent).queryOptions.queryType ==
+			Components.interfaces.nsINavHistoryQueryOptions.QUERY_TYPE_HISTORY && node.uri)
+          return "";
+        var bmsvc = Components.classes["@mozilla.org/browser/nav-bookmarks-service;1"]
+                              .getService(Components.interfaces.nsINavBookmarksService);
+        var rowId = node.itemId;
+        try {
+          var parentFolderId = bmsvc.getFolderIdForItem(rowId);
+          var folderTitle = bmsvc.getItemTitle(parentFolderId);
+        } catch(ex) {
+          var folderTitle = "";
+        }
+        return folderTitle;
+      case this.COLUMN_TYPE_PARENTFOLDERPATH:
+        if (PlacesUtils.nodeIsQuery(node.parent) &&
+            PlacesUtils.asQuery(node.parent).queryOptions.queryType ==
+			Components.interfaces.nsINavHistoryQueryOptions.QUERY_TYPE_HISTORY && node.uri)
+          return "";
+        var bmsvc = Components.classes["@mozilla.org/browser/nav-bookmarks-service;1"]
+                              .getService(Components.interfaces.nsINavBookmarksService);
+        var rowId = node.itemId;
+        try {
+          var FolderId;
+          var parentFolderId = bmsvc.getFolderIdForItem(rowId);
+          var folderTitle = bmsvc.getItemTitle(parentFolderId);
+          while ((FolderId = bmsvc.getFolderIdForItem(parentFolderId))) {
+            if (FolderId == parentFolderId)
+              break;
+            parentFolderId = FolderId;
+            var text = bmsvc.getItemTitle(parentFolderId);
+            if (!text)
+              break;
+            folderTitle = text + " /"+ folderTitle;
+          }
+          folderTitle = folderTitle.replace(/^\s/,"");
+        } catch(ex) {
+          var folderTitle = "";
+        }
+        return folderTitle;
     }
     return "";
   },
@@ -1631,6 +1678,14 @@ PlacesTreeView.prototype = {
           newSort = NHQO.SORT_BY_NONE;
         else
           newSort = NHQO.SORT_BY_TAGS_ASCENDING;
+
+        break;
+      case this.COLUMN_TYPE_PARENTFOLDER:
+        return;
+
+        break;
+      case this.COLUMN_TYPE_PARENTFOLDERPATH:
+        return;
 
         break;
       default:

--- a/browser/components/places/content/treeView.js
+++ b/browser/components/places/content/treeView.js
@@ -1471,7 +1471,7 @@ PlacesTreeView.prototype = {
       case this.COLUMN_TYPE_PARENTFOLDER:
         if (PlacesUtils.nodeIsQuery(node.parent) &&
             PlacesUtils.asQuery(node.parent).queryOptions.queryType ==
-			Components.interfaces.nsINavHistoryQueryOptions.QUERY_TYPE_HISTORY && node.uri)
+            Components.interfaces.nsINavHistoryQueryOptions.QUERY_TYPE_HISTORY && node.uri)
           return "";
         var bmsvc = Components.classes["@mozilla.org/browser/nav-bookmarks-service;1"]
                               .getService(Components.interfaces.nsINavBookmarksService);
@@ -1486,7 +1486,7 @@ PlacesTreeView.prototype = {
       case this.COLUMN_TYPE_PARENTFOLDERPATH:
         if (PlacesUtils.nodeIsQuery(node.parent) &&
             PlacesUtils.asQuery(node.parent).queryOptions.queryType ==
-			Components.interfaces.nsINavHistoryQueryOptions.QUERY_TYPE_HISTORY && node.uri)
+            Components.interfaces.nsINavHistoryQueryOptions.QUERY_TYPE_HISTORY && node.uri)
           return "";
         var bmsvc = Components.classes["@mozilla.org/browser/nav-bookmarks-service;1"]
                               .getService(Components.interfaces.nsINavBookmarksService);

--- a/browser/locales/en-US/chrome/browser/places/places.dtd
+++ b/browser/locales/en-US/chrome/browser/places/places.dtd
@@ -78,15 +78,17 @@
 <!ENTITY cmd.moveBookmarks.label                  "Move…">
 <!ENTITY cmd.moveBookmarks.accesskey              "M">
 
-<!ENTITY col.name.label          "Name">
-<!ENTITY col.tags.label          "Tags">
-<!ENTITY col.url.label           "Location">
-<!ENTITY col.lastvisit.label     "Visit Date">
-<!ENTITY col.visitcount.label    "Visit Count">
-<!ENTITY col.keyword.label       "Keyword">
-<!ENTITY col.description.label   "Description">
-<!ENTITY col.dateadded.label     "Added">
-<!ENTITY col.lastmodified.label  "Last Modified">
+<!ENTITY col.name.label              "Name">
+<!ENTITY col.tags.label              "Tags">
+<!ENTITY col.url.label               "Location">
+<!ENTITY col.lastvisit.label         "Visit Date">
+<!ENTITY col.visitcount.label        "Visit Count">
+<!ENTITY col.keyword.label           "Keyword">
+<!ENTITY col.description.label       "Description">
+<!ENTITY col.dateadded.label         "Added">
+<!ENTITY col.lastmodified.label      "Last Modified">
+<!ENTITY col.parentfolder.label      "Parent Folder">
+<!ENTITY col.parentfolderpath.label  "Parent Folder Path">
 
 <!ENTITY search.label                              "Search:">
 <!ENTITY search.accesskey                          "S">


### PR DESCRIPTION
In reply to issue #43, this pull request adds a "Parent Folder" column and a "Parent Folder Path" column to the Library. Tested and confirmed working on Linux x64 (thanks, @trav90!).

