### PR TITLE
Use -O1 optimization for kiss_fft lib (32bit builds)

### DIFF
--- a/media/kiss_fft/Makefile.in
+++ b/media/kiss_fft/Makefile.in
@@ -16,3 +16,9 @@ DISABLED_CSRCS = kiss_fft.c kiss_fftr.c
 
 include $(topsrcdir)/config/rules.mk
 
+#kiss_fft causes OOM error with some 32bit versions of GCC when using -O2
+ifndef HAVE_64BIT_OS
+ifndef _MSC_VER
+CFLAGS += -O1
+endif
+endif


### PR DESCRIPTION
Followup to commit 96301f23 to work around OOM errors when compiling with 32bit GCC.