### PR TITLE
Further improve styling of Back and Forward buttons in the default theme for Windows

### DIFF
--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1010,7 +1010,6 @@ toolbar[mode=full] .toolbarbutton-1 > .toolbarbutton-menubutton-button {
 }
 
 @conditionalForwardWithUrlbar@ > .toolbarbutton-1:-moz-any([disabled],:not([disabled]):not([open]):not(:active)) > .toolbarbutton-icon {
-  background-image: linear-gradient(hsla(0,0%,100%,.6), hsla(0,0%,100%,.1));
   border-color: hsla(210,54%,20%,.25) hsla(210,54%,20%,.3) hsla(210,54%,20%,.35);
   box-shadow: 0 1px hsla(0,0%,100%,.3) inset,
               0 1px hsla(210,54%,20%,.03),
@@ -1074,7 +1073,6 @@ toolbar[mode=full] .toolbarbutton-1 > .toolbarbutton-menubutton-button {
   border-radius: 10000px;
   padding: 5px;
   border: none;
-  background-image: linear-gradient(hsla(0,0%,100%,.6), hsla(0,0%,100%,.1));
   box-shadow: 0 1px 0 hsla(0,0%,100%,.3) inset,
               0 0 0 1px hsla(0,0%,100%,.3) inset,
               0 0 0 1px hsla(210,54%,20%,.25),


### PR DESCRIPTION
This pull request aims to make the Back and Forward buttons look more in line with the other buttons on the Navigation toolbar, by using the same background image for the idle state of the Back and Forfard buttons as for the other buttons (as defined in line 837).

This is a final follow-up to PR #218.

Before:

![back and forward buttons - before](https://cloud.githubusercontent.com/assets/9977071/12470982/65acc4f6-bff9-11e5-9646-7dc7e598c22f.png)

After:

![back and forward buttons - after](https://cloud.githubusercontent.com/assets/9977071/12470985/79df4048-bff9-11e5-92e9-74e96be70141.png)