### PR TITLE
Style customizeToolbar.xul using skin elements

### DIFF
--- a/browser/components/statusbar/jar.mn
+++ b/browser/components/statusbar/jar.mn
@@ -4,7 +4,7 @@
 
 browser.jar:
 % overlay chrome://browser/content/browser.xul                  chrome://browser/content/statusbar/overlay.xul
-% style chrome://global/content/customizeToolbar.xul            chrome://browser/content/statusbar/overlay.css
+% style chrome://global/content/customizeToolbar.xul            chrome://browser/skin/statusbar/overlay.css
         content/browser/statusbar/overlay.js                    (content/overlay.js)
         content/browser/statusbar/prefs.js                      (content/prefs.js)
         content/browser/statusbar/prefs.xml                     (content/prefs.xml)


### PR DESCRIPTION
This fixes styling issues with `customizeToolbar.xul` so that it can find the stylings for the statusbar buttons, which live in `skin` rather than `content`.