### PR TITLE
bug 1201224 - stop unifying test package during mac universal builds r=gps

### DIFF
--- a/build/macosx/universal/flight.mk
+++ b/build/macosx/universal/flight.mk
@@ -31,29 +31,3 @@ postflight_all:
 # actually does a universal staging with both OBJDIR_ARCH_1 and OBJDIR_ARCH_2.
 	$(MAKE) -C $(OBJDIR_ARCH_1)/$(MOZ_BUILD_APP)/installer \
 	   PKG_SKIP_STRIP=1 stage-package
-ifdef ENABLE_TESTS
-# Now, repeat the process for the test package.
-	$(MAKE) -C $(OBJDIR_ARCH_1) UNIVERSAL_BINARY= CHROME_JAR= package-tests
-	$(MAKE) -C $(OBJDIR_ARCH_2) UNIVERSAL_BINARY= CHROME_JAR= package-tests
-	rm -rf $(DIST_UNI)/test-package-stage
-# automation.py differs because it hardcodes a path to
-# dist/bin. It doesn't matter which one we use.
-	if test -d $(DIST_ARCH_1)/test-package-stage -a                 \
-                -d $(DIST_ARCH_2)/test-package-stage; then              \
-           cp $(DIST_ARCH_1)/test-package-stage/mochitest/automation.py \
-             $(DIST_ARCH_2)/test-package-stage/mochitest/;              \
-           cp -RL $(DIST_ARCH_1)/test-package-stage/mochitest/extensions/specialpowers \
-             $(DIST_ARCH_2)/test-package-stage/mochitest/extensions/;              \
-           cp $(DIST_ARCH_1)/test-package-stage/xpcshell/automation.py  \
-             $(DIST_ARCH_2)/test-package-stage/xpcshell/;               \
-           cp $(DIST_ARCH_1)/test-package-stage/reftest/automation.py   \
-             $(DIST_ARCH_2)/test-package-stage/reftest/;                \
-           cp -RL $(DIST_ARCH_1)/test-package-stage/reftest/specialpowers \
-             $(DIST_ARCH_2)/test-package-stage/reftest/;              \
-           $(TOPSRCDIR)/build/macosx/universal/unify                 \
-             --unify-with-sort "\.manifest$$" \
-             --unify-with-sort "all-test-dirs\.list$$"               \
-             $(DIST_ARCH_1)/test-package-stage                          \
-             $(DIST_ARCH_2)/test-package-stage                          \
-             $(DIST_UNI)/test-package-stage; fi
-endif

--- a/testing/testsuite-targets.mk
+++ b/testing/testsuite-targets.mk
@@ -388,8 +388,8 @@ pgo-profile-run:
 # Package up the tests and test harnesses
 include $(topsrcdir)/toolkit/mozapps/installer/package-name.mk
 
-ifndef UNIVERSAL_BINARY
 PKG_STAGE = $(DIST)/test-package-stage
+
 package-tests: \
   stage-config \
   stage-mochitest \
@@ -403,16 +403,10 @@ package-tests: \
   stage-modules \
   stage-marionette \
   $(NULL)
-else
-# This staging area has been built for us by universal/flight.mk
-PKG_STAGE = $(DIST)/universal/test-package-stage
-endif
 
 package-tests:
 	@rm -f "$(DIST)/$(PKG_PATH)$(TEST_PACKAGE)"
-ifndef UNIVERSAL_BINARY
 	$(NSINSTALL) -D $(DIST)/$(PKG_PATH)
-endif
 	find $(PKG_STAGE) -name "*.pyc" -exec rm {} \;
 	cd $(PKG_STAGE) && \
 	  zip -rq9D "$(call core_abspath,$(DIST)/$(PKG_PATH)$(TEST_PACKAGE))" \


### PR DESCRIPTION
Pick of upstream commit that removes broken code (fixes build failure on Mac)

--HG--
extra : commitid : HuB6LRpFWcT
extra : rebase_source : 54a36df1159fadd6287aefb531a29f42f7aacab6