### PR TITLE
Revise code that vertically centers the Navigation toolbar buttons

### DIFF
--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1908,21 +1908,12 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   padding: 0;
 }
 
-%ifdef WINDOWS_AERO
-/* Make sure the Navigation toolbar buttons are vertically centered between
-   the tabs and the AppMenu button when the tabs are not on top and the
-   Bookmarks toolbar is disabled */
-#nav-bar + #customToolbars + #PersonalToolbar:-moz-any([collapsed=true],[moz-collapsed=true]) + #TabsToolbar[tabsontop=false] {
-  margin-top: 2px;
-}
-%else
-/* Make sure the Navigation toolbar buttons are vertically centered between
-   the tabs and the title bar when the tabs are not on top and the Bookmarks
-   toolbar is disabled */
+/* Make sure the Navigation toolbar buttons are more or less vertically
+   centered between the tabs and the AppMenu button when the tabs are not
+   on top and the Bookmarks toolbar is disabled */
 #nav-bar + #customToolbars + #PersonalToolbar:-moz-any([collapsed=true],[moz-collapsed=true]) + #TabsToolbar[tabsontop=false] {
   margin-top: 1px;
 }
-%endif
 
 /* Make sure the elements on the Tab bar are not "glued" right up against
    the AppMenu button / the caption when the tabs are on top and the window


### PR DESCRIPTION
Commit f0a08bd added some code to vertically center the Navigation toolbar buttons between the tabs on one side and the AppMenu button on the other, but the chosen solution is not ideal; I think that when the Menu bar is active, the gap between the tabs and the Navigation toolbar buttons is too big compared to the gap between the Navigation toolbar buttons and the Menu bar. This pull request reduces the gap by 1px (by reducing the top margin on the Tab bar) and simplifies the relevant code.