### PR TITLE
Extend non-default autocomplete shading to Win8/10

### DIFF
--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1647,15 +1647,19 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   padding: 0 3px;
 }
 
-@media not all and (-moz-windows-default-theme) {
-  richlistitem[type~="action"][actiontype="switchtab"][selected="true"] > .ac-url-box > .ac-action-icon {
-    -moz-image-region: rect(11px, 16px, 22px, 0);
-  }
+@media not all and (-moz-os-version: windows-vista),
+       not all and (-moz-windows-default-theme) {
+  @media not all and (-moz-os-version: windows-win7),
+         not all and (-moz-windows-default-theme) {
+    richlistitem[type~="action"][actiontype$="tab"][selected="true"] > .ac-url-box > .ac-action-icon {
+      -moz-image-region: rect(11px, 16px, 22px, 0);
+    }
 
-  .ac-comment[selected="true"],
-  .ac-url-text[selected="true"],
-  .ac-action-text[selected="true"] {
-    color: inherit !important;
+    .ac-comment[selected="true"],
+    .ac-url-text[selected="true"],
+    .ac-action-text[selected="true"] {
+      color: inherit !important;
+    }
   }
 }
 

--- a/toolkit/themes/windows/global/autocomplete.css
+++ b/toolkit/themes/windows/global/autocomplete.css
@@ -205,7 +205,8 @@ html|span.ac-emphasize-text {
   text-shadow: 0 0 currentColor;
 }
 
-@media (-moz-windows-default-theme) {
+@media (-moz-os-version: windows-vista) and (-moz-windows-default-theme),
+       (-moz-os-version: windows-win7) and (-moz-windows-default-theme) {
   html|span.ac-emphasize-text {
     box-shadow: inset 0 0 1px 1px rgba(0,0,0,0.1);
     background-color: rgba(0,0,0,0.05);


### PR DESCRIPTION
Following up on Awesomebar changes for Win8/10, this makes the URL text be white and Switch to Tab icon use the light version, when the relevant rows are selected. This styling already existed for non-default themes (aka Classic), and is now available to Win8/10 default themes.