### PR TITLE
Disable (infinite) chunk recycling in jemalloc3

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -8976,6 +8976,9 @@ if test -z "$MOZ_NATIVE_JEMALLOC" -a "$MOZ_MEMORY" && test -n "$MOZ_JEMALLOC3" -
   _save_cache_file="$cache_file"
   cache_file=$_objdir/memory/jemalloc/src/config.cache
 
+  # Make Linux builds munmap freed chunks instead of recycling them.
+  ac_configure_args="$ac_configure_args --enable-munmap"
+
   if ! test -e memory/jemalloc; then
     mkdir -p memory/jemalloc
   fi


### PR DESCRIPTION
Jemalloc 3 has, by default, a form of chunk recycling enabled, where it actually doesn't unmap any chunk it ever allocated. Goanna has other uses of mmap, so it can lead to premature address space exhaustion.

With a quick test it appears to be working as intended. Even reduces the memory usage a bit while watching Youtube!