### PR TITLE
On Aero-enabled systems, use Aero-style icons in the various Bookmarks and History menus

### DIFF
--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -542,7 +542,11 @@
 #appmenu_showAllBookmarks,
 #bookmarksShowAll,
 #BMB_bookmarksShowAll {
+%ifdef WINDOWS_AERO
+  list-style-image: url("chrome://browser/skin/places/allBookmarks-aero.png"
+%else
   list-style-image: url("chrome://browser/skin/places/allBookmarks.png"
+%endif
 }
 
 #appmenu_bookmarkThisPage,
@@ -555,7 +559,11 @@
 #appmenu_showAllHistory,
 #menu_showAllHistory,
 #HMB_showAllHistory {
+%ifdef WINDOWS_AERO
+  list-style-image: url("chrome://browser/skin/places/history-aero.png");
+%else
   list-style-image: url("chrome://browser/skin/places/history.png");
+%endif
 }
 
 #appmenu_sanitizeHistory,


### PR DESCRIPTION
This pull request replaces the default "Organize Bookmarks" and "Show All History" icons in the various Bookmarks and History menus with Aero-style versions on Aero-enabled systems.

This is a follow-up to PR #233.