### PR TITLE
Apply the same top margin to the Bookmarks toolbar and the tabs

### DIFF
--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -553,11 +553,11 @@
   }
 
   #navigator-toolbox[tabsontop=false] > #PersonalToolbar {
-    margin-top: 3px;
+    margin-top: 2px;
   }
   
   #navigator-toolbox[tabsontop=false] > #PersonalToolbar:not(:-moz-lwtheme) {
-    margin-top: 2px;
+    margin-top: 1px;
     border-top: 1px solid @toolbarShadowColor@;
     background-image: linear-gradient(@toolbarHighlight@, rgba(255,255,255,0));
   }


### PR DESCRIPTION
Striving for UI consistency, this pull request makes sure the same top margin is applied to the Bookmarks toolbar and the tabs when the tabs are *not* on top, so the distance between the Navigation toolbar buttons and the first element below the Navigation toolbar is always the same (whether the Bookmarks toolbar is enabled, or not).

This is a follow-up to PR #309 / commit fad8b25.

Before:

![screenshot-1](https://cloud.githubusercontent.com/assets/9977071/12539881/6c0b32a0-c2fc-11e5-92cc-2da208b833a6.png)

After:

![screenshot-2](https://cloud.githubusercontent.com/assets/9977071/12539884/784f7e86-c2fc-11e5-8e64-c56f6a862978.png)