### PR TITLE
Add our own MP4Demuxer (with other fixes)

### DIFF
--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -680,6 +680,7 @@ void HTMLMediaElement::AbortExistingLoads()
   mSuspendedForPreloadNone = false;
   mDownloadSuspendedByCache = false;
   mMediaInfo = MediaInfo();
+  mIsEncrypted = false;
   mSourcePointer = nullptr;
   mLastNextFrameStatus = NEXT_FRAME_UNINITIALIZED;
 

--- a/dom/media/MediaData.cpp
+++ b/dom/media/MediaData.cpp
@@ -488,6 +488,7 @@ MediaRawData::MediaRawData()
   : MediaData(RAW_DATA)
   , mData(nullptr)
   , mSize(0)
+  , mCrypto(mCryptoInternal)
   , mBuffer(new MediaLargeByteBuffer(RAW_DATA_DEFAULT_SIZE))
   , mPadding(0)
 {
@@ -497,6 +498,7 @@ MediaRawData::MediaRawData(const uint8_t* aData, size_t aSize)
   : MediaData(RAW_DATA)
   , mData(nullptr)
   , mSize(0)
+  , mCrypto(mCryptoInternal)
   , mBuffer(new MediaLargeByteBuffer(RAW_DATA_DEFAULT_SIZE))
   , mPadding(0)
 {
@@ -518,6 +520,7 @@ MediaRawData::Clone() const
   s->mOffset = mOffset;
   s->mKeyframe = mKeyframe;
   s->mExtraData = mExtraData;
+  s->mCryptoInternal = mCryptoInternal;
   if (mSize) {
     if (!s->EnsureCapacity(mSize)) {
       return nullptr;
@@ -584,6 +587,7 @@ MediaRawData::CreateWriter()
 MediaRawDataWriter::MediaRawDataWriter(MediaRawData* aMediaRawData)
   : mData(nullptr)
   , mSize(0)
+  , mCrypto(aMediaRawData->mCryptoInternal)
   , mTarget(aMediaRawData)
   , mBuffer(aMediaRawData->mBuffer.get())
 {

--- a/dom/media/MediaData.h
+++ b/dom/media/MediaData.h
@@ -348,6 +348,8 @@ public:
   uint8_t* mData;
   // Writeable size of buffer.
   size_t mSize;
+  // Writeable reference to MediaRawData::mCryptoInternal
+  CryptoSample& mCrypto;
 
   // Data manipulation methods. mData and mSize may be updated accordingly.
 
@@ -379,7 +381,7 @@ public:
   // Size of buffer.
   size_t mSize;
 
-  CryptoSample mCrypto;
+  const CryptoSample& mCrypto;
   nsRefPtr<MediaByteBuffer> mExtraData;
 
   // Return a deep copy or nullptr if out of memory.
@@ -401,6 +403,7 @@ private:
   // Returns false if memory couldn't be allocated.
   bool EnsureCapacity(size_t aSize);
   nsRefPtr<MediaLargeByteBuffer> mBuffer;
+  CryptoSample mCryptoInternal;
   uint32_t mPadding;
   MediaRawData(const MediaRawData&); // Not implemented
 };

--- a/dom/media/MediaInfo.h
+++ b/dom/media/MediaInfo.h
@@ -287,16 +287,41 @@ public:
 
 class EncryptionInfo {
 public:
-  EncryptionInfo() : mIsEncrypted(false) {}
+  struct InitData {
+    template<typename AInitDatas>
+    InitData(const nsAString& aType, AInitDatas&& aInitData)
+      : mType(aType)
+      , mInitData(Forward<AInitDatas>(aInitData))
+    {
+    }
 
-  // Encryption type to be passed to JS. Usually `cenc'.
-  nsString mType;
+    // Encryption type to be passed to JS. Usually `cenc'.
+    nsString mType;
 
-  // Encryption data.
-  nsTArray<uint8_t> mInitData;
+    // Encryption data.
+    nsTArray<uint8_t> mInitData;
+  };
+  typedef nsTArray<InitData> InitDatas;
 
   // True if the stream has encryption metadata
-  bool mIsEncrypted;
+  bool IsEncrypted() const
+  {
+    return !mInitDatas.IsEmpty();
+  }
+
+  template<typename AInitDatas>
+  void AddInitData(const nsAString& aType, AInitDatas&& aInitData)
+  {
+    mInitDatas.AppendElement(InitData(aType, Forward<AInitDatas>(aInitData)));
+  }
+
+  void AddInitData(const EncryptionInfo& aInfo)
+  {
+    mInitDatas.AppendElements(aInfo.mInitDatas);
+  }
+
+  // One 'InitData' per encrypted buffer.
+  InitDatas mInitDatas;
 };
 
 class MediaInfo {
@@ -334,7 +359,7 @@ public:
 
   bool IsEncrypted() const
   {
-    return mCrypto.mIsEncrypted;
+    return mCrypto.IsEncrypted();
   }
 
   bool HasValidMedia() const

--- a/dom/media/fmp4/MP4Demuxer.cpp
+++ b/dom/media/fmp4/MP4Demuxer.cpp
@@ -149,7 +149,7 @@ MP4TrackDemuxer::MP4TrackDemuxer(MP4Demuxer* aParent,
 
   MOZ_ASSERT(mInfo);
 
-  nsTArray<mp4_demuxer::Index::Indice> indices;
+  FallibleTArray<mp4_demuxer::Index::Indice> indices;
   if (!mParent->mMetadata->ReadTrackIndex(indices, mInfo->mTrackId)) {
     MOZ_ASSERT(false);
   }

--- a/dom/media/fmp4/MP4Demuxer.cpp
+++ b/dom/media/fmp4/MP4Demuxer.cpp
@@ -1,0 +1,323 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <algorithm>
+#include <limits>
+#include <stdint.h>
+
+#include "MP4Demuxer.h"
+#include "mp4_demuxer/Index.h"
+#include "mp4_demuxer/MoofParser.h"
+#include "mp4_demuxer/MP4Metadata.h"
+#include "mp4_demuxer/ResourceStream.h"
+#include "mp4_demuxer/BufferStream.h"
+
+namespace mozilla {
+
+MP4Demuxer::MP4Demuxer(MediaResource* aResource)
+  : mResource(aResource)
+  , mStream(new mp4_demuxer::ResourceStream(aResource))
+  , mInitData(new MediaLargeByteBuffer)
+{
+}
+
+nsRefPtr<MP4Demuxer::InitPromise>
+MP4Demuxer::Init()
+{
+  AutoPinned<mp4_demuxer::ResourceStream> stream(mStream);
+
+  // Check that we have enough data to read the metadata.
+  MediaByteRange br = mp4_demuxer::MP4Metadata::MetadataRange(stream);
+  if (br.IsNull()) {
+    return InitPromise::CreateAndReject(DemuxerFailureReason::WAITING_FOR_DATA, __func__);
+  }
+
+  if (!mInitData->SetLength(br.Length())) {
+    // OOM
+    return InitPromise::CreateAndReject(DemuxerFailureReason::DEMUXER_ERROR, __func__);
+  }
+
+  size_t size;
+  mStream->ReadAt(br.mStart, mInitData->Elements(), br.Length(), &size);
+  if (size != size_t(br.Length())) {
+    return InitPromise::CreateAndReject(DemuxerFailureReason::DEMUXER_ERROR, __func__);
+  }
+
+  nsRefPtr<mp4_demuxer::BufferStream> bufferstream =
+    new mp4_demuxer::BufferStream(mInitData);
+
+  mMetadata = MakeUnique<mp4_demuxer::MP4Metadata>(bufferstream);
+
+  if (!mMetadata->GetNumberTracks(mozilla::TrackInfo::kAudioTrack) &&
+      !mMetadata->GetNumberTracks(mozilla::TrackInfo::kVideoTrack)) {
+    return InitPromise::CreateAndReject(DemuxerFailureReason::DEMUXER_ERROR, __func__);
+  }
+
+  return InitPromise::CreateAndResolve(NS_OK, __func__);
+}
+
+already_AddRefed<MediaDataDemuxer>
+MP4Demuxer::Clone() const
+{
+  nsRefPtr<MP4Demuxer> demuxer = new MP4Demuxer(mResource);
+  demuxer->mInitData = mInitData;
+  nsRefPtr<mp4_demuxer::BufferStream> bufferstream =
+    new mp4_demuxer::BufferStream(mInitData);
+  demuxer->mMetadata = MakeUnique<mp4_demuxer::MP4Metadata>(bufferstream);
+  if (!mMetadata->GetNumberTracks(mozilla::TrackInfo::kAudioTrack) &&
+      !mMetadata->GetNumberTracks(mozilla::TrackInfo::kVideoTrack)) {
+    NS_WARNING("Couldn't recreate MP4Demuxer");
+    return nullptr;
+  }
+  return demuxer.forget();
+}
+
+bool
+MP4Demuxer::HasTrackType(TrackInfo::TrackType aType) const
+{
+  return !!GetNumberTracks(aType);
+}
+
+uint32_t
+MP4Demuxer::GetNumberTracks(TrackInfo::TrackType aType) const
+{
+  return mMetadata->GetNumberTracks(aType);
+}
+
+already_AddRefed<MediaTrackDemuxer>
+MP4Demuxer::GetTrackDemuxer(TrackInfo::TrackType aType, uint32_t aTrackNumber)
+{
+  if (mMetadata->GetNumberTracks(aType) <= aTrackNumber) {
+    return nullptr;
+  }
+  nsRefPtr<MediaTrackDemuxer> e =
+    new MP4TrackDemuxer(this, aType, aTrackNumber);
+  return e.forget();
+}
+
+bool
+MP4Demuxer::IsSeekable() const
+{
+  return mMetadata->CanSeek();
+}
+
+void
+MP4Demuxer::NotifyDataArrived(uint32_t aLength, int64_t aOffset)
+{
+  // TODO. May not be required for our use
+}
+
+UniquePtr<EncryptionInfo>
+MP4Demuxer::GetCrypto()
+{
+  const mp4_demuxer::CryptoFile& cryptoFile = mMetadata->Crypto();
+  if (!cryptoFile.valid) {
+    return nullptr;
+  }
+
+  const nsTArray<mp4_demuxer::PsshInfo>& psshs = cryptoFile.pssh;
+  nsTArray<uint8_t> initData;
+  for (uint32_t i = 0; i < psshs.Length(); i++) {
+    initData.AppendElements(psshs[i].data);
+  }
+
+  if (initData.IsEmpty()) {
+    return nullptr;
+  }
+
+  auto crypto = MakeUnique<EncryptionInfo>();
+  crypto->AddInitData(NS_LITERAL_STRING("cenc"), Move(initData));
+
+  return crypto;
+}
+
+MP4TrackDemuxer::MP4TrackDemuxer(MP4Demuxer* aParent,
+                                 TrackInfo::TrackType aType,
+                                 uint32_t aTrackNumber)
+  : mParent(aParent)
+  , mStream(new mp4_demuxer::ResourceStream(mParent->mResource))
+  , mMonitor("MP4TrackDemuxer")
+{
+  mInfo = mParent->mMetadata->GetTrackInfo(aType, aTrackNumber);
+
+  MOZ_ASSERT(mInfo);
+
+  nsTArray<mp4_demuxer::Index::Indice> indices;
+  if (!mParent->mMetadata->ReadTrackIndex(indices, mInfo->mTrackId)) {
+    MOZ_ASSERT(false);
+  }
+  mIndex = new mp4_demuxer::Index(indices,
+                                  mStream,
+                                  mInfo->mTrackId,
+                                  mInfo->IsAudio(),
+                                  &mMonitor);
+  mIterator = MakeUnique<mp4_demuxer::SampleIterator>(mIndex);
+}
+
+UniquePtr<TrackInfo>
+MP4TrackDemuxer::GetInfo() const
+{
+  return mInfo->Clone();
+}
+
+nsRefPtr<MP4TrackDemuxer::SeekPromise>
+MP4TrackDemuxer::Seek(media::TimeUnit aTime)
+{
+  int64_t seekTime = aTime.ToMicroseconds();
+  mQueuedSample = nullptr;
+
+  MonitorAutoLock mon(mMonitor);
+  mIterator->Seek(seekTime);
+
+  // Check what time we actually seeked to.
+  mQueuedSample = mIterator->GetNext();
+  if (mQueuedSample) {
+    seekTime = mQueuedSample->mTime;
+  }
+
+  return SeekPromise::CreateAndResolve(media::TimeUnit::FromMicroseconds(seekTime), __func__);
+}
+
+nsRefPtr<MP4TrackDemuxer::SamplesPromise>
+MP4TrackDemuxer::GetSamples(int32_t aNumSamples)
+{
+  nsRefPtr<SamplesHolder> samples = new SamplesHolder;
+  if (!aNumSamples) {
+    return SamplesPromise::CreateAndReject(DemuxerFailureReason::DEMUXER_ERROR, __func__);
+  }
+
+  if (mQueuedSample) {
+    samples->mSamples.AppendElement(mQueuedSample);
+    mQueuedSample = nullptr;
+    aNumSamples--;
+  }
+  MonitorAutoLock mon(mMonitor);
+  nsRefPtr<MediaRawData> sample;
+  while (aNumSamples && (sample = mIterator->GetNext())) {
+    samples->mSamples.AppendElement(sample);
+    aNumSamples--;
+  }
+
+  if (samples->mSamples.IsEmpty()) {
+    return SamplesPromise::CreateAndReject(DemuxerFailureReason::END_OF_STREAM, __func__);
+  } else {
+    UpdateSamples(samples->mSamples);
+    return SamplesPromise::CreateAndResolve(samples, __func__);
+  }
+}
+
+void
+MP4TrackDemuxer::Reset()
+{
+  mQueuedSample = nullptr;
+  // TODO, Seek to first frame available, which isn't always 0.
+  MonitorAutoLock mon(mMonitor);
+  mIterator->Seek(0);
+}
+
+void
+MP4TrackDemuxer::UpdateSamples(nsTArray<nsRefPtr<MediaRawData>>& aSamples)
+{
+  for (size_t i = 0; i < aSamples.Length(); i++) {
+    MediaRawData* sample = aSamples[i];
+    if (sample->mCrypto.valid) {
+      nsAutoPtr<MediaRawDataWriter> writer(sample->CreateWriter());
+      writer->mCrypto.mode = mInfo->mCrypto.mode;
+      writer->mCrypto.iv_size = mInfo->mCrypto.iv_size;
+      writer->mCrypto.key.AppendElements(mInfo->mCrypto.key);
+    }
+    if (mInfo->GetAsVideoInfo()) {
+      sample->mExtraData = mInfo->GetAsVideoInfo()->mExtraData;
+    }
+  }
+  if (mNextKeyframeTime.isNothing() ||
+      aSamples.LastElement()->mTime >= mNextKeyframeTime.value().ToMicroseconds()) {
+    mNextKeyframeTime.reset();
+    mp4_demuxer::Microseconds frameTime = mIterator->GetNextKeyframeTime();
+    if (frameTime != -1) {
+      mNextKeyframeTime.emplace(
+        media::TimeUnit::FromMicroseconds(frameTime));
+    }
+  }
+}
+
+nsresult
+MP4TrackDemuxer::GetNextRandomAccessPoint(media::TimeUnit* aTime)
+{
+  if (mNextKeyframeTime.isNothing()) {
+    // There's no next key frame.
+    *aTime =
+      media::TimeUnit::FromMicroseconds(std::numeric_limits<int64_t>::max());
+  } else {
+    *aTime = mNextKeyframeTime.value();
+  }
+  return NS_OK;
+}
+
+nsRefPtr<MP4TrackDemuxer::SkipAccessPointPromise>
+MP4TrackDemuxer::SkipToNextRandomAccessPoint(media::TimeUnit aTimeThreshold)
+{
+  MonitorAutoLock mon(mMonitor);
+  mQueuedSample = nullptr;
+  // Loop until we reach the next keyframe after the threshold.
+  uint32_t parsed = 0;
+  bool found = false;
+  nsRefPtr<MediaRawData> sample;
+  while (!found && (sample = mIterator->GetNext())) {
+    parsed++;
+    if (sample->mKeyframe && sample->mTime >= aTimeThreshold.ToMicroseconds()) {
+      found = true;
+      mQueuedSample = sample;
+    }
+  }
+  if (found) {
+    return SkipAccessPointPromise::CreateAndResolve(parsed, __func__);
+  } else {
+    SkipFailureHolder failure(DemuxerFailureReason::END_OF_STREAM, parsed);
+    return SkipAccessPointPromise::CreateAndReject(Move(failure), __func__);
+  }
+}
+
+int64_t
+MP4TrackDemuxer::GetEvictionOffset(media::TimeUnit aTime)
+{
+  MonitorAutoLock mon(mMonitor);
+  return int64_t(mIndex->GetEvictionOffset(aTime.ToMicroseconds()));
+}
+
+media::TimeIntervals
+MP4TrackDemuxer::GetBuffered()
+{
+  AutoPinned<MediaResource> resource(mParent->mResource);
+  nsTArray<MediaByteRange> byteRanges;
+  nsresult rv = resource->GetCachedRanges(byteRanges);
+
+  if (NS_FAILED(rv)) {
+    return media::TimeIntervals();
+  }
+  nsTArray<mp4_demuxer::Interval<int64_t>> timeRanges;
+
+  MonitorAutoLock mon(mMonitor);
+  mIndex->UpdateMoofIndex(byteRanges);
+  int64_t endComposition =
+    mIndex->GetEndCompositionIfBuffered(byteRanges);
+
+  mIndex->ConvertByteRangesToTimeRanges(byteRanges, &timeRanges);
+  if (endComposition) {
+    mp4_demuxer::Interval<int64_t>::SemiNormalAppend(
+      timeRanges, mp4_demuxer::Interval<int64_t>(endComposition, endComposition));
+  }
+  // convert timeRanges.
+  media::TimeIntervals ranges;
+  for (size_t i = 0; i < timeRanges.Length(); i++) {
+    ranges +=
+      media::TimeInterval(media::TimeUnit::FromMicroseconds(timeRanges[i].start),
+                          media::TimeUnit::FromMicroseconds(timeRanges[i].end));
+  }
+  return ranges;
+}
+
+} // namespace mozilla

--- a/dom/media/fmp4/MP4Demuxer.h
+++ b/dom/media/fmp4/MP4Demuxer.h
@@ -51,6 +51,7 @@ private:
   nsRefPtr<mp4_demuxer::ResourceStream> mStream;
   nsRefPtr<MediaLargeByteBuffer> mInitData;
   UniquePtr<mp4_demuxer::MP4Metadata> mMetadata;
+  nsTArray<nsRefPtr<MP4TrackDemuxer>> mDemuxers;
 };
 
 class MP4TrackDemuxer : public MediaTrackDemuxer
@@ -76,7 +77,11 @@ public:
 
   virtual int64_t GetEvictionOffset(media::TimeUnit aTime) override;
 
+  virtual void BreakCycles() override;
+
 private:
+  friend class MP4Demuxer;
+  void NotifyDataArrived();
   void UpdateSamples(nsTArray<nsRefPtr<MediaRawData>>& aSamples);
   nsRefPtr<MP4Demuxer> mParent;
   nsRefPtr<mp4_demuxer::Index> mIndex;

--- a/dom/media/fmp4/MP4Demuxer.h
+++ b/dom/media/fmp4/MP4Demuxer.h
@@ -1,0 +1,97 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#if !defined(MP4Demuxer_h_)
+#define MP4Demuxer_h_
+
+#include "mozilla/Maybe.h"
+#include "mozilla/Monitor.h"
+#include "MediaDataDemuxer.h"
+#include "MediaResource.h"
+
+namespace mp4_demuxer {
+class Index;
+class MP4Metadata;
+class ResourceStream;
+class SampleIterator;
+}
+
+namespace mozilla {
+
+class MP4TrackDemuxer;
+
+class MP4Demuxer : public MediaDataDemuxer
+{
+public:
+  explicit MP4Demuxer(MediaResource* aResource);
+
+  virtual nsRefPtr<InitPromise> Init() override;
+
+  virtual already_AddRefed<MediaDataDemuxer> Clone() const override;
+
+  virtual bool HasTrackType(TrackInfo::TrackType aType) const override;
+
+  virtual uint32_t GetNumberTracks(TrackInfo::TrackType aType) const override;
+
+  virtual already_AddRefed<MediaTrackDemuxer> GetTrackDemuxer(TrackInfo::TrackType aType,
+                                                              uint32_t aTrackNumber) override;
+
+  virtual bool IsSeekable() const override;
+
+  virtual UniquePtr<EncryptionInfo> GetCrypto() override;
+
+  virtual void NotifyDataArrived(uint32_t aLength, int64_t aOffset) override;
+
+private:
+  friend class MP4TrackDemuxer;
+  nsRefPtr<MediaResource> mResource;
+  nsRefPtr<mp4_demuxer::ResourceStream> mStream;
+  nsRefPtr<MediaLargeByteBuffer> mInitData;
+  UniquePtr<mp4_demuxer::MP4Metadata> mMetadata;
+};
+
+class MP4TrackDemuxer : public MediaTrackDemuxer
+{
+public:
+  MP4TrackDemuxer(MP4Demuxer* aParent,
+                  TrackInfo::TrackType aType,
+                  uint32_t aTrackNumber);
+
+  virtual UniquePtr<TrackInfo> GetInfo() const override;
+
+  virtual nsRefPtr<SeekPromise> Seek(media::TimeUnit aTime) override;
+
+  virtual nsRefPtr<SamplesPromise> GetSamples(int32_t aNumSamples = 1) override;
+
+  virtual void Reset() override;
+
+  virtual nsresult GetNextRandomAccessPoint(media::TimeUnit* aTime) override;
+
+  nsRefPtr<SkipAccessPointPromise> SkipToNextRandomAccessPoint(media::TimeUnit aTimeThreshold) override;
+
+  virtual media::TimeIntervals GetBuffered() override;
+
+  virtual int64_t GetEvictionOffset(media::TimeUnit aTime) override;
+
+private:
+  void UpdateSamples(nsTArray<nsRefPtr<MediaRawData>>& aSamples);
+  nsRefPtr<MP4Demuxer> mParent;
+  nsRefPtr<mp4_demuxer::Index> mIndex;
+  UniquePtr<mp4_demuxer::SampleIterator> mIterator;
+  UniquePtr<TrackInfo> mInfo;
+  nsRefPtr<mp4_demuxer::ResourceStream> mStream;
+  Maybe<media::TimeUnit> mNextKeyframeTime;
+  // Queued samples extracted by the demuxer, but not yet returned.
+  nsRefPtr<MediaRawData> mQueuedSample;
+
+  // We do not actually need a monitor, however MoofParser will assert
+  // if a monitor isn't held.
+  Monitor mMonitor;
+};
+
+} // namespace mozilla
+
+#endif

--- a/dom/media/fmp4/MP4Reader.cpp
+++ b/dom/media/fmp4/MP4Reader.cpp
@@ -476,10 +476,9 @@ MP4Reader::ReadUpdatedMetadata(MediaInfo* aInfo)
 bool
 MP4Reader::IsMediaSeekable()
 {
-  // We can seek if we get a duration *and* the reader reports that it's
-  // seekable.
+  // Check Demuxer to see if this content is seekable or not.
   MonitorAutoLock mon(mDemuxerMonitor);
-  return mDecoder->GetResource()->IsTransportSeekable();
+  return mDemuxer->CanSeek();
 }
 
 bool
@@ -967,7 +966,7 @@ MP4Reader::Seek(int64_t aTime, int64_t aEndTime)
   LOG("aTime=(%lld)", aTime);
   MOZ_ASSERT(GetTaskQueue()->IsCurrentThreadIn());
   MonitorAutoLock mon(mDemuxerMonitor);
-  if (!mDecoder->GetResource()->IsTransportSeekable() || !mDemuxer->CanSeek()) {
+  if (!mDemuxer->CanSeek()) {
     VLOG("Seek() END (Unseekable)");
     return SeekPromise::CreateAndReject(NS_ERROR_FAILURE, __func__);
   }

--- a/dom/media/fmp4/MP4Reader.cpp
+++ b/dom/media/fmp4/MP4Reader.cpp
@@ -347,7 +347,7 @@ MP4Reader::ReadMetadata(MediaInfo* aInfo,
     {
       MonitorAutoUnlock unlock(mDemuxerMonitor);
       ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
-      mInfo.mCrypto.mIsEncrypted = mIsEncrypted = mCrypto.valid;
+      mIsEncrypted = mCrypto.valid;
     }
 
     // Remember that we've initialized the demuxer, so that if we're decoding
@@ -375,14 +375,16 @@ MP4Reader::ReadMetadata(MediaInfo* aInfo,
     }
   }
 
-  if (mIsEncrypted) {
+  if (mCrypto.valid) {
     nsTArray<uint8_t> initData;
     ExtractCryptoInitData(initData);
     if (initData.Length() == 0) {
       return NS_ERROR_FAILURE;
     }
-    mInfo.mCrypto.mInitData = initData;
-    mInfo.mCrypto.mType = NS_LITERAL_STRING("cenc");
+
+    // Add init data to info, will get sent from HTMLMediaElement::MetadataLoaded
+    // (i.e., when transitioning from HAVE_NOTHING to HAVE_METADATA).
+    mInfo.mCrypto.AddInitData(NS_LITERAL_STRING("cenc"), Move(initData));
   }
 
   // Get the duration, and report it to the decoder if we have it.

--- a/dom/media/fmp4/MP4Reader.h
+++ b/dom/media/fmp4/MP4Reader.h
@@ -273,8 +273,6 @@ private:
 
   layers::LayersBackend mLayersBackendType;
 
-  nsTArray<nsTArray<uint8_t>> mInitDataEncountered;
-
   // For use with InvokeAndRetry as an already_refed can't be converted to bool
   nsRefPtr<MediaRawData> DemuxVideoSample();
   nsRefPtr<MediaRawData> DemuxAudioSample();

--- a/dom/media/fmp4/SharedDecoderManager.cpp
+++ b/dom/media/fmp4/SharedDecoderManager.cpp
@@ -255,10 +255,7 @@ SharedDecoderProxy::Shutdown()
 bool
 SharedDecoderProxy::IsWaitingMediaResources()
 {
-  if (mManager->mActiveProxy == this) {
-    return mManager->mDecoder->IsWaitingMediaResources();
-  }
-  return mManager->mActiveProxy != nullptr;
+  return mManager->mDecoder->IsWaitingMediaResources();
 }
 
 bool

--- a/dom/media/fmp4/moz.build
+++ b/dom/media/fmp4/moz.build
@@ -6,6 +6,7 @@
 
 EXPORTS += [
     'MP4Decoder.h',
+    'MP4Demuxer.h',
     'MP4Reader.h',
     'MP4Stream.h',
     'PlatformDecoderModule.h',
@@ -23,6 +24,7 @@ UNIFIED_SOURCES += [
 ]
 
 SOURCES += [
+    'MP4Demuxer.cpp',
     'MP4Reader.cpp',
 ]
 

--- a/dom/media/gtest/TestMP4Demuxer.cpp
+++ b/dom/media/gtest/TestMP4Demuxer.cpp
@@ -64,7 +64,7 @@ TEST(MP4Demuxer, Seek)
 }
 
 static nsCString
-ToCryptoString(CryptoSample& aCrypto)
+ToCryptoString(const CryptoSample& aCrypto)
 {
   nsCString res;
   if (aCrypto.valid) {

--- a/dom/media/mediasource/MediaSourceReader.cpp
+++ b/dom/media/mediasource/MediaSourceReader.cpp
@@ -1090,22 +1090,6 @@ MediaSourceReader::MaybeNotifyHaveData()
             IsSeeking(), haveAudio, haveVideo, ended);
 }
 
-static void
-CombineEncryptionData(EncryptionInfo& aTo, const EncryptionInfo& aFrom)
-{
-  if (!aFrom.mIsEncrypted) {
-    return;
-  }
-  aTo.mIsEncrypted = true;
-
-  if (!aTo.mType.IsEmpty() && !aTo.mType.Equals(aFrom.mType)) {
-    NS_WARNING("mismatched encryption types");
-  }
-
-  aTo.mType = aFrom.mType;
-  aTo.mInitData.AppendElements(aFrom.mInitData);
-}
-
 nsresult
 MediaSourceReader::ReadMetadata(MediaInfo* aInfo, MetadataTags** aTags)
 {
@@ -1129,7 +1113,7 @@ MediaSourceReader::ReadMetadata(MediaInfo* aInfo, MetadataTags** aTags)
     const MediaInfo& info = GetAudioReader()->GetMediaInfo();
     MOZ_ASSERT(info.HasAudio());
     mInfo.mAudio = info.mAudio;
-    CombineEncryptionData(mInfo.mCrypto, info.mCrypto);
+    mInfo.mCrypto.AddInitData(info.mCrypto);
     MSE_DEBUG("audio reader=%p duration=%lld",
               mAudioSourceDecoder.get(),
               mAudioSourceDecoder->GetReader()->GetDecoder()->GetMediaDuration());
@@ -1142,7 +1126,7 @@ MediaSourceReader::ReadMetadata(MediaInfo* aInfo, MetadataTags** aTags)
     const MediaInfo& info = GetVideoReader()->GetMediaInfo();
     MOZ_ASSERT(info.HasVideo());
     mInfo.mVideo = info.mVideo;
-    CombineEncryptionData(mInfo.mCrypto, info.mCrypto);
+    mInfo.mCrypto.AddInitData(info.mCrypto);
     MSE_DEBUG("video reader=%p duration=%lld",
               GetVideoReader(),
               GetVideoReader()->GetDecoder()->GetMediaDuration());

--- a/media/libstagefright/binding/Adts.cpp
+++ b/media/libstagefright/binding/Adts.cpp
@@ -62,10 +62,10 @@ Adts::ConvertSample(uint16_t aChannelCount, int8_t aFrequencyIndex,
 
   if (aSample->mCrypto.valid) {
     if (aSample->mCrypto.plain_sizes.Length() == 0) {
-      aSample->mCrypto.plain_sizes.AppendElement(kADTSHeaderSize);
-      aSample->mCrypto.encrypted_sizes.AppendElement(aSample->mSize - kADTSHeaderSize);
+      writer->mCrypto.plain_sizes.AppendElement(kADTSHeaderSize);
+      writer->mCrypto.encrypted_sizes.AppendElement(aSample->mSize - kADTSHeaderSize);
     } else {
-      aSample->mCrypto.plain_sizes[0] += kADTSHeaderSize;
+      writer->mCrypto.plain_sizes[0] += kADTSHeaderSize;
     }
   }
 

--- a/media/libstagefright/binding/BufferStream.cpp
+++ b/media/libstagefright/binding/BufferStream.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "mp4_demuxer/BufferStream.h"
+#include "MediaData.h"
 #include "MediaResource.h"
 #include <algorithm>
 
@@ -12,6 +13,17 @@ namespace mp4_demuxer {
 
 BufferStream::BufferStream()
   : mStartOffset(0)
+  , mData(new mozilla::MediaLargeByteBuffer)
+{
+}
+
+BufferStream::BufferStream(mozilla::MediaLargeByteBuffer* aBuffer)
+  : mStartOffset(0)
+  , mData(aBuffer)
+{
+}
+
+BufferStream::~BufferStream()
 {
 }
 
@@ -19,12 +31,12 @@ BufferStream::BufferStream()
 BufferStream::ReadAt(int64_t aOffset, void* aData, size_t aLength,
                      size_t* aBytesRead)
 {
-  if (aOffset < mStartOffset || aOffset > mStartOffset + mData.Length()) {
+  if (aOffset < mStartOffset || aOffset > mStartOffset + mData->Length()) {
     return false;
   }
   *aBytesRead =
-    std::min(aLength, size_t(mStartOffset + mData.Length() - aOffset));
-  memcpy(aData, mData.Elements() + aOffset - mStartOffset, *aBytesRead);
+    std::min(aLength, size_t(mStartOffset + mData->Length() - aOffset));
+  memcpy(aData, &(*mData)[aOffset - mStartOffset], *aBytesRead);
   return true;
 }
 
@@ -38,7 +50,7 @@ BufferStream::CachedReadAt(int64_t aOffset, void* aData, size_t aLength,
 /*virtual*/ bool
 BufferStream::Length(int64_t* aLength)
 {
-  *aLength = mStartOffset + mData.Length();
+  *aLength = mStartOffset + mData->Length();
   return true;
 }
 
@@ -46,20 +58,20 @@ BufferStream::Length(int64_t* aLength)
 BufferStream::DiscardBefore(int64_t aOffset)
 {
   if (aOffset > mStartOffset) {
-    mData.RemoveElementsAt(0, aOffset - mStartOffset);
+    mData->RemoveElementsAt(0, aOffset - mStartOffset);
     mStartOffset = aOffset;
   }
 }
 
-void
+bool
 BufferStream::AppendBytes(const uint8_t* aData, size_t aLength)
 {
-  mData.AppendElements(aData, aLength);
+  return mData->AppendElements(aData, aLength);
 }
 
 MediaByteRange
 BufferStream::GetByteRange()
 {
-  return MediaByteRange(mStartOffset, mStartOffset + mData.Length());
+  return MediaByteRange(mStartOffset, mStartOffset + mData->Length());
 }
 }

--- a/media/libstagefright/binding/Index.cpp
+++ b/media/libstagefright/binding/Index.cpp
@@ -127,10 +127,10 @@ already_AddRefed<MediaRawData> SampleIterator::GetNext()
       return nullptr;
     }
     ByteReader reader(cenc);
-    sample->mCrypto.valid = true;
-    sample->mCrypto.iv_size = ivSize;
+    writer->mCrypto.valid = true;
+    writer->mCrypto.iv_size = ivSize;
 
-    if (!reader.ReadArray(sample->mCrypto.iv, ivSize)) {
+    if (!reader.ReadArray(writer->mCrypto.iv, ivSize)) {
       return nullptr;
     }
 
@@ -142,13 +142,13 @@ already_AddRefed<MediaRawData> SampleIterator::GetNext()
       }
 
       for (size_t i = 0; i < count; i++) {
-        sample->mCrypto.plain_sizes.AppendElement(reader.ReadU16());
-        sample->mCrypto.encrypted_sizes.AppendElement(reader.ReadU32());
+        writer->mCrypto.plain_sizes.AppendElement(reader.ReadU16());
+        writer->mCrypto.encrypted_sizes.AppendElement(reader.ReadU32());
       }
     } else {
       // No subsample information means the entire sample is encrypted.
-      sample->mCrypto.plain_sizes.AppendElement(0);
-      sample->mCrypto.encrypted_sizes.AppendElement(sample->mSize);
+      writer->mCrypto.plain_sizes.AppendElement(0);
+      writer->mCrypto.encrypted_sizes.AppendElement(sample->mSize);
     }
   }
 

--- a/media/libstagefright/binding/MP4Metadata.cpp
+++ b/media/libstagefright/binding/MP4Metadata.cpp
@@ -279,4 +279,17 @@ MP4Metadata::HasCompleteMetadata(Stream* aSource)
   return parser->HasMetadata();
 }
 
+/*static*/ mozilla::MediaByteRange
+MP4Metadata::MetadataRange(Stream* aSource)
+{
+  // The MoofParser requires a monitor, but we don't need one here.
+  mozilla::Monitor monitor("MP4Metadata::HasCompleteMetadata");
+  mozilla::MonitorAutoLock mon(monitor);
+  auto parser = mozilla::MakeUnique<MoofParser>(aSource, 0, false, &monitor);
+  if (parser->HasMetadata()) {
+    return parser->mInitRange;
+  }
+  return mozilla::MediaByteRange();
+}
+
 } // namespace mp4_demuxer

--- a/media/libstagefright/binding/MoofParser.cpp
+++ b/media/libstagefright/binding/MoofParser.cpp
@@ -128,6 +128,7 @@ MoofParser::HasMetadata()
   BoxContext context(stream, byteRanges);
   for (Box box(&context, mOffset); box.IsAvailable(); box = box.Next()) {
     if (box.IsType("moov")) {
+      mInitRange = MediaByteRange(box.Range().mStart, box.Range().mEnd);
       return true;
     }
   }

--- a/media/libstagefright/binding/MoofParser.cpp
+++ b/media/libstagefright/binding/MoofParser.cpp
@@ -125,14 +125,24 @@ MoofParser::HasMetadata()
   byteRanges.AppendElement(MediaByteRange(0, length));
   nsRefPtr<mp4_demuxer::BlockingStream> stream = new BlockingStream(mSource);
 
+  MediaByteRange ftyp;
+  MediaByteRange moov;
   BoxContext context(stream, byteRanges);
   for (Box box(&context, mOffset); box.IsAvailable(); box = box.Next()) {
+    if (box.IsType("ftyp")) {
+      ftyp = box.Range();
+      continue;
+    }
     if (box.IsType("moov")) {
-      mInitRange = MediaByteRange(box.Range().mStart, box.Range().mEnd);
-      return true;
+      moov = box.Range();
+      break;
     }
   }
-  return false;
+  if (!ftyp.Length() || !moov.Length()) {
+    return false;
+  }
+  mInitRange = ftyp.Extents(moov);
+  return true;
 }
 
 Interval<Microseconds>

--- a/media/libstagefright/binding/include/mp4_demuxer/BufferStream.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/BufferStream.h
@@ -5,8 +5,13 @@
 #ifndef BUFFER_STREAM_H_
 #define BUFFER_STREAM_H_
 
-#include "mp4_demuxer/mp4_demuxer.h"
+#include "mp4_demuxer/Stream.h"
 #include "nsTArray.h"
+#include "MediaResource.h"
+
+namespace mozilla {
+class MediaLargeByteBuffer;
+}
 
 namespace mp4_demuxer {
 
@@ -17,6 +22,7 @@ public:
    * Therefore BufferStream shouldn't get used after aData is destroyed.
    */
   BufferStream();
+  explicit BufferStream(mozilla::MediaLargeByteBuffer* aBuffer);
 
   virtual bool ReadAt(int64_t aOffset, void* aData, size_t aLength,
                       size_t* aBytesRead) override;
@@ -26,13 +32,14 @@ public:
 
   virtual void DiscardBefore(int64_t aOffset) override;
 
-  void AppendBytes(const uint8_t* aData, size_t aLength);
+  bool AppendBytes(const uint8_t* aData, size_t aLength);
 
   mozilla::MediaByteRange GetByteRange();
 
 private:
+  ~BufferStream();
   int64_t mStartOffset;
-  nsTArray<uint8_t> mData;
+  nsRefPtr<mozilla::MediaLargeByteBuffer> mData;
 };
 }
 

--- a/media/libstagefright/binding/include/mp4_demuxer/MP4Metadata.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/MP4Metadata.h
@@ -12,6 +12,7 @@
 #include "nsAutoPtr.h"
 #include "nsTArray.h"
 #include "MediaInfo.h"
+#include "MediaResource.h"
 
 namespace mozilla { class MediaByteRange; }
 
@@ -29,6 +30,7 @@ public:
   ~MP4Metadata();
 
   static bool HasCompleteMetadata(Stream* aSource);
+  static mozilla::MediaByteRange MetadataRange(Stream* aSource);
   uint32_t GetNumberTracks(mozilla::TrackInfo::TrackType aType) const;
   mozilla::UniquePtr<mozilla::TrackInfo> GetTrackInfo(mozilla::TrackInfo::TrackType aType,
                                                       size_t aTrackNumber) const;

--- a/media/libstagefright/binding/mp4_demuxer.cpp
+++ b/media/libstagefright/binding/mp4_demuxer.cpp
@@ -134,9 +134,10 @@ MP4Demuxer::DemuxAudioSample()
   nsRefPtr<mozilla::MediaRawData> sample(mAudioIterator->GetNext());
   if (sample) {
     if (sample->mCrypto.valid) {
-      sample->mCrypto.mode = mAudioConfig->mCrypto.mode;
-      sample->mCrypto.iv_size = mAudioConfig->mCrypto.iv_size;
-      sample->mCrypto.key.AppendElements(mAudioConfig->mCrypto.key);
+      nsAutoPtr<MediaRawDataWriter> writer(sample->CreateWriter());
+      writer->mCrypto.mode = mAudioConfig->mCrypto.mode;
+      writer->mCrypto.iv_size = mAudioConfig->mCrypto.iv_size;
+      writer->mCrypto.key.AppendElements(mAudioConfig->mCrypto.key);
     }
   }
   return sample.forget();
@@ -151,8 +152,9 @@ MP4Demuxer::DemuxVideoSample()
   if (sample) {
     sample->mExtraData = mVideoConfig->GetAsVideoInfo()->mExtraData;
     if (sample->mCrypto.valid) {
-      sample->mCrypto.mode = mVideoConfig->mCrypto.mode;
-      sample->mCrypto.key.AppendElements(mVideoConfig->mCrypto.key);
+      nsAutoPtr<MediaRawDataWriter> writer(sample->CreateWriter());
+      writer->mCrypto.mode = mVideoConfig->mCrypto.mode;
+      writer->mCrypto.key.AppendElements(mVideoConfig->mCrypto.key);
     }
     if (sample->mTime >= mNextKeyframeTime) {
       mNextKeyframeTime = mVideoIterator->GetNextKeyframeTime();


### PR DESCRIPTION
Another step on the road to supporting FFmpeg! Changes in this PR:

Use MediaRawDataWriter (introduced in PR #619) to access MediaRawData::mCrypto (for consistencies' sake).

Fixed potential crash points in MP4Reader & SharedDecoderProxy

Adds a new MP4Demuxer now that we aren't dependent on libstagefright's demuxer (also PR #619)

Various changes/fixes related to MP4Metadata and BufferStream (needed by the MP4Demuxer)

Fixes an issue with encrypted events being fired (affects our MSE support and will be needed by the MP4Demuxer once we are able to use MSE + H.264/MP4 together).

Tested MP4 on YouTube and other sites, as well as tested MSE videos using a test suite. All seems to work as intended.