### PR TITLE
Do not fold gkmedias into libxul on Windows and add missing symbols

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -7701,7 +7701,8 @@ dnl =
 dnl ========================================================
 MOZ_ARG_HEADER(Static build options)
 
-if test -n "$GKMEDIAS_SHARED_LIBRARY"; then
+if test "$OS_ARCH" = "WINNT"; then
+  GKMEDIAS_SHARED_LIBRARY=1
   AC_DEFINE(GKMEDIAS_SHARED_LIBRARY)
 fi
 AC_SUBST(GKMEDIAS_SHARED_LIBRARY)

--- a/layout/media/symbols.def.in
+++ b/layout/media/symbols.def.in
@@ -579,6 +579,7 @@ hb_font_create
 hb_font_destroy
 hb_font_funcs_create
 hb_font_funcs_set_glyph_contour_point_func
+hb_font_funcs_set_glyph_extents_func
 hb_font_funcs_set_glyph_func
 hb_font_funcs_set_glyph_h_advance_func
 hb_font_funcs_set_glyph_h_kerning_func


### PR DESCRIPTION
Just what it says on the shipping label