### PR TITLE
Revert "Ensure decoders are properly shutdown"

### DIFF
--- a/dom/media/fmp4/MP4Reader.h
+++ b/dom/media/fmp4/MP4Reader.h
@@ -93,6 +93,8 @@ private:
 
   bool EnsureDecodersSetup();
 
+  bool CheckIfDecoderSetup();
+
   // Sends input to decoder for aTrack, and output to the state machine,
   // if necessary.
   void Update(TrackType aTrack);


### PR DESCRIPTION
Should fix Windows hangs caused by PR #659.

Currently building on Linux to make sure no issues are seen (although I don't foresee any).