### PR TITLE
Bump the minimum supported GCC version to 4.6

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -398,9 +398,9 @@ fi
 MOZ_TOOL_VARIABLES
 
 if test -n "$GNU_CC" -a -z "$CLANG_CC" ; then
-    if test "$GCC_MAJOR_VERSION" -eq 4 -a "$GCC_MINOR_VERSION" -lt 4 ||
+    if test "$GCC_MAJOR_VERSION" -eq 4 -a "$GCC_MINOR_VERSION" -lt 6 ||
        test "$GCC_MAJOR_VERSION" -lt 4; then
-        AC_MSG_ERROR([Only GCC 4.4 or newer supported])
+        AC_MSG_ERROR([Only GCC 4.6 or newer is supported])
     fi
 fi
 

--- a/mfbt/Compiler.h
+++ b/mfbt/Compiler.h
@@ -13,13 +13,13 @@
 #define MOZ_IS_GCC 1
    /*
     * This macro should simplify gcc version checking. For example, to check
-    * for gcc 4.5.1 or later, check `#ifdef MOZ_GCC_VERSION_AT_LEAST(4, 5, 1)`.
+    * for gcc 4.6.0 or later, check `#ifdef MOZ_GCC_VERSION_AT_LEAST(4, 6, 0)`.
     */
 #  define MOZ_GCC_VERSION_AT_LEAST(major, minor, patchlevel)          \
      ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) \
       >= ((major) * 10000 + (minor) * 100 + (patchlevel)))
-#if !MOZ_GCC_VERSION_AT_LEAST(4, 4, 0)
-#  error "mfbt (and Goanna) require at least gcc 4.4 to build."
+#if !MOZ_GCC_VERSION_AT_LEAST(4, 6, 0)
+#  error "mfbt (and Goanna) require at least gcc 4.6 to build."
 #endif
 
 #else


### PR DESCRIPTION
Just what it says in the tin.

Additional pull requests will be submitted soon that removes conditionals and workarounds used for GCC versions 4.5 and lower.