### PR TITLE
Places - "gEditItemOverlay is null" when using the keyboard to cancel "Bookmark all tabs" dialog

### DIFF
--- a/browser/components/places/content/bookmarkProperties.js
+++ b/browser/components/places/content/bookmarkProperties.js
@@ -471,7 +471,6 @@ var BookmarkPropertiesPanel = {
     // The order here is important! We have to uninit the panel first, otherwise
     // late changes could force it to commit more transactions.
     gEditItemOverlay.uninitPanel(true);
-    gEditItemOverlay = null;
     this._endBatch();
     window.arguments[0].performed = true;
   },
@@ -481,7 +480,6 @@ var BookmarkPropertiesPanel = {
     // changes done as part of Undo may change the panel contents and by
     // that force it to commit more transactions.
     gEditItemOverlay.uninitPanel(true);
-    gEditItemOverlay = null;
     this._endBatch();
     PlacesUtils.transactionManager.undoTransaction();
     window.arguments[0].performed = false;

--- a/browser/components/places/content/editBookmarkOverlay.js
+++ b/browser/components/places/content/editBookmarkOverlay.js
@@ -213,6 +213,12 @@ var gEditItemOverlay = {
       // observe only tags changes, through bookmarks.
       if (this._itemId != -1 || this._uri || this._multiEdit)
         PlacesUtils.bookmarks.addObserver(this, false);
+
+      this._element("namePicker").addEventListener("blur", this);
+      this._element("locationField").addEventListener("blur", this);
+      this._element("tagsField").addEventListener("blur", this);
+      this._element("keywordField").addEventListener("blur", this);
+      this._element("descriptionField").addEventListener("blur", this);
       window.addEventListener("unload", this, false);
       this._observersAdded = true;
     }
@@ -392,6 +398,12 @@ var gEditItemOverlay = {
       if (this._itemId != -1 || this._uri || this._multiEdit)
         PlacesUtils.bookmarks.removeObserver(this);
 
+      this._element("namePicker").removeEventListener("blur", this);
+      this._element("locationField").removeEventListener("blur", this);
+      this._element("tagsField").removeEventListener("blur", this);
+      this._element("keywordField").removeEventListener("blur", this);
+      this._element("descriptionField").removeEventListener("blur", this);
+
       this._observersAdded = false;
     }
 
@@ -532,7 +544,7 @@ var gEditItemOverlay = {
     return false;
   },
 
-  onNamePickerChange: function EIO_onNamePickerChange() {
+  onNamePickerBlur: function EIO_onNamePickerBlur() {
     if (this._itemId == -1)
       return;
 
@@ -884,6 +896,11 @@ var gEditItemOverlay = {
       }
       this._element("tagsField").value = tags.join(", ");
       this._updateTags();
+      break;
+    case "blur":
+      let replaceFn = (str, firstLetter) => firstLetter.toUpperCase();
+      let nodeName = aEvent.target.id.replace(/editBMPanel_(\w)/, replaceFn);
+      this["on" + nodeName + "Blur"]();
       break;
     case "unload":
       this.uninitPanel(false);

--- a/browser/components/places/content/editBookmarkOverlay.xul
+++ b/browser/components/places/content/editBookmarkOverlay.xul
@@ -33,7 +33,6 @@
                  control="editBMPanel_namePicker"
                  observes="paneElementsBroadcaster"/>
           <textbox id="editBMPanel_namePicker"
-                   onblur="gEditItemOverlay.onNamePickerChange();"
                    observes="paneElementsBroadcaster"/>
         </row>
 
@@ -45,7 +44,6 @@
                  observes="paneElementsBroadcaster"/>
           <textbox id="editBMPanel_locationField"
                    class="uri-element"
-                   onblur="gEditItemOverlay.onLocationFieldBlur();"
                    observes="paneElementsBroadcaster"/>
         </row>
 
@@ -148,7 +146,6 @@
                      completedefaultindex="true"
                      tabscrolling="true"
                      showcommentcolumn="true"
-                     onblur="gEditItemOverlay.onTagsFieldBlur();"
                      observes="paneElementsBroadcaster"
                      placeholder="&editBookmarkOverlay.tagsEmptyDesc.label;"/>
             <button id="editBMPanel_tagsSelectorExpander"
@@ -178,7 +175,6 @@
                  control="editBMPanel_keywordField"
                  observes="paneElementsBroadcaster"/>
           <textbox id="editBMPanel_keywordField"
-                   onblur="gEditItemOverlay.onKeywordFieldBlur();"
                    observes="paneElementsBroadcaster"/>
         </row>
 
@@ -191,7 +187,6 @@
                  observes="paneElementsBroadcaster"/>
           <textbox id="editBMPanel_descriptionField"
                    multiline="true"
-                   onblur="gEditItemOverlay.onDescriptionFieldBlur();"
                    observes="paneElementsBroadcaster"/>
         </row>
       </rows>


### PR DESCRIPTION
Steps to reproduce:
1. Open 2 or more tabs
2. Right click one
3. Click bookmark all tabs
4. hit [esc] on the keyboard to cancel the dialog

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1033463
__________
I've created the new build (x64) and tested.
