### PR TITLE
Allocations optimizations.

### DIFF
--- a/gfx/thebes/gfxFont.h
+++ b/gfx/thebes/gfxFont.h
@@ -1273,13 +1273,14 @@ public:
 
     gfxFont *GetFont() const { return mFont; }
 
-    // returns true if features exist in output, false otherwise
-    static bool
+    static void
     MergeFontFeatures(const gfxFontStyle *aStyle,
                       const nsTArray<gfxFontFeature>& aFontFeatures,
                       bool aDisableLigatures,
                       const nsAString& aFamilyName,
-                      nsDataHashtable<nsUint32HashKey,uint32_t>& aMergedFeatures);
+                      PLDHashOperator (*aHandleFeature)(const uint32_t&,
+                                                        uint32_t&, void*),
+                      void* aHandleFeatureData);
 
 protected:
     // the font this shaper is working with

--- a/gfx/thebes/gfxGraphiteShaper.cpp
+++ b/gfx/thebes/gfxGraphiteShaper.cpp
@@ -150,7 +150,6 @@ gfxGraphiteShaper::ShapeText(gfxContext      *aContext,
                       mFont->GetFontEntry()->mFeatureSettings,
                       aShapedText->DisableLigatures(),
                       mFont->GetFontEntry()->FamilyName(),
-                      mFallbackToSmallCaps,
                       AddFeature,
                       &f); 
 

--- a/gfx/thebes/gfxGraphiteShaper.cpp
+++ b/gfx/thebes/gfxGraphiteShaper.cpp
@@ -143,20 +143,16 @@ gfxGraphiteShaper::ShapeText(gfxContext      *aContext,
         grLang = GetGraphiteTagForLang(langString);
     }
     gr_feature_val *grFeatures = gr_face_featureval_for_lang(mGrFace, grLang);
-
-    nsDataHashtable<nsUint32HashKey,uint32_t> mergedFeatures;
-
-    // if style contains font-specific features
-    if (MergeFontFeatures(style,
-                          mFont->GetFontEntry()->mFeatureSettings,
-                          aShapedText->DisableLigatures(),
-                          mFont->GetFontEntry()->FamilyName(),
-                          mergedFeatures))
-    {
-        // enumerate result and insert into Graphite feature list
-        GrFontFeatures f = {mGrFace, grFeatures};
-        mergedFeatures.Enumerate(AddFeature, &f);
-    }
+    
+    // Insert any merged features into Graphite feature list.
+    GrFontFeatures f = {mGrFace, grFeatures};
+    MergeFontFeatures(style,
+                      mFont->GetFontEntry()->mFeatureSettings,
+                      aShapedText->DisableLigatures(),
+                      mFont->GetFontEntry()->FamilyName(),
+                      mFallbackToSmallCaps,
+                      AddFeature,
+                      &f); 
 
     size_t numChars = gr_count_unicode_characters(gr_utf16,
                                                   aText, aText + aLength,

--- a/gfx/thebes/gfxHarfBuzzShaper.cpp
+++ b/gfx/thebes/gfxHarfBuzzShaper.cpp
@@ -932,19 +932,16 @@ gfxHarfBuzzShaper::ShapeText(gfxContext      *aContext,
     }
 
     const gfxFontStyle *style = mFont->GetStyle();
-
+    
+    // Insert any merged features into hb_feature array.
     nsAutoTArray<hb_feature_t,20> features;
-    nsDataHashtable<nsUint32HashKey,uint32_t> mergedFeatures;
-
-    if (MergeFontFeatures(style,
-                          entry->mFeatureSettings,
-                          aShapedText->DisableLigatures(),
-                          entry->FamilyName(),
-                          mergedFeatures))
-    {
-        // enumerate result and insert into hb_feature array
-        mergedFeatures.Enumerate(AddFeature, &features);
-    }
+    MergeFontFeatures(style,
+                      entry->mFeatureSettings,
+                      aShapedText->DisableLigatures(),
+                      entry->FamilyName(),
+                      addSmallCaps,
+                      AddOpenTypeFeature,
+                      &features);
 
     bool isRightToLeft = aShapedText->IsRightToLeft();
     hb_buffer_t *buffer = hb_buffer_create();

--- a/gfx/thebes/gfxHarfBuzzShaper.cpp
+++ b/gfx/thebes/gfxHarfBuzzShaper.cpp
@@ -939,8 +939,7 @@ gfxHarfBuzzShaper::ShapeText(gfxContext      *aContext,
                       entry->mFeatureSettings,
                       aShapedText->DisableLigatures(),
                       entry->FamilyName(),
-                      addSmallCaps,
-                      AddOpenTypeFeature,
+                      AddFeature,
                       &features);
 
     bool isRightToLeft = aShapedText->IsRightToLeft();

--- a/ipc/chromium/src/chrome/common/ipc_channel_posix.cc
+++ b/ipc/chromium/src/chrome/common/ipc_channel_posix.cc
@@ -368,14 +368,20 @@ bool Channel::ChannelImpl::EnqueueHelloMessage() {
   return true;
 }
 
-static void
-ClearAndShrink(std::string& s, size_t capacity)
+void Channel::ChannelImpl::ClearAndShrinkInputOverflowBuf()
 {
-  // This swap trick is the closest thing C++ has to a guaranteed way to
-  // shrink the capacity of a string.
-  std::string tmp;
-  tmp.reserve(capacity);
-  s.swap(tmp);
+  // If input_overflow_buf_ has grown, shrink it back to its normal size.
+  static size_t previousCapacityAfterClearing = 0;
+    if (input_overflow_buf_.capacity() > previousCapacityAfterClearing) {
+      // This swap trick is the closest thing C++ has to a guaranteed way
+      // to shrink the capacity of a string.
+      std::string tmp;
+      tmp.reserve(Channel::kReadBufferSize);
+      input_overflow_buf_.swap(tmp);
+      previousCapacityAfterClearing = input_overflow_buf_.capacity();
+    } else {
+      input_overflow_buf_.clear();
+    }
 }
 
 bool Channel::ChannelImpl::Connect() {
@@ -504,7 +510,7 @@ bool Channel::ChannelImpl::ProcessIncomingMessages() {
     } else {
       if (input_overflow_buf_.size() >
          static_cast<size_t>(kMaximumMessageSize - bytes_read)) {
-        ClearAndShrink(input_overflow_buf_, Channel::kReadBufferSize);
+        ClearAndShrinkInputOverflowBuf();
         LOG(ERROR) << "IPC message is too big";
         return false;
       }
@@ -605,7 +611,7 @@ bool Channel::ChannelImpl::ProcessIncomingMessages() {
       }
     }
     if (end == p) {
-      ClearAndShrink(input_overflow_buf_, Channel::kReadBufferSize);
+      ClearAndShrinkInputOverflowBuf();
     } else if (!overflowp) {
       // p is from input_buf_
       input_overflow_buf_.assign(p, end - p);

--- a/ipc/chromium/src/chrome/common/ipc_channel_posix.h
+++ b/ipc/chromium/src/chrome/common/ipc_channel_posix.h
@@ -49,6 +49,8 @@ class Channel::ChannelImpl : public MessageLoopForIO::Watcher {
   bool ProcessIncomingMessages();
   bool ProcessOutgoingMessages();
 
+  void ClearAndShrinkInputOverflowBuf();
+
   // MessageLoopForIO::Watcher implementation.
   virtual void OnFileCanReadWithoutBlocking(int fd);
   virtual void OnFileCanWriteWithoutBlocking(int fd);

--- a/toolkit/components/url-classifier/ProtocolParser.cpp
+++ b/toolkit/components/url-classifier/ProtocolParser.cpp
@@ -400,7 +400,7 @@ ProtocolParser::ProcessChunk(bool* aDone)
   // Pull the chunk out of the pending stream data.
   nsAutoCString chunk;
   chunk.Assign(Substring(mPending, 0, mChunkState.length));
-  mPending = Substring(mPending, mChunkState.length);
+  mPending.Cut(0, mChunkState.length);
 
   *aDone = false;
   mState = PROTOCOL_STATE_CONTROL;
@@ -646,14 +646,14 @@ ProtocolParser::ProcessHostSubComplete(uint8_t aNumEntries,
 }
 
 bool
-ProtocolParser::NextLine(nsACString& line)
+ProtocolParser::NextLine(nsACString& aLine)
 {
   int32_t newline = mPending.FindChar('\n');
   if (newline == kNotFound) {
     return false;
   }
-  line.Assign(Substring(mPending, 0, newline));
-  mPending = Substring(mPending, newline + 1);
+  aLine.Assign(Substring(mPending, 0, newline));
+  mPending.Cut(0, newline + 1);
   return true;
 }
 


### PR DESCRIPTION
All three bugs come from the meta bug of [cumulative-heap-profiling](https://bugzilla.mozilla.org/show_bug.cgi?id=1094552). There are some other deps. on bugs that still apply to Pale Moon, but need to either be ported across with other features that Mozilla has added to Firefox, or account for refactoring, the ones here were easy picks.

I have been testing this for about a day, everything seems to be working. 

A quick test on memory usage:
Without this pull request: 448 MB
With this pull request: 436 MB