### PR TITLE
Build GStreamer 0.10 support by default again

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -5584,7 +5584,7 @@ dnl = Enable GStreamer
 dnl ========================================================
 if test "$OS_TARGET" = "Linux"; then
   MOZ_GSTREAMER=1
-  GST_API_VERSION=1.0
+  GST_API_VERSION=0.10
 fi
 
 MOZ_ARG_ENABLE_STRING(gstreamer,


### PR DESCRIPTION
GStreamer 1.x support is causing way too many segfaults at present, and needs some serious TLC before we start using it again by default.