### PR TITLE
Minor fix: about:newtab - throws a warning

### DIFF
--- a/browser/base/content/newtab/cells.js
+++ b/browser/base/content/newtab/cells.js
@@ -29,7 +29,7 @@ Cell.prototype = {
   /**
    * The cell's DOM node.
    */
-  get node() this._node,
+  get node() { return this._node; },
 
   /**
    * The cell's offset in the grid.

--- a/browser/base/content/newtab/drag.js
+++ b/browser/base/content/newtab/drag.js
@@ -18,15 +18,15 @@ let gDrag = {
    * The site that is dragged.
    */
   _draggedSite: null,
-  get draggedSite() this._draggedSite,
+  get draggedSite() { return this._draggedSite; },
 
   /**
    * The cell width/height at the point the drag started.
    */
   _cellWidth: null,
   _cellHeight: null,
-  get cellWidth() this._cellWidth,
-  get cellHeight() this._cellHeight,
+  get cellWidth() { return this._cellWidth; },
+  get cellHeight() { return this._cellHeight; },
 
   /**
    * Start a new drag operation.
@@ -146,6 +146,6 @@ let gDrag = {
 
     // After the 'dragstart' event has been processed we can remove the
     // temporary drag element from the DOM.
-    setTimeout(function () scrollbox.removeChild(dragElement), 0);
+    setTimeout(() => scrollbox.removeChild(dragElement), 0);
   }
 };

--- a/browser/base/content/newtab/drop.js
+++ b/browser/base/content/newtab/drop.js
@@ -73,7 +73,7 @@ let gDrop = {
     });
 
     // Re-pin all shifted pinned cells.
-    pinnedSites.forEach(function (aSite) aSite.pin(sites.indexOf(aSite)), this);
+    pinnedSites.forEach(aSite => aSite.pin(sites.indexOf(aSite)));
   },
 
   /**

--- a/browser/base/content/newtab/grid.js
+++ b/browser/base/content/newtab/grid.js
@@ -12,7 +12,7 @@ let gGrid = {
    * The DOM node of the grid.
    */
   _node: null,
-  get node() this._node,
+  get node() { return this._node; },
 
   /**
    * The cached DOM fragment for sites.
@@ -23,15 +23,15 @@ let gGrid = {
    * All cells contained in the grid.
    */
   _cells: null,
-  get cells() this._cells,
+  get cells() { return this._cells; },
 
   /**
    * All sites contained in the grid's cells. Sites may be empty.
    */
-  get sites() [cell.site for each (cell in this.cells)],
+  get sites() { return [for (cell of this.cells) cell.site]; },
 
   // Tells whether the grid has already been initialized.
-  get ready() !!this._node,
+  get ready() { return !!this._node; },
 
   /**
    * Initializes the grid.

--- a/browser/base/content/newtab/sites.js
+++ b/browser/base/content/newtab/sites.js
@@ -22,22 +22,22 @@ Site.prototype = {
   /**
    * The site's DOM node.
    */
-  get node() this._node,
+  get node() { return this._node; },
 
   /**
    * The site's link.
    */
-  get link() this._link,
+  get link() { return this._link; },
 
   /**
    * The url of the site's link.
    */
-  get url() this.link.url,
+  get url() { return this.link.url; },
 
   /**
    * The title of the site's link.
    */
-  get title() this.link.title,
+  get title() { return this.link.title; },
 
   /**
    * The site's parent cell.


### PR DESCRIPTION
`about:newtab`

Pale Moon throws a warning in the Browser Console:
```
JavaScript 1.6's for-each-in loops are deprecated;
consider using ES6 for-of instead newTab.js:457:25
```
See also https://bugzilla.mozilla.org/show_bug.cgi?id=1113032

---

I've created the new build (x64) and tested.
