### PR TITLE
In the Library, replace the term "Parent Folder" with "Containing Folder"

### DIFF
--- a/browser/locales/en-US/chrome/browser/places/places.dtd
+++ b/browser/locales/en-US/chrome/browser/places/places.dtd
@@ -57,8 +57,8 @@
 <!ENTITY cmd.open_all_in_tabs.label      "Open All in Tabs">
 <!ENTITY cmd.open_all_in_tabs.accesskey  "O">
 
-<!ENTITY cmd.openParentFolder.label      "Open Parent Folder">
-<!ENTITY cmd.openParentFolder.accesskey  "P">
+<!ENTITY cmd.openParentFolder.label      "Open Containing Folder">
+<!ENTITY cmd.openParentFolder.accesskey  "F">
 
 <!ENTITY cmd.properties.label      "Properties">
 <!ENTITY cmd.properties.accesskey  "i">
@@ -90,8 +90,8 @@
 <!ENTITY col.description.label       "Description">
 <!ENTITY col.dateadded.label         "Added">
 <!ENTITY col.lastmodified.label      "Last Modified">
-<!ENTITY col.parentfolder.label      "Parent Folder">
-<!ENTITY col.parentfolderpath.label  "Parent Folder Path">
+<!ENTITY col.parentfolder.label      "Containing Folder">
+<!ENTITY col.parentfolderpath.label  "Containing Folder Path">
 
 <!ENTITY search.label                              "Search:">
 <!ENTITY search.accesskey                          "S">


### PR DESCRIPTION
I noticed that the context menu for downloads includes an "Open Containing Folder" item, and from a consistency point of view, I think it's best to use the term "Containing Folder" for the "Parent Folder" features of the Library as well.

This is a follow-up to PRs #211 and #216.