### PR TITLE
Bring in upstream fixes to Mac makefiles

### DIFF
--- a/addon-sdk/Makefile.in
+++ b/addon-sdk/Makefile.in
@@ -30,7 +30,7 @@ TEST_FILES = \
 # Remove this once the test harness uses the APIs built into Firefox
 TEST_FILES += source/lib
 
-PKG_STAGE = $(DIST)/test-package-stage
+PKG_STAGE = $(DIST)/test-stage
 
 stage-tests-package:: $(TEST_FILES)
 	$(INSTALL) $^ $(PKG_STAGE)/jetpack

--- a/browser/app/profile/extensions/Makefile.in
+++ b/browser/app/profile/extensions/Makefile.in
@@ -8,7 +8,7 @@ topsrcdir  = @top_srcdir@
 srcdir     = @srcdir@
 VPATH      = @srcdir@
 
-DISTROEXT = $(call core_abspath,$(FINAL_TARGET))/distribution/extensions
+DISTROEXT = $(abspath $(FINAL_TARGET))/distribution/extensions
 
 include $(DEPTH)/config/autoconf.mk
 include $(topsrcdir)/config/config.mk
@@ -40,7 +40,7 @@ include $(topsrcdir)/config/rules.mk
 $(all_xpis): $(DISTROEXT)/%.xpi: $(call mkdir_deps,$(DISTROEXT)) libs-%
 	cd $* && \
 	$(ZIP) -r9XD $@ * -x \*.in -x \*.mkdir.done
-	cd $(call core_abspath,$(srcdir)/$*) && \
+	cd $(abspath $(srcdir)/$*) && \
 	$(ZIP) -r9XD $@ * -x \*.in -x \*.mkdir.done
 
 .PHONY: $(all_xpis:.xpi=)

--- a/browser/base/Makefile.in
+++ b/browser/base/Makefile.in
@@ -12,7 +12,7 @@ include $(DEPTH)/config/autoconf.mk
 
 include $(topsrcdir)/config/config.mk
 
-abs_srcdir = $(call core_abspath,$(srcdir))
+abs_srcdir = $(abspath $(srcdir))
 
 CHROME_DEPS += $(abs_srcdir)/content/overrides/app-license.html
 

--- a/build/automation-build.mk
+++ b/build/automation-build.mk
@@ -8,7 +8,7 @@ browser_path := \"$(browser_path)\"
 
 _PROFILE_DIR = $(TARGET_DEPTH)/_profile/pgo
 
-ABSOLUTE_TOPSRCDIR = $(call core_abspath,$(MOZILLA_DIR))
+ABSOLUTE_TOPSRCDIR = $(abspath $(MOZILLA_DIR))
 _CERTS_SRC_DIR = $(ABSOLUTE_TOPSRCDIR)/build/pgo/certs
 
 AUTOMATION_PPARGS = 	\

--- a/build/macosx/universal/flight.mk
+++ b/build/macosx/universal/flight.mk
@@ -33,25 +33,25 @@ ifdef ENABLE_TESTS
 # Now, repeat the process for the test package.
 	$(MAKE) -C $(OBJDIR_ARCH_1) UNIVERSAL_BINARY= CHROME_JAR= package-tests
 	$(MAKE) -C $(OBJDIR_ARCH_2) UNIVERSAL_BINARY= CHROME_JAR= package-tests
-	rm -rf $(DIST_UNI)/test-package-stage
+	rm -rf $(DIST_UNI)/test-stage
 # automation.py differs because it hardcodes a path to
 # dist/bin. It doesn't matter which one we use.
-	if test -d $(DIST_ARCH_1)/test-package-stage -a                 \
-                -d $(DIST_ARCH_2)/test-package-stage; then              \
-           cp $(DIST_ARCH_1)/test-package-stage/mochitest/automation.py \
-             $(DIST_ARCH_2)/test-package-stage/mochitest/;              \
-           cp -RL $(DIST_ARCH_1)/test-package-stage/mochitest/extensions/specialpowers \
-             $(DIST_ARCH_2)/test-package-stage/mochitest/extensions/;              \
-           cp $(DIST_ARCH_1)/test-package-stage/xpcshell/automation.py  \
-             $(DIST_ARCH_2)/test-package-stage/xpcshell/;               \
-           cp $(DIST_ARCH_1)/test-package-stage/reftest/automation.py   \
-             $(DIST_ARCH_2)/test-package-stage/reftest/;                \
-           cp -RL $(DIST_ARCH_1)/test-package-stage/reftest/specialpowers \
-             $(DIST_ARCH_2)/test-package-stage/reftest/;              \
+	if test -d $(DIST_ARCH_1)/test-stage -a                 \
+                -d $(DIST_ARCH_2)/test-stage; then              \
+           cp $(DIST_ARCH_1)/test-stage/mochitest/automation.py \
+             $(DIST_ARCH_2)/test-stage/mochitest/;              \
+           cp -RL $(DIST_ARCH_1)/test-stage/mochitest/extensions/specialpowers \
+             $(DIST_ARCH_2)/test-stage/mochitest/extensions/;              \
+           cp $(DIST_ARCH_1)/test-stage/xpcshell/automation.py  \
+             $(DIST_ARCH_2)/test-stage/xpcshell/;               \
+           cp $(DIST_ARCH_1)/test-stage/reftest/automation.py   \
+             $(DIST_ARCH_2)/test-stage/reftest/;                \
+           cp -RL $(DIST_ARCH_1)/test-stage/reftest/specialpowers \
+             $(DIST_ARCH_2)/test-stage/reftest/;              \
            $(TOPSRCDIR)/build/macosx/universal/unify                 \
              --unify-with-sort "\.manifest$$" \
              --unify-with-sort "all-test-dirs\.list$$"               \
-             $(DIST_ARCH_1)/test-package-stage                          \
-             $(DIST_ARCH_2)/test-package-stage                          \
-             $(DIST_UNI)/test-package-stage; fi
+             $(DIST_ARCH_1)/test-stage                          \
+             $(DIST_ARCH_2)/test-stage                          \
+             $(DIST_UNI)/test-stage; fi
 endif

--- a/build/macosx/universal/flight.mk
+++ b/build/macosx/universal/flight.mk
@@ -19,14 +19,12 @@ topsrcdir = $(TOPSRCDIR)
 DEPTH = $(OBJDIR)
 include $(OBJDIR)/config/autoconf.mk
 
-core_abspath = $(if $(filter /%,$(1)),$(1),$(CURDIR)/$(1))
-
 DIST = $(OBJDIR)/dist
 
 postflight_all:
 	mkdir -p $(DIST_UNI)/$(MOZ_PKG_APPNAME)
 	rm -f $(DIST_ARCH_2)/universal
-	ln -s $(call core_abspath,$(DIST_UNI)) $(DIST_ARCH_2)/universal
+	ln -s $(abspath $(DIST_UNI)) $(DIST_ARCH_2)/universal
 # Stage a package for buildsymbols to be happy. Doing so in OBJDIR_ARCH_1
 # actually does a universal staging with both OBJDIR_ARCH_1 and OBJDIR_ARCH_2.
 	$(MAKE) -C $(OBJDIR_ARCH_1)/$(MOZ_BUILD_APP)/installer \

--- a/build/macosx/universal/flight.mk
+++ b/build/macosx/universal/flight.mk
@@ -29,29 +29,3 @@ postflight_all:
 # actually does a universal staging with both OBJDIR_ARCH_1 and OBJDIR_ARCH_2.
 	$(MAKE) -C $(OBJDIR_ARCH_1)/$(MOZ_BUILD_APP)/installer \
 	   PKG_SKIP_STRIP=1 stage-package
-ifdef ENABLE_TESTS
-# Now, repeat the process for the test package.
-	$(MAKE) -C $(OBJDIR_ARCH_1) UNIVERSAL_BINARY= CHROME_JAR= package-tests
-	$(MAKE) -C $(OBJDIR_ARCH_2) UNIVERSAL_BINARY= CHROME_JAR= package-tests
-	rm -rf $(DIST_UNI)/test-stage
-# automation.py differs because it hardcodes a path to
-# dist/bin. It doesn't matter which one we use.
-	if test -d $(DIST_ARCH_1)/test-stage -a                 \
-                -d $(DIST_ARCH_2)/test-stage; then              \
-           cp $(DIST_ARCH_1)/test-stage/mochitest/automation.py \
-             $(DIST_ARCH_2)/test-stage/mochitest/;              \
-           cp -RL $(DIST_ARCH_1)/test-stage/mochitest/extensions/specialpowers \
-             $(DIST_ARCH_2)/test-stage/mochitest/extensions/;              \
-           cp $(DIST_ARCH_1)/test-stage/xpcshell/automation.py  \
-             $(DIST_ARCH_2)/test-stage/xpcshell/;               \
-           cp $(DIST_ARCH_1)/test-stage/reftest/automation.py   \
-             $(DIST_ARCH_2)/test-stage/reftest/;                \
-           cp -RL $(DIST_ARCH_1)/test-stage/reftest/specialpowers \
-             $(DIST_ARCH_2)/test-stage/reftest/;              \
-           $(TOPSRCDIR)/build/macosx/universal/unify                 \
-             --unify-with-sort "\.manifest$$" \
-             --unify-with-sort "all-test-dirs\.list$$"               \
-             $(DIST_ARCH_1)/test-stage                          \
-             $(DIST_ARCH_2)/test-stage                          \
-             $(DIST_UNI)/test-stage; fi
-endif

--- a/config/android-common.mk
+++ b/config/android-common.mk
@@ -18,7 +18,10 @@ AIDL=$(ANDROID_BUILD_TOOLS)/aidl
 ADB=$(ANDROID_PLATFORM_TOOLS)/adb
 ZIPALIGN=$(ANDROID_SDK)/../../tools/zipalign
 # DEBUG_JARSIGNER always debug signs.
-DEBUG_JARSIGNER=$(PYTHON) $(call core_abspath,$(topsrcdir)/mobile/android/debug_sign_tool.py)
+DEBUG_JARSIGNER=$(PYTHON) $(abspath $(topsrcdir)/mobile/android/debug_sign_tool.py) \
+  --keytool=$(KEYTOOL) \
+  --jarsigner=$(JARSIGNER) \
+  $(NULL)
 
 # For Android, this defaults to $(ANDROID_SDK)/android.jar
 ifndef JAVA_BOOTCLASSPATH

--- a/config/config.mk
+++ b/config/config.mk
@@ -621,7 +621,7 @@ endif
 PWD := $(CURDIR)
 endif
 
-NSINSTALL_PY := $(PYTHON) $(call core_abspath,$(topsrcdir)/config/nsinstall.py)
+NSINSTALL_PY := $(PYTHON) $(abspath $(topsrcdir)/config/nsinstall.py)
 # For Pymake, wherever we use nsinstall.py we're also going to try to make it
 # a native command where possible. Since native commands can't be used outside
 # of single-line commands, we continue to provide INSTALL for general use.
@@ -676,7 +676,7 @@ else
   IS_LANGUAGE_REPACK = 1
 endif
 
-EXPAND_LOCALE_SRCDIR = $(if $(filter en-US,$(AB_CD)),$(topsrcdir)/$(1)/en-US,$(call core_realpath,$(L10NBASEDIR))/$(AB_CD)/$(subst /locales,,$(1)))
+EXPAND_LOCALE_SRCDIR = $(if $(filter en-US,$(AB_CD)),$(topsrcdir)/$(1)/en-US,$(or $(realpath $(L10NBASEDIR)),$(abspath $(L10NBASEDIR)))/$(AB_CD)/$(subst /locales,,$(1)))
 
 ifdef relativesrcdir
 LOCALE_SRCDIR = $(call EXPAND_LOCALE_SRCDIR,$(relativesrcdir))
@@ -723,7 +723,7 @@ ifdef MOZ_DEBUG
 JAVAC_FLAGS += -g
 endif
 
-CREATE_PRECOMPLETE_CMD = $(PYTHON) $(call core_abspath,$(topsrcdir)/config/createprecomplete.py)
+CREATE_PRECOMPLETE_CMD = $(PYTHON) $(abspath $(topsrcdir)/config/createprecomplete.py)
 
 # MDDEPDIR is the subdirectory where dependency files are stored
 MDDEPDIR := .deps

--- a/config/nspr/Makefile.in
+++ b/config/nspr/Makefile.in
@@ -20,7 +20,7 @@ $(error config/nspr/Makefile.in is not compatible with MOZ_NATIVE_NSPR)
 endif
 
 # Copy NSPR to the SDK
-ABS_DIST = $(call core_abspath,$(DIST))
+ABS_DIST = $(abspath $(DIST))
 
 ifdef MOZ_FOLD_LIBS
 # Trick the nspr build system into not building shared libraries.

--- a/dom/tests/browser/browser_webapps_perms_reinstall.js
+++ b/dom/tests/browser/browser_webapps_perms_reinstall.js
@@ -131,8 +131,8 @@ function writeUpdatesToWebappManifest(aRestore)
   let devPath = ["_tests", "testing", "mochitest",
                  "browser", "dom" , "tests", "browser"];
   // make package-tests moves tests to:
-  // dist/test-package-stage/mochitest/browser/dom/tests/browser
-  let slavePath = ["dist", "test-package-stage", "mochitest",
+  // dist/test-stage/mochitest/browser/dom/tests/browser
+  let slavePath = ["dist", "test-stage", "mochitest",
                    "browser", "dom", "tests", "browser"];
 
   newfile = newfile.parent; // up to dist/

--- a/js/src/config/config.mk
+++ b/js/src/config/config.mk
@@ -621,7 +621,7 @@ endif
 PWD := $(CURDIR)
 endif
 
-NSINSTALL_PY := $(PYTHON) $(call core_abspath,$(topsrcdir)/config/nsinstall.py)
+NSINSTALL_PY := $(PYTHON) $(abspath $(topsrcdir)/config/nsinstall.py)
 # For Pymake, wherever we use nsinstall.py we're also going to try to make it
 # a native command where possible. Since native commands can't be used outside
 # of single-line commands, we continue to provide INSTALL for general use.
@@ -676,7 +676,7 @@ else
   IS_LANGUAGE_REPACK = 1
 endif
 
-EXPAND_LOCALE_SRCDIR = $(if $(filter en-US,$(AB_CD)),$(topsrcdir)/$(1)/en-US,$(call core_realpath,$(L10NBASEDIR))/$(AB_CD)/$(subst /locales,,$(1)))
+EXPAND_LOCALE_SRCDIR = $(if $(filter en-US,$(AB_CD)),$(topsrcdir)/$(1)/en-US,$(or $(realpath $(L10NBASEDIR)),$(abspath $(L10NBASEDIR)))/$(AB_CD)/$(subst /locales,,$(1)))
 
 ifdef relativesrcdir
 LOCALE_SRCDIR = $(call EXPAND_LOCALE_SRCDIR,$(relativesrcdir))
@@ -723,7 +723,7 @@ ifdef MOZ_DEBUG
 JAVAC_FLAGS += -g
 endif
 
-CREATE_PRECOMPLETE_CMD = $(PYTHON) $(call core_abspath,$(topsrcdir)/config/createprecomplete.py)
+CREATE_PRECOMPLETE_CMD = $(PYTHON) $(abspath $(topsrcdir)/config/createprecomplete.py)
 
 # MDDEPDIR is the subdirectory where dependency files are stored
 MDDEPDIR := .deps

--- a/js/src/tests/Makefile.in
+++ b/js/src/tests/Makefile.in
@@ -39,7 +39,7 @@ TEST_FILES = \
   test262/ \
   $(NULL)
 
-PKG_STAGE = $(DIST)/test-package-stage
+PKG_STAGE = $(DIST)/test-stage
 
 # stage tests for packaging
 stage-package:

--- a/layout/tools/reftest/Makefile.in
+++ b/layout/tools/reftest/Makefile.in
@@ -80,7 +80,7 @@ copy-harness: $(_HARNESS_FILES)
 	$(INSTALL) $(_HARNESS_FILES) $(_DEST_DIR)
 	(cd $(DIST)/xpi-stage && tar $(TAR_CREATE_FLAGS) - reftest) | (cd $(_DEST_DIR) && tar -xf -)
 
-PKG_STAGE = $(DIST)/test-package-stage
+PKG_STAGE = $(DIST)/test-stage
 
 # stage harness and tests for packaging
 stage-package:

--- a/mobile/android/base/locales/Makefile.in
+++ b/mobile/android/base/locales/Makefile.in
@@ -14,12 +14,12 @@ include $(topsrcdir)/config/config.mk
 # http://code.google.com/p/android/issues/detail?id=3639
 AB_rCD = $(if $(filter he, $(AB_CD)),iw,$(if $(filter id, $(AB_CD)),in,$(subst -,-r,$(AB_CD))))
 
-SYNCSTRINGSPATH = $(call core_abspath,$(call MERGE_FILE,sync_strings.dtd))
-STRINGSPATH = $(call core_abspath,$(call MERGE_FILE,android_strings.dtd))
+SYNCSTRINGSPATH = $(abspath $(call MERGE_FILE,sync_strings.dtd))
+STRINGSPATH = $(abspath $(call MERGE_FILE,android_strings.dtd))
 ifeq (,$(XPI_NAME))
-BRANDPATH = $(call core_abspath,$(DEPTH)/dist/bin/chrome/$(AB_CD)/locale/branding/brand.dtd)
+BRANDPATH = $(abspath $(DEPTH)/dist/bin/chrome/$(AB_CD)/locale/branding/brand.dtd)
 else
-BRANDPATH = $(call core_abspath,$(DIST)/xpi-stage/$(XPI_NAME)/chrome/$(AB_CD)/locale/branding/brand.dtd)
+BRANDPATH = $(abspath $(DIST)/xpi-stage/$(XPI_NAME)/chrome/$(AB_CD)/locale/branding/brand.dtd)
 endif
 $(warnIfEmpty,AB_CD) # todo: $(errorIfEmpty )
 
@@ -38,7 +38,7 @@ chrome-%::
 	@$(MAKE) $(dir-res-values)-$(AB_rCD)/strings.xml AB_CD=$*
 
 # setup the path to bookmarks.inc. copied and tweaked version of MERGE_FILE from config/config.mk
-MOBILE_LOCALE_SRCDIR = $(if $(filter en-US,$(AB_CD)),$(topsrcdir)/mobile/locales/en-US,$(call core_realpath,$(L10NBASEDIR))/$(AB_CD)/mobile)
+MOBILE_LOCALE_SRCDIR = $(if $(filter en-US,$(AB_CD)),$(topsrcdir)/mobile/locales/en-US,$(or $(realpath $(L10NBASEDIR)),$(abspath $(L10NBASEDIR)))/$(AB_CD)/mobile)
 
 ifdef LOCALE_MERGEDIR
 BOOKMARKSPATH = $(firstword \
@@ -46,7 +46,7 @@ BOOKMARKSPATH = $(firstword \
   $(wildcard $(MOBILE_LOCALE_SRCDIR)/profile/bookmarks.inc ) \
   $(topsrcdir)/mobile/locales/en-US/profile/bookmarks.inc )
 else
-BOOKMARKSPATH = $(call core_abspath,$(MOBILE_LOCALE_SRCDIR)/profile/bookmarks.inc)
+BOOKMARKSPATH = $(abspath $(MOBILE_LOCALE_SRCDIR)/profile/bookmarks.inc)
 endif
 
 # Determine the ../res/values[-*]/ path

--- a/modules/libmar/tests/Makefile.in
+++ b/modules/libmar/tests/Makefile.in
@@ -10,7 +10,7 @@ relativesrcdir = @relativesrcdir@
 
 include $(DEPTH)/config/autoconf.mk
 
-TESTROOT = $(call core_abspath,$(DEPTH))/_tests/xpcshell/$(relativesrcdir)
+TESTROOT = $(abspath $(DEPTH))/_tests/xpcshell/$(relativesrcdir)
 
 DEFINES += -DBIN_SUFFIX=$(BIN_SUFFIX)
 

--- a/security/build/Makefile.in
+++ b/security/build/Makefile.in
@@ -95,7 +95,7 @@ NSS_EXTRA_DLLS += freebl_64int_3
 NSS_EXTRA_DLLS += freebl_64fpu_3
 endif
 
-ABS_DIST := $(call core_abspath,$(DIST))
+ABS_DIST := $(abspath $(DIST))
 ifeq ($(HOST_OS_ARCH),WINNT)
 ifdef CYGDRIVE_MOUNT
 ABS_DIST := $(shell cygpath -w $(ABS_DIST) | sed -e 's|\\|/|g')
@@ -293,7 +293,7 @@ export::
 	cp -Rp $(topsrcdir)/security/coreconf $(NSS_SRCDIR)/security
 	cp -Rp $(topsrcdir)/security/dbm $(NSS_SRCDIR)/security
 	cp -Rp $(topsrcdir)/dbm $(NSS_SRCDIR)
-	(cd $(NSS_SRCDIR) && patch -p1 < $(call core_abspath,$(MOZ_NSS_PATCH)))
+	(cd $(NSS_SRCDIR) && patch -p1 < $(abspath $(MOZ_NSS_PATCH)))
 else
 NSS_SRCDIR = $(topsrcdir)
 endif

--- a/testing/mochitest/Makefile.in
+++ b/testing/mochitest/Makefile.in
@@ -167,7 +167,7 @@ TEST_HARNESS_PLUGINS := \
 endif
 
 # Rules for staging the necessary harness bits for a test package
-PKG_STAGE = $(DIST)/test-package-stage
+PKG_STAGE = $(DIST)/test-stage
 DIST_BIN = $(DIST)/bin
 
 $(_DEST_DIR):

--- a/testing/mozbase/Makefile.in
+++ b/testing/mozbase/Makefile.in
@@ -43,7 +43,7 @@ libs:: $(MOZBASE_PACKAGES)
 libs:: $(MOZBASE_EXTRAS)
 	$(PYTHON) $(topsrcdir)/config/nsinstall.py $^ $(_DEST_DIR)
 
-stage-package: PKG_STAGE = $(DIST)/test-package-stage
+stage-package: PKG_STAGE = $(DIST)/test-stage
 stage-package:
 	$(NSINSTALL) -D $(PKG_STAGE)/mozbase
 	@(cd $(srcdir) && tar $(TAR_CREATE_FLAGS) - $(MOZBASE_PACKAGES)) | (cd $(PKG_STAGE)/mozbase && tar -xf -)

--- a/testing/peptest/Makefile.in
+++ b/testing/peptest/Makefile.in
@@ -34,7 +34,7 @@ libs:: $(PEPTEST_EXTRAS)
 libs:: $(PEPTEST_TESTS)
 	$(PYTHON) $(topsrcdir)/config/nsinstall.py $^ $(_DEST_DIR)
 
-stage-package: PKG_STAGE = $(DIST)/test-package-stage
+stage-package: PKG_STAGE = $(DIST)/test-stage
 stage-package:
 	$(NSINSTALL) -D $(PKG_STAGE)/peptest
 	@(cd $(srcdir) && tar $(TAR_CREATE_FLAGS) - $(PEPTEST_HARNESS)) | (cd $(PKG_STAGE)/peptest && tar -xf -)

--- a/testing/profiles/Makefile.in
+++ b/testing/profiles/Makefile.in
@@ -20,7 +20,7 @@ _DEST_DIR = $(DEPTH)/_tests/testing/mochitest/profile_data
 libs:: $(MOCHITEST_PROFILE_FILES)
 	$(PYTHON) $(topsrcdir)/config/nsinstall.py $^ $(_DEST_DIR)
 
-stage-package: PKG_STAGE = $(DIST)/test-package-stage
+stage-package: PKG_STAGE = $(DIST)/test-stage
 stage-package:
 	$(NSINSTALL) -D $(PKG_STAGE)/
 	@(cd $(srcdir) && tar $(TAR_CREATE_FLAGS) - $(MOCHITEST_PROFILE_FILES)) | (cd $(PKG_STAGE)/mochitest/profile_data && tar -xf -)

--- a/testing/testsuite-targets.mk
+++ b/testing/testsuite-targets.mk
@@ -263,12 +263,12 @@ crashtest-ipc-gpu:
 	$(call RUN_REFTEST,"$(topsrcdir)/$(TEST_PATH)" $(OOP_CONTENT) $(GPU_RENDERING))
 	$(CHECK_TEST_ERROR)
 
-jstestbrowser: TESTS_PATH?=test-package-stage/jsreftest/tests/
+jstestbrowser: TESTS_PATH?=test-stage/jsreftest/tests/
 jstestbrowser:
 	$(MAKE) -C $(DEPTH)/config
 	$(MAKE) -C $(DEPTH)/js/src/config
 	$(MAKE) stage-jstests
-	$(call RUN_REFTEST,"$(DIST)/$(TESTS_PATH)/jstests.list" --extra-profile-file=$(DIST)/test-package-stage/jsreftest/tests/user.js)
+	$(call RUN_REFTEST,'$(DIST)/$(TESTS_PATH)/jstests.list' --extra-profile-file=$(DIST)/test-stage/jsreftest/tests/user.js)
 	$(CHECK_TEST_ERROR)
 
 GARBAGE += $(addsuffix .log,$(MOCHITESTS) reftest crashtest jstestbrowser)
@@ -389,7 +389,7 @@ pgo-profile-run:
 include $(topsrcdir)/toolkit/mozapps/installer/package-name.mk
 
 ifndef UNIVERSAL_BINARY
-PKG_STAGE = $(DIST)/test-package-stage
+PKG_STAGE = $(DIST)/test-stage
 package-tests: \
   stage-config \
   stage-mochitest \
@@ -405,7 +405,7 @@ package-tests: \
   $(NULL)
 else
 # This staging area has been built for us by universal/flight.mk
-PKG_STAGE = $(DIST)/universal/test-package-stage
+PKG_STAGE = $(DIST)/universal/test-stage
 endif
 
 package-tests:

--- a/testing/testsuite-targets.mk
+++ b/testing/testsuite-targets.mk
@@ -388,8 +388,8 @@ pgo-profile-run:
 # Package up the tests and test harnesses
 include $(topsrcdir)/toolkit/mozapps/installer/package-name.mk
 
-ifndef UNIVERSAL_BINARY
 PKG_STAGE = $(DIST)/test-stage
+
 package-tests: \
   stage-config \
   stage-mochitest \
@@ -403,16 +403,10 @@ package-tests: \
   stage-modules \
   stage-marionette \
   $(NULL)
-else
-# This staging area has been built for us by universal/flight.mk
-PKG_STAGE = $(DIST)/universal/test-stage
-endif
 
 package-tests:
 	@rm -f "$(DIST)/$(PKG_PATH)$(TEST_PACKAGE)"
-ifndef UNIVERSAL_BINARY
 	$(NSINSTALL) -D $(DIST)/$(PKG_PATH)
-endif
 	find $(PKG_STAGE) -name "*.pyc" -exec rm {} \;
 	cd $(PKG_STAGE) && \
 	  zip -rq9D "$(abspath $(DIST)/$(PKG_PATH)$(TEST_PACKAGE))" \

--- a/testing/testsuite-targets.mk
+++ b/testing/testsuite-targets.mk
@@ -34,15 +34,15 @@ RUN_MOCHITEST_B2G_DESKTOP = \
   $(PYTHON) _tests/testing/mochitest/runtestsb2g.py --autorun --close-when-done \
     --console-level=INFO --log-file=./$@.log --file-level=INFO \
     --desktop --profile ${GAIA_PROFILE_DIR} \
-    --failure-file=$(call core_abspath,_tests/testing/mochitest/makefailures.json) \
+    --failure-file=$(abspath _tests/testing/mochitest/makefailures.json) \
     $(TEST_PATH_ARG) $(EXTRA_TEST_ARGS)
 
 RUN_MOCHITEST = \
   rm -f ./$@.log && \
   $(PYTHON) _tests/testing/mochitest/runtests.py --autorun --close-when-done \
     --console-level=INFO --log-file=./$@.log --file-level=INFO \
-    --failure-file=$(call core_abspath,_tests/testing/mochitest/makefailures.json) \
-    --testing-modules-dir=$(call core_abspath,_tests/modules) \
+    --failure-file=$(abspath _tests/testing/mochitest/makefailures.json) \
+    --testing-modules-dir=$(abspath _tests/modules) \
     --extra-profile-file=$(DIST)/plugins \
     $(SYMBOLS_PATH) $(TEST_PATH_ARG) $(EXTRA_TEST_ARGS)
 
@@ -51,7 +51,7 @@ RERUN_MOCHITEST = \
   $(PYTHON) _tests/testing/mochitest/runtests.py --autorun --close-when-done \
     --console-level=INFO --log-file=./$@.log --file-level=INFO \
     --run-only-tests=makefailures.json \
-    --testing-modules-dir=$(call core_abspath,_tests/modules) \
+    --testing-modules-dir=$(abspath _tests/modules) \
     --extra-profile-file=$(DIST)/plugins \
     $(SYMBOLS_PATH) $(TEST_PATH_ARG) $(EXTRA_TEST_ARGS)
 
@@ -60,7 +60,7 @@ RUN_MOCHITEST_REMOTE = \
   $(PYTHON) _tests/testing/mochitest/runtestsremote.py --autorun --close-when-done \
     --console-level=INFO --log-file=./$@.log --file-level=INFO $(DM_FLAGS) --dm_trans=$(DM_TRANS) \
     --app=$(TEST_PACKAGE_NAME) --deviceIP=${TEST_DEVICE} --xre-path=${MOZ_HOST_BIN} \
-    --testing-modules-dir=$(call core_abspath,_tests/modules) --httpd-path=. \
+    --testing-modules-dir=$(abspath _tests/modules) --httpd-path=. \
     $(SYMBOLS_PATH) $(TEST_PATH_ARG) $(EXTRA_TEST_ARGS)
 
 RUN_MOCHITEST_ROBOCOP = \
@@ -285,9 +285,9 @@ xpcshell-tests:
 	  --manifest=$(DEPTH)/_tests/xpcshell/xpcshell.ini \
 	  --build-info-json=$(DEPTH)/mozinfo.json \
 	  --no-logfiles \
-	  --tests-root-dir=$(call core_abspath,_tests/xpcshell) \
-	  --testing-modules-dir=$(call core_abspath,_tests/modules) \
-	  --xunit-file=$(call core_abspath,_tests/xpcshell/results.xml) \
+	  --tests-root-dir=$(abspath _tests/xpcshell) \
+	  --testing-modules-dir=$(abspath _tests/modules) \
+	  --xunit-file=$(abspath _tests/xpcshell/results.xml) \
 	  --xunit-suite-name=xpcshell \
           $(SYMBOLS_PATH) \
 	  $(TEST_PATH_ARG) $(EXTRA_TEST_ARGS) \
@@ -332,7 +332,7 @@ xpcshell-tests-remote:
 	    --manifest=$(DEPTH)/_tests/xpcshell/xpcshell_android.ini \
 	    --build-info-json=$(DEPTH)/mozinfo.json \
 	    --no-logfiles \
-	    --testing-modules-dir=$(call core_abspath,_tests/modules) \
+	    --testing-modules-dir=$(abspath _tests/modules) \
 	    --dm_trans=$(DM_TRANS) \
 	    --deviceIP=${TEST_DEVICE} \
 	    --objdir=$(DEPTH) \
@@ -415,7 +415,7 @@ ifndef UNIVERSAL_BINARY
 endif
 	find $(PKG_STAGE) -name "*.pyc" -exec rm {} \;
 	cd $(PKG_STAGE) && \
-	  zip -rq9D "$(call core_abspath,$(DIST)/$(PKG_PATH)$(TEST_PACKAGE))" \
+	  zip -rq9D "$(abspath $(DIST)/$(PKG_PATH)$(TEST_PACKAGE))" \
 	  * -x \*/.mkdir.done
 
 ifeq ($(MOZ_WIDGET_TOOLKIT),android)

--- a/testing/xpcshell/Makefile.in
+++ b/testing/xpcshell/Makefile.in
@@ -46,7 +46,7 @@ MOZINFO_FILES := \
   mozinfo.py
 
 # Rules for staging the necessary harness bits for a test package
-PKG_STAGE = $(DIST)/test-package-stage
+PKG_STAGE = $(DIST)/test-stage
 
 libs::
 	$(INSTALL) xpcshell.ini $(DEPTH)/_tests/xpcshell

--- a/toolkit/components/feeds/Makefile.in
+++ b/toolkit/components/feeds/Makefile.in
@@ -18,7 +18,7 @@ DISABLED_EXTRA_COMPONENTS = FeedProcessor.js FeedProcessor.manifest
 
 include $(topsrcdir)/config/rules.mk
 
-ABS_SRCDIR := $(call core_abspath,$(srcdir))
+ABS_SRCDIR := $(abspath $(srcdir))
 ifeq ($(OS_ARCH),WINNT)
 
 ABS_DEPTH := $(call core_abspath,$(DEPTH))

--- a/toolkit/locales/l10n.mk
+++ b/toolkit/locales/l10n.mk
@@ -34,8 +34,6 @@ run_for_effects := $(shell if test ! -d $(DIST); then $(NSINSTALL) -D $(DIST); f
 
 AB = $(firstword $(subst -, ,$(AB_CD)))
 
-core_abspath = $(if $(findstring :,$(1)),$(1),$(if $(filter /%,$(1)),$(1),$(CURDIR)/$(1)))
-
 # These are defaulted to be compatible with the files the wget-en-US target
 # pulls. You may override them if you provide your own files. You _must_
 # override them when MOZ_PKG_PRETTYNAMES is defined - the defaults will not
@@ -51,7 +49,7 @@ DEFINES += \
 	-DMOZ_LANGPACK_EID=$(MOZ_LANGPACK_EID) \
 	-DMOZ_APP_VERSION=$(MOZ_APP_VERSION) \
 	-DMOZ_APP_MAXVERSION=$(MOZ_APP_MAXVERSION) \
-	-DLOCALE_SRCDIR=$(call core_abspath,$(LOCALE_SRCDIR)) \
+	-DLOCALE_SRCDIR=$(abspath $(LOCALE_SRCDIR)) \
 	-DPKG_BASENAME="$(PKG_BASENAME)" \
 	-DPKG_INST_BASENAME="$(PKG_INST_BASENAME)" \
 	$(NULL)

--- a/toolkit/mozapps/installer/linux/rpm/mozilla.spec
+++ b/toolkit/mozapps/installer/linux/rpm/mozilla.spec
@@ -81,7 +81,7 @@ rm icons.list #cleanup
 make package-tests
 testdir=$RPM_BUILD_ROOT/%{_datadir}/%{_testsinstalldir}/tests
 mkdir -p $testdir
-cp -a dist/test-package-stage/* $testdir/
+cp -a dist/test-stage/* $testdir/
 %endif
 
 %clean

--- a/toolkit/mozapps/installer/packager.mk
+++ b/toolkit/mozapps/installer/packager.mk
@@ -97,8 +97,8 @@ endif # MOZ_NATIVE_NSPR
 MAKE_JSSHELL  = $(ZIP) -9j $(PKG_JSSHELL) $(JSSHELL_BINS)
 endif # LIBXUL_SDK
 
-_ABS_DIST = $(call core_abspath,$(DIST))
-JARLOG_DIR = $(call core_abspath,$(DEPTH)/jarlog/)
+_ABS_DIST = $(abspath $(DIST))
+JARLOG_DIR = $(abspath $(DEPTH)/jarlog/)
 JARLOG_FILE_AB_CD = $(JARLOG_DIR)/$(AB_CD).log
 
 TAR_CREATE_FLAGS := --exclude=.mkdir.done $(TAR_CREATE_FLAGS)
@@ -352,14 +352,14 @@ ABI_DIR = armeabi
 endif
 endif
 
-GOANNA_APP_AP_PATH = $(call core_abspath,$(DEPTH)/mobile/android/base)
+GOANNA_APP_AP_PATH = $(abspath,$(DEPTH)/mobile/android/base)
 
 ifdef ENABLE_TESTS
 INNER_ROBOCOP_PACKAGE=echo
 ifeq ($(MOZ_BUILD_APP),mobile/android)
 UPLOAD_EXTRA_FILES += robocop.apk
 UPLOAD_EXTRA_FILES += fennec_ids.txt
-ROBOCOP_PATH = $(call core_abspath,$(_ABS_DIST)/../build/mobile/robocop)
+ROBOCOP_PATH = $(abspath,$(_ABS_DIST)/../build/mobile/robocop)
 # Robocop and Fennec need to be signed with the same key, which means
 # release signing them both.
 INNER_ROBOCOP_PACKAGE= \

--- a/toolkit/mozapps/update/test/Makefile.in
+++ b/toolkit/mozapps/update/test/Makefile.in
@@ -10,7 +10,7 @@ relativesrcdir = @relativesrcdir@
 
 include $(DEPTH)/config/autoconf.mk
 
-TESTROOT = $(call core_abspath,$(DEPTH))/_tests/xpcshell/$(relativesrcdir)
+TESTROOT = $(abspath $(DEPTH))/_tests/xpcshell/$(relativesrcdir)
 
 DEFINES += \
   -DAB_CD=$(AB_CD) \

--- a/uriloader/exthandler/tests/Makefile.in
+++ b/uriloader/exthandler/tests/Makefile.in
@@ -23,7 +23,7 @@ LIBS +=		\
 include $(topsrcdir)/config/rules.mk
 
 ifdef MOZ_WIDGET_GTK
-export PERSONAL_MAILCAP=$(call core_abspath,$(srcdir))/mailcap
+export PERSONAL_MAILCAP=$(abspath $(srcdir))/mailcap
 endif
 
 # need the executable for running the xpcshell unit tests

--- a/widget/cocoa/Makefile.in
+++ b/widget/cocoa/Makefile.in
@@ -80,7 +80,7 @@ $(NIB_DEST)/%: $(srcdir)/resources/MainMenu.nib/% $(NIB_DEST)
 	$(INSTALL) $< $(NIB_DEST)
 
 # for objdir builds, symlink the cursors dir
-ABS_topsrcdir   := $(call core_abspath,$(topsrcdir))
+ABS_topsrcdir   := $(abspath $(topsrcdir))
 ifneq ($(ABS_topsrcdir),$(MOZ_BUILD_ROOT))
 export::
 	ln -fs $(srcdir)/cursors

--- a/xpcom/tests/Makefile.in
+++ b/xpcom/tests/Makefile.in
@@ -145,7 +145,7 @@ else
 getnativepath = $(1)
 endif
 
-abs_srcdir = $(call core_abspath,$(srcdir))
+abs_srcdir = $(abspath $(srcdir))
 
 DIST_PATH = $(DIST)/bin/
 RM_DIST = rm -f

--- a/xulrunner/installer/windows/Makefile.in
+++ b/xulrunner/installer/windows/Makefile.in
@@ -9,9 +9,9 @@ VPATH		= @srcdir@
 
 include $(DEPTH)/config/autoconf.mk
 
-CONFIG_DIR=$(call core_abspath,$(srcdir))
-OBJ_DIR=$(call core_abspath,$(DEPTH))
-SRC_DIR=$(call core_abspath,$(topsrcdir))
+CONFIG_DIR=$(abspath $(srcdir))
+OBJ_DIR=$(abspath $(DEPTH))
+SRC_DIR=$(abspath $(topsrcdir))
 
 include $(topsrcdir)/config/rules.mk
 


### PR DESCRIPTION
Upstream FF has changed the Mac build infrastructure somewhat -- in particular it seems they are moving to simplify the "universal" build, which makes sense given that the Mac world has moved away from i386 and ppc entirely.

This ends up dropping support for ancient versions of Make, as well as bringing in a couple of trivial fixups.  They are not strictly necessary but I tried to bring them all in to keep the history as similar to upstream as possible, rather than dealing with conflicts picking out just the bits I need and then again if we cherry-pick later fixes.

Let me know if I should make a different patch with only the parts I care about (the ` build/macosx/universal/flight.mk` bits) at the expense of making future cherry-picks harder.

(How do I verify that these changes do not break Linux / Windows builds?  Is there a Pale Moon CI that will automatically build such versions?)