### PR TITLE
Add indicators for (non-)native extensions in Add-ons Manager

### DIFF
--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -1310,6 +1310,8 @@
                                                   [this.mAddon.name], 1);
             } else {
               this.removeAttribute("notification");
+              if (this.mAddon.type == "extension")
+                this.setAttribute("native", this.mAddon.native);
             }
           }
 

--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -6395,9 +6395,13 @@ AddonInternal.prototype = {
     if (!aPlatformVersion)
       aPlatformVersion = Services.appinfo.platformVersion;
 
+    this.native = false;
+  
     let version;
-    if (app.id == Services.appinfo.ID)
+    if (app.id == Services.appinfo.ID) {
       version = aAppVersion;
+      this.native = true;
+    }
 #ifdef MOZ_PHOENIX_EXTENSIONS
     else if (app.id == FIREFOX_ID) {
      version = FIREFOX_APPCOMPATVERSION;
@@ -6658,7 +6662,7 @@ function AddonWrapper(aAddon) {
    "providesUpdatesSecurely", "blocklistState", "blocklistURL", "appDisabled",
    "softDisabled", "skinnable", "size", "foreignInstall", "hasBinaryComponents",
    "strictCompatibility", "compatibilityOverrides", "updateURL",
-   "getDataDirectory", "multiprocessCompatible", "jetsdk"].forEach(function(aProp) {
+   "getDataDirectory", "multiprocessCompatible", "jetsdk", "native"].forEach(function(aProp) {
      this.__defineGetter__(aProp, function AddonWrapper_propertyGetter() aAddon[aProp]);
   }, this);
 

--- a/toolkit/mozapps/extensions/internal/XPIProviderUtils.js
+++ b/toolkit/mozapps/extensions/internal/XPIProviderUtils.js
@@ -70,7 +70,7 @@ const PROP_JSON_FIELDS = ["id", "syncGUID", "location", "version", "type",
                           "skinnable", "size", "sourceURI", "releaseNotesURI",
                           "softDisabled", "foreignInstall", "hasBinaryComponents",
                           "strictCompatibility", "locales", "targetApplications",
-                          "targetPlatforms", "multiprocessCompatible", "jetsdk"];
+                          "targetPlatforms", "multiprocessCompatible", "jetsdk", "native"];
 
 // Time to wait before async save of XPI JSON database, in milliseconds
 const ASYNC_SAVE_DELAY_MS = 20;

--- a/toolkit/themes/linux/mozapps/extensions/extensions.css
+++ b/toolkit/themes/linux/mozapps/extensions/extensions.css
@@ -510,6 +510,20 @@
                                     rgba(135, 135, 135, 0.1));
 }
 
+.addon[native] .name-container::after {
+  content: " •";
+  font-size: 150%;
+  line-height: 75%;
+}
+
+.addon[native="true"] .name-container::after {
+  color: #3366FF;
+}
+
+.addon[native="false"] .name-container::after {
+  color: #FF6600;
+}
+
 .addon-view[notification="warning"] {
   background-image: url("chrome://mozapps/skin/extensions/stripes-warning.png"),
                     linear-gradient(rgba(255, 255, 0, 0.04),

--- a/toolkit/themes/osx/mozapps/extensions/extensions.css
+++ b/toolkit/themes/osx/mozapps/extensions/extensions.css
@@ -652,6 +652,20 @@
   color: #686A6B;
 }
 
+.addon[native] .name-container::after {
+  content: " •";
+  font-size: 150%;
+  line-height: 75%;
+}
+
+.addon[native="true"] .name-container::after {
+  color: #3366FF;
+}
+
+.addon[native="false"] .name-container::after {
+  color: #FF6600;
+}
+
 .addon-view[notification="warning"] {
   background-image: url("chrome://mozapps/skin/extensions/stripes-warning.png"),
                     linear-gradient(rgba(255, 255, 0, 0.04),

--- a/toolkit/themes/windows/mozapps/extensions/extensions.css
+++ b/toolkit/themes/windows/mozapps/extensions/extensions.css
@@ -641,6 +641,20 @@
   color: #888A8B;
 }
 
+.addon[native] .name-container::after {
+  content: " •";
+  font-size: 150%;
+  line-height: 75%;
+}
+
+.addon[native="true"] .name-container::after {
+  color: #3366FF;
+}
+
+.addon[native="false"] .name-container::after {
+  color: #FF6600;
+}
+
 .addon-view[notification="warning"] {
   background-image: url("chrome://mozapps/skin/extensions/stripes-warning.png"),
                     linear-gradient(rgba(255, 255, 0, 0.04),


### PR DESCRIPTION
This is a proposition for #585.

Blue dot means a native extension directly targeting Pale Moon.
Orange dot means a non-native extension targeting Firefox, but still allowed to run.

![preview](https://cloud.githubusercontent.com/assets/20323160/19369315/e6b37c52-91a4-11e6-96f5-851ee1cc3e4c.png)

Initially this works only with default theme because some CSS rules are needed.