### PR TITLE
Remove duplicate comment in download.xml ("components" subtree)

### DIFF
--- a/browser/components/downloads/content/download.xml
+++ b/browser/components/downloads/content/download.xml
@@ -77,13 +77,6 @@
                 flex="1"
                 class="downloadContainer"
                 style="width: &downloadDetails.width;">
-        <!-- We're letting localizers put a min-width in here primarily
-             because of the downloads summary at the bottom of the list of
-             download items. An element in the summary has the same min-width
-             on a description, and we don't want the panel to change size if the
-             summary isn't being displayed, so we ensure that items share the
-             same minimum width.
-             -->
         <xul:description class="downloadDisplayName"
                          crop="center"
                          style="min-width: &downloadsSummary.minWidth2;"


### PR DESCRIPTION
This pull request removes a duplicate comment in download.xml (in the "components" subtree).

This is a follow-up to PR #265 (which resolved issue #175).