### PR TITLE
DOM full screen mode: remember visibility state of the Sidebar

### DIFF
--- a/browser/base/content/browser-fullScreen.js
+++ b/browser/base/content/browser-fullScreen.js
@@ -83,6 +83,8 @@ var FullScreen = {
       // This is needed if they use the context menu to quit fullscreen
       this._isPopupOpen = false;
 
+      document.documentElement.removeAttribute("inDOMFullscreen");
+
       this.cleanup();
     }
   },
@@ -129,9 +131,7 @@ var FullScreen = {
       return;
     }
 
-    // Ensure the sidebar is hidden.
-    if (!document.getElementById("sidebar-box").hidden)
-      toggleSidebar();
+    document.documentElement.setAttribute("inDOMFullscreen", true);
 
     if (gFindBarInitialized)
       gFindBar.close();

--- a/browser/base/content/browser.css
+++ b/browser/base/content/browser.css
@@ -127,6 +127,11 @@ toolbar[printpreview="true"] {
 }
 %endif
 
+#main-window[inDOMFullscreen] #sidebar-box,
+#main-window[inDOMFullscreen] #sidebar-splitter {
+  visibility: collapse;
+}
+
 .bookmarks-toolbar-customize,
 #wrapper-personal-bookmarks > #personal-bookmarks > #PlacesToolbar > hbox > #PlacesToolbarItems {
   display: none;


### PR DESCRIPTION
Currently, after viewing an HTML5 video in full screen, the user has to manually re-enable the Sidebar. This pull request aims to resolve that.

Reference thread: https://forum.palemoon.org/viewtopic.php?f=3&t=10639

Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=714675