### PR TITLE
Don't set tab title to "Connecting..." when loading additional content

### DIFF
--- a/browser/base/content/tabbrowser.xml
+++ b/browser/base/content/tabbrowser.xml
@@ -549,7 +549,8 @@
                   if (!(aStateFlags & nsIWebProgressListener.STATE_RESTORING)) {
                     this.mTab.setAttribute("busy", "true");
                     if (!gMultiProcessBrowser) {
-                      if (!(this.mBrowser.docShell.loadType & Ci.nsIDocShell.LOAD_CMD_RELOAD))
+                      if (aWebProgress.isTopLevel &&
+                          !(this.mBrowser.docShell.loadType & Ci.nsIDocShell.LOAD_CMD_RELOAD))
                         this.mTabBrowser.setTabTitleLoading(this.mTab);
                     }
                   }


### PR DESCRIPTION
Aiming to resolve issue #287, this pull request makes sure the tab title is not set to "Connecting..." when additional content is being loaded (after the initial page load).