### PR TITLE
Fix: Plugin placeholder image/text (ask to activate) missing

### DIFF
--- a/toolkit/mozapps/plugins/content/pluginProblemBinding.css
+++ b/toolkit/mozapps/plugins/content/pluginProblemBinding.css
@@ -25,6 +25,9 @@ object:-moz-handler-clicktoplay,
 object:-moz-handler-playpreview,
 object:-moz-handler-vulnerable-updatable,
 object:-moz-handler-vulnerable-no-update {
+  /* Initialize the overlay with visibility:hidden to prevent flickering if
+   * the plugin is too small to show the overlay */
+    visibility: hidden;
     display: inline-block;
     overflow: hidden;
     opacity: 1 !important;

--- a/toolkit/mozapps/plugins/content/pluginProblemContent.css
+++ b/toolkit/mozapps/plugins/content/pluginProblemContent.css
@@ -55,18 +55,6 @@ html|applet:not([height]), html|applet[height=""] {
   line-height: initial;
 }
 
-/* Initialize the overlay with visibility:hidden to prevent flickering if
-* the plugin is too small to show the overlay */
-.mainBox > .hoverBox,
-.mainBox > .closeIcon {
-  visibility: hidden;
-}
-
-.visible > .hoverBox,
-.visible > .closeIcon {
-  visibility: visible;
-}
-
 .mainBox[chromedir="rtl"] {
   direction: rtl;
 }


### PR DESCRIPTION
Ad #553 

- Fix: Plugin placeholder image/text (ask to activate) missing
- Code cleanup
- Click-to-play plugins fail to show placeholder after resizing

See also:
https://hg.mozilla.org/mozilla-central/rev/65f6618c1e64

__________

The suggestion (for example).

I've created the new build (x64) and tested.
