### PR TITLE
Minor fix - cache clearing - throws a errors

### DIFF
--- a/browser/components/preferences/advanced.js
+++ b/browser/components/preferences/advanced.js
@@ -221,8 +221,8 @@ var gAdvancedPane = {
       expected: 0,
       sum: 0,
       QueryInterface: function listener_qi(iid) {
-        if (iid.equals(Ci.nsISupports) ||
-            iid.equals(Ci.nsICacheStorageVisitor)) {
+        if (iid.equals(Components.interfaces.nsISupports) ||
+            iid.equals(Components.interfaces.nsICacheStorageVisitor)) {
           return this;
         }
         throw Components.results.NS_ERROR_NO_INTERFACE;


### PR DESCRIPTION
__Menu:__
__"Tools" - "Options" - "Advanced" - "Network" - "Cached web content" - button "Clear now"__

...after pressing button "Clear Now" throws an errors in the Error Console:
```
Error: ReferenceError: Ci is not defined
Source File: chrome://browser/content/preferences/advanced.js
Line: 195
```
See also:
https://forum.palemoon.org/viewtopic.php?f=56&t=12738#p89991

__________

I've created the new build (x64) and tested.
