### PR TITLE
TTrueOrFalse looks like a typo?  Fails build.

### DIFF
--- a/widget/cocoa/TextInputHandler.mm
+++ b/widget/cocoa/TextInputHandler.mm
@@ -1953,7 +1953,7 @@ TextInputHandler::InsertText(NSAttributedString *aAttrString)
      TrueOrFalse(IgnoreIMEComposition()),
      currentKeyEvent ? currentKeyEvent->mKeyEvent : nullptr,
      currentKeyEvent ?
-       TTrueOrFalse(currentKeyEvent->mKeyDownHandled) : "N/A",
+       TrueOrFalse(currentKeyEvent->mKeyDownHandled) : "N/A",
      currentKeyEvent ?
        TrueOrFalse(currentKeyEvent->mKeyPressDispatched) : "N/A",
      currentKeyEvent ?


### PR DESCRIPTION
Looks like commit https://github.com/MoonchildProductions/Pale-Moon/commit/e948b4f60bd2977f464b9e768bc496c69be59ac0 by @wolfbeast broke this?

```
28:22.15 /Users/pale/jenkins/workspace/palemoon/widget/cocoa/TextInputHandler.mm:1956:8: error: use of undeclared identifier 'TTrueOrFalse'; did you mean 'TrueOrFalse'?
28:22.15        TTrueOrFalse(currentKeyEvent->mKeyDownHandled) : "N/A",
28:22.15        ^~~~~~~~~~~~
28:22.16        TrueOrFalse
28:22.16 /Users/pale/jenkins/workspace/palemoon/obj-x86_64-apple-darwin12.5.0/dist/include/nspr/prlog.h:179:19: note: expanded from macro 'PR_LOG'
28:22.16       PR_LogPrint _args;         \
28:22.16                   ^
28:22.17 /Users/pale/jenkins/workspace/palemoon/widget/cocoa/TextInputHandler.mm:71:1: note: 'TrueOrFalse' declared here
28:22.17 TrueOrFalse(bool aBool)
28:22.17 ^
28:22.17 1 error generated.
28:22.18 
```