### PR TITLE
Disable -Wuninitialized warnings for js/Vector.h

### DIFF
--- a/js/public/Vector.h
+++ b/js/public/Vector.h
@@ -527,6 +527,7 @@ class Vector : private AllocPolicy
 
 // Clang unnecessarily warns 'uninitialized use of storage', and since
 // this is a header it warns for a huge number of files... #298
+#if defined(__GNUC__) && defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
 
@@ -541,6 +542,18 @@ Vector<T,N,AllocPolicy>::Vector(AllocPolicy ap)
 {}
 
 #pragma GCC diagnostic pop
+#else /* is MSVC */
+
+template <class T, size_t N, class AllocPolicy>
+JS_ALWAYS_INLINE
+Vector<T,N,AllocPolicy>::Vector(AllocPolicy ap)
+  : AllocPolicy(ap), mBegin((T *)storage.addr()), mLength(0),
+    mCapacity(sInlineCapacity)
+#ifdef DEBUG
+  , mReserved(sInlineCapacity), entered(false)
+#endif
+{}
+#endif
 
 /* Move constructor. */
 template <class T, size_t N, class AllocPolicy>

--- a/js/public/Vector.h
+++ b/js/public/Vector.h
@@ -527,8 +527,8 @@ class Vector : private AllocPolicy
 
 // Clang unnecessarily warns 'uninitialized use of storage', and since
 // this is a header it warns for a huge number of files... #298
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
 
 template <class T, size_t N, class AllocPolicy>
 JS_ALWAYS_INLINE
@@ -540,7 +540,7 @@ Vector<T,N,AllocPolicy>::Vector(AllocPolicy ap)
 #endif
 {}
 
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 /* Move constructor. */
 template <class T, size_t N, class AllocPolicy>

--- a/js/public/Vector.h
+++ b/js/public/Vector.h
@@ -530,6 +530,7 @@ class Vector : private AllocPolicy
 #if defined(__GNUC__) && defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
 
 template <class T, size_t N, class AllocPolicy>
 JS_ALWAYS_INLINE
@@ -541,18 +542,8 @@ Vector<T,N,AllocPolicy>::Vector(AllocPolicy ap)
 #endif
 {}
 
+#if defined(__GNUC__) && defined(__clang__)
 #pragma GCC diagnostic pop
-#else /* is MSVC */
-
-template <class T, size_t N, class AllocPolicy>
-JS_ALWAYS_INLINE
-Vector<T,N,AllocPolicy>::Vector(AllocPolicy ap)
-  : AllocPolicy(ap), mBegin((T *)storage.addr()), mLength(0),
-    mCapacity(sInlineCapacity)
-#ifdef DEBUG
-  , mReserved(sInlineCapacity), entered(false)
-#endif
-{}
 #endif
 
 /* Move constructor. */

--- a/js/public/Vector.h
+++ b/js/public/Vector.h
@@ -527,7 +527,7 @@ class Vector : private AllocPolicy
 
 // Clang unnecessarily warns 'uninitialized use of storage', and since
 // this is a header it warns for a huge number of files... #298
-#if defined(__GNUC__) && defined(__clang__)
+#if defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #endif
@@ -542,7 +542,7 @@ Vector<T,N,AllocPolicy>::Vector(AllocPolicy ap)
 #endif
 {}
 
-#if defined(__GNUC__) && defined(__clang__)
+#if defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Followup to PR #302

Since Clang can use most GCC pragma, this PR will silence the -Wuninitialized warnings discussed in Issue #298 with both GCC and Clang.

Tested and seems to work as intended with both GCC & Clang on my Manjaro Linux box.
