### PR TITLE
Don't set extended display name attributes on history downloads

### DIFF
--- a/browser/components/downloads/content/allDownloadsViewOverlay.js
+++ b/browser/components/downloads/content/allDownloadsViewOverlay.js
@@ -498,8 +498,10 @@ DownloadElementShell.prototype = {
   _updateDisplayNameAndIcon: function DES__updateDisplayNameAndIcon() {
     let metaData = this.getDownloadMetaData();
     this._element.setAttribute("displayName", metaData.displayName);
-    this._element.setAttribute("extendedDisplayName", metaData.extendedDisplayName);
-    this._element.setAttribute("extendedDisplayNameTip", metaData.extendedDisplayNameTip);
+    if ("extendedDisplayName" in metaData)
+      this._element.setAttribute("extendedDisplayName", metaData.extendedDisplayName);
+    if ("extendedDisplayNameTip" in metaData)
+      this._element.setAttribute("extendedDisplayNameTip", metaData.extendedDisplayNameTip);
     this._element.setAttribute("image", this._getIcon());
   },
 


### PR DESCRIPTION
This pull request makes sure that the "extendedDisplayName" and "extendedDisplayNameTip" attributes are not set (without value) on history downloads.

This is a follow-up to PR #265, refining the solution to issue #175.