### PR TITLE
Media decoder fixes

### DIFF
--- a/dom/media/fmp4/MP4Reader.h
+++ b/dom/media/fmp4/MP4Reader.h
@@ -28,12 +28,6 @@ typedef std::deque<nsRefPtr<MediaRawData>> MediaSampleQueue;
 class MP4Stream;
 
 #if defined(MOZ_GONK_MEDIACODEC) || defined(XP_WIN) || defined(MOZ_APPLEMEDIA) || defined(MOZ_FFMPEG)
-#define MP4_READER_DORMANT
-#else
-#undef MP4_READER_DORMANT
-#endif
-
-#if defined(XP_WIN) || defined(MOZ_APPLEMEDIA) || defined(MOZ_FFMPEG)
 #define MP4_READER_DORMANT_HEURISTIC
 #else
 #undef MP4_READER_DORMANT_HEURISTIC
@@ -61,11 +55,6 @@ public:
   virtual bool HasAudio() override;
   virtual bool HasVideo() override;
 
-  // PreReadMetadata() is called by MediaDecoderStateMachine::DecodeMetadata()
-  // before checking hardware resource. In Gonk, it requests hardware codec so
-  // MediaDecoderStateMachine could go to DORMANT state if the hardware codec is
-  // not available.
-  virtual void PreReadMetadata() override;
   virtual nsresult ReadMetadata(MediaInfo* aInfo,
                                 MetadataTags** aTags) override;
 
@@ -104,6 +93,8 @@ private:
 
   bool EnsureDecodersSetup();
 
+  bool CheckIfDecoderSetup();
+
   // Sends input to decoder for aTrack, and output to the state machine,
   // if necessary.
   void Update(TrackType aTrack);
@@ -135,7 +126,6 @@ private:
   bool IsSupportedAudioMimeType(const nsACString& aMimeType);
   bool IsSupportedVideoMimeType(const nsACString& aMimeType);
   void NotifyResourcesStatusChanged();
-  void RequestCodecResource();
   virtual bool IsWaitingOnCDMResource() override;
 
   Microseconds GetNextKeyframeTime();
@@ -285,8 +275,6 @@ private:
 
   // Synchronized by decoder monitor.
   bool mIsEncrypted;
-
-  bool mAreDecodersSetup;
 
   bool mIndexReady;
   int64_t mLastSeenEnd;

--- a/dom/media/fmp4/MP4Reader.h
+++ b/dom/media/fmp4/MP4Reader.h
@@ -93,8 +93,6 @@ private:
 
   bool EnsureDecodersSetup();
 
-  bool CheckIfDecoderSetup();
-
   // Sends input to decoder for aTrack, and output to the state machine,
   // if necessary.
   void Update(TrackType aTrack);

--- a/dom/media/fmp4/PlatformDecoderModule.h
+++ b/dom/media/fmp4/PlatformDecoderModule.h
@@ -241,11 +241,6 @@ public:
   virtual bool IsWaitingMediaResources() {
     return false;
   };
-  virtual bool IsDormantNeeded() {
-    return false;
-  };
-  virtual void AllocateMediaResources() {}
-  virtual void ReleaseMediaResources() {}
   virtual bool IsHardwareAccelerated() const { return false; }
 
   // ConfigurationChanged will be called to inform the video or audio decoder

--- a/dom/media/fmp4/SharedDecoderManager.cpp
+++ b/dom/media/fmp4/SharedDecoderManager.cpp
@@ -141,11 +141,6 @@ SharedDecoderManager::Select(SharedDecoderProxy* aProxy)
 
   mActiveProxy = aProxy;
   mActiveCallback = aProxy->mCallback;
-
-  if (mDecoderReleasedResources) {
-    mDecoder->AllocateMediaResources();
-    mDecoderReleasedResources = false;
-  }
 }
 
 void
@@ -173,14 +168,6 @@ SharedDecoderManager::DrainComplete()
   } else {
     mActiveCallback->DrainComplete();
   }
-}
-
-void
-SharedDecoderManager::ReleaseMediaResources()
-{
-  mDecoderReleasedResources = true;
-  mDecoder->ReleaseMediaResources();
-  mActiveProxy = nullptr;
 }
 
 void
@@ -256,20 +243,6 @@ bool
 SharedDecoderProxy::IsWaitingMediaResources()
 {
   return mManager->mDecoder->IsWaitingMediaResources();
-}
-
-bool
-SharedDecoderProxy::IsDormantNeeded()
-{
-  return mManager->mDecoder->IsDormantNeeded();
-}
-
-void
-SharedDecoderProxy::ReleaseMediaResources()
-{
-  if (mManager->mActiveProxy == this) {
-    mManager->ReleaseMediaResources();
-  }
 }
 
 bool

--- a/dom/media/fmp4/SharedDecoderManager.h
+++ b/dom/media/fmp4/SharedDecoderManager.h
@@ -74,8 +74,6 @@ public:
   virtual nsresult Drain() override;
   virtual nsresult Shutdown() override;
   virtual bool IsWaitingMediaResources() override;
-  virtual bool IsDormantNeeded() override;
-  virtual void ReleaseMediaResources() override;
   virtual bool IsHardwareAccelerated() const override;
 
   friend class SharedDecoderManager;

--- a/dom/media/fmp4/gonk/GonkAudioDecoderManager.cpp
+++ b/dom/media/fmp4/gonk/GonkAudioDecoderManager.cpp
@@ -74,8 +74,13 @@ GonkAudioDecoderManager::Init(MediaDataDecoderCallback* aCallback)
   mLooper->setName("GonkAudioDecoderManager");
   mLooper->start();
 
-  mDecoder = MediaCodecProxy::CreateByType(mLooper, "audio/mp4a-latm", false, false, nullptr);
+  mDecoder = MediaCodecProxy::CreateByType(mLooper, "audio/mp4a-latm", false, nullptr);
   if (!mDecoder.get()) {
+    return nullptr;
+  }
+  if (!mDecoder->AskMediaCodecAndWait())
+  {
+    mDecoder = nullptr;
     return nullptr;
   }
   sp<AMessage> format = new AMessage;

--- a/dom/media/fmp4/gonk/GonkMediaDataDecoder.cpp
+++ b/dom/media/fmp4/gonk/GonkMediaDataDecoder.cpp
@@ -137,15 +137,23 @@ GonkMediaDataDecoder::~GonkMediaDataDecoder()
 nsresult
 GonkMediaDataDecoder::Init()
 {
-  mDecoder = mManager->Init(mCallback);
+  sp<MediaCodecProxy> decoder;
+  decoder = mManager->Init(mCallback);
+  mDecoder = decoder;
   mDrainComplete = false;
-  return mDecoder.get() ? NS_OK : NS_ERROR_UNEXPECTED;
+
+  return NS_OK;
 }
 
 nsresult
 GonkMediaDataDecoder::Shutdown()
 {
+  if (!mDecoder.get()) {
+    return NS_OK;
+  }
+
   mDecoder->stop();
+  mDecoder->ReleaseMediaResources();
   mDecoder = nullptr;
   return NS_OK;
 }
@@ -257,19 +265,10 @@ GonkMediaDataDecoder::Drain()
 
 bool
 GonkMediaDataDecoder::IsWaitingMediaResources() {
-  return mDecoder->IsWaitingResources();
-}
-
-void
-GonkMediaDataDecoder::AllocateMediaResources()
-{
-  mManager->AllocateMediaResources();
-}
-
-void
-GonkMediaDataDecoder::ReleaseMediaResources()
-{
-  mManager->ReleaseMediaResources();
+  if (!mDecoder.get()) {
+    return true;
+  }
+  return false;
 }
 
 } // namespace mozilla

--- a/dom/media/fmp4/gonk/GonkMediaDataDecoder.h
+++ b/dom/media/fmp4/gonk/GonkMediaDataDecoder.h
@@ -40,13 +40,9 @@ public:
                           nsRefPtr<MediaData>& aOutput) = 0;
 
   // Flush the queued sample.
-  // It this function is overrided by subclass, this functino should be called
+  // It this function is overrided by subclass, this function should be called
   // in the overrided function.
   virtual nsresult Flush();
-
-  virtual void AllocateMediaResources() {}
-
-  virtual void ReleaseMediaResources() {}
 
   // It should be called in MediaTash thread.
   bool HasQueuedSample() {
@@ -99,12 +95,6 @@ public:
   virtual nsresult Shutdown() override;
 
   virtual bool IsWaitingMediaResources() override;
-
-  virtual bool IsDormantNeeded() { return true;}
-
-  virtual void AllocateMediaResources() override;
-
-  virtual void ReleaseMediaResources() override;
 
 private:
 

--- a/dom/media/fmp4/gonk/GonkVideoDecoderManager.cpp
+++ b/dom/media/fmp4/gonk/GonkVideoDecoderManager.cpp
@@ -42,10 +42,6 @@ using namespace android;
 typedef android::MediaCodecProxy MediaCodecProxy;
 
 namespace mozilla {
-enum {
-  kNotifyCodecReserved = 'core',
-  kNotifyCodecCanceled = 'coca',
-};
 
 GonkVideoDecoderManager::GonkVideoDecoderManager(
   MediaTaskQueue* aTaskQueue,
@@ -112,11 +108,15 @@ GonkVideoDecoderManager::Init(MediaDataDecoderCallback* aCallback)
     return nullptr;
   }
   mDecoder = MediaCodecProxy::CreateByType(mLooper, mMimeType.get(), false, mVideoListener);
+  mDecoder->AskMediaCodecAndWait();
+
   uint32_t capability = MediaCodecProxy::kEmptyCapability;
   if (mDecoder->getCapability(&capability) == OK && (capability &
       MediaCodecProxy::kCanExposeGraphicBuffer)) {
     mNativeWindow = new GonkNativeWindow();
   }
+
+  mReaderCallback->NotifyResourcesStatusChanged();
 
   return mDecoder;
 }
@@ -490,14 +490,9 @@ GonkVideoDecoderManager::Flush()
 }
 
 void
-GonkVideoDecoderManager::AllocateMediaResources()
-{
-  mDecoder->RequestMediaResources();
-}
-
-void
 GonkVideoDecoderManager::codecReserved()
 {
+  GVDM_LOG("codecReserved");
   sp<AMessage> format = new AMessage;
   sp<Surface> surface;
 
@@ -517,24 +512,12 @@ GonkVideoDecoderManager::codecReserved()
     GVDM_LOG("Failed to configure codec!!!!");
     mReaderCallback->Error();
   }
-
-  if (mHandler != nullptr) {
-    // post kNotifyCodecReserved to Looper thread.
-    sp<AMessage> notify = new AMessage(kNotifyCodecReserved, mHandler->id());
-    notify->post();
-  }
 }
 
 void
 GonkVideoDecoderManager::codecCanceled()
 {
   mDecoder = nullptr;
-  if (mHandler != nullptr) {
-    // post kNotifyCodecCanceled to Looper thread.
-    sp<AMessage> notify = new AMessage(kNotifyCodecCanceled, mHandler->id());
-    notify->post();
-  }
-
 }
 
 // Called on GonkVideoDecoderManager::mManagerLooper thread.
@@ -542,21 +525,6 @@ void
 GonkVideoDecoderManager::onMessageReceived(const sp<AMessage> &aMessage)
 {
   switch (aMessage->what()) {
-    case kNotifyCodecReserved:
-    {
-      // Our decode may have acquired the hardware resource that it needs
-      // to start. Notify the state machine to resume loading metadata.
-      GVDM_LOG("CodecReserved!");
-      mReaderCallback->NotifyResourcesStatusChanged();
-      break;
-    }
-
-    case kNotifyCodecCanceled:
-    {
-      mReaderCallback->ReleaseMediaResources();
-      break;
-    }
-
     case kNotifyPostReleaseBuffer:
     {
       ReleaseAllPendingVideoBuffers();

--- a/dom/media/fmp4/gonk/GonkVideoDecoderManager.h
+++ b/dom/media/fmp4/gonk/GonkVideoDecoderManager.h
@@ -51,8 +51,6 @@ public:
 
   virtual nsresult Flush() override;
 
-  virtual void AllocateMediaResources();
-
   virtual void ReleaseMediaResources();
 
   static void RecycleCallback(TextureClient* aClient, void* aClosure);
@@ -146,7 +144,6 @@ private:
 
   android::sp<MediaCodecProxy> mDecoder;
   nsRefPtr<layers::ImageContainer> mImageContainer;
-  MediaDataDecoderCallback* mCallback;
 
   android::MediaBuffer* mVideoBuffer;
 

--- a/dom/media/fmp4/wmf/WMFMediaDataDecoder.cpp
+++ b/dom/media/fmp4/wmf/WMFMediaDataDecoder.cpp
@@ -86,13 +86,6 @@ WMFMediaDataDecoder::EnsureDecodeTaskDispatched()
   }
 }
 
-void
-WMFMediaDataDecoder::ProcessReleaseDecoder()
-{
-  mMFTManager->Shutdown();
-  mDecoder = nullptr;
-}
-
 // Inserts data into the decoder's pipeline.
 nsresult
 WMFMediaDataDecoder::Input(MediaRawData* aSample)
@@ -207,24 +200,6 @@ WMFMediaDataDecoder::Drain()
 {
   mTaskQueue->Dispatch(NS_NewRunnableMethod(this, &WMFMediaDataDecoder::ProcessDrain));
   return NS_OK;
-}
-
-void
-WMFMediaDataDecoder::AllocateMediaResources()
-{
-  mDecoder = mMFTManager->Init();
-}
-
-void
-WMFMediaDataDecoder::ReleaseMediaResources()
-{
-  DebugOnly<nsresult> rv = mTaskQueue->FlushAndDispatch(
-    NS_NewRunnableMethod(this, &WMFMediaDataDecoder::ProcessReleaseDecoder));
-#ifdef DEBUG
-  if (NS_FAILED(rv)) {
-    NS_WARNING("WMFMediaDataDecoder::ReleaseMediaResources() dispatch of task failed!");
-  }
-#endif
 }
 
 bool

--- a/dom/media/fmp4/wmf/WMFMediaDataDecoder.h
+++ b/dom/media/fmp4/wmf/WMFMediaDataDecoder.h
@@ -70,9 +70,6 @@ public:
   virtual nsresult Shutdown() override;
 
   virtual bool IsWaitingMediaResources() { return false; };
-  virtual bool IsDormantNeeded() { return true; };
-  virtual void AllocateMediaResources() override;
-  virtual void ReleaseMediaResources() override;
   virtual bool IsHardwareAccelerated() const override;
 
 private:
@@ -92,7 +89,6 @@ private:
   void ProcessDrain();
 
   void ProcessShutdown();
-  void ProcessReleaseDecoder();
 
   RefPtr<FlushableMediaTaskQueue> mTaskQueue;
   MediaDataDecoderCallback* mCallback;

--- a/dom/media/fmp4/wrappers/H264Converter.cpp
+++ b/dom/media/fmp4/wrappers/H264Converter.cpp
@@ -118,40 +118,6 @@ H264Converter::IsWaitingMediaResources()
 }
 
 bool
-H264Converter::IsDormantNeeded()
-{
-  if (mNeedAVCC) {
-    return true;
-  }
-  return mDecoder ?
-    mDecoder->IsDormantNeeded() : MediaDataDecoder::IsDormantNeeded();
-}
-
-void
-H264Converter::AllocateMediaResources()
-{
-  if (mNeedAVCC) {
-    // Nothing to do, decoder will be allocated on the fly when required.
-    return;
-  }
-  if (mDecoder) {
-    mDecoder->AllocateMediaResources();
-  }
-}
-
-void
-H264Converter::ReleaseMediaResources()
-{
-  if (mNeedAVCC) {
-    Shutdown();
-    return;
-  }
-  if (mDecoder) {
-    mDecoder->ReleaseMediaResources();
-  }
-}
-
-bool
 H264Converter::IsHardwareAccelerated() const
 {
   if (mDecoder) {
@@ -214,7 +180,7 @@ H264Converter::CheckForSPSChange(MediaRawData* aSample)
   // The SPS has changed, signal to flush the current decoder and create a
   // new one.
   mDecoder->Flush();
-  ReleaseMediaResources();
+  Shutdown();
   return CreateDecoderAndInit(aSample);
 }
 

--- a/dom/media/fmp4/wrappers/H264Converter.h
+++ b/dom/media/fmp4/wrappers/H264Converter.h
@@ -35,9 +35,6 @@ public:
   virtual nsresult Drain() override;
   virtual nsresult Shutdown() override;
   virtual bool IsWaitingMediaResources() override;
-  virtual bool IsDormantNeeded() override;
-  virtual void AllocateMediaResources() override;
-  virtual void ReleaseMediaResources() override;
   virtual bool IsHardwareAccelerated() const override;
 
   // Return true if mimetype is H.264.

--- a/dom/media/omx/MediaCodecProxy.cpp
+++ b/dom/media/omx/MediaCodecProxy.cpp
@@ -138,6 +138,20 @@ MediaCodecProxy::AskMediaCodecAndWait()
   return true;
 }
 
+bool
+MediaCodecProxy::AsyncAskMediaCodec()
+{
+  if ((strncasecmp(mCodecMime.get(), "video/", 6) != 0) ||
+      (mResourceHandler == nullptr)) {
+    return false;
+  }
+  // request video codec
+  mResourceHandler->requestResource(mCodecEncoder
+    ? IMediaResourceManagerService::HW_VIDEO_ENCODER
+    : IMediaResourceManagerService::HW_VIDEO_DECODER);
+  return true;
+}
+
 void
 MediaCodecProxy::SetMediaCodecFree()
 {

--- a/dom/media/omx/MediaCodecProxy.cpp
+++ b/dom/media/omx/MediaCodecProxy.cpp
@@ -78,42 +78,38 @@ sp<MediaCodecProxy>
 MediaCodecProxy::CreateByType(sp<ALooper> aLooper,
                               const char *aMime,
                               bool aEncoder,
-                              bool aAsync,
                               wp<CodecResourceListener> aListener)
 {
-  sp<MediaCodecProxy> codec = new MediaCodecProxy(aLooper, aMime, aEncoder, aAsync, aListener);
-  if ((!aAsync && codec->allocated()) || codec->requestResource()) {
-    return codec;
-  }
-  return nullptr;
+  sp<MediaCodecProxy> codec = new MediaCodecProxy(aLooper,
+                                                  aMime,
+                                                  aEncoder,
+                                                  aListener);
+  return codec;
 }
 
 MediaCodecProxy::MediaCodecProxy(sp<ALooper> aLooper,
                                  const char *aMime,
                                  bool aEncoder,
-                                 bool aAsync,
                                  wp<CodecResourceListener> aListener)
   : mCodecLooper(aLooper)
   , mCodecMime(aMime)
   , mCodecEncoder(aEncoder)
   , mListener(aListener)
+  , mMediaCodecLock("MediaCodecProxy::mMediaCodecLock")
+  , mPendingRequestMediaResource(false)
 {
   MOZ_ASSERT(mCodecLooper != nullptr, "ALooper should not be nullptr.");
-  if (aAsync) {
-    mResourceHandler = new MediaResourceHandler(this);
-  } else {
-    allocateCodec();
-  }
+  mResourceHandler = new MediaResourceHandler(this);
 }
 
 MediaCodecProxy::~MediaCodecProxy()
 {
   releaseCodec();
-  cancelResource();
+  SetMediaCodecFree();
 }
 
 bool
-MediaCodecProxy::requestResource()
+MediaCodecProxy::AskMediaCodecAndWait()
 {
   if (mResourceHandler == nullptr) {
     return false;
@@ -124,30 +120,39 @@ MediaCodecProxy::requestResource()
         ? IMediaResourceManagerService::HW_VIDEO_ENCODER
         : IMediaResourceManagerService::HW_VIDEO_DECODER);
   } else if (strncasecmp(mCodecMime.get(), "audio/", 6) == 0) {
-    mResourceHandler->requestResource(mCodecEncoder
-        ? IMediaResourceManagerService::HW_AUDIO_ENCODER
-        : IMediaResourceManagerService::HW_AUDIO_DECODER);
+    if (allocateCodec()) {
+      return true;
+    }
   } else {
     return false;
   }
+
+  mozilla::MonitorAutoLock mon(mMediaCodecLock);
+  mPendingRequestMediaResource = true;
+
+  while (mPendingRequestMediaResource) {
+    mMediaCodecLock.Wait();
+  }
+  MCP_LOG("AskMediaCodecAndWait complete");
 
   return true;
 }
 
 void
-MediaCodecProxy::RequestMediaResources()
-{
-  requestResource();
-}
-
-void
-MediaCodecProxy::cancelResource()
+MediaCodecProxy::SetMediaCodecFree()
 {
   if (mResourceHandler == nullptr) {
     return;
   }
 
+  mozilla::MonitorAutoLock mon(mMediaCodecLock);
+  if (mPendingRequestMediaResource) {
+    mPendingRequestMediaResource = false;
+    mon.NotifyAll();
+  }
+
   mResourceHandler->cancelResource();
+  mResourceHandler = nullptr;
 }
 
 bool
@@ -462,31 +467,23 @@ MediaCodecProxy::getCapability(uint32_t *aCapability)
 void
 MediaCodecProxy::resourceReserved()
 {
+  MCP_LOG("resourceReserved");
   // Create MediaCodec
   releaseCodec();
   if (!allocateCodec()) {
-    cancelResource();
+    SetMediaCodecFree();
     return;
   }
+
+  // Notify initialization waiting.
+  mozilla::MonitorAutoLock mon(mMediaCodecLock);
+  mPendingRequestMediaResource = false;
+  mon.NotifyAll();
 
   // Notification
   sp<CodecResourceListener> listener = mListener.promote();
   if (listener != nullptr) {
     listener->codecReserved();
-  }
-}
-
-// Called on a Binder thread
-void
-MediaCodecProxy::resourceCanceled()
-{
-  // Release MediaCodec
-  releaseCodec();
-
-  // Notification
-  sp<CodecResourceListener> listener = mListener.promote();
-  if (listener != nullptr) {
-    listener->codecCanceled();
   }
 }
 
@@ -611,23 +608,10 @@ status_t MediaCodecProxy::Output(MediaBuffer** aBuffer, int64_t aTimeoutUs)
   return err;
 }
 
-bool MediaCodecProxy::IsWaitingResources()
-{
-  if (mResourceHandler.get()) {
-    return mResourceHandler->IsWaitingResource();
-  }
-  return false;
-}
-
-bool MediaCodecProxy::IsDormantNeeded()
-{
-  return mCodecLooper.get() ? true : false;
-}
-
 void MediaCodecProxy::ReleaseMediaResources()
 {
   releaseCodec();
-  cancelResource();
+  SetMediaCodecFree()
 }
 
 void MediaCodecProxy::ReleaseMediaBuffer(MediaBuffer* aBuffer) {

--- a/dom/media/omx/MediaCodecProxy.h
+++ b/dom/media/omx/MediaCodecProxy.h
@@ -139,6 +139,10 @@ public:
   // allocated.
   bool AskMediaCodecAndWait();
 
+  // It asks for the OMX codec asynchronously.
+  // Only video codec is supported.
+  bool AsyncAskMediaCodec();
+
   // Free the OMX codec so others can allocate it.
   void SetMediaCodecFree();
 

--- a/dom/media/omx/MediaCodecReader.cpp
+++ b/dom/media/omx/MediaCodecReader.cpp
@@ -1342,7 +1342,7 @@ MediaCodecReader::CreateMediaCodec(sp<ALooper>& aLooper,
 
     const char* mime;
     if (sourceFormat->findCString(kKeyMIMEType, &mime)) {
-      aTrack.mCodec = MediaCodecProxy::CreateByType(aLooper, mime, false, aAsync, aListener);
+      aTrack.mCodec = MediaCodecProxy::CreateByType(aLooper, mime, false, aListener);
     }
 
     if (aTrack.mCodec == nullptr) {

--- a/dom/media/omx/MediaCodecReader.cpp
+++ b/dom/media/omx/MediaCodecReader.cpp
@@ -1870,6 +1870,7 @@ MediaCodecReader::EnsureCodecFormatParsed(Track& aTrack)
   size_t size = 0;
   int64_t timeUs = INT64_C(0);
   uint32_t flags = 0;
+  FillCodecInputData(aTrack);
   while ((status = aTrack.mCodec->dequeueOutputBuffer(&index, &offset, &size,
                      &timeUs, &flags)) != INFO_FORMAT_CHANGED) {
     if (status == OK) {
@@ -1884,12 +1885,7 @@ MediaCodecReader::EnsureCodecFormatParsed(Track& aTrack)
       return false; // something wrong!!!
     }
 
-    status = FillCodecInputData(aTrack);
-    if (status == INFO_FORMAT_CHANGED) {
-      break;
-    } else if (status != OK) {
-      return false;
-    }
+    FillCodecInputData(aTrack);
   }
   return aTrack.mCodec->getOutputFormat(&format) == OK;
 }

--- a/dom/media/omx/MediaCodecReader.cpp
+++ b/dom/media/omx/MediaCodecReader.cpp
@@ -45,11 +45,6 @@ using namespace mozilla::layers;
 
 namespace mozilla {
 
-enum {
-  kNotifyCodecReserved = 'core',
-  kNotifyCodecCanceled = 'coca',
-};
-
 static const int64_t sInvalidDurationUs = INT64_C(-1);
 static const int64_t sInvalidTimestampUs = INT64_C(-1);
 
@@ -72,25 +67,6 @@ IsValidTimestampUs(int64_t aTimestamp)
   return aTimestamp >= INT64_C(0);
 }
 
-MediaCodecReader::MessageHandler::MessageHandler(MediaCodecReader* aReader)
-  : mReader(aReader)
-{
-}
-
-MediaCodecReader::MessageHandler::~MessageHandler()
-{
-  mReader = nullptr;
-}
-
-void
-MediaCodecReader::MessageHandler::onMessageReceived(
-  const sp<AMessage>& aMessage)
-{
-  if (mReader) {
-    mReader->onMessageReceived(aMessage);
-  }
-}
-
 MediaCodecReader::VideoResourceListener::VideoResourceListener(
   MediaCodecReader* aReader)
   : mReader(aReader)
@@ -106,7 +82,7 @@ void
 MediaCodecReader::VideoResourceListener::codecReserved()
 {
   if (mReader) {
-    mReader->codecReserved(mReader->mVideoTrack);
+    mReader->VideoCodecReserved();
   }
 }
 
@@ -114,7 +90,7 @@ void
 MediaCodecReader::VideoResourceListener::codecCanceled()
 {
   if (mReader) {
-    mReader->codecCanceled(mReader->mVideoTrack);
+    mReader->VideoCodecCanceled();
   }
 }
 
@@ -300,7 +276,6 @@ MediaCodecReader::MediaCodecReader(AbstractMediaDecoder* aDecoder)
   , mNextParserPosition(INT64_C(0))
   , mParsedDataLength(INT64_C(0))
 {
-  mHandler = new MessageHandler(this);
   mVideoListener = new VideoResourceListener(this);
 }
 
@@ -697,6 +672,14 @@ MediaCodecReader::ReadMetadata(MediaInfo* aInfo,
   UpdateIsWaitingMediaResources();
   if (IsWaitingMediaResources()) {
     return NS_OK;
+  }
+
+  // Configure video codec after the codecReserved.
+  if (mVideoTrack.mSource != nullptr) {
+    if (!ConfigureMediaCodec(mVideoTrack)) {
+      DestroyMediaCodec(mVideoTrack);
+      return NS_ERROR_FAILURE;
+    }
   }
 
   // TODO: start streaming
@@ -1103,8 +1086,8 @@ MediaCodecReader::ReallocateResources()
   if (CreateLooper() &&
       CreateExtractor() &&
       CreateMediaSources() &&
-      CreateMediaCodecs() &&
-      CreateTaskQueues()) {
+      CreateTaskQueues() &&
+      CreateMediaCodecs()) {
     return true;
   }
 
@@ -1150,9 +1133,6 @@ MediaCodecReader::CreateLooper()
   sp<ALooper> looper = new ALooper;
   looper->setName("MediaCodecReader::mLooper");
 
-  // Register AMessage handler to ALooper.
-  looper->registerHandler(mHandler);
-
   // Start ALooper thread.
   if (looper->start() != OK) {
     return false;
@@ -1168,11 +1148,6 @@ MediaCodecReader::DestroyLooper()
 {
   if (mLooper == nullptr) {
     return;
-  }
-
-  // Unregister AMessage handler from ALooper.
-  if (mHandler != nullptr) {
-    mLooper->unregisterHandler(mHandler->id());
   }
 
   // Stop ALooper thread.
@@ -1304,13 +1279,11 @@ MediaCodecReader::ShutdownTaskQueues()
 bool
 MediaCodecReader::CreateTaskQueues()
 {
-  if (mAudioTrack.mSource != nullptr && mAudioTrack.mCodec != nullptr &&
-      !mAudioTrack.mTaskQueue) {
+  if (mAudioTrack.mSource != nullptr && !mAudioTrack.mTaskQueue) {
     mAudioTrack.mTaskQueue = CreateFlushableMediaDecodeTaskQueue();
     NS_ENSURE_TRUE(mAudioTrack.mTaskQueue, false);
   }
-  if (mVideoTrack.mSource != nullptr && mVideoTrack.mCodec != nullptr &&
-      !mVideoTrack.mTaskQueue) {
+  if (mVideoTrack.mSource != nullptr && !mVideoTrack.mTaskQueue) {
     mVideoTrack.mTaskQueue = CreateFlushableMediaDecodeTaskQueue();
     NS_ENSURE_TRUE(mVideoTrack.mTaskQueue, false);
     mVideoTrack.mReleaseBufferTaskQueue = CreateMediaDecodeTaskQueue();
@@ -1941,58 +1914,21 @@ MediaCodecReader::ClearColorConverterBuffer()
   mColorConverterBufferSize = 0;
 }
 
-// Called on MediaCodecReader::mLooper thread.
+// Called on Binder thread.
 void
-MediaCodecReader::onMessageReceived(const sp<AMessage>& aMessage)
+MediaCodecReader::VideoCodecReserved()
 {
-  switch (aMessage->what()) {
-
-    case kNotifyCodecReserved:
-    {
-      // Our decode may have acquired the hardware resource that it needs
-      // to start. Notify the state machine to resume loading metadata.
-      mDecoder->NotifyWaitingForResourcesStatusChanged();
-      break;
-    }
-
-    case kNotifyCodecCanceled:
-    {
-      ReleaseCriticalResources();
-      break;
-    }
-
-    default:
-      TRESPASS();
-      break;
-  }
+  mDecoder->NotifyWaitingForResourcesStatusChanged();
 }
 
 // Called on Binder thread.
 void
-MediaCodecReader::codecReserved(Track& aTrack)
+MediaCodecReader::VideoCodecCanceled()
 {
-  if (!ConfigureMediaCodec(aTrack)) {
-    DestroyMediaCodec(aTrack);
-    return;
-  }
-
-  if (mHandler != nullptr) {
-    // post kNotifyCodecReserved to MediaCodecReader::mLooper thread.
-    sp<AMessage> notify = new AMessage(kNotifyCodecReserved, mHandler->id());
-    notify->post();
-  }
-}
-
-// Called on Binder thread.
-void
-MediaCodecReader::codecCanceled(Track& aTrack)
-{
-  DestroyMediaCodec(aTrack);
-
-  if (mHandler != nullptr) {
-    // post kNotifyCodecCanceled to MediaCodecReader::mLooper thread.
-    sp<AMessage> notify = new AMessage(kNotifyCodecCanceled, mHandler->id());
-    notify->post();
+  if (mVideoTrack.mTaskQueue) {
+    RefPtr<nsIRunnable> task =
+      NS_NewRunnableMethod(this, &MediaCodecReader::ReleaseCriticalResources);
+    mVideoTrack.mTaskQueue->Dispatch(task);
   }
 }
 

--- a/dom/media/omx/MediaCodecReader.h
+++ b/dom/media/omx/MediaCodecReader.h
@@ -179,8 +179,8 @@ protected:
 
   // Receive a notify from ResourceListener.
   // Called on Binder thread.
-  virtual void codecReserved(Track& aTrack);
-  virtual void codecCanceled(Track& aTrack);
+  virtual void VideoCodecReserved();
+  virtual void VideoCodecCanceled();
 
   virtual bool CreateExtractor();
 
@@ -194,26 +194,6 @@ protected:
   bool mIsWaitingResources;
 
 private:
-  // An intermediary class that can be managed by android::sp<T>.
-  // Redirect onMessageReceived() to MediaCodecReader.
-  class MessageHandler : public android::AHandler
-  {
-  public:
-    MessageHandler(MediaCodecReader* aReader);
-    ~MessageHandler();
-
-    virtual void onMessageReceived(const android::sp<android::AMessage>& aMessage);
-
-  private:
-    // Forbidden
-    MessageHandler() = delete;
-    MessageHandler(const MessageHandler& rhs) = delete;
-    const MessageHandler& operator=(const MessageHandler& rhs) = delete;
-
-    MediaCodecReader *mReader;
-  };
-  friend class MessageHandler;
-
   // An intermediary class that can be managed by android::sp<T>.
   // Redirect codecReserved() and codecCanceled() to MediaCodecReader.
   class VideoResourceListener : public android::MediaCodecProxy::CodecResourceListener
@@ -432,7 +412,6 @@ private:
 
   void ReleaseAllTextureClients();
 
-  android::sp<MessageHandler> mHandler;
   android::sp<VideoResourceListener> mVideoListener;
 
   android::sp<android::ALooper> mLooper;

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -281,10 +281,8 @@ pref("media.wakelock_timeout", 2000);
 // opened as top-level documents, as opposed to inside a media element.
 pref("media.play-stand-alone", true);
 
-#if defined(XP_WIN)
 pref("media.decoder.heuristic.dormant.enabled", true);
 pref("media.decoder.heuristic.dormant.timeout", 60000);
-#endif
 
 #ifdef MOZ_WMF
 pref("media.windows-media-foundation.enabled", true);


### PR DESCRIPTION
This PR improves our MSE support by preventing MSE from notifying that a resource is ready even if it is not. This PR lets the decoders manage their own readiness. These fixes will also prevent double-work later and make it easier for me to get the MediaFormatReader ported over. Other changes:

Cleans up some code.
Enables media.decoder.heuristic.dormant.enabled across all platforms
Added some more async code to OMX MediaCodecProxy
Various crash fixes in OMX and MP4Reader

Tested Youtube and a couple other test sites and all appears to be working as intended.