### PR TITLE
Hack workaround for zero length ArrayLength call on unixThemeStrings:

### DIFF
--- a/layout/style/nsMediaFeatures.cpp
+++ b/layout/style/nsMediaFeatures.cpp
@@ -378,7 +378,7 @@ GetUnixTheme(nsPresContext* aPresContext, const nsMediaFeature* aFeature,
                 nsCSSValue& aResult)
 {
     aResult.Reset();
-#if !defined(XP_WIN)
+#if !defined(XP_WIN) && !defined(XP_MACOSX)
     int32_t metricResult;
     if (NS_SUCCEEDED(
         LookAndFeel::GetInt(LookAndFeel::eIntID_UnixThemeIdentifier,


### PR DESCRIPTION
Building with Mac clang leads to:

```
/Users/pale/jenkins/workspace/palemoon/layout/style/nsMediaFeatures.cpp:387:32: error: no matching function for call to 'ArrayLength'
      for (size_t i = 0; i < ArrayLength(unixThemeStrings); ++i) {
                             ^~~~~~~~~~~
../../dist/include/mozilla/Util.h:303:1: note: candidate template ignored: substitution failure [with T = const UnixThemeName, N = 0]: zero-length arrays are not permitted in C++
ArrayLength(T (&arr)[N])
^                    ~
```
Looking at the Unix themes, they are QT4 and GTK2, neither of which makes sense on a Mac.  And they are already `#ifdef`'ed out on Windows, so let's just do that on Mac too?

Let me know if there's a cleaner fix!  I don't like the taste of using preprocessor directives for this, but it seems to be how it's done here.
