### PR TITLE
Minor fix: Places - controllers - throws an error

### DIFF
--- a/browser/components/places/content/browserPlacesViews.js
+++ b/browser/components/places/content/browserPlacesViews.js
@@ -701,8 +701,16 @@ PlacesViewBase.prototype = {
 
     if (this._controller) {
       this._controller.terminate();
-      this._viewElt.controllers.removeController(this._controller);
-      this._controller = null;
+      // Removing the controller will fail if it is already no longer there.
+      // This can happen if the view element was removed/reinserted without
+      // our knowledge. There is no way to check for that having happened
+      // without the possibility of an exception. :-(
+      try {
+        this._viewElt.controllers.removeController(this._controller);
+      } catch (ex) {
+      } finally {
+        this._controller = null;
+      }
     }
 
     delete this._viewElt._placesView;


### PR DESCRIPTION
Pale Moon throws if the controller has been removed.
```
NS_ERROR_FAILURE: Component returned failure code: 0x80004005 (NS_ERROR_FAILURE)
[nsIControllers.removeController]
browserPlacesViews.js:691:0

```
See also https://hg.mozilla.org/mozilla-central/diff/4e44d3d8917a/browser/components/places/content/browserPlacesViews.js

I have simulated this error... but not easy. STR do not have a common part :-/
