### PR TITLE
Add OSXRunLoopSingleton from upstream mozilla to libcubeb

### DIFF
--- a/media/libcubeb/src/OSXRunLoopSingleton.cpp
+++ b/media/libcubeb/src/OSXRunLoopSingleton.cpp
@@ -1,0 +1,45 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "OSXRunLoopSingleton.h"
+#include <mozilla/StaticMutex.h>
+
+#include <AudioUnit/AudioUnit.h>
+#include <CoreAudio/AudioHardware.h>
+#include <CoreAudio/HostTime.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+static bool gRunLoopSet = false;
+static mozilla::StaticMutex gMutex;
+
+void mozilla_set_coreaudio_notification_runloop_if_needed()
+{
+  mozilla::StaticMutexAutoLock lock(gMutex);
+  if (gRunLoopSet) {
+    return;
+  }
+
+  /* This is needed so that AudioUnit listeners get called on this thread, and
+   * not the main thread. If we don't do that, they are not called, or a crash
+   * occur, depending on the OSX version. */
+  AudioObjectPropertyAddress runloop_address = {
+    kAudioHardwarePropertyRunLoop,
+    kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyElementMaster
+  };
+
+  CFRunLoopRef run_loop = nullptr;
+
+  OSStatus r;
+  r = AudioObjectSetPropertyData(kAudioObjectSystemObject,
+                                 &runloop_address,
+                                 0, NULL, sizeof(CFRunLoopRef), &run_loop);
+  if (r != noErr) {
+    NS_WARNING("Could not make global CoreAudio notifications use their own thread.");
+  }
+
+  gRunLoopSet = true;
+}
+

--- a/media/libcubeb/src/OSXRunLoopSingleton.h
+++ b/media/libcubeb/src/OSXRunLoopSingleton.h
@@ -1,0 +1,26 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef OSXRUNLOOPSINGLETON_H_
+#define OSXRUNLOOPSINGLETON_H_
+
+#include <mozilla/Types.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/* This function tells CoreAudio to use its own thread for device change
+ * notifications, and can be called from any thread without external
+ * synchronization. */
+void MOZ_EXPORT
+mozilla_set_coreaudio_notification_runloop_if_needed();
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // OSXRUNLOOPSINGLETON_H_
+

--- a/media/libcubeb/src/moz.build
+++ b/media/libcubeb/src/moz.build
@@ -40,6 +40,9 @@ if CONFIG['OS_TARGET'] == 'Darwin':
         'cubeb_audiounit.c',
         'cubeb_osx_run_loop.c',
     ]
+    CPP_SOURCES += [
+        'OSXRunLoopSingleton.cpp',
+    ]
 
 if CONFIG['OS_TARGET'] == 'WINNT':
     CSRCS += [


### PR DESCRIPTION
I'm not sure why this goes into libcubeb, but cubeb_osx_run_loop.c
definitely links against it and won't compile without it.