### PR TITLE
Use -O1 optimization for kiss_fft lib (32bit GCC builds) 

### DIFF
--- a/media/kiss_fft/moz.build
+++ b/media/kiss_fft/moz.build
@@ -14,6 +14,11 @@ SOURCES += [
     'kiss_fftr.c',
 ]
 
+# kiss_fft causes OOM error with some 32bit versions of GCC when using -O2
+if '64' not in CONFIG['OS_TEST']:
+    if CONFIG['GNU_CC']:
+        CFLAGS += ['-Os']
+
 if CONFIG['GKMEDIAS_SHARED_LIBRARY']:
     NO_VISIBILITY_FLAGS = True
 

--- a/media/kiss_fft/moz.build
+++ b/media/kiss_fft/moz.build
@@ -17,7 +17,7 @@ SOURCES += [
 # kiss_fft causes OOM error with some 32bit versions of GCC when using -O2
 if '64' not in CONFIG['OS_TEST']:
     if CONFIG['GNU_CC']:
-        CFLAGS += ['-Os']
+        CFLAGS += ['-O1']
 
 if CONFIG['GKMEDIAS_SHARED_LIBRARY']:
     NO_VISIBILITY_FLAGS = True


### PR DESCRIPTION
A re-land of commit 1fd9a69.

Needed to build Tycho with GCC 4.9 and below.