### PR TITLE
Minor fix - about:cache - throws an error

### DIFF
--- a/toolkit/components/aboutcache/content/aboutCache.js
+++ b/toolkit/components/aboutcache/content/aboutCache.js
@@ -9,6 +9,10 @@ var searchParams = new URLSearchParams(search ? search[1] : '');
 var storage = searchParams.get('storage');
 var context = searchParams.get('context');
 
+if (context == null) {
+  context = "";
+}
+
 // The context is in a format as used by the HTTP cache v2 back end
 var [context, isAnon, isInBrowser, appId, isPrivate] = context.match(/(a,)?(b,)?(i\d+,)?(p,)?/);
 if (appId)


### PR DESCRIPTION
Minor fix - about:cache - throws an error in Error Console:
```
Error: TypeError: context is null
Source File: chrome://global/content/aboutCache.js
Line: 13
```

See also:
https://forum.palemoon.org/viewtopic.php?f=56&t=12683#p89640
__________

I've created the new build (x64) and tested.
