### PR TITLE
Minor fix: Async (Object.create vs. __proto__)

### DIFF
--- a/services/common/async.js
+++ b/services/common/async.js
@@ -194,9 +194,9 @@ this.Async = {
 
   querySpinningly: function querySpinningly(query, names) {
     // 'Synchronously' asyncExecute, fetching all results by name.
-    let storageCallback = {names: names,
-                           syncCb: Async.makeSyncCallback()};
-    storageCallback.__proto__ = Async._storageCallbackPrototype;
+    let storageCallback = Object.create(Async._storageCallbackPrototype);
+    storageCallback.names = names;
+    storageCallback.syncCb = Async.makeSyncCallback();
     query.executeAsync(storageCallback);
     return Async.waitForSyncCallback(storageCallback.syncCb);
   },


### PR DESCRIPTION
Pale Moon throws a warning in Browser Console after run:
```
mutating the [[Prototype]] of an object will cause your code to run very slowly;
instead create the object with the correct initial [[Prototype]] value using Object.create
async.js:199:4
```
See also https://bugzilla.mozilla.org/show_bug.cgi?id=1166406
__________
I've created the new build (x64) and tested.
