### PR TITLE
Cleanup old GCC version checks

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2747,26 +2747,6 @@ if test "$OS_TARGET" != WINNT; then
     MOZ_LLVM_PR8927
 fi
 
-dnl Check for __force_align_arg_pointer__ for SSE2 on gcc
-dnl ========================================================
-if test "$GNU_CC"; then
-  CFLAGS_save="${CFLAGS}"
-  CFLAGS="${CFLAGS} -Werror"
-  AC_CACHE_CHECK(for __force_align_arg_pointer__ attribute,
-                 ac_cv_force_align_arg_pointer,
-                 [AC_TRY_COMPILE([__attribute__ ((__force_align_arg_pointer__)) void test() {}],
-                                 [],
-                                 ac_cv_force_align_arg_pointer="yes",
-                                 ac_cv_force_align_arg_pointer="no")])
-  CFLAGS="${CFLAGS_save}"
-  if test "$ac_cv_force_align_arg_pointer" = "yes"; then
-    HAVE_GCC_ALIGN_ARG_POINTER=1
-  else
-    HAVE_GCC_ALIGN_ARG_POINTER=
-  fi
-fi
-AC_SUBST(HAVE_GCC_ALIGN_ARG_POINTER)
-
 dnl Checks for header files.
 dnl ========================================================
 AC_HEADER_DIRENT

--- a/configure.in
+++ b/configure.in
@@ -1949,13 +1949,8 @@ ia64*-hpux*)
         MOZ_OPTIMIZE_FLAGS="-O2"
         MOZ_DEBUG_FLAGS="-g"
     elif test "$GNU_CC" -o "$GNU_CXX"; then
-        case $GCC_VERSION in
-        4.5.*)
-            # -Os is broken on gcc 4.5.x we need to tweak it to get good results.
-            MOZ_OPTIMIZE_SIZE_TWEAK="-finline-limit=50"
-        esac
         MOZ_PGO_OPTIMIZE_FLAGS="-O3"
-        MOZ_OPTIMIZE_FLAGS="-Os $MOZ_OPTIMIZE_SIZE_TWEAK"
+        MOZ_OPTIMIZE_FLAGS="-Os"
         if test -z "$CLANG_CC"; then
           MOZ_OPTIMIZE_FLAGS="-freorder-blocks $MOZ_OPTIMIZE_FLAGS"
         fi 
@@ -6803,7 +6798,6 @@ AC_SUBST(MOZ_FRAMEPTR_FLAGS)
 AC_SUBST(MOZ_OPTIMIZE_FLAGS)
 AC_SUBST(MOZ_OPTIMIZE_LDFLAGS)
 AC_SUBST(MOZ_ALLOW_HEAP_EXECUTE_FLAGS)
-AC_SUBST(MOZ_OPTIMIZE_SIZE_TWEAK)
 AC_SUBST(MOZ_PGO_OPTIMIZE_FLAGS)
 
 dnl ========================================================

--- a/dom/plugins/base/npapi.h
+++ b/dom/plugins/base/npapi.h
@@ -304,10 +304,10 @@ typedef enum {
 
 #define NP_ABI_GCC3_MASK  0x10000000
 /*
- *   gcc 3.x generated vtables on UNIX and OSX are incompatible with
- *   previous compilers.
+ *   gcc 3.x and higher generated vtables on UNIX and OSX are
+ *   incompatible with previous compilers.
  */
-#if (defined(XP_UNIX) && defined(__GNUC__) && (__GNUC__ >= 3))
+#if (defined(XP_UNIX) && defined(__GNUC__))
 #define _NP_ABI_MIXIN_FOR_GCC3 NP_ABI_GCC3_MASK
 #else
 #define _NP_ABI_MIXIN_FOR_GCC3 0

--- a/dom/plugins/base/npfunctions.h
+++ b/dom/plugins/base/npfunctions.h
@@ -216,8 +216,7 @@ typedef OSErr (*BP_GetSupportedMIMETypesProcPtr)(BPSupportedMIMETypes*, UInt32);
 #endif
 
 #if defined(XP_UNIX)
-/* GCC 3.3 and later support the visibility attribute. */
-#if defined(__GNUC__) && ((__GNUC__ >= 4) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3))
+#if defined(__GNUC__)
 #define NP_VISIBILITY_DEFAULT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
 #define NP_VISIBILITY_DEFAULT __global

--- a/gfx/2d/convolver.cpp
+++ b/gfx/2d/convolver.cpp
@@ -155,12 +155,6 @@ class CircularRowBuffer {
 // Convolves horizontally along a single row. The row data is given in
 // |src_data| and continues for the num_values() of the filter.
 template<bool has_alpha>
-// This function is miscompiled with gcc 4.5 with pgo. See bug 827946.
-#if defined(__GNUC__) && defined(MOZ_GCC_VERSION_AT_LEAST)
-#if MOZ_GCC_VERSION_AT_LEAST(4, 5, 0) && !MOZ_GCC_VERSION_AT_LEAST(4, 6, 0)
-__attribute__((optimize("-O1")))
-#endif
-#endif
 void ConvolveHorizontally(const unsigned char* src_data,
                           const ConvolutionFilter1D& filter,
                           unsigned char* out_row) {

--- a/gfx/cairo/libpixman/src/Makefile.in
+++ b/gfx/cairo/libpixman/src/Makefile.in
@@ -53,12 +53,10 @@ USE_VMX=1
 VMX_CFLAGS=-maltivec
 endif
 ifeq (86,$(findstring 86,$(OS_TEST)))
+USE_SSE2=1
 USE_MMX=1
 MMX_CFLAGS=-mmmx -Winline
 ifeq (64,$(findstring 64,$(OS_TEST)))
-USE_SSE2=1
-endif
-ifdef HAVE_GCC_ALIGN_ARG_POINTER
 USE_SSE2=1
 endif
 ifdef USE_SSE2

--- a/js/public/Utility.h
+++ b/js/public/Utility.h
@@ -253,9 +253,7 @@ __BitScanReverse64(unsigned __int64 val)
 # define js_bitscan_clz64(val)  __BitScanReverse64(val)
 #elif MOZ_IS_GCC
 
-#if MOZ_GCC_VERSION_AT_LEAST(3, 4, 0)
 # define USE_BUILTIN_CTZ
-#endif
 
 #elif defined(__clang__)
 

--- a/js/src/assembler/jit/ExecutableAllocator.h
+++ b/js/src/assembler/jit/ExecutableAllocator.h
@@ -404,7 +404,7 @@ public:
 #elif WTF_CPU_MIPS
     static void cacheFlush(void* code, size_t size)
     {
-#if defined(__GNUC__)
+#if WTF_COMPILER_GCC
         intptr_t end = reinterpret_cast<intptr_t>(code) + size;
         __builtin___clear_cache(reinterpret_cast<char*>(code), reinterpret_cast<char*>(end));
 #else

--- a/js/src/assembler/jit/ExecutableAllocator.h
+++ b/js/src/assembler/jit/ExecutableAllocator.h
@@ -404,25 +404,9 @@ public:
 #elif WTF_CPU_MIPS
     static void cacheFlush(void* code, size_t size)
     {
-#if WTF_COMPILER_GCC && (GCC_VERSION >= 40300)
-#if WTF_MIPS_ISA_REV(2) && (GCC_VERSION < 40403)
-        int lineSize;
-        asm("rdhwr %0, $1" : "=r" (lineSize));
-        //
-        // Modify "start" and "end" to avoid GCC 4.3.0-4.4.2 bug in
-        // mips_expand_synci_loop that may execute synci one more time.
-        // "start" points to the first byte of the cache line.
-        // "end" points to the last byte of the line before the last cache line.
-        // Because size is always a multiple of 4, this is safe to set
-        // "end" to the last byte.
-        //
-        intptr_t start = reinterpret_cast<intptr_t>(code) & (-lineSize);
-        intptr_t end = ((reinterpret_cast<intptr_t>(code) + size - 1) & (-lineSize)) - 1;
-        __builtin___clear_cache(reinterpret_cast<char*>(start), reinterpret_cast<char*>(end));
-#else
+#if defined(__GNUC__)
         intptr_t end = reinterpret_cast<intptr_t>(code) + size;
         __builtin___clear_cache(reinterpret_cast<char*>(code), reinterpret_cast<char*>(end));
-#endif
 #else
         _flush_cache(reinterpret_cast<char*>(code), size, BCACHE);
 #endif

--- a/js/src/configure.in
+++ b/js/src/configure.in
@@ -396,9 +396,9 @@ fi
 MOZ_TOOL_VARIABLES
 
 if test -n "$GNU_CC" -a -z "$CLANG_CC" ; then
-    if test "$GCC_MAJOR_VERSION" -eq 4 -a "$GCC_MINOR_VERSION" -lt 4 ||
+    if test "$GCC_MAJOR_VERSION" -eq 4 -a "$GCC_MINOR_VERSION" -lt 6 ||
        test "$GCC_MAJOR_VERSION" -lt 4; then
-        AC_MSG_ERROR([Only GCC 4.4 or newer supported])
+        AC_MSG_ERROR([Only GCC 4.6 or newer is supported])
     fi
 fi
 

--- a/js/src/configure.in
+++ b/js/src/configure.in
@@ -1570,13 +1570,8 @@ ia64*-hpux*)
         MOZ_OPTIMIZE_FLAGS="-O2"
         MOZ_DEBUG_FLAGS="-g"
     elif test "$GNU_CC" -o "$GNU_CXX"; then
-        case $GCC_VERSION in
-        4.5.*)
-            # -Os is broken on gcc 4.5.x we need to tweak it to get good results.
-            MOZ_OPTIMIZE_SIZE_TWEAK="-finline-limit=50"
-        esac
         MOZ_PGO_OPTIMIZE_FLAGS="-O3"
-        MOZ_OPTIMIZE_FLAGS="-O3 $MOZ_OPTIMIZE_SIZE_TWEAK"
+        MOZ_OPTIMIZE_FLAGS="-O3"
         if test -z "$CLANG_CC"; then
            MOZ_OPTIMIZE_FLAGS="-freorder-blocks $MOZ_OPTIMIZE_FLAGS"
         fi
@@ -3274,7 +3269,6 @@ AC_SUBST(MOZ_OPTIMIZE)
 AC_SUBST(MOZ_FRAMEPTR_FLAGS)
 AC_SUBST(MOZ_OPTIMIZE_FLAGS)
 AC_SUBST(MOZ_OPTIMIZE_LDFLAGS)
-AC_SUBST(MOZ_OPTIMIZE_SIZE_TWEAK)
 AC_SUBST(MOZ_PGO_OPTIMIZE_FLAGS)
 
 dnl ========================================================

--- a/js/src/jsutil.h
+++ b/js/src/jsutil.h
@@ -364,7 +364,6 @@ typedef size_t jsbitmap;
     JS_END_MACRO
 #elif MOZ_IS_GCC
 
-#if MOZ_GCC_VERSION_AT_LEAST(4, 6, 0)
 # define JS_SILENCE_UNUSED_VALUE_IN_EXPR(expr)                                \
     JS_BEGIN_MACRO                                                            \
         _Pragma("GCC diagnostic push")                                        \
@@ -372,7 +371,6 @@ typedef size_t jsbitmap;
         expr;                                                                 \
         _Pragma("GCC diagnostic pop")                                         \
     JS_END_MACRO
-#endif
 #endif
 
 #if !defined(JS_SILENCE_UNUSED_VALUE_IN_EXPR)

--- a/mfbt/Assertions.h
+++ b/mfbt/Assertions.h
@@ -50,9 +50,6 @@
  *
  * This macro can be used in any location where both an extern declaration and a
  * typedef could be used.
- *
- * Be aware of the gcc 4.2 concerns noted further down when writing patches that
- * use this macro, particularly if a patch only bounces on OS X.
  */
 #ifdef __cplusplus
 #  if defined(__clang__)
@@ -316,23 +313,8 @@ MOZ_ReportAssertionFailure(const char* s, const char* file, int ln)
  * probably use the higher level MOZ_NOT_REACHED, which uses this when
  * appropriate.
  */
-#if defined(__clang__)
+#if defined(__clang__) || defined(__GNUC__)
 #  define MOZ_NOT_REACHED_MARKER() __builtin_unreachable()
-#elif defined(__GNUC__)
-   /*
-    * __builtin_unreachable() was implemented in gcc 4.5.  If we don't have
-    * that, call a noreturn function; abort() will do nicely.  Qualify the call
-    * in C++ in case there's another abort() visible in local scope.
-    */
-#  if MOZ_GCC_VERSION_AT_LEAST(4, 5, 0)
-#    define MOZ_NOT_REACHED_MARKER() __builtin_unreachable()
-#  else
-#    ifdef __cplusplus
-#      define MOZ_NOT_REACHED_MARKER() ::abort()
-#    else
-#      define MOZ_NOT_REACHED_MARKER() abort()
-#    endif
-#  endif
 #elif defined(_MSC_VER)
 #  define MOZ_NOT_REACHED_MARKER() __assume(0)
 #else

--- a/mfbt/Atomics.h
+++ b/mfbt/Atomics.h
@@ -46,8 +46,7 @@
  */
 #elif defined(__GNUC__) && !defined(__ANDROID__)
 #  include "mozilla/Compiler.h"
-#  if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L) && \
-      MOZ_GCC_VERSION_AT_LEAST(4, 5, 2)
+#  if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L)
 #    define MOZ_HAVE_CXX11_ATOMICS
 #  endif
 #elif defined(_MSC_VER) && _MSC_VER >= 1700
@@ -260,8 +259,7 @@ struct IntrinsicAddSub<T*, Order> : public IntrinsicBase<T*, Order>
     static ptrdiff_t fixupAddend(ptrdiff_t val) {
 #if defined(__clang__) || defined(_MSC_VER)
       return val;
-#elif defined(__GNUC__) && MOZ_GCC_VERSION_AT_LEAST(4, 6, 0) && \
-      !MOZ_GCC_VERSION_AT_LEAST(4, 7, 0)
+#elif defined(__GNUC__) && !MOZ_GCC_VERSION_AT_LEAST(4, 7, 0)
       return val * sizeof(T);
 #else
       return val;

--- a/mfbt/Attributes.h
+++ b/mfbt/Attributes.h
@@ -89,9 +89,7 @@
 #      define MOZ_HAVE_CXX11_OVERRIDE
 #      define MOZ_HAVE_CXX11_FINAL       final
 #    endif
-#    if MOZ_GCC_VERSION_AT_LEAST(4, 6, 0)
 #      define MOZ_HAVE_CXX11_CONSTEXPR
-#    endif
 #    define MOZ_HAVE_CXX11_DELETE
 #  else
      /* __final is a non-C++11 GCC synonym for 'final', per GCC r176655. */

--- a/mfbt/NullPtr.h
+++ b/mfbt/NullPtr.h
@@ -22,9 +22,7 @@
 #  endif
 #elif defined(__GNUC__)
 #  if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
-#    if MOZ_GCC_VERSION_AT_LEAST(4, 6, 0)
 #      define MOZ_HAVE_CXX11_NULLPTR
-#    endif
 #  endif
 #elif _MSC_VER >= 1600
 # define MOZ_HAVE_CXX11_NULLPTR

--- a/mfbt/TypedEnum.h
+++ b/mfbt/TypedEnum.h
@@ -27,10 +27,8 @@
 #  endif
 #elif defined(__GNUC__)
 #  if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
-#    if MOZ_GCC_VERSION_AT_LEAST(4, 5, 1)
 #      define MOZ_HAVE_CXX11_ENUM_TYPE
 #      define MOZ_HAVE_CXX11_STRONG_ENUMS
-#    endif
 #  endif
 #elif defined(_MSC_VER)
 #  if _MSC_VER >= 1400

--- a/modules/libpref/src/Makefile.in
+++ b/modules/libpref/src/Makefile.in
@@ -35,15 +35,6 @@ GARBAGE		+= greprefs.js
 grepref_files = $(topsrcdir)/netwerk/base/public/security-prefs.js $(srcdir)/init/all.js
 
 
-# Optimizer bug with GCC 3.2.2 on OS/2
-ifeq ($(OS_ARCH), OS2)
-nsPrefService.$(OBJ_SUFFIX): nsPrefService.cpp
-	$(REPORT_BUILD)
-	@$(MAKE_DEPS_AUTO_CXX)
-	$(ELOG) $(CCC) $(OUTOPTION)$@ -c $(COMPILE_CXXFLAGS:-O2=-O1) $(_VPATH_SRCS)
-endif
-
-
 greprefs.js: $(grepref_files)
 	$(PYTHON) $(topsrcdir)/config/Preprocessor.py $(PREF_PPFLAGS) $(DEFINES) $(ACDEFINES) $(XULPPFLAGS) $^ > $@
 

--- a/toolkit/mozapps/update/updater/updater.cpp
+++ b/toolkit/mozapps/update/updater/updater.cpp
@@ -128,10 +128,8 @@ static bool sUseHardLinks = true;
 #define BZ2_CRC32TABLE_UNDECLARED
 
 #if MOZ_IS_GCC
-#if MOZ_GCC_VERSION_AT_LEAST(3, 3, 0)
 extern "C"  __attribute__((visibility("default"))) unsigned int BZ2_crc32Table[256];
 #undef BZ2_CRC32TABLE_UNDECLARED
-#endif
 #elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
 extern "C" __global unsigned int BZ2_crc32Table[256];
 #undef BZ2_CRC32TABLE_UNDECLARED

--- a/xpcom/glue/nsCOMPtr.h
+++ b/xpcom/glue/nsCOMPtr.h
@@ -81,10 +81,8 @@
 
 #ifdef __GNUC__
   // Our use of nsCOMPtr_base::mRawPtr violates the C++ standard's aliasing
-  // rules. Mark it with the may_alias attribute so that gcc 3.3 and higher
-  // don't reorder instructions based on aliasing assumptions for
-  // this variable.  Fortunately, gcc versions < 3.3 do not do any
-  // optimizations that break nsCOMPtr.
+  // rules. Mark it with the may_alias attribute so that gcc doesn't reorder
+  // instructions based on aliasing assumptions for this variable.
 
   #define NS_MAY_ALIAS_PTR(t)    t*  __attribute__((__may_alias__))
 #else

--- a/xpcom/reflect/xptcall/src/md/unix/xptcinvoke_arm.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcinvoke_arm.cpp
@@ -14,8 +14,7 @@
 #endif
 
 #if MOZ_IS_GCC
-#if MOZ_GCC_VERSION_AT_LEAST(4, 5, 0) \
-    && defined(__ARM_EABI__) && !defined(__ARM_PCS_VFP) && !defined(__ARM_PCS)
+#if defined(__ARM_EABI__) && !defined(__ARM_PCS_VFP) && !defined(__ARM_PCS)
 #error "Can't identify floating point calling conventions.\nPlease ensure that your toolchain defines __ARM_PCS or __ARM_PCS_VFP."
 #endif
 #endif

--- a/xpcom/reflect/xptcall/src/md/unix/xptcstubs_arm_openbsd.cpp
+++ b/xpcom/reflect/xptcall/src/md/unix/xptcstubs_arm_openbsd.cpp
@@ -9,15 +9,9 @@
 #include "xptiprivate.h"
 
 #ifdef __GNUC__
-/* This tells gcc3.4+ not to optimize away symbols.
- * @see http://gcc.gnu.org/gcc-3.4/changes.html
+/* This tells gcc not to optimize away symbols.
  */
 #define DONT_DROP_OR_WARN __attribute__((used))
-#else
-/* This tells older gccs not to warn about unused vairables.
- * @see http://docs.freebsd.org/info/gcc/gcc.info.Variable_Attributes.html
- */
-#define DONT_DROP_OR_WARN __attribute__((unused))
 #endif
 
 /* Specify explicitly a symbol for this function, don't try to guess the c++ mangled symbol.  */


### PR DESCRIPTION
This PR removes the majority of GCC version checks and workarounds for versions <=4.6. Confirmed to build and work with the following:

GCC 4.7 on CentOS 6 (x64)
GCC 4.9 on CentOS 6 (x64)
GCC 5.2 on Manjaro (x64)
GCC 4.9 on CentOS 6 (x86)