### PR TITLE
Build with GStreamer 1.x support by default

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -5578,7 +5578,7 @@ dnl = Enable GStreamer
 dnl ========================================================
 if test "$OS_TARGET" = "Linux"; then
   MOZ_GSTREAMER=1
-  GST_API_VERSION=0.10
+  GST_API_VERSION=1.0
 fi
 
 MOZ_ARG_ENABLE_STRING(gstreamer,


### PR DESCRIPTION
Those who do not want 1.x support for whatever reason can use -enable-gstreamer=0.10 or -disable-gstreamer options.