### PR TITLE
Windows 10 theme changes

### DIFF
--- a/browser/base/content/browser-title.css
+++ b/browser/base/content/browser-title.css
@@ -189,7 +189,7 @@
       top: -5px;
     }
     
-    #main-window[darkwindowframe="true"]:not(:-moz-window-inactive)::after {
+    #main-window[darkwindowframe="true"]:not(:-moz-window-inactive):not(:-moz-lwtheme)::after {
       /* Dark window frame/accent color on Win 8/10 */
       color: white;
     }

--- a/browser/themes/windows/browser-aero.css
+++ b/browser/themes/windows/browser-aero.css
@@ -174,7 +174,7 @@
 /* ==== Windows 10 styling ==== */
 
   @media (-moz-os-version: windows-win10) {
-    /* Draw XUL caption buttons Win10 in lwthemes */
+    /* Draw XUL caption buttons on Win10 in lwthemes */
 
     #titlebar-buttonbox,
     .titlebar-button {
@@ -209,19 +209,14 @@
       padding-right: 19px;
     }
 	
-    #titlebar-close {
-      list-style-image: url(chrome://browser/skin/caption-buttons.svg#close-highlight);
-      background-color: hsl(0, 86%, 49%) !important; 
-      opacity: 0;
-    }
-    
     #titlebar-close:hover {
-      opacity: 1;
+      list-style-image: url(chrome://browser/skin/caption-buttons.svg#close-highlight);
+      background-color: hsla(0, 86%, 49%, 1) !important; 
       transition: opacity linear 100ms;
     }
 
     #titlebar-close:hover:active {
-      background-color: hsl(0, 86%, 42%) !important; 
+      background-color: hsla(0, 86%, 49%, 0.6) !important; 
       transition: none;
     }
     
@@ -323,25 +318,17 @@
     .titlebar-button:not(:hover) > .toolbarbutton-icon:-moz-window-inactive {
       opacity: 0.5;
     }
-
-    #titlebar-close:hover {
-      background-color: hsl(355, 86%, 49%);
-    }
-
-    #titlebar-close:hover:active {
-      background-color: hsl(355, 82%, 69%);
-    }
           
     /* dark persona/titlebar */
     .titlebar-button:-moz-lwtheme-brighttext:hover,
-    #main-window[darkwindowframe="true"] .titlebar-button:hover {
-      background-color: hsla(0, 0%, 100%, .22);
+    #main-window[darkwindowframe="true"] .titlebar-button:not(:-moz-window-inactive):not(:-moz-lwtheme):hover {
+      background-color: hsla(0, 0%, 100%, .12);
       transition: background-color linear 100ms;
     }
 
     .titlebar-button:-moz-lwtheme-brighttext:hover:active,
-    #main-window[darkwindowframe="true"] .titlebar-button:hover:active	{
-      background-color: hsla(0, 0%, 100%, .32);
+    #main-window[darkwindowframe="true"] .titlebar-button:not(:-moz-window-inactive):not(:-moz-lwtheme):hover:active	{
+      background-color: hsla(0, 0%, 100%, .22);
       transition: none;
     }
       


### PR DESCRIPTION
In an effort to make the Windows 10 styling look more system-native, the following changes were made:

- Window title on dark windows frames is now not used in lwtheme mode. It was ignoring the styles the lwthemes wanted.
- Altered the close button animation. The most noticeable change here will be the opacity change when clicked - this is to mirror behavior in Windows 10.
- Bright caption buttons (for dark window frames) had the exact opposite issue of the window title above: it was working for lwthemes, but not inactive windows. I also lowered the brightness slightly to match the style used in the system.