### PR TITLE
Fix vcomp110.dll packaging

### DIFF
--- a/browser/installer/package-manifest.in
+++ b/browser/installer/package-manifest.in
@@ -99,7 +99,7 @@
 #elif MOZ_MSVC_REDIST == 1700
 @BINPATH@/msvcp110.dll
 @BINPATH@/msvcr110.dll
-; @BINPATH@/vcomp110.dll
+@BINPATH@/vcomp110.dll
 #endif
 #endif
 #endif

--- a/browser/installer/removed-files.in
+++ b/browser/installer/removed-files.in
@@ -699,6 +699,7 @@ xpicleanup@BIN_SUFFIX@
   #if MOZ_MSVC_REDIST != 1700
     msvcp110.dll
     msvcr110.dll
+    vcomp110.dll
   #endif
   plugins/npnul32.dll
 #endif

--- a/build/win32/Makefile.in
+++ b/build/win32/Makefile.in
@@ -54,6 +54,9 @@ REDIST_FILES = \
   msvcp110.dll \
   msvcr110.dll \
   $(NULL)
+REDIST_OPENMP_FILES = \
+  vcomp110.dll \
+  $(NULL)
 endif
 
 ifdef REDIST_FILES
@@ -63,6 +66,7 @@ libs-preqs = \
 
 libs:: $(libs-preqs)
 	install --preserve-timestamps $(foreach f,$(REDIST_FILES),"$(WIN32_REDIST_DIR)"/$(f)) $(FINAL_TARGET)
+	install --preserve-timestamps $(foreach f,$(REDIST_OPENMP_FILES),"$(WIN32_REDIST_OPENMP_DIR)"/$(f)) $(FINAL_TARGET)
 endif
 
 endif # ! MOZ_DEBUG

--- a/configure.in
+++ b/configure.in
@@ -494,6 +494,16 @@ case "$target" in
             AC_MSG_ERROR([Invalid Win32 Redist directory: ${WIN32_REDIST_DIR}])
           fi
           WIN32_REDIST_DIR=`cd "$WIN32_REDIST_DIR" && pwd`
+          # Make sure the OpenMP directory is defined for VS2012
+          if test $_MSC_VER -eq 1700; then
+            if test -z "$WIN32_REDIST_OPENMP_DIR"; then
+              WIN32_REDIST_OPENMP_DIR=`dirname "$WIN32_REDIST_DIR"`/Microsoft.VC110.OPENMP
+            fi
+            if test ! -d "$WIN32_REDIST_OPENMP_DIR"; then
+              AC_MSG_ERROR([Invalid Win32 Redist OpenMP directory: ${WIN32_REDIST_OPENMP_DIR}])
+            fi
+            WIN32_REDIST_OPENMP_DIR=`cd "$WIN32_REDIST_OPENMP_DIR" && pwd`
+          fi
         fi
 
         dnl Ensure that mt.exe is 'Microsoft (R) Manifest Tool',
@@ -8479,6 +8489,7 @@ AC_SUBST(MOZ_MAPINFO)
 AC_SUBST(MOZ_BROWSE_INFO)
 AC_SUBST(MOZ_TOOLS_DIR)
 AC_SUBST(WIN32_REDIST_DIR)
+AC_SUBST(WIN32_REDIST_OPENMP_DIR)
 AC_SUBST(MAKENSISU)
 
 dnl Echo the CFLAGS to remove extra whitespace.


### PR DESCRIPTION
The packaging step cannot find vcomp110.dll, this pull request fixes that. See the commit message for more information.