### PR TITLE
Minor fix: Permissions - about:permissions - throws a warning

### DIFF
--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -575,18 +575,17 @@ let AboutPermissions = {
       itemCnt++;
     }, this);
 
-    let (enumerator = Services.perms.enumerator) {
-      while (enumerator.hasMoreElements()) {
-        if (itemCnt % this.LIST_BUILD_CHUNK == 0) {
-          yield true;
-        }
-        let permission = enumerator.getNext().QueryInterface(Ci.nsIPermission);
-        // Only include sites with exceptions set for supported permission types.
-        if (this._supportedPermissions.indexOf(permission.type) != -1) {
-          this.addHost(permission.host);
-        }
-        itemCnt++;
+    let enumerator = Services.perms.enumerator;
+    while (enumerator.hasMoreElements()) {
+      if (itemCnt % this.LIST_BUILD_CHUNK == 0) {
+        yield true;
       }
+      let permission = enumerator.getNext().QueryInterface(Ci.nsIPermission);
+      // Only include sites with exceptions set for supported permission types.
+      if (this._supportedPermissions.indexOf(permission.type) != -1) {
+        this.addHost(permission.host);
+      }
+      itemCnt++;
     }
 
     yield false;
@@ -678,7 +677,8 @@ let AboutPermissions = {
    *        The host string corresponding to the site to delete.
    */
   deleteFromSitesList: function(aHost) {
-    for each (let site in this._sites) {
+    for (let host in this._sites) {
+      let site = this._sites[host];
       if (site.host.hasRootDomain(aHost)) {
         if (site == this._selectedSite) {
           // Replace site-specific interface with "All Sites" interface.


### PR DESCRIPTION
Pale Moon throws a warning in the Browser Console:
```
JavaScript 1.7's let blocks are deprecated aboutPermissions.js:565:49
```

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1115293

---

I've created the new build (x64) and tested.
