### PR TITLE
Break long code lines in allDownloadsViewOverlay.js

### DIFF
--- a/browser/components/downloads/content/allDownloadsViewOverlay.js
+++ b/browser/components/downloads/content/allDownloadsViewOverlay.js
@@ -499,9 +499,12 @@ DownloadElementShell.prototype = {
 
   _updateDisplayNameAndIcon: function DES__updateDisplayNameAndIcon() {
     let metaData = this.getDownloadMetaData();
-    this._element.setAttribute("displayName", metaData.displayName);
-    this._element.setAttribute("extendedDisplayName", metaData.extendedDisplayName);
-    this._element.setAttribute("extendedDisplayNameTip", metaData.extendedDisplayNameTip);
+    this._element.setAttribute("displayName",
+                               metaData.displayName);
+    this._element.setAttribute("extendedDisplayName",
+                               metaData.extendedDisplayName);
+    this._element.setAttribute("extendedDisplayNameTip",
+                               metaData.extendedDisplayNameTip);
     this._element.setAttribute("image", this._getIcon());
   },
 


### PR DESCRIPTION
This pull request breaks a few long code lines in allDownloadsViewOverlay.js, just to improve readability.

This is a follow-up to PR #265 (which resolved issue #175).