### PR TITLE
Add tooltip to the Pale Moon button on Windows

### DIFF
--- a/browser/base/content/browser.xul
+++ b/browser/base/content/browser.xul
@@ -310,6 +310,7 @@
       <button id="appmenu-button"
               type="menu"
               label="&brandShortName;"
+              tooltiptext="&appMenuButton.tooltip;"
               style="-moz-user-focus: ignore;">
 #include browser-appmenu.inc
       </button>


### PR DESCRIPTION
On Linux, the Pale Moon button has a descriptive tooltip; on Windows, for some reason, this tooltip has been omitted. This pull request adds the "Open Pale Moon menu" tooltip to the Pale Moon button on Windows.

Tested and confirmed working on Windows 7.