### PR TITLE
Add a Mac mozconfig starter

### DIFF
--- a/build/macosx/mozconfig.tycho
+++ b/build/macosx/mozconfig.tycho
@@ -1,0 +1,31 @@
+mk_add_options MOZ_MAKE_FLAGS=-j8
+# Pale Moon branding
+
+ac_add_options --with-distribution-id=MCP
+#
+ac_add_options --enable-update-packaging
+ac_add_options --enable-official-branding
+ac_add_options --enable-release
+export MOZILLA_OFFICIAL=1
+#
+mk_add_options MOZ_CO_PROJECT=browser
+ac_add_options --enable-application=browser
+#
+ac_add_options --enable-optimize="-O2"
+#
+ac_add_options --enable-jemalloc
+#ac_add_options --enable-shared-js
+#
+ac_add_options --disable-debug
+ac_add_options --disable-tests
+ac_add_options --disable-mochitests
+#
+ac_add_options --disable-crashreporter
+ac_add_options --disable-accessibility
+ac_add_options --disable-parental-controls
+ac_add_options --disable-webrtc
+ac_add_options --disable-safe-browsing
+ac_add_options --disable-url-classifier
+ac_add_options --disable-sandbox
+#
+#ac_add_options --enable-strip


### PR DESCRIPTION
This is the `mozconfig` I am currently using to build release-branded Tycho.  Hopefully it seems reasonable.