### PR TITLE
Make sure code for download display name is formatted consistently

### DIFF
--- a/browser/components/downloads/content/allDownloadsViewOverlay.js
+++ b/browser/components/downloads/content/allDownloadsViewOverlay.js
@@ -319,14 +319,12 @@ DownloadElementShell.prototype = {
         let referrer = this._dataItem.referrer || this._dataItem.uri;
         let [displayHost, fullHost] = DownloadUtils.getURIHost(referrer);
         this._metaData = {
-          state:              this._dataItem.state,
-          endTime:            this._dataItem.endTime,
-          fileName:           this._dataItem.target,
-          displayName:        this._dataItem.target,
-          extendedDisplayName:
-            s.statusSeparator(this._dataItem.target, displayHost),
-          extendedDisplayNameTip:
-            s.statusSeparator(this._dataItem.target, fullHost)
+          state:                  this._dataItem.state,
+          endTime:                this._dataItem.endTime,
+          fileName:               this._dataItem.target,
+          displayName:            this._dataItem.target,
+          extendedDisplayName:    s.statusSeparator(this._dataItem.target, displayHost),
+          extendedDisplayNameTip: s.statusSeparator(this._dataItem.target, fullHost)
         };
         if (this._dataItem.done)
           this._metaData.fileSize = this._dataItem.maxBytes;

--- a/toolkit/mozapps/downloads/content/downloads.js
+++ b/toolkit/mozapps/downloads/content/downloads.js
@@ -886,10 +886,8 @@ function createDownloadItem(aAttrs)
     DownloadUtils.getURIHost(aAttrs.referrer || aAttrs.uri);
   dl.setAttribute("type", "download");
   dl.setAttribute("id", "dl" + aAttrs.dlid);
-  dl.setAttribute("extendedDisplayName",
-                  s.statusSeparator(displayName, displayHost));
-  dl.setAttribute("extendedDisplayNameTip",
-                  s.statusSeparator(displayName, fullHost));
+  dl.setAttribute("extendedDisplayName", s.statusSeparator(displayName, displayHost));
+  dl.setAttribute("extendedDisplayNameTip", s.statusSeparator(displayName, fullHost));
   dl.setAttribute("image", "moz-icon://" + aAttrs.file + "?size=32");
   dl.setAttribute("lastSeconds", Infinity);
 


### PR DESCRIPTION
This pull request merely reformats a few lines of code in allDownloadsViewOverlay.js (components) and downloads.js (mozapps), making sure the code for the download display name is formatted consistently.

This is a follow-up to PR #265 (which resolved issue #175).