### PR TITLE
Fix issue with the styling of the History Menu button on Linux

### DIFF
--- a/browser/themes/linux/browser.css
+++ b/browser/themes/linux/browser.css
@@ -806,7 +806,7 @@ toolbar[iconsize="small"] #downloads-button {
 
 toolbar[iconsize="small"] #webrtc-status-button /* temporary placeholder (bug 824825) */,
 toolbar[iconsize="small"] #history-button,
-toolbar[iconsize=small] > #history-menu-button {
+toolbar[iconsize="small"] #history-menu-button {
   -moz-image-region: rect(0px 32px 16px 16px);
 }
 


### PR DESCRIPTION
This pull request fixes an issue with the styling of the History Menu button on Linux, where the icon is not displayed properly when Pale Moon is in Small Icons mode and is being customized.

This is a follow-up to PR #228.