### PR TITLE
Minor fix: Downloads - fix typo, style clean up

### DIFF
--- a/browser/components/downloads/DownloadsCommon.jsm
+++ b/browser/components/downloads/DownloadsCommon.jsm
@@ -447,7 +447,7 @@ this.DownloadsCommon = {
   {
     // We apply an algorithm similar to the DownloadUtils.getTimeLeft function,
     // though tailored to a single time estimation for all downloads.  We never
-    // apply sommothing if the new value is less than half the previous value.
+    // apply something if the new value is less than half the previous value.
     let shouldApplySmoothing = aLastSeconds >= 0 &&
                                aSeconds > aLastSeconds / 2;
     if (shouldApplySmoothing) {
@@ -551,7 +551,7 @@ this.DownloadsCommon = {
   },
 
   /**
-   * Show a donwloaded file in the system file manager.
+   * Show a downloaded file in the system file manager.
    * If you have a dataItem, use dataItem.showLocalFile.
    *
    * @param aFile
@@ -1383,7 +1383,7 @@ DownloadsDataItem.prototype = {
     } else if (this._download.hasProgress) {
       // If the final size and progress are known, use them.
       this.maxBytes = this._download.totalBytes;
-    this.percentComplete = this._download.progress;
+      this.percentComplete = this._download.progress;
     } else {
       // The download final size and progress percentage is unknown.
       this.maxBytes = -1;

--- a/browser/components/downloads/content/allDownloadsViewOverlay.js
+++ b/browser/components/downloads/content/allDownloadsViewOverlay.js
@@ -542,7 +542,7 @@ DownloadElementShell.prototype = {
       if (aAnnoName == DOWNLOAD_META_DATA_ANNO) {
         let metaData = this.getDownloadMetaData();
         let annotatedMetaData = this._getAnnotatedMetaData();
-        metaData.endTme = annotatedMetaData.endTime;
+        metaData.endTime = annotatedMetaData.endTime;
         if ("fileSize" in annotatedMetaData)
           metaData.fileSize = annotatedMetaData.fileSize;
         else

--- a/browser/components/downloads/content/allDownloadsViewOverlay.js
+++ b/browser/components/downloads/content/allDownloadsViewOverlay.js
@@ -307,7 +307,7 @@ DownloadElementShell.prototype = {
    *   set.  If available, it's set to the downloaded file name.  If not,
    *   the places title for the download uri is used.  As a last resort,
    *   we fallback to the download uri.
-   * - fileSize (only set for downloads which completed succesfully):
+   * - fileSize (only set for downloads which completed successfully):
    *   the downloaded file size.  For downloads done after the landing of
    *   bug 826991, this value is "static" - that is, it does not necessarily
    *   mean that the file is in place and has this size.
@@ -606,7 +606,7 @@ DownloadElementShell.prototype = {
       return false;
     switch (aCommand) {
       case "downloadsCmd_open": {
-        // We cannot open a session dowload file unless it's done ("openable").
+        // We cannot open a session download file unless it's done ("openable").
         // If it's finished, we need to make sure the file was not removed,
         // as we do for past downloads.
         if (this._dataItem && !this._dataItem.openable)
@@ -718,7 +718,7 @@ DownloadElementShell.prototype = {
            this.downloadURI.toLowerCase().includes(aTerm);
   },
 
-  // Handles return kepress on the element (the keypress listener is
+  // Handles return keypress on the element (the keypress listener is
   // set in the DownloadsPlacesView object).
   doDefaultCommand: function DES_doDefaultCommand() {
     function getDefaultCommandForState(aState) {
@@ -765,7 +765,7 @@ DownloadElementShell.prototype = {
 
 /**
  * A Downloads Places View is a places view designed to show a places query
- * for history donwloads alongside the current "session"-downloads.
+ * for history downloads alongside the current "session"-downloads.
  *
  * As we don't use the places controller, some methods implemented by other
  * places views are not implemented by this view.
@@ -886,7 +886,7 @@ DownloadsPlacesView.prototype = {
    *        The places node for a history download. Required if there's no data
    *        item.
    * @param [optional] aNewest
-   *        @see onDataItemAdded. Ignored for history downlods.
+   *        @see onDataItemAdded. Ignored for history downloads.
    * @param [optional] aDocumentFragment
    *        To speed up the appending of multiple elements to the end of the
    *        list which are coming in a single batch (i.e. invalidateContainer),
@@ -915,9 +915,9 @@ DownloadsPlacesView.prototype = {
     // 1) There's only one shell and it's for a history download (it has
     //    no data item). In this case, we update this shell and move it
     //    if necessary
-    // 2) There are multiple shells, indicicating multiple downloads for
+    // 2) There are multiple shells, indicating multiple downloads for
     //    the same download uri are running. In this case we create
-    //    anoter shell for the download (so we have one shell for each data
+    //    another shell for the download (so we have one shell for each data
     //    item).
     //
     // Note: If a cancelled session download is already in the list, and the
@@ -944,7 +944,7 @@ DownloadsPlacesView.prototype = {
     if (shouldCreateShell) {
       // Bug 836271: The annotations for a url should be cached only when the
       // places node is available, i.e. when we know we we'd be notified for
-      // annoation changes. 
+      // annotation changes. 
       // Otherwise we may cache NOT_AVILABLE values first for a given session
       // download, and later use these NOT_AVILABLE values when a history
       // download for the same URL is added.
@@ -1391,7 +1391,7 @@ DownloadsPlacesView.prototype = {
   },
 
   _canClearDownloads: function DPV__canClearDownloads() {
-    // Downloads can be cleared if there's at least one removeable download in
+    // Downloads can be cleared if there's at least one removable download in
     // the list (either a history download or a completed session download).
     // Because history downloads are always removable and are listed after the
     // session downloads, check from bottom to top.
@@ -1512,7 +1512,7 @@ DownloadsPlacesView.prototype = {
       }
     }
     else if (aEvent.charCode == " ".charCodeAt(0)) {
-      // Pausue/Resume every selected download
+      // Pause/Resume every selected download
       for (let element of selectedElements) {
         if (element._shell.isCommandEnabled("downloadsCmd_pauseResume"))
           element._shell.doCommand("downloadsCmd_pauseResume");

--- a/browser/components/downloads/content/downloads.js
+++ b/browser/components/downloads/content/downloads.js
@@ -198,7 +198,7 @@ const DownloadsPanel = {
   get panel()
   {
     // If the downloads panel overlay hasn't loaded yet, just return null
-    // without reseting this.panel.
+    // without resetting this.panel.
     let downloadsPanel = document.getElementById("downloadsPanel");
     if (!downloadsPanel)
       return null;
@@ -559,7 +559,7 @@ const DownloadsPanel = {
 
       // At this point, if the window is minimized, opening the panel could fail
       // without any notification, and there would be no way to either open or
-      // close the panel anymore.  To prevent this, check if the window is
+      // close the panel any more.  To prevent this, check if the window is
       // minimized and in that case force the panel to the closed state.
       if (window.windowState == Ci.nsIDOMChromeWindow.STATE_MINIMIZED) {
         DownloadsButton.releaseAnchor();


### PR DESCRIPTION

__A typo in metadata."endTme" is forcing us to take a fallback path when showing the date__
See also https://bugzilla.mozilla.org/show_bug.cgi?id=1058105

__Style clean up__
See also https://bugzilla.mozilla.org/show_bug.cgi?id=577266
