### PR TITLE
Expect missing files for SDK builds

### DIFF
--- a/browser/installer/Makefile.in
+++ b/browser/installer/Makefile.in
@@ -18,7 +18,9 @@ MOZ_PKG_REMOVALS = $(srcdir)/removed-files.in
 MOZ_PKG_MANIFEST_P = $(srcdir)/package-manifest.in
 # Some files have been already bundled with xulrunner
 ifndef SYSTEM_LIBXUL
+ifndef LIBXUL_SDK
 MOZ_PKG_FATAL_WARNINGS = 1
+endif
 endif
 
 MOZ_NONLOCALIZED_PKG_LIST = \


### PR DESCRIPTION
If it is not just libxul being used in the build but the whole "goanna SDK", this should also allow omni.ja files to exclude some parts of the runtime.