### PR TITLE
Downloads API Shims, pt.2

### DIFF
--- a/toolkit/components/jsdownloads/src/DownloadCore.jsm
+++ b/toolkit/components/jsdownloads/src/DownloadCore.jsm
@@ -62,6 +62,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "Promise",
                                   "resource://gre/modules/commonjs/sdk/core/promise.js");
 XPCOMUtils.defineLazyModuleGetter(this, "Task",
                                   "resource://gre/modules/Task.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "DownloadsCommon",
+                                  "resource://gre/modules/DownloadsCommon.jsm");
 
 const BackgroundFileSaverStreamListener = Components.Constructor(
       "@mozilla.org/network/background-file-saver;1?mode=streamlistener",
@@ -411,6 +413,34 @@ Download.prototype = {
       }
     }
     this._notifyChange();
+  },
+
+  /**
+   * Opens the downloaded file in the system file manager.
+   *
+   * @returns {Promise}
+   * @resolves When the file manager has been opened.
+   * @rejects Javascript exception.
+   */
+  showContainingDirectory: function() {
+    if (this.succeeded) {
+      DownloadsCommon.showDownloadedFile(this.target.file);
+    }
+    return Promise.resolve();
+  },
+
+  /**
+   * Launches the downloaded file.
+   *
+   * @returns {Promise}
+   * @resolves When the file manager has been opened.
+   * @rejects Javascript exception.
+   */
+  launch: function() {
+    if (this.succeeded) {
+      this.target.file.launch();
+    }
+    return Promise.resolve();
   },
 };
 


### PR DESCRIPTION
This isn't every shim that can be possibly made for the newer API, but in it's current state I have tested this extremely well unlike last time. It unbreaks a portion of addons (not all, obviously.) It's in a state where I'm comfortable with merging since it doesn't break anything.

The major problem with last attempt was Mozilla's API has changed so severely I really can't import even tiny bits of their code without major problems. I have to cut corners, unless I want to import newer mozilla core JSM (which isn't going to happen for obvious reasons. ;P)

Commit message is pretty descriptive, and I've made an effort to document as well as possible inside the source itself. Most of the changes were implemented from scratch to mostly follow Mozilla's docs.

There are a few caveats, obviously. Downloads.ALL won't retrieve both public and private downloads. This requires importing DownloadCombinedList, which for multiple reasons can't possibly work as-is.

I'll still probably work on this further, but it should be safe to merge what I have done.

EDIT: https://addons.mozilla.org/en-US/firefox/addon/download-flash-and-video/ which was posted to #326 is made functional by this PR, for example - probably owing to it using only the common functions I implemented. It doesn't show up in the Downloads List for some reason, though.