### PR TITLE
Minor fix: about:sessionrestore - throws a warnings

### DIFF
--- a/browser/components/sessionstore/content/aboutSessionRestore.js
+++ b/browser/components/sessionstore/content/aboutSessionRestore.js
@@ -70,7 +70,7 @@ function initTreeView() {
       };
     });
     gTreeData.push(winState);
-    for each (var tab in winState.tabs)
+    for (let tab of winState.tabs)
       gTreeData.push(tab);
   }, this);
 
@@ -193,7 +193,7 @@ function toggleRowChecked(aIx) {
 
   if (treeView.isContainer(aIx)) {
     // (un)check all tabs of this window as well
-    for each (var tab in item.tabs) {
+    for (let tab of item.tabs) {
       tab.checked = item.checked;
       treeView.treeBox.invalidateRow(gTreeData.indexOf(tab));
     }


### PR DESCRIPTION
`about:sessionrestore`

Pale Moon throws a warnings in the Browser Console:
```
JavaScript 1.6's for-each-in loops are deprecated; consider using ES6 for-of instead
aboutSessionRestore.js:73:8

JavaScript 1.6's for-each-in loops are deprecated; consider using ES6 for-of instead
aboutSessionRestore.js:194:8
```

---

I've created the new build (x64) and tested.
