### PR TITLE
Minor fix: DevTools - Storage Inspector - throws an error

### DIFF
--- a/toolkit/devtools/server/actors/storage.js
+++ b/toolkit/devtools/server/actors/storage.js
@@ -555,7 +555,8 @@ StorageActors.createActor({
    *        cookie change in the "cookie-change" topic.
    */
   observe: function(subject, topic, action) {
-    if (topic !== "cookie-changed" ||
+    if (!subject ||
+        topic !== "cookie-changed" ||
         !this.storageActor ||
         !this.storageActor.windows) {
       return null;


### PR DESCRIPTION
__Steps to reproduce:__
1) Open DevTools (Menu: "Tools" - "Web Developer" - "Storage Inspector")
2) Clean Recent History - Cookies (Menu: "History" - "Clean Recent History...")

Pale Moon throws an errors in the Browser Console:
```
TypeError: cookies is null storage.js:477:8
```

---

I've created the new build (x64) and tested.
