### PR TITLE
Enable Pale Moon to be built with GCC 6.x

### DIFF
--- a/config/gcc-stl-wrapper.template.h
+++ b/config/gcc-stl-wrapper.template.h
@@ -22,6 +22,11 @@
 #define NOMINMAX 1
 #endif
 
+// Don't include mozalloc for cstdlib. See bug 1245076.
+#ifndef moz_dont_include_mozalloc_for_cstdlib
+#  define moz_dont_include_mozalloc_for_cstdlib
+#endif
+#ifndef moz_dont_include_mozalloc_for_${HEADER}
 // mozalloc.h wants <new>; break the cycle by always explicitly
 // including <new> here.  NB: this is a tad sneaky.  Sez the gcc docs:
 //
@@ -30,15 +35,17 @@
 //    same name as the current file. It simply looks for the file
 //    named, starting with the directory in the search path after the
 //    one where the current file was found.
-#include_next <new>
+#  include_next <new>
 
 // See if we're in code that can use mozalloc.  NB: this duplicates
 // code in nscore.h because nscore.h pulls in prtypes.h, and chromium
 // can't build with that being included before base/basictypes.h.
-#if !defined(XPCOM_GLUE) && !defined(NS_NO_XPCOM) && !defined(MOZ_NO_MOZALLOC)
-#  include "mozilla/mozalloc.h"
-#else
-#  error "STL code can only be used with infallible ::operator new()"
+#  if !defined(XPCOM_GLUE) && !defined(NS_NO_XPCOM) && !defined(MOZ_NO_MOZALLOC)
+#    include "mozilla/mozalloc.h"
+#  else
+#    error "STL code can only be used with infallible ::operator new()"
+#  endif
+
 #endif
 
 #if defined(DEBUG) && !defined(_GLIBCXX_DEBUG)

--- a/configure.in
+++ b/configure.in
@@ -1463,6 +1463,12 @@ else
     _DEFINES_CXXFLAGS='-DMOZILLA_CLIENT -D_MOZILLA_CONFIG_H_ $(ACDEFINES)'
 fi
 
+#FIXME: Work around breaking optimizations performed by GCC 6
+if test "$GCC_MAJOR_VERSION" -eq "6" ; then
+    CFLAGS="$CFLAGS -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2"
+    CXXFLAGS="$CXXFLAGS -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2"
+fi
+
 dnl gcc can come with its own linker so it is better to use the pass-thru calls
 dnl MKSHLIB_FORCE_ALL is used to force the linker to include all object
 dnl files present in an archive. MKSHLIB_UNFORCE_ALL reverts the linker to

--- a/gfx/graphite2/src/Collider.cpp
+++ b/gfx/graphite2/src/Collider.cpp
@@ -26,7 +26,7 @@ of the License or (at your option) any later version.
 */
 #include <algorithm>
 #include <limits>
-#include <math.h>
+#include <cmath>
 #include <string>
 #include <functional>
 #include "inc/Collider.h"

--- a/gfx/graphite2/src/Collider.cpp
+++ b/gfx/graphite2/src/Collider.cpp
@@ -26,7 +26,7 @@ of the License or (at your option) any later version.
 */
 #include <algorithm>
 #include <limits>
-#include <cmath>
+#include <math.h>
 #include <string>
 #include <functional>
 #include "inc/Collider.h"


### PR DESCRIPTION
This PR enables GCC 6 to build Pale Moon. Detailed changes:

Our STL wrappers includes mozalloc.h, which includes stdlib.h, which in libstdc++ >= 6 is now itself a wrapper around cstdlib, which circles back to our STL wrapper. With this PR mozalloc.h is no longer included in the cstdlib, allowing GCC 6 to compile Pale Moon successfully (although the browser segfaults immediately after opening).

GCC 6 also fails to build Graphite, but using cmath as opposed to math.h in Collider.cpp resolves the issue (this has been [fixed upstream](https://github.com/silnrsi/graphite/commit/fc73a64f5f86bb00ae082a7991497cbc392bf3fd) as well).

GCC 6 made several breaking changes to the way it optimizes some code. By passing the extra flags in this PR when using GCC 6, it resolves the immediate segfaulting (see above).

While far from "supporting" GCC 6 (for what it's worth Mozilla does not fully support it either), this will at least allow it to compile a working browser. I can confirm it works as intended, and does not break GCC 4.9 builds.