### PR TITLE
Remove transparent borders and negative margins from the tabs (default Windows theme)

### DIFF
--- a/browser/base/content/tabbrowser.xml
+++ b/browser/base/content/tabbrowser.xml
@@ -3386,9 +3386,9 @@
           this._lastTabClosedByMouse = true;
 
           if (this.getAttribute("overflow") == "true") {
-            // Don't need to do anything if we're in overflow mode and we're closing
-            // the last tab.
-            if (isEndTab)
+            // Don't need to do anything if we're in overflow mode and aren't scrolled
+            // all the way to the right, or if we're closing the last tab.
+            if (isEndTab || !this.mTabstrip._scrollButtonDown.disabled)
               return;
 
             // If the tab has an owner that will become the active tab, the owner will

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1951,36 +1951,20 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   background: @toolbarShadowOnTab@, @bgTabTexture@,
               linear-gradient(-moz-dialog, -moz-dialog);
   background-clip: padding-box;
-  border: 2px solid;
+  /* top margin of 0 is important for Fitts' Law in ToT/FS */
+  margin: 0px 0.5px 0px;
+  border: 1px solid #929292;
   border-bottom: none;
-  border-radius: 6px 6px 0px 0px;
-  -moz-border-top-colors: transparent #929292;
-  -moz-border-left-colors: transparent #929292;
-  -moz-border-right-colors: transparent #929292;
+  border-radius: 5px 5px 0px 0px;
   box-shadow: inset 0.5px 1px 1px rgba(255,255,255,.7);
 }
 
 .tabbrowser-tab {
-  margin: -1px -0.5px 0px;
   padding: 3px 3px 4px 1px;
 }
 
-.tabbrowser-tab:not([pinned]) {
-  max-width: 252px;
-  min-width: 102px;
-}
-
 .tabs-newtab-button {
-  margin: -1px 0px 0px -0.5px;
   padding: 3px 1px 4px 1px;
-}
-
-/* top margin of 0 is important for Fitts' Law in ToT/FS */
-#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-tab,
-#main-window[sizemode="maximized"][tabsontop=true] .tabs-newtab-button,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-tab,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabs-newtab-button {
-  margin-top: 0px;
 }
 
 @media (-moz-os-version: windows-win8) {
@@ -1989,7 +1973,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
      on our other controls in the navigation toolbars */
   .tabbrowser-tab,
   .tabs-newtab-button {
-    border-radius: 3.5px 3.5px 0px 0px;
+    border-radius: 2.5px 2.5px 0px 0px;
   }
 }
 
@@ -2049,9 +2033,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 .tabbrowser-tab:-moz-lwtheme-brighttext,
 .tabs-newtab-button:-moz-lwtheme-brighttext {
   box-shadow:none;
-  -moz-border-top-colors: transparent #707070;
-  -moz-border-left-colors: transparent #707070;
-  -moz-border-right-colors: transparent #707070;
+  border-color: #707070;
 }
 
 .tabbrowser-tab[selected="true"]:-moz-lwtheme {
@@ -2060,9 +2042,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 
 .tabbrowser-tab[selected="true"]:-moz-lwtheme-brighttext {
   background-image: linear-gradient(rgba(128,128,128,.9), rgba(32,32,32,.9) 50%, rgba(32,32,32,.9) 80%, rgba(32,32,32,.8) 100%);
-  -moz-border-top-colors: transparent #D0D0D0;
-  -moz-border-left-colors: transparent #D0D0D0;
-  -moz-border-right-colors: transparent #D0D0D0;
+  border-color: #D0D0D0;
 }
 
 .tabbrowser-tab:-moz-lwtheme-brighttext:not([selected="true"]),
@@ -2171,15 +2151,6 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   -moz-margin-end: -0.5px;
 }
 
-/* Prevent the icon from being vertically stretched when the tabs
-   are on top and the window is maximized or in full-screen mode */
-#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-up > .toolbarbutton-icon,
-#main-window[sizemode="maximized"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-down > .toolbarbutton-icon,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-up > .toolbarbutton-icon,
-#main-window[sizemode="fullscreen"][tabsontop=true] .tabbrowser-arrowscrollbox > .scrollbutton-down > .toolbarbutton-icon {
-  margin-bottom: 1px;
-}
-
 %ifdef WINDOWS_AERO
 .tabbrowser-arrowscrollbox > .scrollbutton-up:-moz-system-metric(windows-compositor):not(:-moz-lwtheme),
 .tabbrowser-arrowscrollbox > .scrollbutton-down:-moz-system-metric(windows-compositor):not(:-moz-lwtheme) {
@@ -2244,7 +2215,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 }
 
 .tabs-newtab-button {
-  width: 30px;
+  width: 28px;
 }
 
 #TabsToolbar > #new-tab-button {


### PR DESCRIPTION
Aiming to resolve issues #367 and #384, this pull request removes the transparent outer borders and the negative margins (introduced by PR #317 / commit a6c16f0) from the tabs. In addition, it reverts the current workaround for issue #384, which was introduced by commit 1ba944a.