### PR TITLE
Comment out undefined object in the XSS filter (fixes debug builds)

### DIFF
--- a/caps/src/nsScriptSecurityManager.cpp
+++ b/caps/src/nsScriptSecurityManager.cpp
@@ -517,9 +517,11 @@ nsScriptSecurityManager::XSSFilterPermitsJSAction(JSContext *cx, JSString *str)
 
     if (!subjectPrincipal) {
         // See bug 553448 for discussion of this case.
-        NS_ASSERTION(!JS_GetSecurityCallbacks(js::GetRuntime(cx))->findObjectPrincipals,
-                     "XSS: Should have been able to find subject principal."
-                     "Reluctantly allowing script.");
+        // findObjectPrincipals is not defined, and therefore breaks debug builds.
+        // Commenting out the below assertion as a workaround. See Issue #432.
+        //NS_ASSERTION(!JS_GetSecurityCallbacks(js::GetRuntime(cx))->findObjectPrincipals,
+        //             "XSS: Should have been able to find subject principal."
+        //             "Reluctantly allowing script.");
         return true;
     }
 


### PR DESCRIPTION
Fixes Issue #432. Confirmed works with GCC 4.9