### PR TITLE
Revert Mac screensaver changes fixes -- they break the build

### DIFF
--- a/content/html/content/public/HTMLMediaElement.h
+++ b/content/html/content/public/HTMLMediaElement.h
@@ -1110,9 +1110,6 @@ protected:
   // True if the media has an audio track
   bool mHasAudio;
 
-  // True if the media has a video track
-  bool mHasVideo;
-
   // True if the media's channel's download has been suspended.
   bool mDownloadSuspendedByCache;
 

--- a/content/html/content/src/HTMLMediaElement.cpp
+++ b/content/html/content/src/HTMLMediaElement.cpp
@@ -1917,7 +1917,6 @@ HTMLMediaElement::HTMLMediaElement(already_AddRefed<nsINodeInfo> aNodeInfo)
     mMediaSecurityVerified(false),
     mCORSMode(CORS_NONE),
     mHasAudio(false),
-    mHasVideo(false),
     mDownloadSuspendedByCache(false),
     mAudioChannelType(AUDIO_CHANNEL_NORMAL),
     mPlayingThroughTheAudioChannel(false),
@@ -2740,7 +2739,6 @@ void HTMLMediaElement::MetadataLoaded(int aChannels,
   mChannels = aChannels;
   mRate = aRate;
   mHasAudio = aHasAudio;
-  mHasVideo = aHasVideo;
   mTags = aTags;
   ChangeReadyState(nsIDOMHTMLMediaElement::HAVE_METADATA);
   DispatchAsyncEvent(NS_LITERAL_STRING("durationchange"));
@@ -3116,6 +3114,9 @@ VideoFrameContainer* HTMLMediaElement::GetVideoFrameContainer()
     return nullptr;
   }
 
+  if (mVideoFrameContainer)
+    return mVideoFrameContainer;
+
   // If we have a print surface, this is just a static image so
   // no image container is required
   if (mPrintSurface)
@@ -3125,11 +3126,6 @@ VideoFrameContainer* HTMLMediaElement::GetVideoFrameContainer()
   nsCOMPtr<nsIDOMHTMLVideoElement> video = do_QueryObject(this);
   if (!video)
     return nullptr;
-
-  mHasVideo = true;
-
-  if (mVideoFrameContainer)
-    return mVideoFrameContainer;
 
   mVideoFrameContainer =
     new VideoFrameContainer(this, LayerManager::CreateAsynchronousImageContainer());

--- a/content/html/content/src/HTMLVideoElement.cpp
+++ b/content/html/content/src/HTMLVideoElement.cpp
@@ -271,7 +271,7 @@ HTMLVideoElement::WakeLockUpdate()
     return;
   }
 
-  if (!mScreenWakeLock && !mPaused && !hidden && mHasVideo) {
+  if (!mScreenWakeLock && !mPaused && !hidden) {
     nsCOMPtr<nsIPowerManagerService> pmService =
       do_GetService(POWERMANAGERSERVICE_CONTRACTID);
     NS_ENSURE_TRUE_VOID(pmService);

--- a/widget/cocoa/nsAppShell.mm
+++ b/widget/cocoa/nsAppShell.mm
@@ -45,7 +45,7 @@ using namespace mozilla::widget;
 // Gecko. For example when we're playing video in a foreground tab we
 // don't want the screen saver to turn on.
 
-class MacWakeLockListener MOZ_FINAL : public nsIDOMMozWakeLockListener {
+class MacWakeLockListener : public nsIDOMMozWakeLockListener {
 public:
 NS_DECL_ISUPPORTS;
 
@@ -303,8 +303,7 @@ nsAppShell::~nsAppShell()
 }
 
 NS_IMPL_ISUPPORTS(MacWakeLockListener, nsIDOMMozWakeLockListener)
-nsCOMPtr<nsIPowerManagerService> sPowerManagerService = nullptr;
-nsCOMPtr<nsIDOMMozWakeLockListener> sWakeLockListener = nullptr;
+mozilla::StaticRefPtr<MacWakeLockListener> sWakeLockListener;
 
 static void
 AddScreenWakeLockListener()

--- a/widget/cocoa/nsAppShell.mm
+++ b/widget/cocoa/nsAppShell.mm
@@ -35,68 +35,8 @@
 #include "GoannaProfiler.h"
 
 #include "npapi.h"
-#include <IOKit/pwr_mgt/IOPMLib.h>
-#include "nsIDOMWakeLockListener.h"
-#include "nsIPowerManagerService.h"
 
 using namespace mozilla::widget;
-
-// A wake lock listener that disables screen saver when requested by
-// Gecko. For example when we're playing video in a foreground tab we
-// don't want the screen saver to turn on.
-
-class MacWakeLockListener : public nsIDOMMozWakeLockListener {
-public:
-NS_DECL_ISUPPORTS;
-
-private:
-  IOPMAssertionID mAssertionID = kIOPMNullAssertionID;
-  NS_IMETHOD Callback(const nsAString& aTopic, const nsAString& aState) {
-    bool isLocked = mLockedTopics.Contains(aTopic);
-    bool shouldLock = aState.EqualsLiteral("locked-foreground");
-    if (isLocked == shouldLock) {
-      return NS_OK;
-    }
-    if (shouldLock) {
-      if (!mLockedTopics.Count()) {
-        // This is the first topic to request the screen saver be disabled.
-        // Prevent screen saver.
-        CFStringRef cf_topic =
-          ::CFStringCreateWithCharacters(kCFAllocatorDefault,
-                                         reinterpret_cast<const UniChar*>
-                                           (aTopic.Data()),
-                                         aTopic.Length());
-        IOReturn success =
-          ::IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep,
-                                        kIOPMAssertionLevelOn,
-                                        cf_topic,
-                                        &mAssertionID);
-        CFRelease(cf_topic);
-        if (success != kIOReturnSuccess) {
-          NS_WARNING("fail to disable screensaver");
-        }
-      }
-      mLockedTopics.PutEntry(aTopic);
-    } else {
-      mLockedTopics.RemoveEntry(aTopic);
-      if (!mLockedTopics.Count()) {
-        // No other outstanding topics have requested screen saver be disabled.
-        // Re-enable screen saver.
-        if (mAssertionID != kIOPMNullAssertionID) {
-          IOReturn result = ::IOPMAssertionRelease(mAssertionID);
-          if (result != kIOReturnSuccess) {
-            NS_WARNING("fail to release screensaver");
-          }
-        }
-      }
-    }
-    return NS_OK;
-  }
-  // Keep track of all the topics that have requested a wake lock. When the
-  // number of topics in the hashtable reaches zero, we can uninhibit the
-  // screensaver again.
-  nsTHashtable<nsStringHashKey> mLockedTopics;
-};
 
 // defined in nsCocoaWindow.mm
 extern int32_t             gXULModalLevel;
@@ -300,34 +240,6 @@ nsAppShell::~nsAppShell()
   [mDelegate release];
 
   NS_OBJC_END_TRY_ABORT_BLOCK
-}
-
-NS_IMPL_ISUPPORTS(MacWakeLockListener, nsIDOMMozWakeLockListener)
-mozilla::StaticRefPtr<MacWakeLockListener> sWakeLockListener;
-
-static void
-AddScreenWakeLockListener()
-{
-  nsCOMPtr<nsIPowerManagerService> sPowerManagerService = do_GetService(
-                                                          POWERMANAGERSERVICE_CONTRACTID);
-  if (sPowerManagerService) {
-    sWakeLockListener = new MacWakeLockListener();
-    sPowerManagerService->AddWakeLockListener(sWakeLockListener);
-  } else {
-    NS_WARNING("Failed to retrieve PowerManagerService, wakelocks will be broken!");
-  }
-}
-
-static void
-RemoveScreenWakeLockListener()
-{
-  nsCOMPtr<nsIPowerManagerService> sPowerManagerService = do_GetService(
-                                                          POWERMANAGERSERVICE_CONTRACTID);
-  if (sPowerManagerService) {
-    sPowerManagerService->RemoveWakeLockListener(sWakeLockListener);
-    sPowerManagerService = nullptr;
-    sWakeLockListener = nullptr;
-  }
 }
 
 // An undocumented CoreGraphics framework method, present in the same form
@@ -840,12 +752,7 @@ nsAppShell::Run(void)
     return NS_OK;
 
   mStarted = true;
-
-  AddScreenWakeLockListener();
-
   NS_OBJC_TRY_ABORT([NSApp run]);
-
-  RemoveScreenWakeLockListener();
 
   return NS_OK;
 }

--- a/widget/cocoa/nsAppShell.mm
+++ b/widget/cocoa/nsAppShell.mm
@@ -308,7 +308,8 @@ mozilla::StaticRefPtr<MacWakeLockListener> sWakeLockListener;
 static void
 AddScreenWakeLockListener()
 {
-  sPowerManagerService = do_GetService(POWERMANAGERSERVICE_CONTRACTID);
+  nsCOMPtr<nsIPowerManagerService> sPowerManagerService = do_GetService(
+                                                          POWERMANAGERSERVICE_CONTRACTID);
   if (sPowerManagerService) {
     sWakeLockListener = new MacWakeLockListener();
     sPowerManagerService->AddWakeLockListener(sWakeLockListener);
@@ -320,7 +321,8 @@ AddScreenWakeLockListener()
 static void
 RemoveScreenWakeLockListener()
 {
-  sPowerManagerService = do_GetService(POWERMANAGERSERVICE_CONTRACTID);
+  nsCOMPtr<nsIPowerManagerService> sPowerManagerService = do_GetService(
+                                                          POWERMANAGERSERVICE_CONTRACTID);
   if (sPowerManagerService) {
     sPowerManagerService->RemoveWakeLockListener(sWakeLockListener);
     sPowerManagerService = nullptr;

--- a/widget/windows/nsAppShell.cpp
+++ b/widget/windows/nsAppShell.cpp
@@ -15,64 +15,8 @@
 #include "WinIMEHandler.h"
 #include "mozilla/widget/AudioSession.h"
 #include "mozilla/HangMonitor.h"
-#include "nsIDOMWakeLockListener.h"
-#include "nsIPowerManagerService.h"
-#include "mozilla/StaticPtr.h"
-#include "nsTHashtable.h"
-#include "nsHashKeys.h"
 
 using namespace mozilla::widget;
-
-// A wake lock listener that disables screen saver when requested by
-// Gecko. For example when we're playing video in a foreground tab we
-// don't want the screen saver to turn on.
-class WinWakeLockListener MOZ_FINAL : public nsIDOMMozWakeLockListener {
-public:
-  NS_DECL_ISUPPORTS;
-
-  NS_IMETHOD Callback(const nsAString& aTopic, const nsAString& aState) {
-    if (!aTopic.EqualsASCII("screen")) {
-      return NS_OK;
-    }
-    // Note the wake lock code ensures that we're not sent duplicate
-    // "locked-foreground" notifications when multipe wake locks are held.
-    if (aState.EqualsASCII("locked-foreground")) {
-      // Prevent screen saver.
-      SetThreadExecutionState(ES_DISPLAY_REQUIRED|ES_CONTINUOUS);
-    } else {
-      // Re-enable screen saver.
-      SetThreadExecutionState(ES_CONTINUOUS);
-    }
-    return NS_OK;
-  }
-};
-
-NS_IMPL_ISUPPORTS1(WinWakeLockListener, nsIDOMMozWakeLockListener)
-nsCOMPtr<nsIPowerManagerService> sPowerManagerService = nullptr;
-nsCOMPtr<nsIDOMMozWakeLockListener> sWakeLockListener = nullptr;
-
-static void
-AddScreenWakeLockListener()
-{
-  sPowerManagerService = do_GetService(POWERMANAGERSERVICE_CONTRACTID);
-  if (sPowerManagerService) {
-    sWakeLockListener = new WinWakeLockListener();
-    sPowerManagerService->AddWakeLockListener(sWakeLockListener);
-  } else {
-    NS_WARNING("Failed to retrieve PowerManagerService, wakelocks will be broken!");
-  }
-}
-
-static void
-RemoveScreenWakeLockListener()
-{
-  sPowerManagerService = do_GetService(POWERMANAGERSERVICE_CONTRACTID);
-  if (sPowerManagerService) {
-    sPowerManagerService->RemoveWakeLockListener(sWakeLockListener);
-    sPowerManagerService = nullptr;
-    sWakeLockListener = nullptr;
-  }
-}
 
 const PRUnichar* kAppShellEventId = L"nsAppShell:EventID";
 const PRUnichar* kTaskbarButtonEventId = L"TaskbarButtonCreated";
@@ -154,13 +98,7 @@ nsAppShell::Run(void)
   // appropriate response to failing to start an audio session.
   mozilla::widget::StartAudioSession();
 
-  // Add an observer that disables the screen saver when requested by Gecko.
-  // For example when we're playing video in the foreground tab.
-  AddScreenWakeLockListener();
-
   nsresult rv = nsBaseAppShell::Run();
-
-  RemoveScreenWakeLockListener();
 
   mozilla::widget::StopAudioSession();
 


### PR DESCRIPTION
Sounds like this is an important feature, but it breaks the build (see #301).  We should re-consider it once it compiles :smile: 

!!! before considering this PR, take a look at #321, which might be an actual fix rather than a revert!