### PR TITLE
Fix Mac screensaver WakeLockListener, take 3

### DIFF
--- a/widget/cocoa/nsAppShell.mm
+++ b/widget/cocoa/nsAppShell.mm
@@ -302,7 +302,7 @@ nsAppShell::~nsAppShell()
   NS_OBJC_END_TRY_ABORT_BLOCK
 }
 
-NS_IMPL_ISUPPORTS(MacWakeLockListener, nsIDOMMozWakeLockListener)
+NS_IMPL_ISUPPORTS1(MacWakeLockListener, nsIDOMMozWakeLockListener)
 nsCOMPtr<nsIPowerManagerService> sPowerManagerService = nullptr;
 nsCOMPtr<nsIDOMMozWakeLockListener> sWakeLockListener = nullptr;
 

--- a/widget/cocoa/nsAppShell.mm
+++ b/widget/cocoa/nsAppShell.mm
@@ -49,6 +49,10 @@ class MacWakeLockListener MOZ_FINAL : public nsIDOMMozWakeLockListener {
 public:
 NS_DECL_ISUPPORTS;
 
+  MacWakeLockListener() {
+    mLockedTopics.Init();
+  }
+
 private:
   IOPMAssertionID mAssertionID = kIOPMNullAssertionID;
   NS_IMETHOD Callback(const nsAString& aTopic, const nsAString& aState) {


### PR DESCRIPTION
It turns out the code was actually very close to working -- fixing the `NS_IMPL_ISUPPORTS1` declaration fixes the build, and actually initializing the hashtable by calling `mLockedTopics.Init()` fixes the crash.

I tested that now a YouTube HTML5 video both does not crash and suppresses screensaver activation!

Fixes #301 