### PR TITLE
Add a site indicator to in-progress downloads

### DIFF
--- a/browser/components/downloads/content/allDownloadsViewOverlay.css
+++ b/browser/components/downloads/content/allDownloadsViewOverlay.css
@@ -21,6 +21,15 @@ richlistitem.download[active] {
   -moz-binding: url('chrome://browser/content/downloads/download.xml#download-full-ui');
 }
 
+richlistitem.download[active]:-moz-any([state="-1"],/* Starting (initial) */
+                                       [state="0"], /* Downloading        */
+                                       [state="4"], /* Paused             */
+                                       [state="5"], /* Starting (queued)  */
+                                       [state="7"]) /* Scanning           */
+{
+  -moz-binding: url('chrome://browser/content/downloads/download.xml#download-in-progress-full-ui');
+}
+
 .download-state:not(          [state="0"]  /* Downloading        */)
                                            .downloadPauseMenuItem,
 .download-state:not(          [state="4"]  /* Paused             */)
@@ -41,7 +50,7 @@ richlistitem.download[active] {
                               [state="4"], /* Paused             */
                               [state="5"]) /* Starting (queued)  */)
                                            .downloadShowMenuItem,
-.download-state[state="7"]                 .downloadCommandsSeparator
+.download-state[state="7"] /* Scanning */  .downloadCommandsSeparator
 {
   display: none;
 }

--- a/browser/components/downloads/content/allDownloadsViewOverlay.js
+++ b/browser/components/downloads/content/allDownloadsViewOverlay.js
@@ -301,12 +301,12 @@ DownloadElementShell.prototype = {
    *   was downloaded.  The file may not exist.  This is set for session
    *   downloads that have a local file set, and for history downloads done
    *   after the landing of bug 591289.
-   * - fileName: the downloaded file name on the file system. Set if filePath
+   * - fileName: the downloaded file name on the file system.  Set if filePath
    *   is set.
    * - displayName: the user-facing label for the download.  This is always
    *   set.  If available, it's set to the downloaded file name.  If not,
-   *   the places title for the download uri is used it's set.  As a last
-   *   resort, we fallback to the download uri.
+   *   the places title for the download uri is used.  As a last resort,
+   *   we fallback to the download uri.
    * - fileSize (only set for downloads which completed succesfully):
    *   the downloaded file size.  For downloads done after the landing of
    *   bug 826991, this value is "static" - that is, it does not necessarily
@@ -315,11 +315,18 @@ DownloadElementShell.prototype = {
   getDownloadMetaData: function DES_getDownloadMetaData() {
     if (!this._metaData) {
       if (this._dataItem) {
+        let s = DownloadsCommon.strings;
+        let referrer = this._dataItem.referrer || this._dataItem.uri;
+        let [displayHost, fullHost] = DownloadUtils.getURIHost(referrer);
         this._metaData = {
-          state:       this._dataItem.state,
-          endTime:     this._dataItem.endTime,
-          fileName:    this._dataItem.target,
-          displayName: this._dataItem.target
+          state:              this._dataItem.state,
+          endTime:            this._dataItem.endTime,
+          fileName:           this._dataItem.target,
+          displayName:        this._dataItem.target,
+          extendedDisplayName:
+            s.statusSeparator(this._dataItem.target, displayHost),
+          extendedDisplayNameTip:
+            s.statusSeparator(this._dataItem.target, fullHost)
         };
         if (this._dataItem.done)
           this._metaData.fileSize = this._dataItem.maxBytes;
@@ -365,9 +372,9 @@ DownloadElementShell.prototype = {
           DownloadUtils.getTransferTotal(this._dataItem.currBytes,
                                          this._dataItem.maxBytes);
 
-         // We use the same XUL label to display both the state and the amount
-         // transferred, for example "Paused -  1.1 MB".
-         return s.statusSeparatorBeforeNumber(s.statePaused, transfer);
+        // We use the same XUL label to display both the state and the amount
+        // transferred, for example "Paused -  1.1 MB".
+        return s.statusSeparatorBeforeNumber(s.statePaused, transfer);
       }
       if (this._dataItem.state == nsIDM.DOWNLOAD_DOWNLOADING) {
         let [status, newEstimatedSecondsLeft] =
@@ -493,6 +500,8 @@ DownloadElementShell.prototype = {
   _updateDisplayNameAndIcon: function DES__updateDisplayNameAndIcon() {
     let metaData = this.getDownloadMetaData();
     this._element.setAttribute("displayName", metaData.displayName);
+    this._element.setAttribute("extendedDisplayName", metaData.extendedDisplayName);
+    this._element.setAttribute("extendedDisplayNameTip", metaData.extendedDisplayNameTip);
     this._element.setAttribute("image", this._getIcon());
   },
 

--- a/browser/components/downloads/content/download.xml
+++ b/browser/components/downloads/content/download.xml
@@ -33,10 +33,10 @@
              summary isn't being displayed, so we ensure that items share the
              same minimum width.
              -->
-        <xul:description class="downloadTarget"
+        <xul:description class="downloadDisplayName"
                          crop="center"
                          style="min-width: &downloadsSummary.minWidth2;"
-                         xbl:inherits="value=target,tooltiptext=target"/>
+                         xbl:inherits="value=displayName,tooltiptext=displayName"/>
         <xul:progressmeter anonid="progressmeter"
                            class="downloadProgress"
                            min="0"
@@ -64,6 +64,53 @@
     </content>
   </binding>
 
+  <binding id="download-in-progress"
+           extends="chrome://global/content/bindings/richlistbox.xml#richlistitem">
+    <content orient="horizontal"
+             align="center"
+             onclick="DownloadsView.onDownloadClick(event);">
+      <xul:image class="downloadTypeIcon"
+                 validate="always"
+                 xbl:inherits="src=image"/>
+      <xul:image class="downloadTypeIcon blockedIcon"/>
+      <xul:vbox pack="center"
+                flex="1"
+                class="downloadContainer"
+                style="width: &downloadDetails.width;">
+        <!-- We're letting localizers put a min-width in here primarily
+             because of the downloads summary at the bottom of the list of
+             download items. An element in the summary has the same min-width
+             on a description, and we don't want the panel to change size if the
+             summary isn't being displayed, so we ensure that items share the
+             same minimum width.
+             -->
+        <xul:description class="downloadDisplayName"
+                         crop="center"
+                         style="min-width: &downloadsSummary.minWidth2;"
+                         xbl:inherits="value=displayName,tooltiptext=extendedDisplayNameTip"/>
+        <xul:progressmeter anonid="progressmeter"
+                           class="downloadProgress"
+                           min="0"
+                           max="100"
+                           xbl:inherits="mode=progressmode,value=progress"/>
+        <xul:description class="downloadDetails"
+                         crop="end"
+                         xbl:inherits="value=status,tooltiptext=statusTip"/>
+      </xul:vbox>
+      <xul:stack>
+        <xul:button class="downloadButton downloadCancel"
+                    tooltiptext="&cmd.cancel.label;"
+                    oncommand="DownloadsView.onDownloadCommand(event, 'downloadsCmd_cancel');"/>
+        <xul:button class="downloadButton downloadRetry"
+                    tooltiptext="&cmd.retry.label;"
+                    oncommand="DownloadsView.onDownloadCommand(event, 'downloadsCmd_retry');"/>
+        <xul:button class="downloadButton downloadShow"
+                    tooltiptext="&cmd.show.label;"
+                    oncommand="DownloadsView.onDownloadCommand(event, 'downloadsCmd_show');"/>
+      </xul:stack>
+    </content>
+  </binding>
+
   <binding id="download-full-ui"
            extends="chrome://global/content/bindings/richlistbox.xml#richlistitem">
     <resources>
@@ -76,7 +123,7 @@
                  xbl:inherits="src=image"/>
       <xul:image class="downloadTypeIcon blockedIcon"/>
       <xul:vbox pack="center" flex="1">
-        <xul:description class="downloadTarget"
+        <xul:description class="downloadDisplayName"
                          crop="center"
                          xbl:inherits="value=displayName,tooltiptext=displayName"/>
         <xul:progressmeter anonid="progressmeter"
@@ -102,6 +149,45 @@
 #else
                   tooltiptext="&cmd.show.label;"
 #endif
+                  oncommand="goDoCommand('downloadsCmd_show')"/>
+
+    </content>
+  </binding>
+
+  <binding id="download-in-progress-full-ui"
+           extends="chrome://global/content/bindings/richlistbox.xml#richlistitem">
+    <resources>
+      <stylesheet src="chrome://browser/content/downloads/download.css"/>
+    </resources>
+
+    <content orient="horizontal" align="center">
+      <xul:image class="downloadTypeIcon"
+                 validate="always"
+                 xbl:inherits="src=image"/>
+      <xul:image class="downloadTypeIcon blockedIcon"/>
+      <xul:vbox pack="center" flex="1">
+        <xul:description class="downloadDisplayName"
+                         crop="center"
+                         xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"/>
+        <xul:progressmeter anonid="progressmeter"
+                           class="downloadProgress"
+                           min="0"
+                           max="100"
+                           xbl:inherits="mode=progressmode,value=progress"/>
+        <xul:description class="downloadDetails"
+                         style="width: &downloadDetails.width;"
+                         crop="end"
+                         xbl:inherits="value=status,tooltiptext=statusTip"/>
+      </xul:vbox>
+
+      <xul:button class="downloadButton downloadCancel"
+                  tooltiptext="&cmd.cancel.label;"
+                  oncommand="goDoCommand('downloadsCmd_cancel')"/>
+      <xul:button class="downloadButton downloadRetry"
+                  tooltiptext="&cmd.retry.label;"
+                  oncommand="goDoCommand('downloadsCmd_retry')"/>
+      <xul:button class="downloadButton downloadShow"
+                  tooltiptext="&cmd.show.label;"
                   oncommand="goDoCommand('downloadsCmd_show')"/>
 
     </content>

--- a/browser/components/downloads/content/downloads.css
+++ b/browser/components/downloads/content/downloads.css
@@ -8,6 +8,15 @@ richlistitem[type="download"] {
   -moz-binding: url('chrome://browser/content/downloads/download.xml#download');
 }
 
+richlistitem[type="download"]:-moz-any([state="-1"],/* Starting (initial) */
+                                       [state="0"], /* Downloading        */
+                                       [state="4"], /* Paused             */
+                                       [state="5"], /* Starting (queued)  */
+                                       [state="7"]) /* Scanning           */
+{
+  -moz-binding: url('chrome://browser/content/downloads/download.xml#download-in-progress');
+}
+
 richlistitem[type="download"]:not([selected]) button {
   /* Only focus buttons in the selected item. */
   -moz-user-focus: none;
@@ -26,9 +35,9 @@ richlistitem[type="download"]:not([selected]) button {
                                            .downloadTypeIcon.blockedIcon,
 
 .download-state:not(:-moz-any([state="-1"],/* Starting (initial) */
-                              [state="5"], /* Starting (queued)  */
                               [state="0"], /* Downloading        */
                               [state="4"], /* Paused             */
+                              [state="5"], /* Starting (queued)  */
                               [state="7"]) /* Scanning           */)
                                            .downloadProgress,
 
@@ -57,7 +66,7 @@ richlistitem[type="download"]:not([selected]) button {
                               [state="5"]) /* Starting (queued)  */)
                                            .downloadShowMenuItem,
 
-.download-state[state="7"]                 .downloadCommandsSeparator
+.download-state[state="7"] /* Scanning */  .downloadCommandsSeparator
 
 {
   display: none;
@@ -66,9 +75,9 @@ richlistitem[type="download"]:not([selected]) button {
 /*** Visibility of download buttons and indicator controls. ***/
 
 .download-state:not(:-moz-any([state="-1"],/* Starting (initial) */
-                              [state="5"], /* Starting (queued)  */
                               [state="0"], /* Downloading        */
-                              [state="4"]) /* Paused             */)
+                              [state="4"], /* Paused             */
+                              [state="5"]) /* Starting (queued)  */)
                                            .downloadCancel,
 
 .download-state:not(:-moz-any([state="2"], /* Failed             */

--- a/browser/components/downloads/content/downloads.js
+++ b/browser/components/downloads/content/downloads.js
@@ -1066,6 +1066,10 @@ function DownloadsViewItem(aDataItem, aElement)
   // (double slash) from the icon URI specification (see test_moz_icon_uri.js).
   this.image = "moz-icon://" + this.dataItem.file + "?size=32";
 
+  let s = DownloadsCommon.strings;
+  let [displayHost, fullHost] =
+    DownloadUtils.getURIHost(this.dataItem.referrer || this.dataItem.uri);
+
   let attributes = {
     "type": "download",
     "class": "download-state",
@@ -1073,7 +1077,9 @@ function DownloadsViewItem(aDataItem, aElement)
     "downloadGuid": this.dataItem.downloadGuid,
     "state": this.dataItem.state,
     "progress": this.dataItem.inProgress ? this.dataItem.percentComplete : 100,
-    "target": this.dataItem.target,
+    "displayName": this.dataItem.target,
+    "extendedDisplayName": s.statusSeparator(this.dataItem.target, displayHost),
+    "extendedDisplayNameTip": s.statusSeparator(this.dataItem.target, fullHost),
     "image": this.image
   };
 

--- a/browser/themes/linux/downloads/downloads.css
+++ b/browser/themes/linux/downloads/downloads.css
@@ -97,33 +97,32 @@ richlistitem[type="download"]:last-child {
   list-style-image: url("chrome://global/skin/icons/Error.png");
 }
 
-/* We hold .downloadTarget, .downloadProgress and .downloadDetails inside of
-   a vbox with class .downloadContainer. We set the font-size of the entire
-   container to 90% because:
+/* We hold .downloadDisplayName, .downloadProgress and .downloadDetails
+   inside of a vbox with class .downloadContainer. We set the font-size of
+   the entire container to 90% because:
 
    1) This is the size that we want .downloadDetails to be
    2) The container's width is set by localizers by &downloadDetails.width;,
       which is a ch unit. Since this is the value that should control the
       panel width, we apply it to the outer container to constrain
-      .downloadTarget and .downloadProgress.
+      .downloadDisplayName and .downloadProgress.
 
-   Finally, since we want .downloadTarget's font-size to be at 100% of the
-   font-size of .downloadContainer's parent, we use calc to go from the
+   Finally, since we want .downloadDisplayName's font-size to be at 100% of
+   the font-size of .downloadContainer's parent, we use calc to go from the
    smaller font-size back to the original font-size.
  */
-
 #downloadsSummaryDetails,
 .downloadContainer {
   font-size: 90%;
 }
 
 #downloadsSummaryDescription,
-.downloadTarget {
+.downloadDisplayName {
   margin-bottom: 7px;
   cursor: inherit;
 }
 
-.downloadTarget {
+.downloadDisplayName {
   font-size: calc(100%/0.9);
 }
 

--- a/browser/themes/osx/downloads/downloads.css
+++ b/browser/themes/osx/downloads/downloads.css
@@ -105,18 +105,18 @@ richlistitem[type="download"]:first-child {
   list-style-image: url("chrome://global/skin/icons/Error.png");
 }
 
-/* We hold .downloadTarget, .downloadProgress and .downloadDetails inside of
-   a vbox with class .downloadContainer. We set the font-size of the entire
-   container to 90% because:
+/* We hold .downloadDisplayName, .downloadProgress and .downloadDetails
+   inside of a vbox with class .downloadContainer. We set the font-size of
+   the entire container to 90% because:
 
    1) This is the size that we want .downloadDetails to be
    2) The container's width is set by localizers by &downloadDetails.width;,
       which is a ch unit. Since this is the value that should control the
       panel width, we apply it to the outer container to constrain
-      .downloadTarget and .downloadProgress.
+      .downloadDisplayName and .downloadProgress.
 
-   Finally, since we want .downloadTarget's font-size to be at 100% of the
-   font-size of .downloadContainer's parent, we use calc to go from the
+   Finally, since we want .downloadDisplayName's font-size to be at 100% of
+   the font-size of .downloadContainer's parent, we use calc to go from the
    smaller font-size back to the original font-size.
  */
 #downloadsSummaryDetails,
@@ -125,12 +125,12 @@ richlistitem[type="download"]:first-child {
 }
 
 #downloadsSummaryDescription,
-.downloadTarget {
+.downloadDisplayName {
   margin-bottom: 6px;
   cursor: inherit;
 }
 
-.downloadTarget {
+.downloadDisplayName {
   font-size: calc(100%/0.9);
 }
 

--- a/browser/themes/windows/downloads/downloads.css
+++ b/browser/themes/windows/downloads/downloads.css
@@ -109,18 +109,18 @@ richlistitem[type="download"]:first-child {
   list-style-image: url("chrome://global/skin/icons/Error.png");
 }
 
-/* We hold .downloadTarget, .downloadProgress and .downloadDetails inside of
-   a vbox with class .downloadContainer. We set the font-size of the entire
-   container to 90% because:
+/* We hold .downloadDisplayName, .downloadProgress and .downloadDetails
+   inside of a vbox with class .downloadContainer. We set the font-size of
+   the entire container to 90% because:
 
    1) This is the size that we want .downloadDetails to be
    2) The container's width is set by localizers by &downloadDetails.width;,
       which is a ch unit. Since this is the value that should control the
       panel width, we apply it to the outer container to constrain
-      .downloadTarget and .downloadProgress.
+      .downloadDisplayName and .downloadProgress.
 
-   Finally, since we want .downloadTarget's font-size to be at 100% of the
-   font-size of .downloadContainer's parent, we use calc to go from the
+   Finally, since we want .downloadDisplayName's font-size to be at 100% of
+   the font-size of .downloadContainer's parent, we use calc to go from the
    smaller font-size back to the original font-size.
  */
 #downloadsSummaryDetails,
@@ -129,12 +129,12 @@ richlistitem[type="download"]:first-child {
 }
 
 #downloadsSummaryDescription,
-.downloadTarget {
+.downloadDisplayName {
   margin-bottom: 6px;
   cursor: inherit;
 }
 
-.downloadTarget {
+.downloadDisplayName {
   font-size: calc(100%/0.9);
 }
 

--- a/toolkit/mozapps/downloads/content/download.xml
+++ b/toolkit/mozapps/downloads/content/download.xml
@@ -74,7 +74,7 @@
       </property>
     </implementation>
   </binding>
-  
+
   <binding id="download-starting" extends="chrome://mozapps/content/downloads/download.xml#download-base">
     <content>
       <xul:hbox flex="1">
@@ -83,7 +83,7 @@
                      xbl:inherits="src=image"/>
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
-          <xul:label xbl:inherits="value=target,tooltiptext=target"
+          <xul:label xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"
                      crop="center" class="name"/>
           <xul:progressmeter mode="normal" value="0" flex="1"
                              anonid="progressmeter"/>
@@ -98,7 +98,7 @@
       </xul:hbox>
     </content>  
   </binding>
-  
+
   <binding id="download-downloading" extends="chrome://mozapps/content/downloads/download.xml#download-base">
     <content>
       <xul:hbox flex="1" class="downloadContentBox">
@@ -107,8 +107,8 @@
                      xbl:inherits="src=image"/>
         </xul:vbox>
         <xul:vbox flex="1">
-          <xul:label xbl:inherits="value=target,tooltiptext=target"
-                       crop="center" flex="2" class="name"/>
+          <xul:label xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"
+                     crop="center" flex="2" class="name"/>
           <xul:hbox>
             <xul:vbox flex="1">
               <xul:progressmeter mode="normal" value="0" flex="1"
@@ -129,7 +129,7 @@
       </xul:hbox>
     </content>
   </binding>
-  
+
   <binding id="download-paused" extends="chrome://mozapps/content/downloads/download.xml#download-base">
     <content>
       <xul:hbox flex="1">
@@ -138,7 +138,7 @@
                      xbl:inherits="src=image"/>
         </xul:vbox>
         <xul:vbox flex="1">
-          <xul:label xbl:inherits="value=target,tooltiptext=target"
+          <xul:label xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"
                      crop="center" flex="2" class="name"/>
           <xul:hbox>
             <xul:vbox flex="1">
@@ -160,7 +160,7 @@
       </xul:hbox>
     </content>
   </binding>
-  
+
   <binding id="download-done" extends="chrome://mozapps/content/downloads/download.xml#download-base">
     <content>
       <xul:hbox flex="1">
@@ -170,7 +170,7 @@
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
           <xul:hbox align="center" flex="1">
-            <xul:label xbl:inherits="value=target,tooltiptext=target"
+            <xul:label xbl:inherits="value=displayName,tooltiptext=displayName"
                        crop="center" flex="1" class="name"/>
             <xul:label xbl:inherits="value=dateTime,tooltiptext=dateTimeTip"
                        class="dateTime"/>
@@ -183,7 +183,7 @@
       </xul:hbox>
     </content>  
   </binding>
-  
+
   <binding id="download-canceled" extends="chrome://mozapps/content/downloads/download.xml#download-base">
     <content>
       <xul:hbox flex="1">
@@ -193,7 +193,7 @@
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
           <xul:hbox align="center" flex="1">
-            <xul:label xbl:inherits="value=target,tooltiptext=target"
+            <xul:label xbl:inherits="value=displayName,tooltiptext=displayName"
                        crop="center" flex="1" class="name"/>
             <xul:label xbl:inherits="value=dateTime,tooltiptext=dateTimeTip"
                        class="dateTime"/>
@@ -209,7 +209,7 @@
       </xul:hbox>
     </content>  
   </binding>
-  
+
   <binding id="download-failed" extends="chrome://mozapps/content/downloads/download.xml#download-base">
     <content>
       <xul:hbox flex="1">
@@ -219,7 +219,7 @@
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
           <xul:hbox align="center" flex="1">
-            <xul:label xbl:inherits="value=target,tooltiptext=target"
+            <xul:label xbl:inherits="value=displayName,tooltiptext=displayName"
                        crop="center" flex="1" class="name"/>
             <xul:label xbl:inherits="value=dateTime,tooltiptext=dateTimeTip"
                        class="dateTime"/>
@@ -244,7 +244,7 @@
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
           <xul:hbox align="center" flex="1">
-            <xul:label xbl:inherits="value=target,tooltiptext=target"
+            <xul:label xbl:inherits="value=displayName,tooltiptext=displayName"
                        crop="center" flex="1" class="name"/>
             <xul:label xbl:inherits="value=dateTime,tooltiptext=dateTimeTip"
                        class="dateTime"/>
@@ -266,7 +266,7 @@
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
           <xul:hbox align="center" flex="1">
-            <xul:label xbl:inherits="value=target,tooltiptext=target"
+            <xul:label xbl:inherits="value=displayName,tooltiptext=displayName"
                        crop="center" flex="1" class="name"/>
             <xul:label xbl:inherits="value=dateTime,tooltiptext=dateTimeTip"
                        class="dateTime"/>
@@ -288,8 +288,8 @@
                      xbl:inherits="src=image"/>
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
-          <xul:label xbl:inherits="value=target,tooltiptext=target"
-                       crop="center" flex="2" class="name"/>
+          <xul:label xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"
+                     crop="center" flex="2" class="name"/>
           <xul:hbox>
             <xul:vbox flex="1">
               <xul:progressmeter mode="undetermined" flex="1" />
@@ -310,7 +310,7 @@
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
           <xul:hbox align="center" flex="1">
-            <xul:label xbl:inherits="value=target,tooltiptext=target"
+            <xul:label xbl:inherits="value=displayName,tooltiptext=displayName"
                        crop="center" flex="1" class="name"/>
             <xul:label xbl:inherits="value=dateTime,tooltiptext=dateTimeTip"
                        class="dateTime"/>

--- a/toolkit/mozapps/downloads/content/downloads.css
+++ b/toolkit/mozapps/downloads/content/downloads.css
@@ -47,4 +47,3 @@ richlistitem[type="download"][state="9"] {
 richlistitem[type="download"]:not([selected="true"]) button {
   -moz-user-focus: none;
 }
-

--- a/toolkit/mozapps/downloads/content/downloads.js
+++ b/toolkit/mozapps/downloads/content/downloads.js
@@ -18,6 +18,7 @@ var Ci = Components.interfaces;
 let Cu = Components.utils;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/DownloadUtils.jsm");
+Cu.import("resource:///modules/DownloadsCommon.jsm");
 Cu.import("resource://gre/modules/PluralForm.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 
@@ -50,7 +51,7 @@ const gListBuildChunk = 3;
 
 // Array of download richlistitem attributes to check when searching
 const gSearchAttributes = [
-  "target",
+  "displayName",
   "status",
   "dateTime",
 ];
@@ -268,7 +269,7 @@ function openDownload(aDownload)
 
     if (!dontAsk) {
       var strings = document.getElementById("downloadStrings");
-      var name = aDownload.getAttribute("target");
+      var name = aDownload.getAttribute("displayName");
       var message = strings.getFormattedString("fileExecutableSecurityWarning", [name, name]);
 
       let title = gStr.fileExecutableSecurityWarningTitle;
@@ -866,7 +867,7 @@ function openExternal(aFile)
  *
  * @param aAttrs
  *        An object that must have the following properties: dlid, file,
- *        target, uri, state, progress, startTime, endTime, currBytes,
+ *        displayName, uri, state, progress, startTime, endTime, currBytes,
  *        maxBytes; optional properties: referrer
  * @return An initialized download richlistitem
  */
@@ -879,8 +880,16 @@ function createDownloadItem(aAttrs)
     dl.setAttribute(attr, aAttrs[attr]);
 
   // Initialize other attributes
+  let s = DownloadsCommon.strings;
+  let displayName = aAttrs.displayName;
+  let [displayHost, fullHost] =
+    DownloadUtils.getURIHost(aAttrs.referrer || aAttrs.uri);
   dl.setAttribute("type", "download");
   dl.setAttribute("id", "dl" + aAttrs.dlid);
+  dl.setAttribute("extendedDisplayName",
+                  s.statusSeparator(displayName, displayHost));
+  dl.setAttribute("extendedDisplayNameTip",
+                  s.statusSeparator(displayName, fullHost));
   dl.setAttribute("image", "moz-icon://" + aAttrs.file + "?size=32");
   dl.setAttribute("lastSeconds", Infinity);
 
@@ -1160,7 +1169,7 @@ function stepListBuilder(aNumItems) {
     let attrs = {
       dlid: gStmt.getInt64(0),
       file: gStmt.getString(1),
-      target: gStmt.getString(2),
+      displayName: gStmt.getString(2),
       uri: gStmt.getString(3),
       state: gStmt.getInt32(4),
       startTime: Math.round(gStmt.getInt64(5) / 1000),
@@ -1222,7 +1231,7 @@ function prependList(aDownload)
   let attrs = {
     dlid: aDownload.id,
     file: aDownload.target.spec,
-    target: aDownload.displayName,
+    displayName: aDownload.displayName,
     uri: aDownload.source.spec,
     state: aDownload.state,
     progress: aDownload.percentComplete,


### PR DESCRIPTION
Aiming to resolve issue #175, this pull request introduces the following changes:

- In the Library and in the classic Download Manager, add the host display name to the display name (the main label) for in-progress downloads, and add the full host name to the display name tooltip
- In the Downloads panel, add the full host name to the display name tooltip for in-progress downloads (Since space is limited here, I decided not to add the host name to the display name itself.)

Library:

![library](https://cloud.githubusercontent.com/assets/9977071/11871722/9e63ce7c-a4d1-11e5-9e4f-4671752bd192.png)

Classic Download Manager:

![classic download manager](https://cloud.githubusercontent.com/assets/9977071/11871793/1c1c63c4-a4d2-11e5-9cb3-c08ece358f1b.png)

Downloads panel:
![downloads panel](https://cloud.githubusercontent.com/assets/9977071/11871728/add4c3fc-a4d1-11e5-93f0-40a185208479.png)