### PR TITLE
Use Mask with alpha to avoid allocating a surface.

### DIFF
--- a/gfx/layers/basic/BasicLayersImpl.cpp
+++ b/gfx/layers/basic/BasicLayersImpl.cpp
@@ -84,13 +84,8 @@ PaintWithMask(gfxContext* aContext, float aOpacity, Layer* aMaskLayer)
 {
   AutoMaskData mask;
   if (GetMaskData(aMaskLayer, &mask)) {
-    if (aOpacity < 1.0) {
-      aContext->PushGroup(gfxASurface::CONTENT_COLOR_ALPHA);
-      aContext->Paint(aOpacity);
-      aContext->PopGroupToSource();
-    }
     aContext->SetMatrix(mask.GetTransform());
-    aContext->Mask(mask.GetSurface());
+    aContext->Mask(mask.GetSurface(), aOpacity);
     return;
   }
 

--- a/gfx/thebes/gfxContext.cpp
+++ b/gfx/thebes/gfxContext.cpp
@@ -1481,7 +1481,6 @@ gfxContext::Mask(gfxASurface *surface, float alpha, const gfxPoint& offset)
     // We clip here to bind to the mask surface bounds, see above.
     mDT->MaskSurface(GeneralPattern(this), 
               sourceSurf,
-              1.0f,
               Point(offset.x - pt.x, offset.y -  pt.y),
               DrawOptions(alpha, CurrentState().op, CurrentState().aaMode));
               

--- a/gfx/thebes/gfxContext.cpp
+++ b/gfx/thebes/gfxContext.cpp
@@ -1457,7 +1457,7 @@ gfxContext::Mask(gfxPattern *pattern)
 }
 
 void
-gfxContext::Mask(gfxASurface *surface, const gfxPoint& offset)
+gfxContext::Mask(gfxASurface *surface, float alpha, const gfxPoint& offset)
 {
   PROFILER_LABEL("gfxContext", "Mask");
   if (mCairo) {
@@ -1481,8 +1481,9 @@ gfxContext::Mask(gfxASurface *surface, const gfxPoint& offset)
     // We clip here to bind to the mask surface bounds, see above.
     mDT->MaskSurface(GeneralPattern(this), 
               sourceSurf,
+              1.0f,
               Point(offset.x - pt.x, offset.y -  pt.y),
-              DrawOptions(1.0f, CurrentState().op, CurrentState().aaMode));
+              DrawOptions(alpha, CurrentState().op, CurrentState().aaMode));
               
     // We set the device offset to zero temporarily. Let's restore it now.
     surface->SetDeviceOffset(pt);

--- a/gfx/thebes/gfxContext.h
+++ b/gfx/thebes/gfxContext.h
@@ -427,7 +427,7 @@ public:
      * Shorthand for creating a pattern and calling the pattern-taking
      * variant of Mask.
      */
-    void Mask(gfxASurface *surface, const gfxPoint& offset = gfxPoint(0.0, 0.0));
+    void Mask(gfxASurface *surface, float alpha = 1.0f, const gfxPoint& offset = gfxPoint(0.0, 0.0));
 
     /**
      ** Shortcuts


### PR DESCRIPTION
[!] [Bug 1152509](https://bugzilla.mozilla.org/show_bug.cgi?id=1152509).
[!] This should give a performance improvement on platforms not using Cairo (especially D2D).

I hope I did not screw up anything in working this in, changes are untested. 