### PR TITLE
Misc. GStreamer tweaks

### DIFF
--- a/content/media/gstreamer/GStreamerLoader.cpp
+++ b/content/media/gstreamer/GStreamerLoader.cpp
@@ -13,6 +13,12 @@
 #define LIBGSTAPP 1
 #define LIBGSTVIDEO 2
 
+#ifdef __OpenBSD__
+#define LIB_GST_SUFFIX ".so"
+#else
+#define LIB_GST_SUFFIX ".so.0"
+#endif
+
 namespace mozilla {
 
 /*
@@ -63,13 +69,13 @@ load_gstreamer()
   if (major == GST_VERSION_MAJOR && minor == GST_VERSION_MINOR) {
     gstreamerLib = RTLD_DEFAULT;
   } else {
-    gstreamerLib = dlopen("libgstreamer-" GST_API_VERSION ".so.0", RTLD_NOW | RTLD_LOCAL);
+    gstreamerLib = dlopen("libgstreamer-" GST_API_VERSION LIB_GST_SUFFIX, RTLD_NOW | RTLD_LOCAL);
   }
 
   void *handles[3] = {
     gstreamerLib,
-    dlopen("libgstapp-" GST_API_VERSION ".so.0", RTLD_NOW | RTLD_LOCAL),
-    dlopen("libgstvideo-" GST_API_VERSION ".so.0", RTLD_NOW | RTLD_LOCAL)
+    dlopen("libgstapp-" GST_API_VERSION LIB_GST_SUFFIX, RTLD_NOW | RTLD_LOCAL),
+    dlopen("libgstvideo-" GST_API_VERSION LIB_GST_SUFFIX, RTLD_NOW | RTLD_LOCAL)
   };
 
   for (size_t i = 0; i < sizeof(handles) / sizeof(handles[0]); i++) {

--- a/content/media/gstreamer/GStreamerReader.cpp
+++ b/content/media/gstreamer/GStreamerReader.cpp
@@ -312,6 +312,7 @@ nsresult GStreamerReader::ReadMetadata(VideoInfo* aInfo,
     }
 
     /* start the pipeline */
+    LOG(PR_LOG_DEBUG, ("starting metadata pipeline"));
     gst_element_set_state(mPlayBin, GST_STATE_PAUSED);
 
     /* Wait for ASYNC_DONE, which is emitted when the pipeline is built,
@@ -332,6 +333,7 @@ nsresult GStreamerReader::ReadMetadata(VideoInfo* aInfo,
       gst_message_unref(message);
       ret = NS_ERROR_FAILURE;
     } else {
+      LOG(PR_LOG_DEBUG, ("read metadata pipeline prerolled"));
       gst_message_unref(message);
       ret = NS_OK;
       break;
@@ -494,6 +496,8 @@ nsresult GStreamerReader::ResetDecode()
 #endif
   mLastReportedByteOffset = 0;
   mByteOffset = 0;
+
+  LOG(PR_LOG_DEBUG, ("reset decode done"));
 
   return res;
 }

--- a/content/media/gstreamer/GStreamerReader.cpp
+++ b/content/media/gstreamer/GStreamerReader.cpp
@@ -347,20 +347,6 @@ nsresult GStreamerReader::ReadMetadata(VideoInfo* aInfo,
     /* we couldn't get this to play */
     return ret;
 
-  /* FIXME: workaround for a bug in matroskademux. This seek makes matroskademux
-   * parse the index */
-  if (gst_element_seek_simple(mPlayBin, GST_FORMAT_TIME,
-        GST_SEEK_FLAG_FLUSH, 0)) {
-    /* after a seek we need to wait again for ASYNC_DONE */
-    message = gst_bus_timed_pop_filtered(mBus, GST_CLOCK_TIME_NONE,
-       (GstMessageType)(GST_MESSAGE_ASYNC_DONE | GST_MESSAGE_ERROR));
-    if (GST_MESSAGE_TYPE(message) == GST_MESSAGE_ERROR) {
-      gst_element_set_state(mPlayBin, GST_STATE_NULL);
-      gst_message_unref(message);
-      return NS_ERROR_FAILURE;
-    }
-  }
-
   /* report the duration */
   gint64 duration;
 #if GST_VERSION_MAJOR >= 1

--- a/content/media/gstreamer/GStreamerReader.cpp
+++ b/content/media/gstreamer/GStreamerReader.cpp
@@ -37,9 +37,16 @@ IsYV12Format(const VideoData::YCbCrBuffer::Plane& aYPlane,
              const VideoData::YCbCrBuffer::Plane& aCbPlane,
              const VideoData::YCbCrBuffer::Plane& aCrPlane);
 
+#if DEBUG
 static const unsigned int MAX_CHANNELS = 4;
-// Let the demuxer work in pull mode for short files
-static const int SHORT_FILE_SIZE = 1024 * 1024;
+#endif
+// Let the demuxer work in pull mode for short files. This used to be a micro
+// optimization to have more accurate durations for ogg files in mochitests.
+// Since we aren't using gstreamer to demux ogg, and having demuxers
+// work in pull mode over http makes them slower (since they really assume
+// near-zero latency in pull mode) set the constant to 0 for now, which
+// effectively disables it.
+static const int SHORT_FILE_SIZE = 0;
 // The default resource->Read() size when working in push mode
 static const int DEFAULT_SOURCE_READ_SIZE = 50 * 1024;
 


### PR DESCRIPTION
This PR fixes an issue with GStreamer on OpenBSD (for if Pale Moon gets BSD builds in the future), disables pull mode over http in the ogg demuxer used by GStreamer (see comment in code), and removes a workaround (read: hack) for matroskademux, since it is not used by default with gst0.10 anyway, and is not even needed at all with gst1.x.

Tested with both gst 0.10 and 1.0.