### PR TITLE
Make the code for the Bookmarks and History menu buttons more consistent

### DIFF
--- a/browser/base/content/browser.xul
+++ b/browser/base/content/browser.xul
@@ -528,10 +528,10 @@
                      persist="class"
                      removable="true"
                      type="menu"
-                     onclick="if (event.button == 1)
-                                toggleSidebar('viewBookmarksSidebar');"
                      label="&bookmarksMenuButton.label;"
                      tooltiptext="&bookmarksMenuButton.tooltip;"
+                     onclick="if (event.button == 1)
+                                toggleSidebar('viewBookmarksSidebar');"
                      ondragenter="PlacesMenuDNDHandler.onDragEnter(event);"
                      ondragover="PlacesMenuDNDHandler.onDragOver(event);"
                      ondragleave="PlacesMenuDNDHandler.onDragLeave(event);"
@@ -617,9 +617,9 @@
                      removable="true"                     
                      type="menu"
                      label="&historyButton.label;"
+                     tooltiptext="&historyButton.tooltip;"
                      onclick="if (event.button == 1)
-                                toggleSidebar('viewHistorySidebar');"
-                     tooltiptext="&historyButton.tooltip;">
+                                toggleSidebar('viewHistorySidebar');">
         <menupopup id="HMB_historyPopup"
                    placespopup="true"
                    context="placesContext"


### PR DESCRIPTION
Just a small correction in browser.xul, that puts the attributes and properties of the Bookmarks and History menu buttons in the same order.