### PR TITLE
Clarify comments with code that centers the Navigation toolbar buttons

### DIFF
--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1911,14 +1911,14 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 %ifdef WINDOWS_AERO
 /* Make sure the Navigation toolbar buttons are vertically centered between
    the tabs and the AppMenu button when the tabs are not on top and the
-   Bookmarks toolbar is disabled */
+   Bookmarks toolbar is disabled or temporarily hidden (full-screen mode) */
 #nav-bar + #customToolbars + #PersonalToolbar:-moz-any([collapsed=true],[moz-collapsed=true]) + #TabsToolbar[tabsontop=false] {
   margin-top: 2px;
 }
 %else
 /* Make sure the Navigation toolbar buttons are vertically centered between
    the tabs and the title bar when the tabs are not on top and the Bookmarks
-   toolbar is disabled */
+   toolbar is disabled or temporarily hidden (full-screen mode) */
 #nav-bar + #customToolbars + #PersonalToolbar:-moz-any([collapsed=true],[moz-collapsed=true]) + #TabsToolbar[tabsontop=false] {
   margin-top: 1px;
 }


### PR DESCRIPTION
This pull request clarifies the comments with the code that vertically centers the Navigation toolbar buttons between the tabs and the AppMenu button / the title bar.

This is a follow-up to PR #317.