### PR TITLE
Minor fix - browser - the context menu

### DIFF
--- a/browser/base/content/nsContextMenu.js
+++ b/browser/base/content/nsContextMenu.js
@@ -1169,8 +1169,7 @@ nsContextMenu.prototype = {
       linkText = this.linkText();
     urlSecurityCheck(this.linkURL, doc.nodePrincipal);
 
-    this.saveHelper(this.linkURL, linkText, null, true, doc);
-    this.saveHelper(this.linkURL, this.linkText, null, true, this.ownerDoc,
+    this.saveHelper(this.linkURL, linkText, null, true, doc,
                     this.linkDownload);
   },
 


### PR DESCRIPTION
This error happens when you do select "Save Link As..." from context menu.

Pale Moon throws an errors in the Error Console:
```
Error: TypeError: doc is undefined
Source File: chrome://browser/content/nsContextMenu.js
Line: 1108
```
See also:
https://forum.palemoon.org/viewtopic.php?f=56&t=12581#p89650
__________
I've created the new build (x64) and tested.
