### PR TITLE
Disable i386 build for Mac; remove MOZ_BUILD_PROJECTS because

### DIFF
--- a/build/macosx/universal/mozconfig
+++ b/build/macosx/universal/mozconfig
@@ -3,9 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # i386/x86-64 Universal Build mozconfig
-
-# As used here, arguments in $MOZ_BUILD_PROJECTS are suitable as arguments
-# to gcc's -arch parameter.
-mk_add_options MOZ_BUILD_PROJECTS="i386 x86_64"
+# i386 removed because no reasonable Mac is 32-bit anymore.
 
 . $topsrcdir/build/macosx/universal/mozconfig.common


### PR DESCRIPTION
it seems to refer to missing $(ARCH)/build.mk files

I'll admit I don't fully understand this change, but setting this doesn't seem to
do anything useful except break the build.

( @mattatobin this replaces the `MOZ_BUILD_APP` change you didn't like, hopefully this makes more sense? )
