### PR TITLE
Pale Moon 26 - patch for the default Windows theme

### DIFF
--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -553,11 +553,11 @@
   }
 
   #navigator-toolbox[tabsontop=false] > #PersonalToolbar {
-    margin-top: 1px;
+    margin-top: 3px;
   }
   
   #navigator-toolbox[tabsontop=false] > #PersonalToolbar:not(:-moz-lwtheme) {
-    margin-top: 0px;
+    margin-top: 2px;
     border-top: 1px solid @toolbarShadowColor@;
     background-image: linear-gradient(@toolbarHighlight@, rgba(255,255,255,0));
   }

--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -466,7 +466,7 @@
   #toolbar-menubar:not(:-moz-lwtheme),
   #TabsToolbar[tabsontop=true]:not(:-moz-lwtheme),
   #nav-bar[tabsontop=false]:not(:-moz-lwtheme),
-  #nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child:not(:-moz-lwtheme) {
+  #nav-bar + #customToolbars + #PersonalToolbar:-moz-any([collapsed=true],[moz-collapsed=true]) + #TabsToolbar[tabsontop=false]:last-child:not(:-moz-lwtheme) {
     background-color: transparent !important;
     color: black;
     border-left-style: none !important;

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1955,13 +1955,36 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   margin: 0px 0.5px 0px;
   padding: 3px 3px 4px 1px;
   border: 1px solid #929292;
-  border-bottom: 0px;
+  border-bottom: none;
   border-radius: 5px 5px 0px 0px;
   box-shadow: inset 0.5px 1px 1px rgba(255,255,255,.7);
 }
 
 .tabs-newtab-button {
   padding: 3px 1px 4px 1px;
+}
+
+/* Add a small visual gap between the tabs and the Menu bar / the top edge
+   of the screen */
+#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab,
+#main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
+  margin: 0px -0.5px 0px;
+  border-width: 2px 2px 0px;
+  border-radius: 6px 6px 0px 0px;
+  -moz-border-top-colors: transparent #929292;
+  -moz-border-left-colors: transparent #929292;
+  -moz-border-right-colors: transparent #929292;
+}
+
+/* Increase the width of the tabs to compensate for the transparent outer
+   border that's added when the tabs are on top and the window is maximized
+   or in full-screen mode */
+#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab[fadein]:not([pinned]),
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab[fadein]:not([pinned]) {
+  max-width: 252px;
+  min-width: 102px;
 }
 
 @media (-moz-os-version: windows-win8) {
@@ -1972,6 +1995,15 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   .tabs-newtab-button {
     border-radius: 2.5px 2.5px 0px 0px;
   }
+
+  /* Set the border radius for the double border that's used when the tabs
+     are on top and the window is maximized or in full-screen mode */
+  #main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab,
+  #main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
+  #main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab,
+  #main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
+    border-radius: 3.5px 3.5px 0px 0px;
+  }
 }
 
 @media (-moz-os-version: windows-win10) {
@@ -1980,6 +2012,15 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   .tabs-newtab-button {
     border-radius: 0px;
     box-shadow: none;
+  }
+
+  /* Set the border radius for the double border that's used when the tabs
+     are on top and the window is maximized or in full-screen mode */
+  #main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab,
+  #main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
+  #main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab,
+  #main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
+    border-radius: 0px;
   }
 }
 
@@ -2033,6 +2074,17 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   border-color: #707070;
 }
 
+/* Apply border color to the double border that's used when the tabs are
+   on top and the window is maximized or in full-screen mode */
+#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab:-moz-lwtheme-brighttext,
+#main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button:-moz-lwtheme-brighttext,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab:-moz-lwtheme-brighttext,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button:-moz-lwtheme-brighttext {
+  -moz-border-top-colors: transparent #707070;
+  -moz-border-left-colors: transparent #707070;
+  -moz-border-right-colors: transparent #707070;
+}
+
 .tabbrowser-tab[selected="true"]:-moz-lwtheme {
   background-image: linear-gradient(rgba(255,255,255,.6), rgba(255,255,255,.8) 50%);
 }
@@ -2040,6 +2092,15 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext {
   background-image: linear-gradient(rgba(128,128,128,.9), rgba(32,32,32,.9) 50%, rgba(32,32,32,.9) 80%, rgba(32,32,32,.8) 100%);
   border-color: #D0D0D0;
+}
+
+/* Apply border color to the double border that's used when the tabs are
+   on top and the window is maximized or in full-screen mode */
+#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext {
+  -moz-border-top-colors: transparent #D0D0D0;
+  -moz-border-left-colors: transparent #D0D0D0;
+  -moz-border-right-colors: transparent #D0D0D0;
 }
 
 .tabbrowser-tab:-moz-lwtheme-brighttext:not([selected="true"]),
@@ -2142,6 +2203,16 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   background-origin: border-box;
 }
 
+/* Add margin to the icon to compensate for the transparent outer border
+   that's added to the tabs when the tabs are on top and the window is
+   maximized or in full-screen mode */
+#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-up > .toolbarbutton-icon,
+#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-down > .toolbarbutton-icon,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-up > .toolbarbutton-icon,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-down > .toolbarbutton-icon {
+  margin-bottom: 1px;
+}
+
 %ifdef WINDOWS_AERO
 .tabbrowser-arrowscrollbox > .scrollbutton-up:-moz-system-metric(windows-compositor):not(:-moz-lwtheme),
 .tabbrowser-arrowscrollbox > .scrollbutton-down:-moz-system-metric(windows-compositor):not(:-moz-lwtheme) {
@@ -2207,6 +2278,14 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 
 .tabs-newtab-button {
   width: 28px;
+}
+
+/* Increase the width of the New Tab button to compensate for the
+   transparent outer border that's added when the tabs are on top
+   and the window is maximized or in full-screen mode */
+#main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
+#main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
+  width: 30px;
 }
 
 #TabsToolbar > #new-tab-button {

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1908,6 +1908,22 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   padding: 0;
 }
 
+%ifdef WINDOWS_AERO
+/* Make sure the Navigation toolbar buttons are vertically centered between
+   the tabs and the AppMenu button when the tabs are not on top and the
+   Bookmarks toolbar is disabled */
+#nav-bar + #customToolbars + #PersonalToolbar:-moz-any([collapsed=true],[moz-collapsed=true]) + #TabsToolbar[tabsontop=false] {
+  margin-top: 2px;
+}
+%else
+/* Make sure the Navigation toolbar buttons are vertically centered between
+   the tabs and the title bar when the tabs are not on top and the Bookmarks
+   toolbar is disabled */
+#nav-bar + #customToolbars + #PersonalToolbar:-moz-any([collapsed=true],[moz-collapsed=true]) + #TabsToolbar[tabsontop=false] {
+  margin-top: 1px;
+}
+%endif
+
 #TabsToolbar:not(:-moz-lwtheme),
 #TabsToolbar[tabsontop=false] {
   background-image: linear-gradient(to top, @toolbarShadowColor@ 1px, rgba(0,0,0,.05) 1px, transparent 50%);

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1950,8 +1950,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   -moz-appearance: none;
   background: @toolbarShadowOnTab@, @bgTabTexture@,
               linear-gradient(-moz-dialog, -moz-dialog);
-  background-origin: border-box;
-  background-repeat: no-repeat;
+  background-clip: padding-box;
   /* top margin of 0 is important for Fitts' Law in ToT/FS */
   margin: 0px 0.5px 0px;
   padding: 3px 3px 4px 1px;

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -2203,6 +2203,12 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   background-origin: border-box;
 }
 
+/* Make sure scrolling down to the last tab with the mousewheel disables
+   the scroll-down arrow */
+.tabbrowser-arrowscrollbox > .scrollbutton-down {
+  -moz-margin-end: -0.5px;
+}
+
 /* Add margin to the icon to compensate for the transparent outer border
    that's added to the tabs when the tabs are on top and the window is
    maximized or in full-screen mode */

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1924,6 +1924,13 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 }
 %endif
 
+/* Make sure the elements on the Tab bar are not "glued" right up against
+   the AppMenu button / the caption when the tabs are on top and the window
+   is unmaximized */
+#main-window[sizemode="normal"] #TabsToolbar[tabsontop=true] {
+  margin-top: 1px;
+}
+
 #TabsToolbar:not(:-moz-lwtheme),
 #TabsToolbar[tabsontop=false] {
   background-image: linear-gradient(to top, @toolbarShadowColor@ 1px, rgba(0,0,0,.05) 1px, transparent 50%);
@@ -1975,13 +1982,6 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
     border-radius: 0px;
     box-shadow: none;
   }
-}
-
-/* Make sure extra margin is added when tabs are not in the title bar so it doesn't
-   "glue" right up against the AppMenu button/caption */
-#main-window[sizemode="normal"][tabsontop=true] .tabbrowser-tab,
-#main-window[sizemode="normal"][tabsontop=true] .tabs-newtab-button {
-  margin-top: 5px;
 }
 
 .tabbrowser-tab:hover,
@@ -2217,10 +2217,6 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 #alltabs-button {
   list-style-image: url("chrome://browser/skin/tabbrowser/alltabs.png");
   -moz-image-region: rect(0, 14px, 16px, 0);
-}
-
-#main-window[sizemode="normal"][tabsontop=true] #alltabs-button {
-  margin-top: 5px;
 }
 
 #alltabs-button[type="menu"] {


### PR DESCRIPTION
This pull request introduces the following changes:

- Make sure that when the tabs are *not* on top, the Navigation toolbar buttons are vertically centered between the Bookmarks toolbar / the tabs on one side, and the AppMenu button (or the title bar) on the other
- Set margin on the Tab bar as a whole, instead of on the individual items it holds
- Make the tab corners more distinct/clean-cut
- Add a small visual gap between the tabs and the Menu bar / the top edge of the screen
- Make sure scrolling down to the last tab with the mousewheel disables the tab scrollbox's scroll-down arrow (for reference, see [this] (http://forum.palemoon.org/viewtopic.php?f=45&t=10828#p75823) post on the forum)

Additional change:

- Make sure that on Aero-enabled systems, the Tab bar is always transparent in full-screen mode

This is a revision of / follow-up to PRs #309, #310 and #313, which were reverted by commit f7c143e.