### PR TITLE
Fix Mac SDK location, and move from 10.6 to 10.8

### DIFF
--- a/build/macosx/universal/mozconfig.common
+++ b/build/macosx/universal/mozconfig.common
@@ -12,7 +12,7 @@ ac_add_app_options x86_64 --target=x86_64-apple-darwin$DARWIN_VERSION
 ac_add_app_options i386 --with-unify-dist=../x86_64/dist
 ac_add_app_options x86_64 --with-unify-dist=../i386/dist
 
-ac_add_options --with-macos-sdk=/Developer/SDKs/MacOSX10.6.sdk
+ac_add_options --with-macos-sdk=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk
 
 . $topsrcdir/build/macosx/mozconfig.common
 


### PR DESCRIPTION
10.6 is ancient at this point, and it's hard to even find the SDK to link against.
Plus Apple moved where they are stored.