### PR TITLE
Disable i386 build on Mac, and fix Make code that assumes multi-arch builds

### DIFF
--- a/build/macosx/universal/flight.mk
+++ b/build/macosx/universal/flight.mk
@@ -7,13 +7,11 @@
 # the two OBJDIRs.
 
 ifndef OBJDIR
-OBJDIR_ARCH_1 = $(MOZ_OBJDIR)/$(firstword $(MOZ_BUILD_PROJECTS))
-OBJDIR_ARCH_2 = $(MOZ_OBJDIR)/$(word 2,$(MOZ_BUILD_PROJECTS))
-DIST_ARCH_1 = $(OBJDIR_ARCH_1)/dist
-DIST_ARCH_2 = $(OBJDIR_ARCH_2)/dist
-DIST_UNI = $(DIST_ARCH_1)/universal
-OBJDIR = $(OBJDIR_ARCH_1)
+OBJDIR = $(MOZ_OBJDIR)/$(firstword $(MOZ_BUILD_PROJECTS))
 endif
+
+DIST_ARCH = $(OBJDIR)/dist
+DIST_UNI = $(DIST_ARCH)/universal
 
 topsrcdir = $(TOPSRCDIR)
 DEPTH = $(OBJDIR)
@@ -25,11 +23,8 @@ DIST = $(OBJDIR)/dist
 
 postflight_all:
 	mkdir -p $(DIST_UNI)/$(MOZ_PKG_APPNAME)
-	rm -f $(DIST_ARCH_2)/universal
-	ln -s $(call core_abspath,$(DIST_UNI)) $(DIST_ARCH_2)/universal
-# Stage a package for buildsymbols to be happy. Doing so in OBJDIR_ARCH_1
-# actually does a universal staging with both OBJDIR_ARCH_1 and OBJDIR_ARCH_2.
-	$(MAKE) -C $(OBJDIR_ARCH_1)/$(MOZ_BUILD_APP)/installer \
+# Stage a package for buildsymbols to be happy.
+	$(MAKE) -C $(OBJDIR)/$(MOZ_BUILD_APP)/installer \
 	   PKG_SKIP_STRIP=1 stage-package
 ifdef ENABLE_TESTS
 # Now, repeat the process for the test package.

--- a/build/macosx/universal/mozconfig
+++ b/build/macosx/universal/mozconfig
@@ -2,10 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# i386/x86-64 Universal Build mozconfig
-
-# As used here, arguments in $MOZ_BUILD_PROJECTS are suitable as arguments
-# to gcc's -arch parameter.
-mk_add_options MOZ_BUILD_PROJECTS="i386 x86_64"
+# Mac OS X build mozconfig, x86_64 only.
 
 . $topsrcdir/build/macosx/universal/mozconfig.common


### PR DESCRIPTION
32-bit Mac has been dying for a long time, and the universal build code is broken, so just rip it out...