### PR TITLE
Various theme-related improvements

### DIFF
--- a/browser/base/content/browser-title.css
+++ b/browser/base/content/browser-title.css
@@ -189,7 +189,7 @@
       top: -5px;
     }
     
-    #main-window[darkwindowframe="true"]::after {
+    #main-window[darkwindowframe="true"]:not(:-moz-window-inactive)::after {
       /* Dark window frame/accent color on Win 8/10 */
       color: white;
     }

--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -409,13 +409,9 @@
   }
 
 /* ==== Windows Vista/7 (true glass) styling ==== */
-/* Also apply this to Windows 8 because the system coloring the background
-   of #main-window is out of our control, and may kill readability */
 
   @media (-moz-os-version: windows-vista),
-         (-moz-os-version: windows-win7),
-         (-moz-os-version: windows-win8) {
-
+         (-moz-os-version: windows-win7) {
     #toolbar-menubar:not(:-moz-lwtheme),
     #TabsToolbar[tabsontop=true]:not(:-moz-lwtheme),
     #nav-bar[tabsontop=false]:not(:-moz-lwtheme),
@@ -431,12 +427,28 @@
     
   }
  
-/* ==== Adjust text for dark window frame colors ==== */
-
-  #main-window[darkwindowframe="true"] #toolbar-menubar:not(:-moz-lwtheme):not(:-moz-window-inactive),
-  #main-window[darkwindowframe="true"] #TabsToolbar:not(:-moz-lwtheme):not(:-moz-window-inactive) {
-    color: white;
+/* ==== Windows 8/10 (flat color) styling ==== */
+ 
+  @media (-moz-os-version: windows-win8),
+         (-moz-os-version: windows-win10) {
+    /* On dark window frames, use a light text color instead of fog on Win8/10 */
+    #main-window[darkwindowframe=true] #toolbar-menubar:not(:-moz-lwtheme),
+    #main-window[darkwindowframe=true] #TabsToolbar[tabsontop=true]:not(:-moz-lwtheme),
+    #main-window[darkwindowframe=true] #nav-bar[tabsontop=false]:not(:-moz-lwtheme),
+    #main-window[darkwindowframe=true] #nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child:not(:-moz-lwtheme) {
+	  color: white;
+	}
+    
+    /* Prevent the dark window frame styles from disturbing native menu styling */
+    #main-window[darkwindowframe=true] #main-menubar > menu:not(:-moz-lwtheme) {
+      color: inherit;
+    }
+    
+    #main-window[darkwindowframe=true] #toolbar-menubar:not(:-moz-lwtheme):-moz-window-inactive {
+      color: ThreeDShadow;
+    }
   }
+  
 /* ==== ==== */
 
   #main-window[sizemode=fullscreen]:not(:-moz-lwtheme) {

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -2123,6 +2123,10 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   padding: 0px;
 }
 
+.tab-close-button:not([selected]):not(:hover):not(:active) {
+  -moz-image-region: rect(0, 64px, 16px, 48px);
+}
+
 .tab-close-button:-moz-lwtheme-brighttext {
   list-style-image: url("chrome://global/skin/icons/close-inverted.png");
 }

--- a/toolkit/themes/windows/global/global.css
+++ b/toolkit/themes/windows/global/global.css
@@ -336,7 +336,3 @@ label[disabled="true"]:-moz-system-metric(windows-classic) {
 .close-icon:hover:active {
   -moz-image-region: rect(0, 48px, 16px, 32px);
 }
-
-.close-icon[selected="true"]:not(:hover):not(:active) {
-  -moz-image-region: rect(0, 16px, 16px, 0);
-}


### PR DESCRIPTION
This PR contains the following:

- The window title on Windows 8/10 for dark window frames was initially set whenever `darkwindowframe` is active, however it is still active when the window is inactive, making the title difficult to see. I've set it to only be white when the window is active.
- The previous `darkwindowframe` style for making the text white applied to only the menubar and tabbar; I've made it also enable when `tabsontop=false`, as there is still glass in the `#nav-bar` too.
- Corrected the mappings of `close-icon` for non-selected tabs.