### PR TITLE
Add missing icons to the various Bookmarks and History menus

### DIFF
--- a/browser/base/content/browser-appmenu.inc
+++ b/browser/base/content/browser-appmenu.inc
@@ -211,6 +211,7 @@
                      tooltip="bhTooltip"
                      popupsinherittooltip="true">
             <menuitem id="appmenu_showAllBookmarks"
+                      class="menuitem-iconic"
                       label="&palemoon.menu.allBookmarks.label;"
                       command="Browser:ShowAllBookmarks"
                       context=""
@@ -253,9 +254,9 @@
             <menuseparator builder="end"
                            class="hide-if-empty-places-result"/>
             <menuitem id="appmenu_unsortedBookmarks"
+                      class="menuitem-iconic"
                       label="&appMenuUnsorted.label;"
-                      oncommand="PlacesCommandHook.showPlacesOrganizer('UnfiledBookmarks');"
-                      class="menuitem-iconic"/>
+                      oncommand="PlacesCommandHook.showPlacesOrganizer('UnfiledBookmarks');"/>
           </menupopup>
       </splitmenu>
       <splitmenu id="appmenu_history"
@@ -272,6 +273,7 @@
                      tooltip="bhTooltip"
                      popupsinherittooltip="true">
             <menuitem id="appmenu_showAllHistory"
+                      class="menuitem-iconic"
                       label="&showAllHistoryCmd2.label;"
                       command="Browser:ShowAllHistory"
                       key="showAllHistoryKb"/>

--- a/browser/base/content/browser-menubar.inc
+++ b/browser/base/content/browser-menubar.inc
@@ -361,6 +361,7 @@
                 <menuitem id="menu_showAllHistory"
                           label="&showAllHistoryCmd2.label;"
 #ifndef XP_MACOSX
+                          class="menuitem-iconic"
                           key="showAllHistoryKb"
 #endif
                           command="Browser:ShowAllHistory"/>
@@ -423,11 +424,17 @@
                                  new PlacesMenu(event, 'place:folder=BOOKMARKS_MENU');"
                tooltip="bhTooltip" popupsinherittooltip="true">
       <menuitem id="bookmarksShowAll"
+#ifndef XP_MACOSX
+                class="menuitem-iconic"
+#endif
                 label="&palemoon.menu.allBookmarks.label;"
                 command="Browser:ShowAllBookmarks"
                 key="manBookmarkKb"/>
       <menuseparator id="organizeBookmarksSeparator"/>
       <menuitem id="menu_bookmarkThisPage"
+#ifndef XP_MACOSX
+                class="menuitem-iconic"
+#endif
                 label="&bookmarkThisPageCmd.label;"
                 command="Browser:AddBookmarkAs"
                 key="addBookmarkAsKb"/>
@@ -473,6 +480,9 @@
       <menuseparator builder="end"
                      class="hide-if-empty-places-result"/>
       <menuitem id="menu_unsortedBookmarks"
+#ifndef XP_MACOSX
+                class="menuitem-iconic"
+#endif
                 label="&unsortedBookmarksCmd.label;"
                 oncommand="PlacesCommandHook.showPlacesOrganizer('UnfiledBookmarks');"/>
     </menupopup>

--- a/browser/base/content/browser.xul
+++ b/browser/base/content/browser.xul
@@ -554,6 +554,9 @@
                     label="&viewBookmarksToolbar.label;"/>
           <menuseparator/>
           <menuitem id="BMB_bookmarksShowAll"
+#ifndef XP_MACOSX
+                    class="menuitem-iconic"
+#endif
                     label="&palemoon.menu.allBookmarks.label;"
                     command="Browser:ShowAllBookmarks"
                     key="manBookmarkKb"/>
@@ -601,9 +604,9 @@
           <menuseparator builder="end"
                          class="hide-if-empty-places-result"/>
           <menuitem id="BMB_unsortedBookmarks"
+                    class="menuitem-iconic"
                     label="&bookmarksMenuButton.unsorted.label;"
-                    oncommand="PlacesCommandHook.showPlacesOrganizer('UnfiledBookmarks');"
-                    class="menuitem-iconic"/>
+                    oncommand="PlacesCommandHook.showPlacesOrganizer('UnfiledBookmarks');"/>
         </menupopup>
       </toolbarbutton>
 
@@ -626,6 +629,7 @@
           <menuitem id="HMB_showAllHistory"
                     label="&showAllHistoryCmd2.label;"
 #ifndef XP_MACOSX
+                    class="menuitem-iconic"
                     key="showAllHistoryKb"
 #endif
                     command="Browser:ShowAllHistory"/>

--- a/browser/themes/linux/browser.css
+++ b/browser/themes/linux/browser.css
@@ -464,18 +464,22 @@ menuitem:not([type]):not(.menuitem-tooltip):not(.menuitem-iconic-tooltip) {
 
 #appmenu_history,
 #appmenu_showAllHistory,
-#menu_showAllHistory {
+#menu_showAllHistory,
+#HMB_showAllHistory {
   list-style-image: url("chrome://browser/skin/Toolbar-small.png");
   -moz-image-region: rect(0px 32px 16px 16px);
 }
 
 #appmenu_bookmarks,
 #appmenu_showAllBookmarks,
-#bookmarksShowAll {
+#bookmarksShowAll,
+#BMB_bookmarksShowAll {
   list-style-image: url("chrome://browser/skin/Toolbar-small.png");
   -moz-image-region: rect(0px 48px 16px 32px);
 }
 
+#appmenu_subscribeToPage:not([disabled]),
+#appmenu_subscribeToPageMenu,
 #subscribeToPageMenuitem:not([disabled]),
 #subscribeToPageMenupopup,
 #BMB_subscribeToPageMenuitem:not([disabled]),
@@ -483,15 +487,20 @@ menuitem:not([type]):not(.menuitem-tooltip):not(.menuitem-iconic-tooltip) {
   list-style-image: url("chrome://browser/skin/page-livemarks.png");
 }
 
+#appmenu_bookmarksToolbar,
 #bookmarksToolbarFolderMenu,
 #BMB_bookmarksToolbar {
   list-style-image: url("chrome://browser/skin/places/bookmarksToolbar.png");
 }
 
+#appmenu_bookmarkThisPage,
+#menu_bookmarkThisPage,
 #BMB_bookmarkThisPage {
   list-style-image: url("chrome://browser/skin/places/starPage.png");
 }
 
+#appmenu_unsortedBookmarks,
+#menu_unsortedBookmarks,
 #BMB_unsortedBookmarks {
   list-style-image: url("chrome://browser/skin/places/unsortedBookmarks.png");
 }
@@ -524,7 +533,8 @@ menuitem:not([type]):not(.menuitem-tooltip):not(.menuitem-iconic-tooltip) {
 }
 
 #appmenu_sanitizeHistory,
-#sanitizeItem {
+#sanitizeItem,
+#HMB_sanitizeItem {
   list-style-image: url("moz-icon://stock/gtk-clear?size=menu");
 }
 

--- a/browser/themes/osx/browser.css
+++ b/browser/themes/osx/browser.css
@@ -2030,8 +2030,8 @@ toolbarbutton.bookmark-item[dragover="true"][open="true"] {
     list-style-image: url("chrome://browser/skin/feeds/feedIcon16.png");
 }
 
-#bookmarksToolbarFolderMenu,
 #appmenu_bookmarksToolbar,
+#bookmarksToolbarFolderMenu,
 #BMB_bookmarksToolbar {
     list-style-image: url("chrome://browser/skin/places/bookmarksToolbar.png");
     -moz-image-region: auto;

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -539,10 +539,23 @@
   }
 }
 
-#BMB_bookmarkThisPage,
-#appmenu_bookmarkThisPage {
+#appmenu_showAllBookmarks,
+#bookmarksShowAll,
+#BMB_bookmarksShowAll {
+  list-style-image: url("chrome://browser/skin/places/allBookmarks.png"
+}
+
+#appmenu_bookmarkThisPage,
+#menu_bookmarkThisPage,
+#BMB_bookmarkThisPage {
   list-style-image: url("chrome://browser/skin/places/bookmark.png");
   -moz-image-region: rect(0 16px 16px 0);
+}
+
+#appmenu_showAllHistory,
+#menu_showAllHistory,
+#HMB_showAllHistory {
+  list-style-image: url("chrome://browser/skin/places/history.png");
 }
 
 /* ::::: titlebar ::::: */
@@ -2651,14 +2664,15 @@ toolbarbutton.bookmark-item[dragover="true"][open="true"] {
   list-style-image: url("chrome://browser/skin/feeds/feedIcon16.png");
 }
 
-#bookmarksToolbarFolderMenu,
 #appmenu_bookmarksToolbar,
+#bookmarksToolbarFolderMenu,
 #BMB_bookmarksToolbar {
   list-style-image: url("chrome://browser/skin/places/bookmarksToolbar.png");
   -moz-image-region: auto;
 }
 
 #appmenu_unsortedBookmarks,
+#menu_unsortedBookmarks,
 #BMB_unsortedBookmarks {
   list-style-image: url("chrome://browser/skin/places/unsortedBookmarks.png");
   -moz-image-region: auto;


### PR DESCRIPTION
This pull request adds the icons that are currently missing in the various Bookmarks and History menus on Windows and on Linux. Tested and confirmed working on Linux x64, but *not* tested on Windows yet.