### PR TITLE
Add media queries for Linux/BSD/OSX (re-land)

### DIFF
--- a/dom/base/nsGkAtomList.h
+++ b/dom/base/nsGkAtomList.h
@@ -2153,6 +2153,10 @@ GK_ATOM(windows_theme_royale, "windows-theme-royale")
 GK_ATOM(windows_theme_zune, "windows-theme-zune")
 GK_ATOM(windows_theme_generic, "windows-theme-generic")
 
+GK_ATOM(nixlike_version_linux, "nixlike-version-gnu-linux")
+GK_ATOM(nixlike_version_bsd, "nixlike-version-bsd")
+GK_ATOM(nixlike_version_macosx, "nixlike-version-macos-x")
+
 // And the same again, as media query keywords.
 GK_ATOM(_moz_color_picker_available, "-moz-color-picker-available")
 GK_ATOM(_moz_scrollbar_start_backward, "-moz-scrollbar-start-backward")
@@ -2171,6 +2175,7 @@ GK_ATOM(_moz_windows_compositor, "-moz-windows-compositor")
 GK_ATOM(_moz_windows_classic, "-moz-windows-classic")
 GK_ATOM(_moz_windows_glass, "-moz-windows-glass")
 GK_ATOM(_moz_windows_theme, "-moz-windows-theme")
+GK_ATOM(_moz_unix_theme, "-moz-unix-theme")
 GK_ATOM(_moz_os_version, "-moz-os-version")
 GK_ATOM(_moz_touch_enabled, "-moz-touch-enabled")
 GK_ATOM(_moz_menubar_drag, "-moz-menubar-drag")

--- a/widget/LookAndFeel.h
+++ b/widget/LookAndFeel.h
@@ -386,6 +386,11 @@ public:
      * is shown.
      */
      eIntID_PhysicalHomeButton,
+     
+    /**
+     * Return the appropriate UnixThemeIdentifier for the current theme.
+     */
+     eIntID_UnixThemeIdentifier,
 
      /*
       * Controls whether overlay scrollbars display when the user moves
@@ -415,6 +420,12 @@ public:
     eWindowsTheme_AeroLite
   };
 
+  enum UnixThemeIdentifier {
+    eUnixThemeGTK2 = 0,
+    eUnixThemeGTK3, // not yet
+    eUnixThemeQt4,
+  };
+
   /**
    * Operating system versions.
    */
@@ -424,6 +435,9 @@ public:
     eOperatingSystemVersion_Windows7,
     eOperatingSystemVersion_Windows8,
     eOperatingSystemVersion_Windows10,
+    eOperatingSystemVersion_GNULinux,
+    eOperatingSystemVersion_BSD,
+    eOperatingSystemVersion_MacOSX,
     eOperatingSystemVersion_Unknown
   };
 

--- a/widget/android/nsLookAndFeel.cpp
+++ b/widget/android/nsLookAndFeel.cpp
@@ -403,6 +403,7 @@ nsLookAndFeel::GetIntImpl(IntID aID, int32_t &aResult)
 
         case eIntID_WindowsDefaultTheme:
         case eIntID_WindowsThemeIdentifier:
+        case eIntID_UnixThemeIdentifier:
         case eIntID_OperatingSystemVersionIdentifier:
             aResult = 0;
             rv = NS_ERROR_NOT_IMPLEMENTED;

--- a/widget/cocoa/nsLookAndFeel.mm
+++ b/widget/cocoa/nsLookAndFeel.mm
@@ -393,9 +393,12 @@ nsLookAndFeel::GetIntImpl(IntID aID, int32_t &aResult)
     case eIntID_WindowsDefaultTheme:
     case eIntID_TouchEnabled:
     case eIntID_WindowsThemeIdentifier:
-    case eIntID_OperatingSystemVersionIdentifier:
+    case eIntID_UnixThemeIdentifier:
       aResult = 0;
       res = NS_ERROR_NOT_IMPLEMENTED;
+      break;
+    case eIntID_OperatingSystemVersionIdentifier:
+      aResult = LookAndFeel::eOperatingSystemVersion_MacOSX;
       break;
     case eIntID_MacGraphiteTheme:
       aResult = [NSColor currentControlTint] == NSGraphiteControlTint;

--- a/widget/gonk/nsLookAndFeel.cpp
+++ b/widget/gonk/nsLookAndFeel.cpp
@@ -363,6 +363,7 @@ nsLookAndFeel::GetIntImpl(IntID aID, int32_t &aResult)
 
         case eIntID_WindowsDefaultTheme:
         case eIntID_WindowsThemeIdentifier:
+        case eIntID_UnixThemeIdentifier:
         case eIntID_OperatingSystemVersionIdentifier:
             aResult = 0;
             rv = NS_ERROR_NOT_IMPLEMENTED;

--- a/widget/gtk/nsLookAndFeel.cpp
+++ b/widget/gtk/nsLookAndFeel.cpp
@@ -620,9 +620,33 @@ nsLookAndFeel::GetIntImpl(IntID aID, int32_t &aResult)
     case eIntID_WindowsClassic:
     case eIntID_WindowsDefaultTheme:
     case eIntID_WindowsThemeIdentifier:
-    case eIntID_OperatingSystemVersionIdentifier:
         aResult = 0;
         res = NS_ERROR_NOT_IMPLEMENTED;
+        break;
+    case eIntID_UnixThemeIdentifier:
+#ifndef XP_WIN
+# if defined(MOZ_WIDGET_GTK2)
+        aResult = LookAndFeel::eUnixThemeGTK2;
+# elif defined(MOZ_WIDGET_QT)
+        aResult = LookAndFeel::eUnixThemeQt4;
+# else
+        aResult = 0;
+        res = NS_ERROR_NOT_IMPLEMENTED;
+# endif
+#else
+        aResult = 0;
+        res = NS_ERROR_NOT_IMPLEMENTED;
+#endif
+        break;
+    case eIntID_OperatingSystemVersionIdentifier:
+#if defined(__linux__) && (__linux__ == 1)
+        aResult = LookAndFeel::eOperatingSystemVersion_GNULinux;
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+        aResult = LookAndFeel::eOperatingSystemVersion_BSD;
+#else
+        aResult = 0;
+        res = NS_ERROR_NOT_IMPLEMENTED;
+#endif
         break;
     case eIntID_TouchEnabled:
         aResult = 0;

--- a/widget/windows/nsLookAndFeel.cpp
+++ b/widget/windows/nsLookAndFeel.cpp
@@ -406,6 +406,10 @@ nsLookAndFeel::GetIntImpl(IntID aID, int32_t &aResult)
     case eIntID_WindowsThemeIdentifier:
         aResult = nsUXThemeData::GetNativeThemeId();
         break;
+    case eIntID_UnixThemeIdentifier:
+        aResult = 0;
+        res = NS_ERROR_NOT_IMPLEMENTED;
+        break;
 
     case eIntID_OperatingSystemVersionIdentifier:
     {


### PR DESCRIPTION
Re-land of https://github.com/MoonchildProductions/Pale-Moon/commit/b1ae9ed81fdcf71c5c712a076f73004af749096a, https://github.com/MoonchildProductions/Pale-Moon/commit/e43ac21a878ab3e5d01421e9823b51975c41b7ff and https://github.com/MoonchildProductions/Pale-Moon/commit/8c6aac9d8b4c7481b8390d91f92ea638c1919050. `nsCSSRuleProcessor.cpp` was not edited due to BMO [965961](https://bugzilla.mozilla.org/show_bug.cgi?id=965961).