### PR TITLE
Provide an indication for when there are no active downloads

### DIFF
--- a/browser/components/downloads/content/downloadsOverlay.xul
+++ b/browser/components/downloads/content/downloadsOverlay.xul
@@ -108,7 +108,7 @@
       <description id="emptyDownloads"
                    mousethrough="always">
            &downloadsPanelEmpty.label;
-	      </description>
+      </description>
 
       <vbox id="downloadsFooter">
         <hbox id="downloadsSummary"

--- a/browser/components/downloads/content/downloadsOverlay.xul
+++ b/browser/components/downloads/content/downloadsOverlay.xul
@@ -105,6 +105,10 @@
                    onmouseout="DownloadsView.onDownloadMouseOut(event);"
                    oncontextmenu="DownloadsView.onDownloadContextMenu(event);"
                    ondragstart="DownloadsView.onDownloadDragStart(event);"/>
+      <description id="emptyDownloads"
+                   mousethrough="always">
+           &downloadsPanelEmpty.label;
+	      </description>
 
       <vbox id="downloadsFooter">
         <hbox id="downloadsSummary"

--- a/browser/locales/en-US/chrome/browser/downloads/downloads.dtd
+++ b/browser/locales/en-US/chrome/browser/downloads/downloads.dtd
@@ -84,6 +84,11 @@
      -->
 <!ENTITY downloadsListEmpty.label         "There are no downloads.">
 
+<!-- LOCALIZATION NOTE (downloadsPanelEmpty.label):
+     This string is shown when there are no items in the Downloads Panel.
+     -->
+<!ENTITY downloadsPanelEmpty.label        "No downloads for this session.">
+
 <!-- LOCALIZATION NOTE (downloadsListNoMatch.label):
      This string is shown when some search terms are specified, but there are no
      results in the Downloads view.

--- a/browser/themes/linux/downloads/downloads.css
+++ b/browser/themes/linux/downloads/downloads.css
@@ -18,13 +18,22 @@
   display: none;
 }
 
+#downloadsPanel[hasdownloads] > #emptyDownloads {
+  display: none;
+}
+
+#emptyDownloads {
+  padding: 10px 20px;
+  max-width: 40ch;
+}
+
 #downloadsHistory {
   background: transparent;
   color: -moz-nativehyperlinktext;
   cursor: pointer;
 }
 
-#downloadsPanel[hasdownloads] > #downloadsFooter {
+#downloadsFooter {
   border-top: 1px solid ThreeDShadow;
   background-image: linear-gradient(hsla(0,0%,0%,.15), hsla(0,0%,0%,.08) 6px);
 }

--- a/browser/themes/osx/downloads/downloads.css
+++ b/browser/themes/osx/downloads/downloads.css
@@ -18,6 +18,15 @@
   display: none;
 }
 
+#downloadsPanel[hasdownloads] > #emptyDownloads {
+  display: none;
+}
+
+#emptyDownloads {
+  padding: 10px 20px;
+  max-width: 40ch;
+}
+
 #downloadsHistory {
   background: transparent;
   color: -moz-nativehyperlinktext;
@@ -35,7 +44,7 @@
 }
 
 @media (-moz-mac-lion-theme) {
-  #downloadsPanel[hasdownloads] > #downloadsFooter {
+  #downloadsFooter {
     background-color: hsla(216,45%,88%,.98);
     box-shadow: 0px 1px 2px rgb(204,214,234) inset;
     border-bottom-left-radius: 3px;

--- a/browser/themes/windows/downloads/downloads.css
+++ b/browser/themes/windows/downloads/downloads.css
@@ -18,6 +18,15 @@
   display: none;
 }
 
+#downloadsPanel[hasdownloads] > #emptyDownloads {
+  display: none;
+}
+
+#emptyDownloads {
+  padding: 10px 20px;
+  max-width: 40ch;
+}
+
 #downloadsHistory {
   background: transparent;
   cursor: pointer;
@@ -40,18 +49,18 @@
   margin: 1em;
 }
 
-#downloadsPanel[hasdownloads] > #downloadsFooter {
+#downloadsFooter {
   background-color: hsla(210,4%,10%,.04);
   box-shadow: 0 1px 0 hsla(210,4%,10%,.08) inset;
   transition-duration: 150ms;
   transition-property: background-color;
 }
 
-#downloadsPanel[hasdownloads] > #downloadsFooter:hover {
+#downloadsFooter:hover {
   background-color: hsla(210,4%,10%,.05);
 }
 
-#downloadsPanel[hasdownloads] > #downloadsFooter:hover:active {
+#downloadsFooter:hover:active {
   background-color: hsla(210,4%,10%,.1);
   box-shadow: 0 2px 0 0 hsla(210,4%,10%,.1) inset;
 }
@@ -59,15 +68,15 @@
 @media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
   @media (-moz-windows-default-theme) {
-    #downloadsPanel[hasdownloads] > #downloadsFooter {
+    #downloadsFooter {
       border-bottom-left-radius: 3px;
       border-bottom-right-radius: 3px;
       transition-duration: 0s;
     }
 
-    #downloadsPanel[hasdownloads] > #downloadsFooter,
-    #downloadsPanel[hasdownloads] > #downloadsFooter:hover,
-    #downloadsPanel[hasdownloads] > #downloadsFooter:hover:active {
+    #downloadsFooter,
+    #downloadsFooter:hover,
+    #downloadsFooter:hover:active {
       background-color: #f1f5fb;
       box-shadow: 0px 1px 2px rgb(204,214,234) inset;
     }


### PR DESCRIPTION
This adds an additional string, `downloadsPanelEmpty.label`, when no active downloads are taking place.

This has been added due to the current ambiguity of the panel, as there is potentially an implication that active downloads might be _somewhere_, just not living in the panel at that time. With this, it is made clear that _nothing_ is currently downloading, or has downloaded in the period of the browser session.

This also keeps the styling of the footer consistent, as otherwise it would change depending whether there was a download present in the panel or not.

Some before/after images (on Windows 10, at least; footer styles will remain as they should on Vista/7/etc):

![Before](http://i.imgur.com/IFNMDnk.png) ![After](http://i.imgur.com/97fZf6P.png)