### PR TITLE
Change default MOZ_OPTIMIZE_FLAGS for GCC to -O2

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1938,7 +1938,7 @@ ia64*-hpux*)
     TARGET_NSPR_MDCPUCFG='\"md/_linux.cfg\"'
 
     MOZ_GFX_OPTIMIZE_MOBILE=1
-    MOZ_OPTIMIZE_FLAGS="-Os -fno-reorder-functions"
+    MOZ_OPTIMIZE_FLAGS="-O2 -fno-reorder-functions"
     if test -z "$CLANG_CC"; then
       MOZ_OPTIMIZE_FLAGS="-freorder-blocks $MOZ_OPTIMIZE_FLAGS"
     fi
@@ -1954,7 +1954,7 @@ ia64*-hpux*)
         MOZ_DEBUG_FLAGS="-g"
     elif test "$GNU_CC" -o "$GNU_CXX"; then
         MOZ_PGO_OPTIMIZE_FLAGS="-O3"
-        MOZ_OPTIMIZE_FLAGS="-Os"
+        MOZ_OPTIMIZE_FLAGS="-O2"
         if test -z "$CLANG_CC"; then
           MOZ_OPTIMIZE_FLAGS="-freorder-blocks $MOZ_OPTIMIZE_FLAGS"
         fi 


### PR DESCRIPTION
https://forum.palemoon.org/viewtopic.php?f=37&p=88000

I'm currently re-building Pale Moon 26.3.3 + this patch and will post results later, but should be safe to merge in.