### PR TITLE
Stop GStreamer from treating an EOS of one stream as EOS of all streams.

### DIFF
--- a/content/media/gstreamer/GStreamerReader.h
+++ b/content/media/gstreamer/GStreamerReader.h
@@ -158,7 +158,10 @@ private:
 
   /* Called at end of stream, when decoding has finished */
   static void EosCb(GstAppSink* aSink, gpointer aUserData);
-  void Eos();
+  /* Notifies that a sink will no longer receive any more data. If nullptr
+   * is passed to this, we'll assume all streams have reached EOS (for example
+   * an error has occurred). */
+  void Eos(GstAppSink* aSink = nullptr);
 
   /* Called when an element is added inside playbin. We use it to find the
    * decodebin instance.
@@ -219,7 +222,8 @@ private:
   /* bool used to signal when gst has detected the end of stream and
    * DecodeAudioData and DecodeVideoFrame should not expect any more data
    */
-  bool mReachedEos;
+  bool mReachedAudioEos;
+  bool mReachedVideoEos;
   /* offset we've reached reading from the source */
   gint64 mByteOffset;
   /* the last offset we reported with NotifyBytesConsumed */


### PR DESCRIPTION
Tested and seems to work as-intended with both 0.10 and 1.x.

This patch also appears to resolve the issue that was reported here: https://forum.palemoon.org/viewtopic.php?f=37&t=10074