### PR TITLE
Minor fix: Menu - "History" - "Recently Closed Tabs" - "Restore All Tabs"

### DIFF
--- a/browser/components/sessionstore/SessionStore.jsm
+++ b/browser/components/sessionstore/SessionStore.jsm
@@ -1023,7 +1023,7 @@ let SessionStoreInternal = {
         delete aTab.linkedBrowser.__SS_hostSchemeData;
         if (aTab.linkedBrowser.__SS_restoreState)
           this._resetTabRestoringState(aTab);
-      });
+      }, this);
       openWindows[aWindow.__SSi] = true;
     });
     // also clear all data about closed tabs and windows


### PR DESCRIPTION
After run the function in main menu:
"History" - "Recently Closed Tabs" - "Restore All Tabs"
throws an error in Browser Console:
```
TypeError: this._resetTabRestoringState is not a function
SessionStore.jsm:1023:10
```
See also https://bugzilla.mozilla.org/show_bug.cgi?id=903244
__________

I've created the new build (x64) and tested.
