### PR TITLE
Simplify CSS for the tabs and the New Tab button (default Windows theme)

### DIFF
--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1951,19 +1951,27 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   background: @toolbarShadowOnTab@, @bgTabTexture@,
               linear-gradient(-moz-dialog, -moz-dialog);
   background-clip: padding-box;
-  /* top margin of 0 is important for Fitts' Law in ToT/FS */
-  margin: 0px 0.5px 0px;
-  border: 1px solid #929292;
+  border: 2px solid;
   border-bottom: none;
-  border-radius: 5px 5px 0px 0px;
+  border-radius: 6px 6px 0px 0px;
+  -moz-border-top-colors: transparent #929292;
+  -moz-border-left-colors: transparent #929292;
+  -moz-border-right-colors: transparent #929292;
   box-shadow: inset 0.5px 1px 1px rgba(255,255,255,.7);
 }
 
 .tabbrowser-tab {
+  margin: -1px -0.5px 0px;
   padding: 3px 3px 4px 1px;
 }
 
+.tabbrowser-tab:not([pinned]) {
+  max-width: 252px;
+  min-width: 102px;
+}
+
 .tabs-newtab-button {
+  margin: -1px 0px 0px -0.5px;
   padding: 3px 1px 4px 1px;
 }
 
@@ -1973,28 +1981,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 #main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
 #main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab,
 #main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
-  border-width: 2px 2px 0px;
-  border-radius: 6px 6px 0px 0px;
-  -moz-border-top-colors: transparent #929292;
-  -moz-border-left-colors: transparent #929292;
-  -moz-border-right-colors: transparent #929292;
-}
-#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab {
-  margin: 0px -0.5px 0px;
-}
-#main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
-  margin: 0px 0px 0px -0.5px;
-}
-
-/* Increase the width of the tabs to compensate for the transparent outer
-   border that's added when the tabs are on top and the window is maximized
-   or in full-screen mode */
-#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab[fadein]:not([pinned]),
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab[fadein]:not([pinned]) {
-  max-width: 252px;
-  min-width: 102px;
+  margin-top: 0px;
 }
 
 @media (-moz-os-version: windows-win8) {
@@ -2003,15 +1990,6 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
      on our other controls in the navigation toolbars */
   .tabbrowser-tab,
   .tabs-newtab-button {
-    border-radius: 2.5px 2.5px 0px 0px;
-  }
-
-  /* Set the border radius for the double border that's used when the tabs
-     are on top and the window is maximized or in full-screen mode */
-  #main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab,
-  #main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
-  #main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab,
-  #main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
     border-radius: 3.5px 3.5px 0px 0px;
   }
 }
@@ -2022,15 +2000,6 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   .tabs-newtab-button {
     border-radius: 0px;
     box-shadow: none;
-  }
-
-  /* Set the border radius for the double border that's used when the tabs
-     are on top and the window is maximized or in full-screen mode */
-  #main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab,
-  #main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
-  #main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab,
-  #main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
-    border-radius: 0px;
   }
 }
 
@@ -2081,15 +2050,6 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 .tabbrowser-tab:-moz-lwtheme-brighttext,
 .tabs-newtab-button:-moz-lwtheme-brighttext {
   box-shadow:none;
-  border-color: #707070;
-}
-
-/* Apply border color to the double border that's used when the tabs are
-   on top and the window is maximized or in full-screen mode */
-#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab:-moz-lwtheme-brighttext,
-#main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button:-moz-lwtheme-brighttext,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab:-moz-lwtheme-brighttext,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button:-moz-lwtheme-brighttext {
   -moz-border-top-colors: transparent #707070;
   -moz-border-left-colors: transparent #707070;
   -moz-border-right-colors: transparent #707070;
@@ -2101,13 +2061,6 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 
 .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext {
   background-image: linear-gradient(rgba(128,128,128,.9), rgba(32,32,32,.9) 50%, rgba(32,32,32,.9) 80%, rgba(32,32,32,.8) 100%);
-  border-color: #D0D0D0;
-}
-
-/* Apply border color to the double border that's used when the tabs are
-   on top and the window is maximized or in full-screen mode */
-#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext {
   -moz-border-top-colors: transparent #D0D0D0;
   -moz-border-left-colors: transparent #D0D0D0;
   -moz-border-right-colors: transparent #D0D0D0;
@@ -2213,15 +2166,14 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   background-origin: border-box;
 }
 
-/* Make sure scrolling down to the last tab with the mousewheel disables
-   the scroll-down arrow */
+/* Make sure scrolling down to the last tab with the mousewheel
+   disables the scroll-down arrow */
 .tabbrowser-arrowscrollbox > .scrollbutton-down {
   -moz-margin-end: -0.5px;
 }
 
-/* Add margin to the icon to compensate for the transparent outer border
-   that's added to the tabs when the tabs are on top and the window is
-   maximized or in full-screen mode */
+/* Prevent the icon from being vertically stretched when the tabs
+   are on top and the window is maximized or in full-screen mode */
 #main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-up > .toolbarbutton-icon,
 #main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-down > .toolbarbutton-icon,
 #main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-up > .toolbarbutton-icon,
@@ -2293,14 +2245,6 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 }
 
 .tabs-newtab-button {
-  width: 28px;
-}
-
-/* Increase the width of the New Tab button to compensate for the
-   transparent outer border that's added when the tabs are on top
-   and the window is maximized or in full-screen mode */
-#main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
   width: 30px;
 }
 


### PR DESCRIPTION
This pull request significantly simplifies the CSS for the tabs and the New Tab button in the default theme for Windows. As an additional benefit, the new code allows the user to customize the width of the tabs with the aid of the Tab Utilities extension, even when the tabs are on top (with the current code, that's not possible). Tested and confirmed working on Windows 7.

This is a follow-up to PR #317 (commit a6c16f0).