### PR TITLE
Minor fix: Options - Applications - throws a warning

### DIFF
--- a/browser/components/preferences/applications.js
+++ b/browser/components/preferences/applications.js
@@ -1814,10 +1814,9 @@ var gApplicationsPane = {
         return this._getIconURLForSystemDefault(aHandlerInfo);
 
       case Ci.nsIHandlerInfo.useHelperApp:
-        let (preferredApp = aHandlerInfo.preferredApplicationHandler) {
-          if (this.isValidHandlerApp(preferredApp))
-            return this._getIconURLForHandlerApp(preferredApp);
-        }
+        let preferredApp = aHandlerInfo.preferredApplicationHandler;
+        if (this.isValidHandlerApp(preferredApp))
+          return this._getIconURLForHandlerApp(preferredApp);
         break;
 
       // This should never happen, but if preferredAction is set to some weird


### PR DESCRIPTION
Pale Moon throws a warning in the Browser Console:
```
JavaScript 1.7's let blocks are deprecated applications.js:1771:70
```

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1108311


---

I've created the new build (x64) and tested.