### PR TITLE
Crop extended display name for in-progress downloads at the end

### DIFF
--- a/browser/components/downloads/content/download.xml
+++ b/browser/components/downloads/content/download.xml
@@ -167,7 +167,7 @@
       <xul:image class="downloadTypeIcon blockedIcon"/>
       <xul:vbox pack="center" flex="1">
         <xul:description class="downloadDisplayName"
-                         crop="center"
+                         crop="end"
                          xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"/>
         <xul:progressmeter anonid="progressmeter"
                            class="downloadProgress"

--- a/toolkit/mozapps/downloads/content/download.xml
+++ b/toolkit/mozapps/downloads/content/download.xml
@@ -84,7 +84,7 @@
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
           <xul:label xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"
-                     crop="center" class="name"/>
+                     crop="end" class="name"/>
           <xul:progressmeter mode="normal" value="0" flex="1"
                              anonid="progressmeter"/>
           <xul:label value="&starting.label;" class="status"/>
@@ -108,7 +108,7 @@
         </xul:vbox>
         <xul:vbox flex="1">
           <xul:label xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"
-                     crop="center" flex="2" class="name"/>
+                     crop="end" flex="2" class="name"/>
           <xul:hbox>
             <xul:vbox flex="1">
               <xul:progressmeter mode="normal" value="0" flex="1"
@@ -139,7 +139,7 @@
         </xul:vbox>
         <xul:vbox flex="1">
           <xul:label xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"
-                     crop="center" flex="2" class="name"/>
+                     crop="end" flex="2" class="name"/>
           <xul:hbox>
             <xul:vbox flex="1">
               <xul:progressmeter mode="normal" value="0" flex="1"
@@ -289,7 +289,7 @@
         </xul:vbox>
         <xul:vbox pack="start" flex="1">
           <xul:label xbl:inherits="value=extendedDisplayName,tooltiptext=extendedDisplayNameTip"
-                     crop="center" flex="2" class="name"/>
+                     crop="end" flex="2" class="name"/>
           <xul:hbox>
             <xul:vbox flex="1">
               <xul:progressmeter mode="undetermined" flex="1" />


### PR DESCRIPTION
This pull request makes sure the extended display name for in-progress downloads is cropped at the end, not in the middle.

This is a follow-up to PR #265, refining the solution to issue #175.