### PR TITLE
Enable {Array, %TypedArray%}.prototype.includes

### DIFF
--- a/js/src/jsarray.cpp
+++ b/js/src/jsarray.cpp
@@ -3160,9 +3160,7 @@ static const JSFunctionSpec array_methods[] = {
     JS_SELF_HOSTED_FN("keys",        "ArrayKeys",        0,0),
 
     /* ES7 additions */
-#ifdef NIGHTLY_BUILD
     JS_SELF_HOSTED_FN("includes",    "ArrayIncludes",    2,0),
-#endif
 
     JS_FS_END
 };

--- a/js/src/vm/TypedArrayObject.cpp
+++ b/js/src/vm/TypedArrayObject.cpp
@@ -824,9 +824,10 @@ TypedArrayObject::protoFunctions[] = {
     // Both of these are actually defined to the same object in FinishTypedArrayInit.
     JS_SELF_HOSTED_FN("values", "TypedArrayValues", 0, JSPROP_DEFINE_LATE),
     JS_SELF_HOSTED_SYM_FN(iterator, "TypedArrayValues", 0, JSPROP_DEFINE_LATE),
-#ifdef NIGHTLY_BUILD
+
+    /* ES7 additions */
     JS_SELF_HOSTED_FN("includes", "TypedArrayIncludes", 2, 0),
-#endif
+    
     JS_FS_END
 };
 


### PR DESCRIPTION
See: [Mozilla Bug 1070767](https://bugzilla.mozilla.org/show_bug.cgi?id=1070767)