### PR TITLE
Allow use of a dedicated flag to not precompile the startup cache

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -7382,12 +7382,12 @@ if test -n "$_ENABLE_CODESIGHS"; then
 fi
 
 dnl ========================================================
-dnl = Allow disabling the startup cache
+dnl = Don't precompile the startup cache
 dnl ========================================================
 MOZ_DISABLE_STARTUPCACHE=
 
 MOZ_ARG_DISABLE_BOOL(startupcache,
-[  --disable-startupcache          Disable the startup cache ],
+[  --disable-startupcache          Don't precompile the startup cache ],
     MOZ_DISABLE_STARTUPCACHE=1,
 	MOZ_DISABLE_STARTUPCACHE=)
 

--- a/configure.in
+++ b/configure.in
@@ -7387,15 +7387,15 @@ dnl ========================================================
 MOZ_DISABLE_STARTUPCACHE=
 
 MOZ_ARG_DISABLE_BOOL(startupcache,
-[  --disable-startupcache          Don't precompile the startup cache ],
-    MOZ_DISABLE_STARTUPCACHE=1,
-	MOZ_DISABLE_STARTUPCACHE=)
+[  --disable-precompiled-startupcache      Don't precompile the startup cache ],
+    MOZ_DISABLE_PRECOMPILED_STARTUPCACHE=1,
+	MOZ_DISABLE_PRECOMPILED_STARTUPCACHE=)
 
-if test -n "$MOZ_DISABLE_STARTUPCACHE"; then
-  AC_DEFINE(MOZ_DISABLE_STARTUPCACHE)
+if test -n "$MOZ_DISABLE_PRECOMPILED_STARTUPCACHE"; then
+  AC_DEFINE(MOZ_DISABLE_PRECOMPILED_STARTUPCACHE)
 fi
 
-AC_SUBST(MOZ_DISABLE_STARTUPCACHE)
+AC_SUBST(MOZ_DISABLE_PRECOMPILED_STARTUPCACHE)
 
 dnl ========================================================
 dnl = Enable Radio Interface for B2G (Gonk usually)

--- a/configure.in
+++ b/configure.in
@@ -7386,10 +7386,10 @@ dnl = Don't precompile the startup cache
 dnl ========================================================
 MOZ_DISABLE_PRECOMPILED_STARTUPCACHE=
 
-MOZ_ARG_DISABLE_BOOL(startupcache,
+MOZ_ARG_DISABLE_BOOL(precompiled-startupcache,
 [  --disable-precompiled-startupcache      Don't precompile the startup cache ],
     MOZ_DISABLE_PRECOMPILED_STARTUPCACHE=1,
-	MOZ_DISABLE_PRECOMPILED_STARTUPCACHE=)
+	MOZ_DISABLE_PRECOMPILED_STARTUPCACHE= )
 
 if test -n "$MOZ_DISABLE_PRECOMPILED_STARTUPCACHE"; then
   AC_DEFINE(MOZ_DISABLE_PRECOMPILED_STARTUPCACHE)

--- a/configure.in
+++ b/configure.in
@@ -7382,6 +7382,22 @@ if test -n "$_ENABLE_CODESIGHS"; then
 fi
 
 dnl ========================================================
+dnl = Allow disabling the startup cache
+dnl ========================================================
+MOZ_DISABLE_STARTUPCACHE=
+
+MOZ_ARG_DISABLE_BOOL(startupcache,
+[  --disable-startupcache          Disable the startup cache ],
+    MOZ_DISABLE_STARTUPCACHE=1,
+	MOZ_DISABLE_STARTUPCACHE=)
+
+if test -n "$MOZ_DISABLE_STARTUPCACHE"; then
+  AC_DEFINE(MOZ_DISABLE_STARTUPCACHE)
+fi
+
+AC_SUBST(MOZ_DISABLE_STARTUPCACHE)
+
+dnl ========================================================
 dnl = Enable Radio Interface for B2G (Gonk usually)
 dnl ========================================================
 MOZ_ARG_ENABLE_BOOL(b2g-ril,

--- a/configure.in
+++ b/configure.in
@@ -7384,7 +7384,7 @@ fi
 dnl ========================================================
 dnl = Don't precompile the startup cache
 dnl ========================================================
-MOZ_DISABLE_STARTUPCACHE=
+MOZ_DISABLE_PRECOMPILED_STARTUPCACHE=
 
 MOZ_ARG_DISABLE_BOOL(startupcache,
 [  --disable-precompiled-startupcache      Don't precompile the startup cache ],

--- a/startupcache/StartupCache.cpp
+++ b/startupcache/StartupCache.cpp
@@ -91,9 +91,6 @@ StartupCache::GetSingleton()
     if (XRE_GetProcessType() != GoannaProcessType_Default) {
       return nullptr;
     }
-#ifdef MOZ_DISABLE_STARTUPCACHE
-    return nullptr;
-#endif
 
     StartupCache::InitSingleton();
   }

--- a/startupcache/StartupCache.cpp
+++ b/startupcache/StartupCache.cpp
@@ -91,6 +91,9 @@ StartupCache::GetSingleton()
     if (XRE_GetProcessType() != GoannaProcessType_Default) {
       return nullptr;
     }
+#ifdef MOZ_DISABLE_STARTUPCACHE
+    return nullptr;
+#endif
 
     StartupCache::InitSingleton();
   }

--- a/toolkit/mozapps/installer/packager.py
+++ b/toolkit/mozapps/installer/packager.py
@@ -351,7 +351,7 @@ def main():
 
     # Fill startup cache
     if isinstance(formatter, OmniJarFormatter) and launcher.can_launch() \
-	  and buildconfig.substs['MOZ_DISABLE_STARTUPCACHE'] != '1':
+	  and buildconfig.substs['MOZ_DISABLE_PRECOMPILED_STARTUPCACHE'] != '1':
         if buildconfig.substs['LIBXUL_SDK']:
             gre_path = mozpack.path.join(buildconfig.substs['LIBXUL_DIST'],
                                          'bin')

--- a/toolkit/mozapps/installer/packager.py
+++ b/toolkit/mozapps/installer/packager.py
@@ -32,7 +32,6 @@ import os
 from StringIO import StringIO
 import subprocess
 import platform
-import sys
 
 # List of libraries to shlibsign.
 SIGN_LIBS = [
@@ -350,24 +349,23 @@ def main():
             if key in log:
                 f.preload(log[key])
 
-    # Fill startup cache on Windows and Linux only
-    # (this currently causes build failure on BSD, so skip on that platfom)
-    if sys.platform == 'win32' or sys.platform.startswith ('linux'):
-      if isinstance(formatter, OmniJarFormatter) and launcher.can_launch():
-          if buildconfig.substs['LIBXUL_SDK']:
-              gre_path = mozpack.path.join(buildconfig.substs['LIBXUL_DIST'],
-                                           'bin')
-          else:
-              gre_path = None
-          for base in sorted([[p for p in [mozpack.path.join('bin', b), b]
-                              if os.path.exists(os.path.join(args.source, p))][0]
-                             for b in sink.packager.get_bases()]):
-              if not gre_path:
-                  gre_path = base
-              base_path = sink.normalize_path(base)
-              if base_path in formatter.omnijars:
-                  precompile_cache(formatter.omnijars[base_path],
-                                   args.source, gre_path, base)
+    # Fill startup cache
+    if isinstance(formatter, OmniJarFormatter) and launcher.can_launch() \
+	  and buildconfig.substs['MOZ_DISABLE_STARTUPCACHE'] != '1':
+        if buildconfig.substs['LIBXUL_SDK']:
+            gre_path = mozpack.path.join(buildconfig.substs['LIBXUL_DIST'],
+                                         'bin')
+        else:
+            gre_path = None
+        for base in sorted([[p for p in [mozpack.path.join('bin', b), b]
+                            if os.path.exists(os.path.join(args.source, p))][0]
+                           for b in sink.packager.get_bases()]):
+            if not gre_path:
+                gre_path = base
+            base_path = sink.normalize_path(base)
+            if base_path in formatter.omnijars:
+                precompile_cache(formatter.omnijars[base_path],
+                                 args.source, gre_path, base)
 
     copier.copy(args.destination)
     generate_precomplete(os.path.normpath(os.path.join(args.destination,


### PR DESCRIPTION
Commit afcb587 disabled the startup cache on BSD. This PR reverts that change, and allows the startup cache to be disabled with an option in .mozconfig instead.

Since the issue with failing to fill the startup cache has been reported for Linux as well, this PR provides a cross-platform  option to disable the startup cache on an as needed basis. This will allow BSD users and Linux users who have encountered this problem to still complete the packaging process without having to modify the source until we can find the root cause for the problem.