### PR TITLE
Minor fix: Places - aOldNode is undefined

### DIFF
--- a/browser/components/places/content/treeView.js
+++ b/browser/components/places/content/treeView.js
@@ -399,7 +399,7 @@ PlacesTreeView.prototype = {
    */
   _getNewRowForRemovedNode:
   function PTV__getNewRowForRemovedNode(aUpdatedContainer, aOldNode) {
-    if (aOldNode === undefined) {
+    if (aOldNode == undefined) {
       return -1;
     }
     let parent = aOldNode.parent;

--- a/browser/components/places/content/treeView.js
+++ b/browser/components/places/content/treeView.js
@@ -399,6 +399,9 @@ PlacesTreeView.prototype = {
    */
   _getNewRowForRemovedNode:
   function PTV__getNewRowForRemovedNode(aUpdatedContainer, aOldNode) {
+    if (!aOldNode) {
+      return -1;
+    }
     let parent = aOldNode.parent;
     if (parent) {
       // If the node's parent is still set, the node is not obsolete

--- a/browser/components/places/content/treeView.js
+++ b/browser/components/places/content/treeView.js
@@ -399,7 +399,7 @@ PlacesTreeView.prototype = {
    */
   _getNewRowForRemovedNode:
   function PTV__getNewRowForRemovedNode(aUpdatedContainer, aOldNode) {
-    if (!aOldNode) {
+    if (aOldNode === undefined) {
       return -1;
     }
     let parent = aOldNode.parent;


### PR DESCRIPTION
Steps to reproduce:
- Deleting a bookmark (= aOldNode)
- Deleting another bookmark (aOldNode does not exist)

If that node was not found, Pale Moon throws an error in Browser Console:
```
TypeError: aOldNode is undefined treeView.js:402:8
```
__________

I've created the new build (x64) and tested.
