### PR TITLE
Three minor aesthetic improvements (default theme for Windows)

### DIFF
--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -553,11 +553,11 @@
   }
 
   #navigator-toolbox[tabsontop=false] > #PersonalToolbar {
-    margin-top: 1px;
+    margin-top: 3px;
   }
   
   #navigator-toolbox[tabsontop=false] > #PersonalToolbar:not(:-moz-lwtheme) {
-    margin-top: 0px;
+    margin-top: 2px;
     border-top: 1px solid @toolbarShadowColor@;
     background-image: linear-gradient(@toolbarHighlight@, rgba(255,255,255,0));
   }

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1931,9 +1931,9 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   /* top margin of 0 is important for Fitts' Law in ToT/FS */
   margin: 0px 0.5px 0px;
   padding: 3px 3px 4px 1px;
-  border: 1px solid #929292;
-  border-bottom: 0px;
+  border-width: 1px 1px 0;
   border-radius: 5px 5px 0px 0px;
+  border-color: #929292;
   box-shadow: inset 0.5px 1px 1px rgba(255,255,255,.7);
 }
 
@@ -1944,7 +1944,11 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 @media (-moz-os-version: windows-win10) {
   /* Square is the new round, courtesy of microsoft */
   .tabbrowser-tab,
-  .tabs-newtab-button {
+  .tabs-newtab-button,
+  #main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab,
+  #main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
+  #main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab,
+  #main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
     border-radius: 0px;
     box-shadow: none;
   }
@@ -1955,6 +1959,19 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 #main-window[sizemode="normal"][tabsontop=true] .tabbrowser-tab,
 #main-window[sizemode="normal"][tabsontop=true] .tabs-newtab-button {
   margin-top: 5px;
+}
+
+/* Add a small visual gap between the tabs and the top edge of the screen */
+#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab,
+#main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
+  margin: 0px -0.5px 0px;
+  border-width: 2px 2px 0;
+  border-radius: 6px 6px 0px 0px;
+  -moz-border-top-colors: transparent #929292;
+  -moz-border-left-colors: transparent #929292;
+  -moz-border-right-colors: transparent #929292;
 }
 
 .tabbrowser-tab:hover,
@@ -2007,6 +2024,16 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   border-color: #707070;
 }
 
+/* Apply border color to the double border used in tabs-on-top mode */
+#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab:-moz-lwtheme-brighttext,
+#main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button:-moz-lwtheme-brighttext,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab:-moz-lwtheme-brighttext,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button:-moz-lwtheme-brighttext {
+  -moz-border-top-colors: transparent #707070;
+  -moz-border-left-colors: transparent #707070;
+  -moz-border-right-colors: transparent #707070;
+}
+
 .tabbrowser-tab[selected="true"]:-moz-lwtheme {
   background-image: linear-gradient(rgba(255,255,255,.6), rgba(255,255,255,.8) 50%);
 }
@@ -2014,6 +2041,14 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext {
   background-image: linear-gradient(rgba(128,128,128,.9), rgba(32,32,32,.9) 50%, rgba(32,32,32,.9) 80%, rgba(32,32,32,.8) 100%);
   border-color: #D0D0D0;
+}
+
+/* Apply border color to the double border used in tabs-on-top mode */
+#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext {
+  -moz-border-top-colors: transparent #D0D0D0;
+  -moz-border-left-colors: transparent #D0D0D0;
+  -moz-border-right-colors: transparent #D0D0D0;
 }
 
 .tabbrowser-tab:-moz-lwtheme-brighttext:not([selected="true"]),

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1954,6 +1954,13 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   }
 }
 
+/* Make sure the Navigation toolbar buttons are more or less vertically centered
+   between the tabs and the AppMenu button */
+#main-window[tabsontop=false] .tabbrowser-tab,
+#main-window[tabsontop=false] .tabs-newtab-button {
+  margin-top: 1px;
+}
+
 /* Make sure extra margin is added when tabs are not in the title bar so it doesn't
    "glue" right up against the AppMenu button/caption */
 #main-window[sizemode="normal"][tabsontop=true] .tabbrowser-tab,

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1927,8 +1927,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   -moz-appearance: none;
   background: @toolbarShadowOnTab@, @bgTabTexture@,
               linear-gradient(-moz-dialog, -moz-dialog);
-  background-origin: border-box;
-  background-repeat: no-repeat;
+  background-clip: padding-box;
   /* top margin of 0 is important for Fitts' Law in ToT/FS */
   margin: 0px 0.5px 0px;
   padding: 3px 3px 4px 1px;


### PR DESCRIPTION
This pull request introduces the following changes:

- Make the tab corners more distinct/clean-cut (and remove unneeded "background-repeat" declaration)
- Add a small visual gap between the tabs and the top edge of the screen when the tabs are on top and Pale Moon is maximized or in full-screen mode
- Make sure that when the tabs are *not* on top, the Navigation toolbar buttons are more or less vertically centered between the Bookmarks toolbar / the tabs on one side, and the AppMenu button on the other

This is a follow-up to commits 1204d1f and 09f2f5c.

Before:

![screenshot-1](https://cloud.githubusercontent.com/assets/9977071/12531171/2f6e5826-c1f4-11e5-8758-e8403630650c.png)

![screenshot-2](https://cloud.githubusercontent.com/assets/9977071/12527891/daabfca8-c185-11e5-935e-d5ba66aacc78.png)

![screenshot-3](https://cloud.githubusercontent.com/assets/9977071/12527237/090ab7b4-c178-11e5-8f6e-af967e0887aa.png)

After:

![screenshot-4](https://cloud.githubusercontent.com/assets/9977071/12532037/1411bf30-c20a-11e5-8e16-b04a0ba7bea5.png)

![screenshot-5](https://cloud.githubusercontent.com/assets/9977071/12532040/1b05f856-c20a-11e5-8eb6-1ed70108d87e.png)

![screenshot-6](https://cloud.githubusercontent.com/assets/9977071/12532049/22844844-c20a-11e5-9d08-74ecb84fc1a8.png)