### PR TITLE
Set ui.key.menuAccessKeyFocuses to "true" by default on Linux

### DIFF
--- a/modules/libpref/src/init/all.js
+++ b/modules/libpref/src/init/all.js
@@ -3647,6 +3647,8 @@ pref("ui.panel.default_level_parent", true);
 
 pref("mousewheel.system_scroll_override_on_root_content.enabled", false);
 
+pref("ui.key.menuAccessKeyFocuses", true);
+
 # XP_UNIX
 #endif
 #endif


### PR DESCRIPTION
Currently on Linux, the preference ui.key.menuAccessKeyFocuses is set to "false" by default. I think it makes sense to set this preference to "true" by default, so when the Menu bar is hidden, pressing the Alt key will bring it up, just like on Windows.