### PR TITLE
Fix Mac signing preventing launch

### DIFF
--- a/browser/app/nsBrowserApp.cpp
+++ b/browser/app/nsBrowserApp.cpp
@@ -52,6 +52,9 @@
 
 using namespace mozilla;
 
+#ifdef XP_MACOSX
+#define kOSXResourcesFolder "Resources"
+#endif
 #define kDesktopFolder "browser"
 #define kMetroFolder "metro"
 #define kMetroAppIniFilename "metroapp.ini"
@@ -242,7 +245,12 @@ static int do_main(int argc, char* argv[], nsIFile *xreDirectory)
 
     nsCOMPtr<nsIFile> greDir;
     exeFile->GetParent(getter_AddRefs(greDir));
-
+#ifdef XP_MACOSX
+    nsCOMPtr<nsIFile> parent;
+    greDir->GetParent(getter_AddRefs(parent));
+    greDir = parent.forget();
+    greDir->AppendNative(NS_LITERAL_CSTRING(kOSXResourcesFolder));
+#endif
     nsCOMPtr<nsIFile> appSubdir;
     greDir->Clone(getter_AddRefs(appSubdir));
     appSubdir->Append(NS_LITERAL_STRING(kDesktopFolder));
@@ -386,6 +394,10 @@ InitXPCOMGlue(const char *argv0, nsIFile **xreDirectory)
 
   // chop XPCOM_DLL off exePath
   *lastSlash = '\0';
+#ifdef XP_MACOSX
+  lastSlash = strrchr(exePath, XPCOM_FILE_PATH_SEPARATOR[0]);
+  strcpy(lastSlash + 1, kOSXResourcesFolder);
+#endif
 #ifdef XP_WIN
   rv = NS_NewLocalFile(NS_ConvertUTF8toUTF16(exePath), false,
                        xreDirectory);

--- a/ipc/glue/GoannaChildProcessHost.cpp
+++ b/ipc/glue/GoannaChildProcessHost.cpp
@@ -138,7 +138,11 @@ GoannaChildProcessHost::GetPathToBinary(FilePath& exePath)
     NS_NewLocalFile(nsDependentString(gGREBinPath), false,
                     getter_AddRefs(childProcPath));
     // We need to use an App Bundle on OS X so that we can hide
-    // the dock icon. See Bug 557225.
+    // the dock icon. See Bug 557225. 
+    nsCOMPtr<nsIFile> tempPath;
+    childProcPath->GetParent(getter_AddRefs(tempPath));
+    childProcPath = tempPath.forget();
+    childProcPath->AppendNative(NS_LITERAL_CSTRING("MacOS"));
     childProcPath->AppendNative(NS_LITERAL_CSTRING("plugin-container.app"));
     childProcPath->AppendNative(NS_LITERAL_CSTRING("Contents"));
     childProcPath->AppendNative(NS_LITERAL_CSTRING("MacOS"));

--- a/xpcom/build/XPCOMInit.cpp
+++ b/xpcom/build/XPCOMInit.cpp
@@ -611,6 +611,17 @@ NS_InitXPCOM2(nsIServiceManager** aResult,
   xpcomLib->GetPath(path);
   gGREBinPath = ToNewUnicode(path);
 
+#ifdef XP_MACOSX
+  nsCOMPtr<nsIFile> parent;
+  xpcomLib->GetParent(getter_AddRefs(parent));
+  parent->AppendNative(NS_LITERAL_CSTRING("MacOS"));
+  bool pathExists = false;
+  parent->Exists(&pathExists);
+  if (pathExists) {
+      xpcomLib = parent.forget();
+  }
+#endif
+
   xpcomLib->AppendNative(nsDependentCString(XPCOM_DLL));
   nsDirectoryService::gService->Set(NS_XPCOM_LIBRARY_FILE, xpcomLib);
 


### PR DESCRIPTION
Cherry-pick of 
Mac v2 signing - Bug 1050944 - Get Firefox to launch and run on OSX with the new .app bundle structure, made necessary by Apple's v2 signatures. r=smichaud, r=ted, sr=bsmedberg

Fixes #514 

This issue submitted with `Pale Moon 27.0.0a2 (x64) (2016-09-13)` on Mac.