### PR TITLE
Add "Open Parent Folder" item to the context menu for bookmarks search results

### DIFF
--- a/browser/components/places/content/bookmarksPanel.xul
+++ b/browser/components/places/content/bookmarksPanel.xul
@@ -24,6 +24,7 @@
 
   <commandset id="placesCommands"/>
   <commandset id="editMenuCommands"/>
+  <keyset id="placesCommandKeys"/>
   <menupopup id="placesContext"/>
 
   <!-- Bookmarks and history tooltip -->

--- a/browser/components/places/content/controller.js
+++ b/browser/components/places/content/controller.js
@@ -188,6 +188,8 @@ PlacesController.prototype = {
     case "placesCmd_createBookmark":
       var node = this._view.selectedNode;
       return node && PlacesUtils.nodeIsURI(node) && node.itemId == -1;
+    case "placesCmd_openParentFolder":
+      return true;
     default:
       return false;
     }
@@ -274,6 +276,9 @@ PlacesController.prototype = {
                                        , uri: NetUtil.newURI(node.uri)
                                        , title: node.title
                                        }, window.top);
+      break;
+    case "placesCmd_openParentFolder":
+      this.openParentFolder();
       break;
     }
   },
@@ -597,7 +602,12 @@ PlacesController.prototype = {
         // We allow pasting into tag containers, so special case that.
         var hideIfNoIP = item.getAttribute("hideifnoinsertionpoint") == "true" &&
                          noIp && !(ip && ip.isTag && item.id == "placesContext_paste");
-        item.hidden = hideIfNoIP || !this._shouldShowMenuItem(item, metadata);
+        // Display the "Open Parent Folder" menu-item only when the context is in
+        // the Library or in the Sidebar, and only when there's no insertion point.
+        var hideParentFolderItem = item.id == "placesContext_openParentFolder" &&
+                                   (!/tree/i.test(this._view.localName) || ip);
+        item.hidden = hideIfNoIP || hideParentFolderItem ||
+                      !this._shouldShowMenuItem(item, metadata);
 
         if (!item.hidden) {
           visibleItemsBeforeSep = true;
@@ -771,6 +781,281 @@ PlacesController.prototype = {
     var itemId = PlacesUtils.getConcreteItemId(this._view.selectedNode);
     var txn = new PlacesSortFolderByNameTransaction(itemId);
     PlacesUtils.transactionManager.doTransaction(txn);
+  },
+
+  /**
+   * Open the parent folder for the selected bookmarks search result
+   */
+  openParentFolder: function PC_openParentFolder(){
+    var view;
+    if (!document.popupNode) {
+      view = document.commandDispatcher.focusedElement;
+    } else {
+      view = PlacesUIUtils.getViewForNode(document.popupNode);    // XULElement
+    }
+    if (!view || view.getAttribute("type") != "places")
+      return;
+    var node = view.selectedNode;    // nsINavHistoryResultNode
+    var aItemId = node.itemId;
+    var aFolderItemId = this.getParentFolderByItemId(aItemId);
+    if (aFolderItemId)
+      this.selectFolderByItemId(view, aFolderItemId, aItemId);
+  },
+
+  getParentFolderByItemId: function PC_getParentFolderByItemId(aItemId) {
+    var bmsvc = Components.classes["@mozilla.org/browser/nav-bookmarks-service;1"]
+                          .getService(Components.interfaces.nsINavBookmarksService);
+    var parentFolderId = bmsvc.getFolderIdForItem(aItemId);
+
+    return parentFolderId;
+  },
+
+  selectItems2: function PC_selectItems2(view, aIDs) {
+    var ids = aIDs; // don't manipulate the caller's array
+
+    // Array of nodes found by findNodes which are to be selected
+    var nodes = [];
+
+    // Array of nodes found by findNodes which should be opened
+    var nodesToOpen = [];
+
+    // A set of URIs of container-nodes that were previously searched,
+    // and thus shouldn't be searched again. This is empty at the initial
+    // start of the recursion and gets filled in as the recursion
+    // progresses.
+    var nodesURIChecked = [];
+
+    /**
+     * Recursively search through a node's children for items
+     * with the given IDs. When a matching item is found, remove its ID
+     * from the IDs array, and add the found node to the nodes dictionary.
+     *
+     * NOTE: This method will leave open any node that had matching items
+     * in its subtree.
+     */
+    function findNodes(node) {
+      var foundOne = false;
+      // See if node matches an ID we wanted; add to results.
+      // For simple folder queries, check both itemId and the concrete
+      // item id.
+      var index = ids.indexOf(node.itemId);
+      if (index == -1 &&
+          node.type == Components.interfaces.nsINavHistoryResultNode.RESULT_TYPE_FOLDER_SHORTCUT) {
+        index = ids.indexOf(PlacesUtils.asQuery(node).folderItemId); //xxx Bug 556739 3.7a5pre
+      }
+
+      if (index != -1) {
+        nodes.push(node);
+        foundOne = true;
+        ids.splice(index, 1);
+      }
+
+      if (ids.length == 0 || !PlacesUtils.nodeIsContainer(node) ||
+          nodesURIChecked.indexOf(node.uri) != -1)
+        return foundOne;
+
+      nodesURIChecked.push(node.uri);
+      PlacesUtils.asContainer(node); //xxx Bug 556739 3.7a6pre
+
+      // Remember the beginning state so that we can re-close
+      // this node if we don't find any additional results here.
+      var previousOpenness = node.containerOpen;
+      node.containerOpen = true;
+      for (var child = 0;  child < node.childCount && ids.length > 0;
+           child++) {
+        var childNode = node.getChild(child);
+        var found = findNodes(childNode);
+        if (!foundOne)
+          foundOne = found;
+      }
+
+      // If we didn't find any additional matches in this node's
+      // subtree, revert the node to its previous openness.
+      if (foundOne)
+        nodesToOpen.unshift(node);
+      node.containerOpen = previousOpenness;
+      return foundOne;
+    } //findNodes
+
+    // Disable notifications while looking for nodes.
+    let result = view.result;
+    let didSuppressNotifications = result.suppressNotifications;
+    if (!didSuppressNotifications)
+      result.suppressNotifications = true
+    try {
+      findNodes(view.result.root);
+    }
+    finally {
+      if (!didSuppressNotifications)
+        result.suppressNotifications = false;
+    }
+
+    // For all the nodes we've found, highlight the corresponding
+    // index in the tree.
+    var resultview = view.view;
+    var selection = resultview.selection;
+    selection.selectEventsSuppressed = true;
+    selection.clearSelection();
+    // Open nodes containing found items
+    for (var i = 0; i < nodesToOpen.length; i++) {
+      nodesToOpen[i].containerOpen = true;
+    }
+    for (var i = 0; i < nodes.length; i++) {
+      if (PlacesUtils.nodeIsContainer(nodes[i]))
+        continue;
+
+      var index = resultview.treeIndexForNode(nodes[i]);
+      selection.rangedSelect(index, index, true);
+    }
+    selection.selectEventsSuppressed = false;
+  },
+
+  selectFolderByItemId: function PC_selectFolderByItemId(view, aFolderItemId, aItemId) {
+    //Library
+    if (view.getAttribute("id") == "placeContent") {
+      view = document.getElementById("placesList");
+      //Select a folder node in folder pane
+      this.selectItems2(view, [aFolderItemId]);
+      view.selectItems([aFolderItemId]);
+      if (view.currentIndex)
+        view.treeBoxObject.ensureRowIsVisible(view.currentIndex);
+      //Reselect child node
+      setTimeout(function(aItemId, view) {
+        var aView = view.ownerDocument.getElementById("placeContent");
+        aView.selectItems([aItemId]);
+        if (aView.currentIndex)
+          aView.treeBoxObject.ensureRowIsVisible(aView.currentIndex);
+      }, 0, aItemId, view);
+      return;
+    }
+
+    //Bookmarks Sidebar
+    if (!view)
+      return;
+    view.place = view.place;
+
+    if ('FlatBookmarksOverlay' in window) {
+      var sidebarwin = view.ownerDocument.defaultView;
+      var searchBox = sidebarwin.document.getElementById("search-box");
+      searchBox.value = "";
+      searchBox.doCommand();
+      sidebarwin.FlatBookmarks._setTreePlace(sidebarwin.FlatBookmarks._makePlaceForFolder(aFolderItemId));
+      view.selectItems([aItemId]);
+      var tbo = view.treeBoxObject;
+      tbo.ensureRowIsVisible(view.currentIndex);
+      view.focus();
+      return;
+    }
+
+    view.findNode = function flatChildNodes(node, aIDs) {
+      var ids = aIDs; // don't manipulate the caller's array
+
+      // Array of nodes found by findNodes which are to be selected
+      var nodes = [];
+
+      // Array of nodes found by findNodes which should be opened
+      var nodesToOpen = [];
+
+      // A set of URIs of container-nodes that were previously searched,
+      // and thus shouldn't be searched again. This is empty at the initial
+      // start of the recursion and gets filled in as the recursion
+      // progresses.
+      var nodesURIChecked = [];
+
+      /**
+       * Recursively search through a node's children for items
+       * with the given IDs. When a matching item is found, remove its ID
+       * from the IDs array, and add the found node to the nodes dictionary.
+       *
+       * NOTE: This method will leave open any node that had matching items
+       * in its subtree.
+       */
+      function findNodes(node) {
+        var foundOne = false;
+        // See if node matches an ID we wanted; add to results.
+        // For simple folder queries, check both itemId and the concrete
+        // item id.
+        var index = ids.indexOf(node.itemId);
+        if (index == -1 &&
+            node.type == Components.interfaces.nsINavHistoryResultNode.RESULT_TYPE_FOLDER_SHORTCUT) {
+          index = ids.indexOf(PlacesUtils.asQuery(node).folderItemId); //xxx Bug 556739 3.7a5pre
+        }
+
+        if (index != -1) {
+          nodes.push(node);
+          foundOne = true;
+          ids.splice(index, 1);
+        }
+
+        if (ids.length == 0 || !PlacesUtils.nodeIsContainer(node) ||
+            nodesURIChecked.indexOf(node.uri) != -1)
+          return foundOne;
+
+        nodesURIChecked.push(node.uri);
+        PlacesUtils.asContainer(node); //xxx Bug 556739 3.7a6pre
+        // Remember the beginning state so that we can re-close
+        // this node if we don't find any additional results here.
+        var previousOpenness = node.containerOpen;
+        node.containerOpen = true;
+        for (var child = 0;  child < node.childCount && ids.length > 0;
+             child++) {
+          var childNode = node.getChild(child);
+          if (PlacesUtils.nodeIsQuery(childNode))
+            continue;
+          var found = findNodes(childNode);
+          if (!foundOne)
+            foundOne = found;
+        }
+
+        // If we didn't find any additional matches in this node's
+        // subtree, revert the node to its previous openness.
+        if (foundOne)
+          nodesToOpen.unshift(node);
+        node.containerOpen = previousOpenness;
+        return foundOne;
+      }//findNodes
+
+      // Disable notifications while looking for nodes.
+      let result = this.result;
+      let didSuppressNotifications = result.suppressNotifications;
+      if (!didSuppressNotifications)
+        result.suppressNotifications = true
+      try {
+        findNodes(this.result.root);
+      }
+      finally {
+        if (!didSuppressNotifications)
+          result.suppressNotifications = false;
+      }
+
+      // Open nodes containing found items
+      for (var i = 0; i < nodesToOpen.length; i++) {
+        nodesToOpen[i].containerOpen = true;
+      }
+      return nodes;
+    };//findNode
+
+    // For all the nodes we've found, highlight the corresponding
+    // index in the tree.
+    var resultview = view.view;
+    var selection = view.view.selection;
+    selection.selectEventsSuppressed = true;
+    selection.clearSelection();
+    var nodes = view.findNode(view.result.root, [aFolderItemId]);
+    if (nodes.length > 0) {
+      var index = resultview.treeIndexForNode(nodes[0]);
+      nodes = view.findNode(nodes[0], [aItemId]);
+      if (nodes.length > 0) {
+        index = resultview.treeIndexForNode(nodes[0]);
+        selection.rangedSelect(index, index, true);
+      }
+    }
+    selection.selectEventsSuppressed = false;
+
+    var tbo = view.treeBoxObject;
+    tbo.ensureRowIsVisible(view.currentIndex);
+    view.focus();
+    return;
   },
 
   /**
@@ -1616,6 +1901,7 @@ function goUpdatePlacesCommands() {
   updatePlacesCommand("placesCmd_moveBookmarks");
   updatePlacesCommand("placesCmd_reload");
   updatePlacesCommand("placesCmd_sortBy:name");
+  updatePlacesCommand("placesCmd_openParentFolder");
   updatePlacesCommand("placesCmd_cut");
   updatePlacesCommand("placesCmd_copy");
   updatePlacesCommand("placesCmd_paste");

--- a/browser/components/places/content/controller.js
+++ b/browser/components/places/content/controller.js
@@ -786,7 +786,7 @@ PlacesController.prototype = {
   /**
    * Open the parent folder for the selected bookmarks search result
    */
-  openParentFolder: function PC_openParentFolder(){
+  openParentFolder: function PC_openParentFolder() {
     var view;
     if (!document.popupNode) {
       view = document.commandDispatcher.focusedElement;

--- a/browser/components/places/content/places.xul
+++ b/browser/components/places/content/places.xul
@@ -53,13 +53,13 @@
     <stringbundle id="brandStrings" src="chrome://branding/locale/brand.properties"/>
   </stringbundleset>
 
-
 #ifdef XP_MACOSX
 #include ../../../base/content/browserMountPoints.inc
 #else
   <commandset id="editMenuCommands"/>
   <commandset id="placesCommands"/>
 #endif
+  <keyset id="placesCommandKeys"/>
 
   <commandset id="organizerCommandSet">
     <command id="OrganizerCommand_find:all"
@@ -83,7 +83,6 @@
     <command id="OrganizerCommand:Forward"
              oncommand="PlacesOrganizer.forward();"/>
   </commandset>
-
 
   <keyset id="placesOrganizerKeyset">
     <!-- Instantiation Keys -->

--- a/browser/components/places/content/placesOverlay.xul
+++ b/browser/components/places/content/placesOverlay.xul
@@ -75,6 +75,8 @@
              oncommand="goDoPlacesCommand('placesCmd_deleteDataHost');"/>
     <command id="placesCmd_createBookmark"
              oncommand="goDoPlacesCommand('placesCmd_createBookmark');"/>
+    <command id="placesCmd_openParentFolder"
+             oncommand="goDoPlacesCommand('placesCmd_openParentFolder');"/>
 
     <!-- Special versions of cut/copy/paste/delete which check for an open context menu. -->
     <command id="placesCmd_cut"
@@ -86,6 +88,20 @@
     <command id="placesCmd_delete"
              oncommand="goDoPlacesCommand('placesCmd_delete');"/>
   </commandset>
+
+  <keyset id="placesCommandKeys">
+#ifdef XP_UNIX
+    <key id="key_placesCmd_openParentFolder"
+         keycode="VK_F1"
+         command="placesCmd_openParentFolder"
+         modifiers="accel,shift"/>
+#else
+    <key id="key_placesCmd_openParentFolder"
+         keycode="VK_F1"
+         command="placesCmd_openParentFolder"
+         modifiers="accel"/>
+#endif
+  </keyset>
 
   <menupopup id="placesContext"
              onpopupshowing="this._view = PlacesUIUtils.getViewForNode(document.popupNode);
@@ -210,6 +226,15 @@
               closemenu="single"
               selection="folder"/>
     <menuseparator id="placesContext_sortSeparator"/>
+    <menuitem id="placesContext_openParentFolder"
+              command="placesCmd_openParentFolder"
+              label="&cmd.openParentFolder.label;"
+              key="key_placesCmd_openParentFolder"
+              accesskey="&cmd.openParentFolder.accesskey;"
+              selectiontype="single"
+              selection="bookmark"
+              forcehideselection="livemarkChild|livemark/feedURI|PlacesOrganizer/OrganizerQuery"/>
+    <menuseparator id="placesContext_parentFolderSeparator"/>
     <menuitem id="placesContext_show:info"
               command="placesCmd_show:info"
               label="&cmd.properties.label;" 

--- a/browser/components/places/content/placesOverlay.xul
+++ b/browser/components/places/content/placesOverlay.xul
@@ -90,17 +90,10 @@
   </commandset>
 
   <keyset id="placesCommandKeys">
-#ifdef XP_UNIX
     <key id="key_placesCmd_openParentFolder"
          keycode="VK_F1"
          command="placesCmd_openParentFolder"
          modifiers="accel,shift"/>
-#else
-    <key id="key_placesCmd_openParentFolder"
-         keycode="VK_F1"
-         command="placesCmd_openParentFolder"
-         modifiers="accel"/>
-#endif
   </keyset>
 
   <menupopup id="placesContext"

--- a/browser/locales/en-US/chrome/browser/places/places.dtd
+++ b/browser/locales/en-US/chrome/browser/places/places.dtd
@@ -57,6 +57,9 @@
 <!ENTITY cmd.open_all_in_tabs.label      "Open All in Tabs">
 <!ENTITY cmd.open_all_in_tabs.accesskey  "O">
 
+<!ENTITY cmd.openParentFolder.label      "Open Parent Folder">
+<!ENTITY cmd.openParentFolder.accesskey  "P">
+
 <!ENTITY cmd.properties.label      "Properties">
 <!ENTITY cmd.properties.accesskey  "i">
 


### PR DESCRIPTION
This pull request adds an "Open Parent Folder" item to the context menu for bookmarks search results in the Library and in the Bookmarks Sidebar. Tested and confirmed working on Linux x64.

This is a follow-up on pull request #211, aiming to resolve issue #43 altogether.

@trav90: Thank you for helping me with this!