### PR TITLE
Add a "History Menu button" and enhance functionality of the Bookmarks Menu button

### DIFF
--- a/browser/base/content/browser-menubar.inc
+++ b/browser/base/content/browser-menubar.inc
@@ -202,7 +202,8 @@
                   <menupopup id="viewSidebarMenu">
                     <menuitem id="menu_bookmarksSidebar"
                               key="viewBookmarksSidebarKb"
-                              observes="viewBookmarksSidebar"/>
+                              observes="viewBookmarksSidebar"
+                              label="&bookmarksButton.label;"/>
                     <menuitem id="menu_historySidebar"
                               key="key_gotoHistory"
                               observes="viewHistorySidebar"

--- a/browser/base/content/browser-sets.inc
+++ b/browser/base/content/browser-sets.inc
@@ -122,7 +122,7 @@
   </commandset>
 
   <broadcasterset id="mainBroadcasterSet">
-    <broadcaster id="viewBookmarksSidebar" autoCheck="false" label="&bookmarksButton.label;"
+    <broadcaster id="viewBookmarksSidebar" autoCheck="false" sidebartitle="&bookmarksButton.label;"
                  type="checkbox" group="sidebar" sidebarurl="chrome://browser/content/bookmarks/bookmarksPanel.xul"
                  oncommand="toggleSidebar('viewBookmarksSidebar');"/>
 

--- a/browser/base/content/browser.css
+++ b/browser/base/content/browser.css
@@ -325,7 +325,9 @@ toolbarbutton.bookmark-item {
 
 %ifdef MENUBAR_CAN_AUTOHIDE
 #toolbar-menubar:not([autohide="true"]) ~ toolbar > #bookmarks-menu-button,
-#toolbar-menubar:not([autohide="true"]) > #bookmarks-menu-button {
+#toolbar-menubar:not([autohide="true"]) > #bookmarks-menu-button,
+#toolbar-menubar:not([autohide="true"]) ~ toolbar > #history-menu-button,
+#toolbar-menubar:not([autohide="true"]) > #history-menu-button {
   display: none;
 }
 %endif

--- a/browser/base/content/browser.xul
+++ b/browser/base/content/browser.xul
@@ -356,7 +356,7 @@
              toolbarname="&navbarCmd.label;" accesskey="&navbarCmd.accesskey;"
              fullscreentoolbar="true" mode="icons" customizable="true"
              iconsize="large"
-             defaultset="unified-back-forward-button,reload-button,stop-button,home-button,urlbar-container,search-container,bookmarks-menu-button,downloads-button,window-controls"
+             defaultset="unified-back-forward-button,reload-button,stop-button,home-button,urlbar-container,search-container,bookmarks-menu-button,history-menu-button,downloads-button,window-controls"
              context="toolbar-context-menu">
 
       <toolbaritem id="unified-back-forward-button" class="chromeclass-toolbar-additional"
@@ -602,6 +602,65 @@
                     label="&bookmarksMenuButton.unsorted.label;"
                     oncommand="PlacesCommandHook.showPlacesOrganizer('UnfiledBookmarks');"
                     class="menuitem-iconic"/>
+        </menupopup>
+      </toolbarbutton>
+
+      <toolbarbutton id="history-menu-button"
+                     class="toolbarbutton-1 chromeclass-toolbar-additional"
+                     type="menu"
+                     label="&historyButton.label;"
+                     onclick="if (event.button == 1)
+                                toggleSidebar('viewHistorySidebar');"
+                     tooltiptext="&historyButton.tooltip;">
+        <menupopup id="HMB_historyPopup"
+                   placespopup="true"
+                   context="placesContext"
+                   oncommand="this.parentNode._placesView._onCommand(event);"
+                   onclick="checkForMiddleClick(this, event);"
+                   onpopupshowing="if (!this.parentNode._placesView)
+                                     new HistoryMenu(event);"
+                   tooltip="bhTooltip"
+                   popupsinherittooltip="true">
+          <menuitem id="HMB_showAllHistory"
+                    label="&showAllHistoryCmd2.label;"
+#ifndef XP_MACOSX
+                    key="showAllHistoryKb"
+#endif
+                    command="Browser:ShowAllHistory"/>
+          <menuitem id="HMB_sanitizeItem"
+                    label="&clearRecentHistory.label;"
+                    key="key_sanitize"
+                    command="Tools:Sanitize"/>
+          <menuseparator id="HMB_sanitizeSeparator"/>
+#ifdef MOZ_SERVICES_SYNC
+          <menuitem id="HMB_sync-tabs-menuitem"
+                    class="syncTabsMenuItem"
+                    label="&syncTabsMenu2.label;"
+                    oncommand="BrowserOpenSyncTabs();"
+                    disabled="true"/>
+#endif
+          <menuitem id="HMB_historyRestoreLastSession"
+                    label="&historyRestoreLastSession.label;"
+                    command="Browser:RestoreLastSession"/>
+          <menu id="HMB_historyUndoMenu"
+                class="recentlyClosedTabsMenu"
+                label="&historyUndoMenu.label;"
+                disabled="true">
+            <menupopup id="HMB_historyUndoPopup"
+                       placespopup="true"
+                       onpopupshowing="document.getElementById('history-menu-button')._placesView.populateUndoSubmenu();"/>
+          </menu>
+          <menu id="HMB_historyUndoWindowMenu"
+                class="recentlyClosedWindowsMenu"
+                label="&historyUndoWindowMenu.label;"
+                disabled="true">
+            <menupopup id="HMB_historyUndoWindowPopup"
+                       placespopup="true"
+                       onpopupshowing="document.getElementById('history-menu-button')._placesView.populateUndoWindowSubmenu();"/>
+          </menu>
+          <menuseparator id="HMB_startHistorySeparator"
+                         class="hide-if-empty-places-result"/>
+          <!-- History menu items -->
         </menupopup>
       </toolbarbutton>
 

--- a/browser/base/content/browser.xul
+++ b/browser/base/content/browser.xul
@@ -830,7 +830,7 @@
                      tooltiptext="&historyButton.tooltip;"/>
 
       <toolbarbutton id="bookmarks-button" class="toolbarbutton-1 chromeclass-toolbar-additional"
-                     observes="viewBookmarksSidebar"
+                     observes="viewBookmarksSidebar" label="&bookmarksButton.label;"
                      tooltiptext="&bookmarksButton.tooltip;"
                      ondrop="bookmarksButtonObserver.onDrop(event)"
                      ondragover="bookmarksButtonObserver.onDragOver(event)"

--- a/browser/base/content/browser.xul
+++ b/browser/base/content/browser.xul
@@ -528,6 +528,8 @@
                      persist="class"
                      removable="true"
                      type="menu"
+                     onclick="if (event.button == 1)
+                                toggleSidebar('viewBookmarksSidebar');"
                      label="&bookmarksMenuButton.label;"
                      tooltiptext="&bookmarksMenuButton.tooltip;"
                      ondragenter="PlacesMenuDNDHandler.onDragEnter(event);"

--- a/browser/themes/linux/browser.css
+++ b/browser/themes/linux/browser.css
@@ -634,8 +634,13 @@ toolbar[mode="full"] .toolbarbutton-1 > .toolbarbutton-menubutton-button {
   -moz-image-region: rect(0px 24px 24px 0px);
 }
 
-#history-button {
+#history-button,
+#history-menu-button {
   -moz-image-region: rect(0px 48px 24px 24px);
+}
+
+#history-menu-button.toolbarbutton-1 {
+  -moz-box-orient: horizontal;
 }
 
 #bookmarks-button,
@@ -800,7 +805,8 @@ toolbar[iconsize="small"] #downloads-button {
 }
 
 toolbar[iconsize="small"] #webrtc-status-button /* temporary placeholder (bug 824825) */,
-toolbar[iconsize="small"] #history-button {
+toolbar[iconsize="small"] #history-button,
+toolbar[iconsize=small] > #history-menu-button {
   -moz-image-region: rect(0px 32px 16px 16px);
 }
 
@@ -1535,6 +1541,16 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 #bookmarks-menu-button[disabled] > .toolbarbutton-menubutton-dropmarker,
 #bookmarks-menu-button[disabled] > .toolbarbutton-menubutton-button > .toolbarbutton-icon,
 #bookmarks-menu-button > .toolbarbutton-menubutton-button[disabled] > .toolbarbutton-icon {
+  opacity: .4;
+}
+
+/* history menu-button */
+
+#history-menu-button[disabled] > .toolbarbutton-icon,
+#history-menu-button[disabled] > .toolbarbutton-menu-dropmarker,
+#history-menu-button[disabled] > .toolbarbutton-menubutton-dropmarker,
+#history-menu-button[disabled] > .toolbarbutton-menubutton-button > .toolbarbutton-icon,
+#history-menu-button > .toolbarbutton-menubutton-button[disabled] > .toolbarbutton-icon {
   opacity: .4;
 }
 

--- a/browser/themes/osx/browser.css
+++ b/browser/themes/osx/browser.css
@@ -601,7 +601,8 @@ toolbar[mode=full] .toolbarbutton-1 > .toolbarbutton-menubutton-button {
     -moz-image-region: rect(0, 108px, 18px, 90px);
 }
 
-#history-button {
+#history-button,
+#history-menu-button {
     -moz-image-region: rect(0, 126px, 18px, 108px);
 }
 

--- a/browser/themes/shared/browser.inc
+++ b/browser/themes/shared/browser.inc
@@ -1,3 +1,3 @@
 %filter substitution
 
-%define primaryToolbarButtons #back-button, #forward-button, #reload-button, #stop-button, #home-button, #print-button, #downloads-button, #downloads-indicator, #history-button, #bookmarks-button, #bookmarks-menu-button, #new-tab-button, #new-window-button, #cut-button, #copy-button, #paste-button, #fullscreen-button, #zoom-out-button, #zoom-in-button, #sync-button, #feed-button, #alltabs-button, #webrtc-status-button
+%define primaryToolbarButtons #back-button, #forward-button, #reload-button, #stop-button, #home-button, #print-button, #downloads-button, #downloads-indicator, #history-button, #history-menu-button, #bookmarks-button, #bookmarks-menu-button, #new-tab-button, #new-window-button, #cut-button, #copy-button, #paste-button, #fullscreen-button, #zoom-out-button, #zoom-in-button, #sync-button, #feed-button, #alltabs-button, #webrtc-status-button

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1123,7 +1123,8 @@ toolbar[mode=full] .toolbarbutton-1 > .toolbarbutton-menubutton-button {
   -moz-image-region: rect(0, 108px, 18px, 90px);
 }
 
-#history-button {
+#history-button,
+#history-menu-button {
   -moz-image-region: rect(0, 126px, 18px, 108px);
 }
 


### PR DESCRIPTION
This pull request introduces the following changes:

- Add a "History Menu button" to the Navigation toolbar
- Make middle-clicking the Bookmarks Menu button toggle the Bookmarks Sidebar
- Set "Bookmarks" label on viewBookmarksSidebar observers directly (instead of on the broadcaster)

Tested and confirmed working on Linux x64 (thanks, @trav90!).