### PR TITLE
Revert pull request #235 and correct CSS for "Organize Bookmarks" icon

### DIFF
--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -542,11 +542,7 @@
 #appmenu_showAllBookmarks,
 #bookmarksShowAll,
 #BMB_bookmarksShowAll {
-%ifdef WINDOWS_AERO
-  list-style-image: url("chrome://browser/skin/places/allBookmarks-aero.png"
-%else
   list-style-image: url("chrome://browser/skin/places/allBookmarks.png"
-%endif
 }
 
 #appmenu_bookmarkThisPage,
@@ -559,11 +555,7 @@
 #appmenu_showAllHistory,
 #menu_showAllHistory,
 #HMB_showAllHistory {
-%ifdef WINDOWS_AERO
-  list-style-image: url("chrome://browser/skin/places/history-aero.png");
-%else
   list-style-image: url("chrome://browser/skin/places/history.png");
-%endif
 }
 
 #appmenu_sanitizeHistory,

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -542,7 +542,7 @@
 #appmenu_showAllBookmarks,
 #bookmarksShowAll,
 #BMB_bookmarksShowAll {
-  list-style-image: url("chrome://browser/skin/places/allBookmarks.png"
+  list-style-image: url("chrome://browser/skin/places/allBookmarks.png");
 }
 
 #appmenu_bookmarkThisPage,


### PR DESCRIPTION
Sorry, I just realized I've made a mistake; the Aero-style icons simply replace the default ones in the theme for Aero-enabled systems, so there's no need to specify different icons in the style sheet, after all.

Thus, the main objective of this PR is to revert PR #235. Additionally, I've made a correction to the CSS for the "Organize Bookmarks" icon, as a follow-up to PR #233.