### PR TITLE
Update TimeIntervals and use in place of dom::TimeRanges

### DIFF
--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -1467,10 +1467,12 @@ HTMLMediaElement::Seek(double aTime,
 
   // Clamp the seek target to inside the seekable ranges.
   nsRefPtr<dom::TimeRanges> seekable = new dom::TimeRanges();
-  if (NS_FAILED(mDecoder->GetSeekable(seekable))) {
+  media::TimeIntervals seekableIntervals = mDecoder->GetSeekable();
+  if (seekableIntervals.IsInvalid()) {
     aRv.Throw(NS_ERROR_DOM_INVALID_STATE_ERR);
     return;
   }
+  seekableIntervals.ToTimeRanges(seekable);
   uint32_t length = 0;
   seekable->GetLength(&length);
   if (!length) {
@@ -1590,9 +1592,8 @@ HTMLMediaElement::Seekable() const
 {
   nsRefPtr<TimeRanges> ranges = new TimeRanges();
   if (mDecoder && mReadyState > nsIDOMHTMLMediaElement::HAVE_NOTHING) {
-    mDecoder->GetSeekable(ranges);
+    mDecoder->GetSeekable().ToTimeRanges(ranges);
   }
-  ranges->Normalize();
   return ranges.forget();
 }
 
@@ -4127,12 +4128,12 @@ HTMLMediaElement::Buffered() const
   nsRefPtr<TimeRanges> ranges = new TimeRanges();
   if (mReadyState > nsIDOMHTMLMediaElement::HAVE_NOTHING) {
     if (mDecoder) {
-      // If GetBuffered fails we ignore the error result and just return the
-      // time ranges we found up till the error.
-      mDecoder->GetBuffered(ranges);
+      media::TimeIntervals buffered = mDecoder->GetBuffered();
+      if (!buffered.IsInvalid()) {
+        buffered.ToTimeRanges(ranges);
+      }
     }
   }
-  ranges->Normalize();
   return ranges.forget();
 }
 

--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -139,7 +139,7 @@ public:
     return mEnd <= aOther.mStart && aOther.mStart - mEnd <= mFuzz + aOther.mFuzz;
   }
 
-  SelfType Union(const SelfType& aOther) const
+  SelfType Span(const SelfType& aOther) const
   {
     SelfType result(*this);
     if (aOther.mStart < mStart) {
@@ -449,7 +449,7 @@ public:
           continue;
         }
         if (current.Intersects(mIntervals[i])) {
-          current = current.Union(mIntervals[i]);
+          current = current.Span(mIntervals[i]);
         } else {
           normalized.AppendElement(current);
           current = mIntervals[i];

--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -118,7 +118,7 @@ public:
   bool Contains(const SelfType& aOther) const
   {
     return (mStart - mFuzz <= aOther.mStart + aOther.mFuzz) &&
-      (aOther.mEnd + aOther.mFuzz <= mEnd - mFuzz);
+      (aOther.mEnd - aOther.mFuzz <= mEnd + mFuzz);
   }
 
   bool ContainsStrict(const SelfType& aOther) const
@@ -127,6 +127,13 @@ public:
   }
 
   bool Intersects(const SelfType& aOther) const
+  {
+    return (mStart - mFuzz < aOther.mEnd + aOther.mFuzz) &&
+      (aOther.mStart - aOther.mFuzz < mEnd + mFuzz);
+  }
+
+  // Same as Intersects, but including the boundaries.
+  bool Touches(const SelfType& aOther) const
   {
     return (mStart - mFuzz <= aOther.mEnd + aOther.mFuzz) &&
       (aOther.mStart - aOther.mFuzz <= mEnd + mFuzz);
@@ -137,6 +144,16 @@ public:
   bool Contiguous(const SelfType& aOther) const
   {
     return mEnd <= aOther.mStart && aOther.mStart - mEnd <= mFuzz + aOther.mFuzz;
+  }
+
+  bool RightOf(const SelfType& aOther) const
+  {
+    return aOther.mEnd - aOther.mFuzz <= mStart + mFuzz;
+  }
+
+  bool LeftOf(const SelfType& aOther) const
+  {
+    return mEnd - mFuzz <= aOther.mStart + aOther.mFuzz;
   }
 
   SelfType Span(const SelfType& aOther) const
@@ -183,6 +200,8 @@ public:
 private:
 };
 
+// An IntervalSet in a collection of Intervals. The IntervalSet is always
+// normalized.
 template<typename T>
 class IntervalSet
 {
@@ -205,18 +224,22 @@ public:
   }
 
   IntervalSet(SelfType&& aOther)
-    : mIntervals(Move(aOther.mIntervals))
   {
+    mIntervals.MoveElementsFrom(Move(aOther.mIntervals));
   }
 
   explicit IntervalSet(const ElemType& aOther)
   {
-    mIntervals.AppendElement(aOther);
+    if (!aOther.IsEmpty()) {
+      mIntervals.AppendElement(aOther);
+    }
   }
 
   explicit IntervalSet(ElemType&& aOther)
   {
-    mIntervals.AppendElement(Move(aOther));
+    if (!aOther.IsEmpty()) {
+      mIntervals.AppendElement(Move(aOther));
+    }
   }
 
   SelfType& operator= (const SelfType& aOther)
@@ -247,19 +270,55 @@ public:
     return *this;
   }
 
-  // + and += operator will append the provided interval or intervalset.
-  // Note that the result is not normalized. Call Normalize() as required.
-  // Alternatively, use Union()
-
   SelfType& Add(const SelfType& aIntervals)
   {
     mIntervals.AppendElements(aIntervals.mIntervals);
+    Normalize();
     return *this;
   }
 
   SelfType& Add(const ElemType& aInterval)
   {
-    mIntervals.AppendElement(aInterval);
+    if (aInterval.IsEmpty()) {
+      return *this;
+    }
+    if (mIntervals.IsEmpty()) {
+      mIntervals.AppendElement(aInterval);
+      return *this;
+    }
+    // Most of our actual usage is adding an interval that will be outside the
+    // range. We can speed up normalization here.
+    if (aInterval.RightOf(mIntervals.LastElement()) &&
+        !aInterval.Touches(mIntervals.LastElement())) {
+      mIntervals.AppendElement(aInterval);
+      return *this;
+    }
+
+    ContainerType normalized;
+    ElemType current(aInterval);
+    bool inserted = false;
+    IndexType i = 0;
+    for (; i < mIntervals.Length(); i++) {
+      ElemType& interval = mIntervals[i];
+      if (current.Touches(interval)) {
+        current = current.Span(interval);
+      } else if (current.LeftOf(interval)) {
+        normalized.AppendElement(Move(current));
+        inserted = true;
+        break;
+      } else {
+        normalized.AppendElement(Move(interval));
+      }
+    }
+    if (!inserted) {
+      normalized.AppendElement(Move(current));
+    }
+    for (; i < mIntervals.Length(); i++) {
+      normalized.AppendElement(Move(mIntervals[i]));
+    }
+    mIntervals.Clear();
+    mIntervals.MoveElementsFrom(Move(normalized));
+
     return *this;
   }
 
@@ -299,18 +358,15 @@ public:
   }
 
   // Mutate this IntervalSet to be the union of this and aOther.
-  // Resulting IntervalSet is normalized.
   SelfType& Union(const SelfType& aOther)
   {
     Add(aOther);
-    Normalize();
     return *this;
   }
 
   SelfType& Union(const ElemType& aInterval)
   {
     Add(aInterval);
-    Normalize();
     return *this;
   }
 
@@ -332,7 +388,8 @@ public:
       }
     }
 
-    mIntervals = intersection;
+    mIntervals.Clear();
+    mIntervals.MoveElementsFrom(Move(intersection));
     return *this;
   }
 
@@ -435,33 +492,6 @@ public:
     return false;
   }
 
-  void Normalize()
-  {
-    if (mIntervals.Length() >= 2) {
-      ContainerType normalized;
-
-      mIntervals.Sort(CompareIntervals());
-
-      // This merges the intervals.
-      ElemType current(mIntervals[0]);
-      for (IndexType i = 1; i < mIntervals.Length(); i++) {
-        if (current.Contains(mIntervals[i])) {
-          continue;
-        }
-        if (current.Intersects(mIntervals[i])) {
-          current = current.Span(mIntervals[i]);
-        } else {
-          normalized.AppendElement(current);
-          current = mIntervals[i];
-        }
-      }
-
-      normalized.AppendElement(current);
-
-      mIntervals = normalized;
-    }
-  }
-
   // Shift all values by aOffset.
   void Shift(T aOffset)
   {
@@ -487,6 +517,31 @@ protected:
   ContainerType mIntervals;
 
 private:
+  void Normalize()
+  {
+    if (mIntervals.Length() >= 2) {
+      ContainerType normalized;
+
+      mIntervals.Sort(CompareIntervals());
+
+      // This merges the intervals.
+      ElemType current(mIntervals[0]);
+      for (IndexType i = 1; i < mIntervals.Length(); i++) {
+        ElemType& interval = mIntervals[i];
+        if (current.Touches(interval)) {
+          current = current.Span(interval);
+        } else {
+          normalized.AppendElement(Move(current));
+          current = Move(interval);
+        }
+      }
+      normalized.AppendElement(Move(current));
+
+      mIntervals.Clear();
+      mIntervals.MoveElementsFrom(Move(normalized));
+    }
+  }
+
   struct CompareIntervals
   {
     bool Equals(const ElemType& aT1, const ElemType& aT2) const

--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -514,8 +514,8 @@ public:
   void Shift(const T& aOffset)
   {
     for (auto& interval : mIntervals) {
-      interval.mStart += aOffset;
-      interval.mEnd += aOffset;
+      interval.mStart = interval.mStart + aOffset;
+      interval.mEnd = interval.mEnd + aOffset;
     }
   }
 

--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -474,7 +474,20 @@ public:
     }
   }
 
-  bool Contains(const T& aX) {
+  bool Contains(const ElemType& aInterval) const {
+    for (const auto& interval : mIntervals) {
+      if (aInterval.LeftOf(interval)) {
+        // Will never succeed.
+        return false;
+      }
+      if (interval.Contains(aInterval)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool Contains(const T& aX) const {
     for (const auto& interval : mIntervals) {
       if (interval.Contains(aX)) {
         return true;
@@ -483,7 +496,7 @@ public:
     return false;
   }
 
-  bool ContainsStrict(const T& aX) {
+  bool ContainsStrict(const T& aX) const {
     for (const auto& interval : mIntervals) {
       if (interval.ContainsStrict(aX)) {
         return true;

--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -193,6 +193,11 @@ public:
     return mStart == mEnd;
   }
 
+  void SetFuzz(const T& aFuzz)
+  {
+    mFuzz = aFuzz;
+  }
+
   T mStart;
   T mEnd;
   T mFuzz;
@@ -506,7 +511,7 @@ public:
   }
 
   // Shift all values by aOffset.
-  void Shift(T aOffset)
+  void Shift(const T& aOffset)
   {
     for (auto& interval : mIntervals) {
       interval.mStart += aOffset;
@@ -514,9 +519,16 @@ public:
     }
   }
 
+  void SetFuzz(const T& aFuzz) {
+    for (auto& interval : mIntervals) {
+      interval.SetFuzz(aFuzz);
+    }
+    Normalize();
+  }
+
   static const IndexType NoIndex = IndexType(-1);
 
-  IndexType Find(T aValue) const
+  IndexType Find(const T& aValue) const
   {
     for (IndexType i = 0; i < mIntervals.Length(); i++) {
       if (mIntervals[i].Contains(aValue)) {

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -12,7 +12,6 @@
 #include "nsTArray.h"
 #include "VideoUtils.h"
 #include "MediaDecoderStateMachine.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "ImageContainer.h"
 #include "MediaResource.h"
 #include "nsError.h"
@@ -1466,22 +1465,21 @@ bool MediaDecoder::IsMediaSeekable()
   return mMediaSeekable;
 }
 
-nsresult MediaDecoder::GetSeekable(dom::TimeRanges* aSeekable)
+media::TimeIntervals MediaDecoder::GetSeekable()
 {
-  double initialTime = 0.0;
-
   // We can seek in buffered range if the media is seekable. Also, we can seek
   // in unbuffered ranges if the transport level is seekable (local file or the
   // server supports range requests, etc.)
   if (!IsMediaSeekable()) {
-    return NS_OK;
+    return media::TimeIntervals();
   } else if (!IsTransportSeekable()) {
-    return GetBuffered(aSeekable);
+    return GetBuffered();
   } else {
-    double end = IsInfinite() ? std::numeric_limits<double>::infinity()
-                              : initialTime + GetDuration();
-    aSeekable->Add(initialTime, end);
-    return NS_OK;
+    return media::TimeIntervals(
+      media::TimeInterval(media::TimeUnit::FromMicroseconds(0),
+                          IsInfinite() ?
+                            media::TimeUnit::FromInfinity() :
+                            media::TimeUnit::FromSeconds(GetDuration())));
   }
 }
 
@@ -1623,9 +1621,9 @@ void MediaDecoder::Invalidate()
 
 // Constructs the time ranges representing what segments of the media
 // are buffered and playable.
-nsresult MediaDecoder::GetBuffered(dom::TimeRanges* aBuffered) {
-  NS_ENSURE_TRUE(mDecoderStateMachine && !mShuttingDown, NS_ERROR_FAILURE);
-  return mDecoderStateMachine->GetBuffered(aBuffered);
+media::TimeIntervals MediaDecoder::GetBuffered() {
+  NS_ENSURE_TRUE(mDecoderStateMachine && !mShuttingDown, media::TimeIntervals::Invalid());
+  return mDecoderStateMachine->GetBuffered();
 }
 
 size_t MediaDecoder::SizeOfVideoQueue() {

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -197,15 +197,10 @@ destroying the MediaDecoder object.
 #include "MediaStreamGraph.h"
 #include "AbstractMediaDecoder.h"
 #include "necko-config.h"
+#include "TimeUnits.h"
 
 class nsIStreamListener;
 class nsIPrincipal;
-
-namespace mozilla {
-namespace dom {
-class TimeRanges;
-}
-}
 
 namespace mozilla {
 namespace layers {
@@ -625,7 +620,7 @@ public:
   virtual bool IsTransportSeekable() override;
 
   // Return the time ranges that can be seeked into.
-  virtual nsresult GetSeekable(dom::TimeRanges* aSeekable);
+  virtual media::TimeIntervals GetSeekable();
 
   // Set the end time of the media resource. When playback reaches
   // this point the media pauses. aTime is in seconds.
@@ -680,7 +675,7 @@ public:
 
   // Constructs the time ranges representing what segments of the media
   // are buffered and playable.
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered);
+  virtual media::TimeIntervals GetBuffered();
 
   // Returns the size, in bytes, of the heap memory used by the currently
   // queued decoded video and audio data.

--- a/dom/media/MediaDecoderReader.cpp
+++ b/dom/media/MediaDecoderReader.cpp
@@ -162,8 +162,8 @@ MediaDecoderReader::SetStartTime(int64_t aStartTime)
   mStartTime = aStartTime;
 }
 
-nsresult
-MediaDecoderReader::GetBuffered(mozilla::dom::TimeRanges* aBuffered)
+media::TimeIntervals
+MediaDecoderReader::GetBuffered()
 {
   AutoPinned<MediaResource> stream(mDecoder->GetResource());
   int64_t durationUs = 0;
@@ -171,8 +171,7 @@ MediaDecoderReader::GetBuffered(mozilla::dom::TimeRanges* aBuffered)
     ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
     durationUs = mDecoder->GetMediaDuration();
   }
-  GetEstimatedBufferedTimeRanges(stream, durationUs, aBuffered);
-  return NS_OK;
+  return GetEstimatedBufferedTimeRanges(stream, durationUs);
 }
 
 int64_t

--- a/dom/media/MediaDecoderReader.h
+++ b/dom/media/MediaDecoderReader.h
@@ -12,12 +12,9 @@
 #include "MediaPromise.h"
 #include "MediaQueue.h"
 #include "AudioCompactor.h"
+#include "TimeUnits.h"
 
 namespace mozilla {
-
-namespace dom {
-class TimeRanges;
-}
 
 class MediaDecoderReader;
 class SharedDecoderManager;
@@ -226,7 +223,7 @@ public:
   // The OggReader relies on this base implementation not performing I/O,
   // since in FirefoxOS we can't do I/O on the main thread, where this is
   // called.
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered);
+  virtual media::TimeIntervals GetBuffered();
 
   virtual int64_t ComputeStartTime(const VideoData* aVideo, const AudioData* aAudio);
 

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -21,7 +21,7 @@
 #include "mozilla/MathAlgorithms.h"
 #include "mozilla/mozalloc.h"
 #include "VideoUtils.h"
-#include "mozilla/dom/TimeRanges.h"
+#include "TimeUnits.h"
 #include "nsDeque.h"
 #include "AudioSegment.h"
 #include "VideoSegment.h"
@@ -1686,17 +1686,13 @@ void MediaDecoderStateMachine::NotifyDataArrived(const char* aBuffer,
   //
   // Make sure to only do this if we have a start time, otherwise the reader
   // doesn't know how to compute GetBuffered.
-  nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-  if (mDecoder->IsInfinite() && (mStartTime != -1) &&
-      NS_SUCCEEDED(mDecoder->GetBuffered(buffered)))
-  {
-    uint32_t length = 0;
-    buffered->GetLength(&length);
-    if (length) {
-      double end = 0;
-      buffered->End(length - 1, &end);
+  media::TimeIntervals buffered{mDecoder->GetBuffered()};
+  if (mDecoder->IsInfinite() && (mStartTime != -1) && !buffered.IsInvalid()) {
+    bool exists;
+    media::TimeUnit end{buffered.GetEnd(&exists)};
+    if (exists) {
       ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
-      mEndTime = std::max<int64_t>(mEndTime, end * USECS_PER_S);
+      mEndTime = std::max<int64_t>(mEndTime, end.ToMicroseconds());
     }
   }
 }
@@ -2117,9 +2113,10 @@ bool MediaDecoderStateMachine::HasLowUndecodedData(int64_t aUsecs)
     return false;
   }
 
-  nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-  nsresult rv = mReader->GetBuffered(buffered.get());
-  NS_ENSURE_SUCCESS(rv, false);
+  media::TimeIntervals buffered{mReader->GetBuffered()};
+  if (buffered.IsInvalid()) {
+    return false;
+  }
 
   int64_t endOfDecodedVideoData = INT64_MAX;
   if (HasVideo() && !VideoQueue().AtEndOfStream()) {
@@ -2134,9 +2131,13 @@ bool MediaDecoderStateMachine::HasLowUndecodedData(int64_t aUsecs)
   }
   int64_t endOfDecodedData = std::min(endOfDecodedVideoData, endOfDecodedAudioData);
 
-  return endOfDecodedData != INT64_MAX &&
-         !buffered->Contains(static_cast<double>(endOfDecodedData) / USECS_PER_S,
-                             static_cast<double>(std::min(endOfDecodedData + aUsecs, GetDuration())) / USECS_PER_S);
+  if (GetDuration() < endOfDecodedData) {
+    // Our duration is not up to date. No point buffering.
+    return false;
+  }
+  media::TimeInterval interval(media::TimeUnit::FromMicroseconds(endOfDecodedData),
+                               media::TimeUnit::FromMicroseconds(std::min(endOfDecodedData + aUsecs, GetDuration())));
+  return endOfDecodedData != INT64_MAX && !buffered.Contains(interval);
 }
 
 void

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -297,16 +297,16 @@ public:
     return mState == DECODER_STATE_SEEKING;
   }
 
-  nsresult GetBuffered(dom::TimeRanges* aBuffered) {
+  media::TimeIntervals GetBuffered() {
     // It's possible for JS to query .buffered before we've determined the start
     // time from metadata, in which case the reader isn't ready to be asked this
     // question.
     ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
     if (mStartTime < 0) {
-      return NS_OK;
+      return media::TimeIntervals();
     }
 
-    return mReader->GetBuffered(aBuffered);
+    return mReader->GetBuffered();
   }
 
   void SetPlaybackRate(double aPlaybackRate);

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "mozilla/dom/HTMLMediaElement.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "mozilla/Preferences.h"
 #include "nsPrintfCString.h"
 #include "nsSize.h"
@@ -1177,8 +1176,8 @@ MediaFormatReader::GetEvictionOffset(double aTime)
   return std::min(audioOffset, videoOffset);
 }
 
-nsresult
-MediaFormatReader::GetBuffered(dom::TimeRanges* aBuffered)
+media::TimeIntervals
+MediaFormatReader::GetBuffered()
 {
   media::TimeIntervals videoti;
   media::TimeIntervals audioti;
@@ -1202,14 +1201,14 @@ MediaFormatReader::GetBuffered(dom::TimeRanges* aBuffered)
   }
   if (HasAudio() && HasVideo()) {
     videoti.Intersection(audioti);
-    videoti.ToTimeRanges(aBuffered);
+    return videoti;
   } else if (HasAudio()) {
-    audioti.ToTimeRanges(aBuffered);
+    return audioti;
   } else if (HasVideo()) {
-    videoti.ToTimeRanges(aBuffered);
+    return videoti;
   }
 
-  return NS_OK;
+  return media::TimeIntervals();
 }
 
 bool MediaFormatReader::IsDormantNeeded()

--- a/dom/media/MediaFormatReader.h
+++ b/dom/media/MediaFormatReader.h
@@ -17,10 +17,6 @@
 
 namespace mozilla {
 
-namespace dom {
-class TimeRanges;
-}
-
 #if defined(MOZ_GONK_MEDIACODEC) || defined(XP_WIN) || defined(MOZ_APPLEMEDIA) || defined(MOZ_FFMPEG)
 #define READER_DORMANT_HEURISTIC
 #else
@@ -81,7 +77,7 @@ public:
                                  uint32_t aLength,
                                  int64_t aOffset) override;
 
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered) override;
+  virtual media::TimeIntervals GetBuffered() override;
 
   // For Media Resource Management
   virtual void SetIdle() override;

--- a/dom/media/TimeUnits.h
+++ b/dom/media/TimeUnits.h
@@ -8,13 +8,21 @@
 #define TIME_UNITS_H
 
 #include "Intervals.h"
-#include "VideoUtils.h"
 #include "mozilla/CheckedInt.h"
 #include "mozilla/FloatingPoint.h"
 #include "mozilla/dom/TimeRanges.h"
 
 namespace mozilla {
 namespace media {
+
+// Number of microseconds per second. 1e6.
+static const int64_t USECS_PER_S = 1000000;
+
+// Number of microseconds per millisecond.
+static const int64_t USECS_PER_MS = 1000;
+
+// Number of nanoseconds per second. 1e9.
+static const int64_t NSECS_PER_S = 1000000000;
 
 struct Microseconds {
   Microseconds()
@@ -89,12 +97,20 @@ public:
     return TimeUnit(aValue.mValue);
   }
 
+  static TimeUnit FromNanoseconds(int64_t aValue) {
+    return TimeUnit(aValue / 1000);
+  }
+
   static TimeUnit FromInfinity() {
     return TimeUnit(INT64_MAX);
   }
 
   int64_t ToMicroseconds() const {
     return mValue.value();
+  }
+
+  int64_t ToNanoseconds() const {
+    return mValue.value() * 1000;
   }
 
   double ToSeconds() const {
@@ -197,6 +213,17 @@ public:
   explicit TimeIntervals(BaseType::ElemType&& aOther)
     : BaseType(Move(aOther))
   {}
+
+  static TimeIntervals Invalid()
+  {
+    return TimeIntervals(TimeInterval(TimeUnit::FromMicroseconds(INT64_MIN),
+                                      TimeUnit::FromMicroseconds(INT64_MIN)));
+  }
+  bool IsInvalid()
+  {
+    return Length() == 1 && Start(0).ToMicroseconds() == INT64_MIN &&
+      End(0).ToMicroseconds() == INT64_MIN;
+  }
 
   TimeIntervals() = default;
 

--- a/dom/media/TimeUnits.h
+++ b/dom/media/TimeUnits.h
@@ -61,11 +61,16 @@ struct Microseconds {
   int64_t mValue;
 };
 
+// TimeUnit at present uses a CheckedInt64 as storage.
+// INT64_MAX has the special meaning of being +oo.
 class TimeUnit final {
 public:
   static TimeUnit FromSeconds(double aValue) {
     MOZ_ASSERT(!IsNaN(aValue));
- 
+
+    if (mozilla::IsInfinite<double>(aValue)) {
+      return FromInfinity();
+    }
     double val = aValue * USECS_PER_S;
     if (val >= double(INT64_MAX)) {
       return FromMicroseconds(INT64_MAX);
@@ -84,12 +89,23 @@ public:
     return TimeUnit(aValue.mValue);
   }
 
+  static TimeUnit FromInfinity() {
+    return TimeUnit(INT64_MAX);
+  }
+
   int64_t ToMicroseconds() const {
     return mValue.value();
   }
 
   double ToSeconds() const {
+    if (IsInfinite()) {
+      return PositiveInfinity<double>();
+    }
     return double(mValue.value()) / USECS_PER_S;
+  }
+
+  bool IsInfinite() const {
+    return mValue.value() == INT64_MAX;
   }
 
   bool operator == (const TimeUnit& aOther) const {
@@ -111,9 +127,16 @@ public:
     return !(*this >= aOther);
   }
   TimeUnit operator + (const TimeUnit& aOther) const {
+    if (IsInfinite() || aOther.IsInfinite()) {
+      return FromInfinity();
+    }
     return TimeUnit(mValue + aOther.mValue);
   }
   TimeUnit operator - (const TimeUnit& aOther) const {
+    if (IsInfinite() && !aOther.IsInfinite()) {
+      return FromInfinity();
+    }
+    MOZ_ASSERT(!IsInfinite() && !aOther.IsInfinite());
     return TimeUnit(mValue - aOther.mValue);
   }
 

--- a/dom/media/VideoUtils.h
+++ b/dom/media/VideoUtils.h
@@ -21,6 +21,7 @@
 #include "prtime.h"
 #include "AudioSampleFormat.h"
 #include "mozilla/RefPtr.h"
+#include "TimeUnits.h"
 
 using mozilla::CheckedInt64;
 using mozilla::CheckedUint64;
@@ -116,19 +117,14 @@ void DeleteOnMainThread(nsAutoPtr<T>& aObject) {
 
 class MediaResource;
 
-namespace dom {
-class TimeRanges;
-}
-
 // Estimates the buffered ranges of a MediaResource using a simple
 // (byteOffset/length)*duration method. Probably inaccurate, but won't
 // do file I/O, and can be used when we don't have detailed knowledge
 // of the byte->time mapping of a resource. aDurationUsecs is the duration
 // of the media in microseconds. Estimated buffered ranges are stored in
 // aOutBuffered. Ranges are 0-normalized, i.e. in the range of (0,duration].
-void GetEstimatedBufferedTimeRanges(mozilla::MediaResource* aStream,
-                                    int64_t aDurationUsecs,
-                                    mozilla::dom::TimeRanges* aOutBuffered);
+media::TimeIntervals GetEstimatedBufferedTimeRanges(mozilla::MediaResource* aStream,
+                                                    int64_t aDurationUsecs);
 
 // Converts from number of audio frames (aFrames) to microseconds, given
 // the specified audio rate (aRate). Stores result in aOutUsecs. Returns true

--- a/dom/media/android/AndroidMediaPluginHost.cpp
+++ b/dom/media/android/AndroidMediaPluginHost.cpp
@@ -4,7 +4,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include "mozilla/Preferences.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "MediaResource.h"
 #include "mozilla/dom/HTMLMediaElement.h"
 #include "AndroidMediaPluginHost.h"

--- a/dom/media/android/AndroidMediaReader.cpp
+++ b/dom/media/android/AndroidMediaReader.cpp
@@ -5,7 +5,6 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include "AndroidMediaReader.h"
 #include "mozilla/TimeStamp.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "mozilla/gfx/Point.h"
 #include "MediaResource.h"
 #include "VideoUtils.h"

--- a/dom/media/fmp4/MP4Reader.cpp
+++ b/dom/media/fmp4/MP4Reader.cpp
@@ -18,7 +18,6 @@
 #include "SharedThreadPool.h"
 #include "mozilla/Preferences.h"
 #include "mozilla/Telemetry.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "mp4_demuxer/AnnexB.h"
 #include "mp4_demuxer/H264.h"
 #include "SharedDecoderManager.h"
@@ -1017,12 +1016,13 @@ MP4Reader::GetEvictionOffset(double aTime)
   return mDemuxer->GetEvictionOffset(aTime * 1000000.0);
 }
 
-nsresult
-MP4Reader::GetBuffered(dom::TimeRanges* aBuffered)
+media::TimeIntervals
+MP4Reader::GetBuffered()
 {
   MonitorAutoLock mon(mDemuxerMonitor);
+  media::TimeIntervals buffered;
   if (!mIndexReady) {
-    return NS_OK;
+    return buffered;
   }
   UpdateIndex();
   MOZ_ASSERT(mStartTime != -1, "Need to finish metadata decode first");
@@ -1035,12 +1035,13 @@ MP4Reader::GetBuffered(dom::TimeRanges* aBuffered)
     nsTArray<Interval<Microseconds>> timeRanges;
     mDemuxer->ConvertByteRangesToTime(ranges, &timeRanges);
     for (size_t i = 0; i < timeRanges.Length(); i++) {
-      aBuffered->Add((timeRanges[i].start - mStartTime) / 1000000.0,
-                     (timeRanges[i].end - mStartTime) / 1000000.0);
+      buffered += media::TimeInterval(
+        media::TimeUnit::FromMicroseconds(timeRanges[i].start - mStartTime),
+        media::TimeUnit::FromMicroseconds(timeRanges[i].end - mStartTime));
     }
   }
 
-  return NS_OK;
+  return buffered;
 }
 
 bool MP4Reader::IsDormantNeeded()

--- a/dom/media/fmp4/MP4Reader.h
+++ b/dom/media/fmp4/MP4Reader.h
@@ -19,10 +19,6 @@
 
 namespace mozilla {
 
-namespace dom {
-class TimeRanges;
-}
-
 typedef std::deque<nsRefPtr<MediaRawData>> MediaSampleQueue;
 
 class MP4Stream;
@@ -68,7 +64,7 @@ public:
   virtual int64_t GetEvictionOffset(double aTime) override;
   virtual void NotifyDataArrived(const char* aBuffer, uint32_t aLength, int64_t aOffset) override;
 
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered) override;
+  virtual media::TimeIntervals GetBuffered() override;
 
   // For Media Resource Management
   virtual void SetIdle() override;

--- a/dom/media/gstreamer/GStreamerReader.h
+++ b/dom/media/gstreamer/GStreamerReader.h
@@ -29,10 +29,6 @@ struct GstURIDecodeBin;
 
 namespace mozilla {
 
-namespace dom {
-class TimeRanges;
-}
-
 class AbstractMediaDecoder;
 
 typedef enum {
@@ -59,7 +55,7 @@ public:
                                 MetadataTags** aTags) override;
   virtual nsRefPtr<SeekPromise>
   Seek(int64_t aTime, int64_t aEndTime) override;
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered) override;
+  virtual media::TimeIntervals GetBuffered() override;
 
   virtual void NotifyDataArrived(const char *aBuffer,
                                  uint32_t aLength,

--- a/dom/media/gtest/TestIntervalSet.cpp
+++ b/dom/media/gtest/TestIntervalSet.cpp
@@ -515,6 +515,20 @@ TEST(IntervalSet, TimeRangesMicroseconds)
     EXPECT_EQ(tr->End(index, rv), i[index].mEnd.ToSeconds());
     EXPECT_EQ(tr->End(index, rv), i.End(index).ToSeconds());
   }
+
+  // Check infinity values aren't lost in the conversion.
+  tr = new dom::TimeRanges();
+  tr->Add(0, 30);
+  tr->Add(50, std::numeric_limits<double>::infinity());
+  media::TimeIntervals i_oo{media::TimeIntervals::FromTimeRanges(tr)};
+  nsRefPtr<dom::TimeRanges> tr2 = new dom::TimeRanges();
+  i_oo.ToTimeRanges(tr2);
+  EXPECT_EQ(tr->Length(), tr2->Length());
+  for (dom::TimeRanges::index_type index = 0; index < tr->Length(); index++) {
+    ErrorResult rv;
+    EXPECT_EQ(tr->Start(index, rv), tr2->Start(index, rv));
+    EXPECT_EQ(tr->End(index, rv), tr2->End(index, rv));
+  }
 }
 
 template<typename T>

--- a/dom/media/gtest/TestIntervalSet.cpp
+++ b/dom/media/gtest/TestIntervalSet.cpp
@@ -89,12 +89,33 @@ TEST(IntervalSet, TimeIntervalsConstructors)
   media::TimeIntervals blah5 = CreateTimeIntervals(start.mValue, end.mValue);
   (void)test1; (void)test2; (void)test3; (void)test4; (void)test5;
   (void)blah1; (void)blah2; (void)blah3; (void)blah4; (void)blah5;
+
+  media::TimeIntervals i0{media::TimeInterval(media::TimeUnit::FromSeconds(0),
+                                              media::TimeUnit::FromSeconds(0))};
+  EXPECT_EQ(0u, i0.Length()); // Constructing with an empty time interval.
 }
 
 TEST(IntervalSet, Length)
 {
   IntInterval i(15, 25);
   EXPECT_EQ(10, i.Length());
+}
+
+TEST(IntervalSet, Intersects)
+{
+  EXPECT_TRUE(IntInterval(1,5).Intersects(IntInterval(3,4)));
+  EXPECT_TRUE(IntInterval(1,5).Intersects(IntInterval(3,7)));
+  EXPECT_TRUE(IntInterval(1,5).Intersects(IntInterval(-1,3)));
+  EXPECT_TRUE(IntInterval(1,5).Intersects(IntInterval(-1,7)));
+  EXPECT_FALSE(IntInterval(1,5).Intersects(IntInterval(6,7)));
+  EXPECT_FALSE(IntInterval(1,5).Intersects(IntInterval(-1,0)));
+  // End boundary is exclusive of the interval.
+  EXPECT_FALSE(IntInterval(1,5).Intersects(IntInterval(5,7)));
+  EXPECT_FALSE(IntInterval(1,5).Intersects(IntInterval(0,1)));
+  // Empty identical interval do not intersect.
+  EXPECT_FALSE(IntInterval(1,1).Intersects(IntInterval(1,1)));
+  // Empty interval do not intersect.
+  EXPECT_FALSE(IntInterval(1,1).Intersects(IntInterval(2,2)));
 }
 
 TEST(IntervalSet, Intersection)
@@ -104,6 +125,14 @@ TEST(IntervalSet, Intersection)
   IntInterval i = i0.Intersection(i1);
   EXPECT_EQ(15, i.mStart);
   EXPECT_EQ(20, i.mEnd);
+  IntInterval j0(10, 20);
+  IntInterval j1(20, 25);
+  IntInterval j = j0.Intersection(j1);
+  EXPECT_TRUE(j.IsEmpty());
+  IntInterval k0(2, 2);
+  IntInterval k1(2, 2);
+  IntInterval k = k0.Intersection(k1);
+  EXPECT_TRUE(k.IsEmpty());
 }
 
 TEST(IntervalSet, Equals)
@@ -150,44 +179,17 @@ TEST(IntervalSet, IntersectionIntervalSet)
 }
 
 template<typename T>
-static void Compare(media::IntervalSet<T> aI1, media::IntervalSet<T> aI2)
+static void Compare(const media::IntervalSet<T>& aI1,
+                    const media::IntervalSet<T>& aI2)
 {
-  media::IntervalSet<T> i1(aI1);
-  media::IntervalSet<T> i2(aI1);
-  EXPECT_EQ(i1.Length(), i2.Length());
-  if (i1.Length() != i2.Length()) {
+  EXPECT_EQ(aI1.Length(), aI2.Length());
+  if (aI1.Length() != aI2.Length()) {
     return;
   }
-  for (uint32_t i = 0; i < i1.Length(); i++) {
-    EXPECT_EQ(i1[i].mStart, i2[i].mStart);
-    EXPECT_EQ(i1[i].mEnd, i2[i].mEnd);
+  for (uint32_t i = 0; i < aI1.Length(); i++) {
+    EXPECT_EQ(aI1[i].mStart, aI2[i].mStart);
+    EXPECT_EQ(aI1[i].mEnd, aI2[i].mEnd);
   }
-}
-
-TEST(IntervalSet, IntersectionNormalizedIntervalSet)
-{
-  media::IntervalSet<int> i0;
-  i0 += IntInterval(5, 10);
-  i0 += IntInterval(8, 25);
-  i0 += IntInterval(24, 60);
-
-  media::IntervalSet<int> i1;
-  i1.Add(IntInterval(7, 15));
-  i1.Add(IntInterval(10, 27));
-  i1.Add(IntInterval(45, 50));
-  i1.Add(IntInterval(53, 57));
-
-  // Compare intersections to ensure an intersection of normalized intervalsets
-  // is equal to the intersection of non-normalized intervalsets.
-  media::IntervalSet<int> intersection = media::Intersection(i0, i1);
-
-  media::IntervalSet<int> i0_normalize(i0);
-  i0_normalize.Normalize();
-  media::IntervalSet<int> i1_normalize(i1);
-  i1_normalize.Normalize();
-  media::IntervalSet<int> intersection_normalize =
-  media::Intersection(i0_normalize, i1_normalize);
-  Compare(intersection, intersection_normalize);
 }
 
 static void GeneratePermutations(media::IntervalSet<int> aI1,
@@ -211,17 +213,20 @@ static void GeneratePermutations(media::IntervalSet<int> aI1,
       for (uint32_t i = 0; i < comb1.size(); i++) {
         i_0 += aI1[comb1[i]];
       }
+      // Test that intervals are always normalized.
+      Compare(aI1, i_0);
       media::IntervalSet<int> i_1;
       for (uint32_t i = 0; i < comb2.size(); i++) {
         i_1 += aI2[comb2[i]];
       }
+      Compare(aI2, i_1);
       // Check intersections yield the same result.
       Compare(i_0.Intersection(i_1), i_ref);
     } while (std::next_permutation(comb2.begin(), comb2.end()));
   } while (std::next_permutation(comb1.begin(), comb1.end()));
 }
 
-TEST(IntervalSet, IntersectionUnorderedIntervalSet)
+TEST(IntervalSet, IntersectionNormalizedIntervalSet)
 {
   media::IntervalSet<int> i0;
   i0 += IntInterval(5, 10);
@@ -270,21 +275,27 @@ TEST(IntervalSet, Normalize)
   i = IntInterval(1, 8) + i;
   media::IntervalSet<int> interval;
   interval += IntInterval(5, 10);
-  // Test += with move.
+  // Test += with rval move.
   i += Duplicate(interval);
   // Test = with move and add with move.
   i = Duplicate(interval) + i;
 
-  media::IntervalSet<int> o(i);
-  o.Normalize();
+  EXPECT_EQ(2u, i.Length());
 
-  EXPECT_EQ(2u, o.Length());
+  EXPECT_EQ(1, i[0].mStart);
+  EXPECT_EQ(10, i[0].mEnd);
 
-  EXPECT_EQ(1, o[0].mStart);
-  EXPECT_EQ(10, o[0].mEnd);
+  EXPECT_EQ(20, i[1].mStart);
+  EXPECT_EQ(30, i[1].mEnd);
 
-  EXPECT_EQ(20, o[1].mStart);
-  EXPECT_EQ(30, o[1].mEnd);
+  media::TimeIntervals ti;
+  ti += media::TimeInterval(media::TimeUnit::FromSeconds(0.0),
+                            media::TimeUnit::FromSeconds(3.203333));
+  ti += media::TimeInterval(media::TimeUnit::FromSeconds(3.203366),
+                            media::TimeUnit::FromSeconds(10.010065));
+  EXPECT_EQ(2u, ti.Length());
+  ti += media::TimeInterval(ti.Start(0), ti.End(0), media::TimeUnit::FromMicroseconds(35000));
+  EXPECT_EQ(1u, ti.Length());
 }
 
 TEST(IntervalSet, Union)
@@ -347,7 +358,6 @@ TEST(IntervalSet, NormalizeFuzz)
   i0 += IntInterval(11, 25, 0);
   i0 += IntInterval(5, 10, 1);
   i0 += IntInterval(40, 60, 1);
-  i0.Normalize();
 
   EXPECT_EQ(2u, i0.Length());
 
@@ -381,7 +391,6 @@ TEST(IntervalSet, UnionFuzz)
   EXPECT_EQ(40, i[1].mStart);
   EXPECT_EQ(60, i[1].mEnd);
 
-  i0.Normalize();
   EXPECT_EQ(2u, i0.Length());
   EXPECT_EQ(5, i0[0].mStart);
   EXPECT_EQ(25, i0[0].mEnd);
@@ -421,28 +430,19 @@ TEST(IntervalSet, TimeRangesSeconds)
     EXPECT_EQ(tr->End(index, rv), i[index].mEnd.ToSeconds());
     EXPECT_EQ(tr->End(index, rv), i.End(index).ToSeconds());
   }
-
-  i.Normalize();
-  tr->Normalize();
-  EXPECT_EQ(tr->Length(), i.Length());
-  for (dom::TimeRanges::index_type index = 0; index < tr->Length(); index++) {
-    ErrorResult rv;
-    EXPECT_EQ(tr->Start(index, rv), i[index].mStart.ToSeconds());
-    EXPECT_EQ(tr->Start(index, rv), i.Start(index).ToSeconds());
-    EXPECT_EQ(tr->End(index, rv), i[index].mEnd.ToSeconds());
-    EXPECT_EQ(tr->End(index, rv), i.End(index).ToSeconds());
-  }
 }
 
 static void CheckTimeRanges(dom::TimeRanges* aTr, const media::TimeIntervals& aTi)
 {
-  EXPECT_EQ(aTr->Length(), aTi.Length());
-  for (dom::TimeRanges::index_type i = 0; i < aTr->Length(); i++) {
+  nsRefPtr<dom::TimeRanges> tr = new dom::TimeRanges;
+  tr->Union(aTr, 0); // This will normalize the time range.
+  EXPECT_EQ(tr->Length(), aTi.Length());
+  for (dom::TimeRanges::index_type i = 0; i < tr->Length(); i++) {
     ErrorResult rv;
-    EXPECT_EQ(aTr->Start(i, rv), aTi[i].mStart.ToSeconds());
-    EXPECT_EQ(aTr->Start(i, rv), aTi.Start(i).ToSeconds());
-    EXPECT_EQ(aTr->End(i, rv), aTi[i].mEnd.ToSeconds());
-    EXPECT_EQ(aTr->End(i, rv), aTi.End(i).ToSeconds());
+    EXPECT_EQ(tr->Start(i, rv), aTi[i].mStart.ToSeconds());
+    EXPECT_EQ(tr->Start(i, rv), aTi.Start(i).ToSeconds());
+    EXPECT_EQ(tr->End(i, rv), aTi[i].mEnd.ToSeconds());
+    EXPECT_EQ(tr->End(i, rv), aTi.End(i).ToSeconds());
   }
 }
 
@@ -468,11 +468,6 @@ TEST(IntervalSet, TimeRangesConversion)
   // operator=(TimeRanges*)
   i3 = tr;
   CheckTimeRanges(tr, i3);
-
-  i1.Normalize();
-  tr->Normalize();
-
-  CheckTimeRanges(tr, i1);
 
   // operator= test
   i1 = tr.get();
@@ -511,7 +506,6 @@ TEST(IntervalSet, TimeRangesMicroseconds)
     EXPECT_EQ(tr->End(index, rv), i.End(index).ToSeconds());
   }
 
-  i.Normalize();
   tr->Normalize();
   EXPECT_EQ(tr->Length(), i.Length());
   for (dom::TimeRanges::index_type index = 0; index < tr->Length(); index++) {
@@ -583,8 +577,6 @@ TEST(IntervalSet, FooIntervalSet)
   is.Add(i);
   is = is + i;
   is = i + is;
-  EXPECT_EQ(5u, is.Length());
-  is.Normalize();
   EXPECT_EQ(1u, is.Length());
   EXPECT_EQ(Foo<int>(), is[0].mStart);
   EXPECT_EQ(Foo<int>(4,5,6), is[0].mEnd);

--- a/dom/media/gtest/TestMP4Reader.cpp
+++ b/dom/media/gtest/TestMP4Reader.cpp
@@ -10,7 +10,7 @@
 #include "MockMediaResource.h"
 #include "MockMediaDecoderOwner.h"
 #include "mozilla/Preferences.h"
-#include "mozilla/dom/TimeRanges.h"
+#include "TimeUnits.h"
 
 using namespace mozilla;
 using namespace mozilla::dom;
@@ -83,15 +83,10 @@ TEST(MP4Reader, BufferedRange)
   // Video 3-4 sec, audio 2.986666-4.010666 sec
   b->resource->MockAddBufferedRange(248400, 327455);
 
-  nsRefPtr<TimeRanges> ranges = new TimeRanges();
-  EXPECT_EQ(NS_OK, b->reader->GetBuffered(ranges));
-  EXPECT_EQ(1U, ranges->Length());
-  double start = 0;
-  EXPECT_EQ(NS_OK, ranges->Start(0, &start));
-  EXPECT_NEAR(270000 / 90000.0, start, 0.000001);
-  double end = 0;
-  EXPECT_EQ(NS_OK, ranges->End(0, &end));
-  EXPECT_NEAR(360000 / 90000.0, end, 0.000001);
+  media::TimeIntervals ranges = b->reader->GetBuffered();
+  EXPECT_EQ(1U, ranges.Length());
+  EXPECT_NEAR(270000 / 90000.0, ranges.Start(0).ToSeconds(), 0.000001);
+  EXPECT_NEAR(360000 / 90000.0, ranges.End(0).ToSeconds(), 0.000001);
 }
 
 TEST(MP4Reader, BufferedRangeMissingLastByte)
@@ -104,15 +99,10 @@ TEST(MP4Reader, BufferedRangeMissingLastByte)
   b->resource->MockAddBufferedRange(248400, 324912);
   b->resource->MockAddBufferedRange(324913, 327455);
 
-  nsRefPtr<TimeRanges> ranges = new TimeRanges();
-  EXPECT_EQ(NS_OK, b->reader->GetBuffered(ranges));
-  EXPECT_EQ(1U, ranges->Length());
-  double start = 0;
-  EXPECT_EQ(NS_OK, ranges->Start(0, &start));
-  EXPECT_NEAR(270000.0 / 90000.0, start, 0.000001);
-  double end = 0;
-  EXPECT_EQ(NS_OK, ranges->End(0, &end));
-  EXPECT_NEAR(357000 / 90000.0, end, 0.000001);
+  media::TimeIntervals ranges = b->reader->GetBuffered();
+  EXPECT_EQ(1U, ranges.Length());
+  EXPECT_NEAR(270000.0 / 90000.0, ranges.Start(0).ToSeconds(), 0.000001);
+  EXPECT_NEAR(357000 / 90000.0, ranges.End(0).ToSeconds(), 0.000001);
 }
 
 TEST(MP4Reader, BufferedRangeSyncFrame)
@@ -125,15 +115,10 @@ TEST(MP4Reader, BufferedRangeSyncFrame)
   b->resource->MockClearBufferedRanges();
   b->resource->MockAddBufferedRange(146336, 327455);
 
-  nsRefPtr<TimeRanges> ranges = new TimeRanges();
-  EXPECT_EQ(NS_OK, b->reader->GetBuffered(ranges));
-  EXPECT_EQ(1U, ranges->Length());
-  double start = 0;
-  EXPECT_EQ(NS_OK, ranges->Start(0, &start));
-  EXPECT_NEAR(270000.0 / 90000.0, start, 0.000001);
-  double end = 0;
-  EXPECT_EQ(NS_OK, ranges->End(0, &end));
-  EXPECT_NEAR(360000 / 90000.0, end, 0.000001);
+  media::TimeIntervals ranges = b->reader->GetBuffered();
+  EXPECT_EQ(1U, ranges.Length());
+  EXPECT_NEAR(270000.0 / 90000.0, ranges.Start(0).ToSeconds(), 0.000001);
+  EXPECT_NEAR(360000 / 90000.0, ranges.End(0).ToSeconds(), 0.000001);
 }
 
 TEST(MP4Reader, CompositionOrder)
@@ -183,23 +168,14 @@ TEST(MP4Reader, CompositionOrder)
   b->resource->MockAddBufferedRange(12616, 13196);
   b->resource->MockAddBufferedRange(13220, 13901);
 
-  nsRefPtr<TimeRanges> ranges = new TimeRanges();
-  EXPECT_EQ(NS_OK, b->reader->GetBuffered(ranges));
-  EXPECT_EQ(2U, ranges->Length());
+  media::TimeIntervals ranges = b->reader->GetBuffered();
+  EXPECT_EQ(2U, ranges.Length());
 
-  double start = 0;
-  EXPECT_EQ(NS_OK, ranges->Start(0, &start));
-  EXPECT_NEAR(166.0 / 2500.0, start, 0.000001);
-  double end = 0;
-  EXPECT_EQ(NS_OK, ranges->End(0, &end));
-  EXPECT_NEAR(332.0 / 2500.0, end, 0.000001);
+  EXPECT_NEAR(166.0 / 2500.0, ranges.Start(0).ToSeconds(), 0.000001);
+  EXPECT_NEAR(332.0 / 2500.0, ranges.End(0).ToSeconds(), 0.000001);
 
-  start = 0;
-  EXPECT_EQ(NS_OK, ranges->Start(1, &start));
-  EXPECT_NEAR(581.0 / 2500.0, start, 0.000001);
-  end = 0;
-  EXPECT_EQ(NS_OK, ranges->End(1, &end));
-  EXPECT_NEAR(11255.0 / 44100.0, end, 0.000001);
+  EXPECT_NEAR(581.0 / 2500.0, ranges.Start(1).ToSeconds(), 0.000001);
+  EXPECT_NEAR(11255.0 / 44100.0, ranges.End(1).ToSeconds(), 0.000001);
 }
 
 TEST(MP4Reader, Normalised)
@@ -233,14 +209,9 @@ TEST(MP4Reader, Normalised)
   b->resource->MockClearBufferedRanges();
   b->resource->MockAddBufferedRange(48, 13901);
 
-  nsRefPtr<TimeRanges> ranges = new TimeRanges();
-  EXPECT_EQ(NS_OK, b->reader->GetBuffered(ranges));
-  EXPECT_EQ(1U, ranges->Length());
+  media::TimeIntervals ranges = b->reader->GetBuffered();
+  EXPECT_EQ(1U, ranges.Length());
 
-  double start = 0;
-  EXPECT_EQ(NS_OK, ranges->Start(0, &start));
-  EXPECT_NEAR(166.0 / 2500.0, start, 0.000001);
-  double end = 0;
-  EXPECT_EQ(NS_OK, ranges->End(0, &end));
-  EXPECT_NEAR(11255.0 / 44100.0, end, 0.000001);
+  EXPECT_NEAR(166.0 / 2500.0, ranges.Start(0).ToSeconds(), 0.000001);
+  EXPECT_NEAR(11255.0 / 44100.0, ranges.End(0).ToSeconds(), 0.000001);
 }

--- a/dom/media/mediasource/MediaSource.cpp
+++ b/dom/media/mediasource/MediaSource.cpp
@@ -16,7 +16,6 @@
 #include "mozilla/Preferences.h"
 #include "mozilla/dom/BindingDeclarations.h"
 #include "mozilla/dom/HTMLMediaElement.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "mozilla/mozalloc.h"
 #include "nsContentTypeParser.h"
 #include "nsDebug.h"

--- a/dom/media/mediasource/MediaSourceDecoder.cpp
+++ b/dom/media/mediasource/MediaSourceDecoder.cpp
@@ -7,7 +7,6 @@
 
 #include "prlog.h"
 #include "mozilla/dom/HTMLMediaElement.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "MediaDecoderStateMachine.h"
 #include "MediaSource.h"
 #include "MediaSourceReader.h"
@@ -68,26 +67,30 @@ MediaSourceDecoder::Load(nsIStreamListener**, MediaDecoder*)
   return ScheduleStateMachineThread();
 }
 
-nsresult
-MediaSourceDecoder::GetSeekable(dom::TimeRanges* aSeekable)
+media::TimeIntervals
+MMediaSourceDecoder::GetSeekable()
 {
   MOZ_ASSERT(NS_IsMainThread());
   if (!mMediaSource) {
-    return NS_ERROR_FAILURE;
+    NS_WARNING("MediaSource element isn't attached");
+    return media::TimeIntervals::Invalid();
   }
 
+  media::TimeIntervals seekable;
   double duration = mMediaSource->Duration();
   if (IsNaN(duration)) {
     // Return empty range.
   } else if (duration > 0 && mozilla::IsInfinite(duration)) {
-    nsRefPtr<dom::TimeRanges> bufferedRanges = new dom::TimeRanges();
-    mReader->GetBuffered(bufferedRanges);
-    aSeekable->Add(bufferedRanges->GetStartTime(), bufferedRanges->GetEndTime());
+    media::TimeIntervals buffered = mReader->GetBuffered();
+    if (buffered.Length()) {
+      seekable += media::TimeInterval(buffered.GetStart(), buffered.GetEnd());
+    }
   } else {
-    aSeekable->Add(0, duration);
+    seekable += media::TimeInterval(media::TimeUnit::FromSeconds(0),
+                                    media::TimeUnit::FromSeconds(duration));
   }
-  MSE_DEBUG("ranges=%s", DumpTimeRanges(aSeekable).get());
-  return NS_OK;
+  MSE_DEBUG("ranges=%s", DumpTimeRanges(seekable).get());
+  return seekable;
 }
 
 void
@@ -316,22 +319,25 @@ MediaSourceDecoder::SelectDecoder(int64_t aTarget,
 {
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
 
+  media::TimeUnit target{media::TimeUnit::FromMicroseconds(aTarget)};
+  media::TimeUnit tolerance{media::TimeUnit::FromMicroseconds(aTolerance + aTarget)};
+
+  // aTolerance gives a slight bias toward the start of a range only.
   // Consider decoders in order of newest to oldest, as a newer decoder
   // providing a given buffered range is expected to replace an older one.
   for (int32_t i = aTrackDecoders.Length() - 1; i >= 0; --i) {
     nsRefPtr<SourceBufferDecoder> newDecoder = aTrackDecoders[i];
 
-    nsRefPtr<dom::TimeRanges> ranges = new dom::TimeRanges();
-    newDecoder->GetBuffered(ranges);
-    if (ranges->Find(double(aTarget) / USECS_PER_S,
-                     double(aTolerance) / USECS_PER_S) == dom::TimeRanges::NoIndex) {
-      MSE_DEBUGV("SelectDecoder(%lld fuzz:%lld) newDecoder=%p (%d/%d) target not in ranges=%s",
-                 aTarget, aTolerance, newDecoder.get(), i+1,
-                 aTrackDecoders.Length(), DumpTimeRanges(ranges).get());
-      continue;
+    media::TimeIntervals ranges = newDecoder->GetBuffered();
+    for (uint32_t j = 0; j < ranges.Length(); j++) {
+      if (target < ranges.End(j) && tolerance >= ranges.Start(j)) {
+        return newDecoder.forget();
+      }
     }
 
-    return newDecoder.forget();
+    MSE_DEBUGV("SelectDecoder(%lld fuzz:%lld) newDecoder=%p (%d/%d) target not in ranges=%s",
+               aTarget, aTolerance, newDecoder.get(), i+1,
+               aTrackDecoders.Length(), DumpTimeRanges(ranges).get());
   }
 
   return nullptr;

--- a/dom/media/mediasource/MediaSourceDecoder.cpp
+++ b/dom/media/mediasource/MediaSourceDecoder.cpp
@@ -68,7 +68,7 @@ MediaSourceDecoder::Load(nsIStreamListener**, MediaDecoder*)
 }
 
 media::TimeIntervals
-MMediaSourceDecoder::GetSeekable()
+MediaSourceDecoder::GetSeekable()
 {
   MOZ_ASSERT(NS_IsMainThread());
   if (!mMediaSource) {

--- a/dom/media/mediasource/MediaSourceDecoder.h
+++ b/dom/media/mediasource/MediaSourceDecoder.h
@@ -38,7 +38,7 @@ public:
   virtual MediaDecoder* Clone() override;
   virtual MediaDecoderStateMachine* CreateStateMachine() override;
   virtual nsresult Load(nsIStreamListener**, MediaDecoder*) override;
-  virtual nsresult GetSeekable(dom::TimeRanges* aSeekable) override;
+  virtual media::TimeIntervals GetSeekable() override;
 
   virtual void Shutdown() override;
 

--- a/dom/media/mediasource/MediaSourceReader.cpp
+++ b/dom/media/mediasource/MediaSourceReader.cpp
@@ -7,7 +7,6 @@
 
 #include <cmath>
 #include "prlog.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "DecoderTraits.h"
 #include "MediaDecoderOwner.h"
 #include "MediaFormatReader.h"
@@ -40,8 +39,6 @@ extern PRLogModuleInfo* GetMediaSourceLog();
 // switching to the new stream. This value is based on the end of frame
 // default value used in Blink, kDefaultBufferDurationInMs.
 #define EOS_FUZZ_US 125000
-
-using mozilla::dom::TimeRanges;
 
 namespace mozilla {
 
@@ -230,10 +227,9 @@ static void
 AdjustEndTime(int64_t* aEndTime, SourceBufferDecoder* aDecoder)
 {
   if (aDecoder) {
-    nsRefPtr<dom::TimeRanges> ranges = new dom::TimeRanges();
-    aDecoder->GetBuffered(ranges);
-    if (ranges->Length() > 0) {
-      int64_t end = std::ceil(ranges->GetEndTime() * USECS_PER_S);
+    media::TimeIntervals ranges = aDecoder->GetBuffered();
+    if (ranges.Length()) {
+      int64_t end = ranges.GetEnd().ToMicroseconds();
       *aEndTime = std::max(*aEndTime, end);
     }
   }
@@ -585,9 +581,8 @@ MediaSourceReader::SwitchAudioSource(int64_t* aTarget)
     // A decoder buffered range is continuous. We would have failed the exact
     // search but succeeded the fuzzy one if our target was shortly before
     // start time.
-    nsRefPtr<dom::TimeRanges> ranges = new dom::TimeRanges();
-    newDecoder->GetBuffered(ranges);
-    int64_t startTime = ranges->GetStartTime() * USECS_PER_S;
+    media::TimeIntervals ranges = newDecoder->GetBuffered();
+    int64_t startTime = ranges.GetStart().ToMicroseconds();
     if (*aTarget < startTime) {
       *aTarget = startTime;
     }
@@ -631,9 +626,8 @@ MediaSourceReader::SwitchVideoSource(int64_t* aTarget)
     // A decoder buffered range is continuous. We would have failed the exact
     // search but succeeded the fuzzy one if our target was shortly before
     // start time.
-    nsRefPtr<dom::TimeRanges> ranges = new dom::TimeRanges();
-    newDecoder->GetBuffered(ranges);
-    int64_t startTime = ranges->GetStartTime() * USECS_PER_S;
+    media::TimeIntervals ranges = newDecoder->GetBuffered();
+    int64_t startTime = ranges.GetStart().ToMicroseconds();
     if (*aTarget < startTime) {
       *aTarget = startTime;
     }
@@ -982,44 +976,39 @@ MediaSourceReader::DoVideoSeek()
   MSE_DEBUG("reader=%p", GetVideoReader());
 }
 
-nsresult
-MediaSourceReader::GetBuffered(dom::TimeRanges* aBuffered)
+media::TimeIntervals
+MediaSourceReader::GetBuffered()
 {
   ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
-  MOZ_ASSERT(aBuffered->Length() == 0);
-  if (mTrackBuffers.IsEmpty()) {
-    return NS_OK;
+  media::TimeIntervals buffered;
+
+  media::TimeUnit highestEndTime;
+  nsTArray<media::TimeIntervals> activeRanges;
+  // Must set the capacity of the nsTArray first: bug #1164444
+  activeRanges.SetCapacity(mTrackBuffers.Length());
+
+  for (const auto& trackBuffer : mTrackBuffers) {
+    activeRanges.AppendElement(trackBuffer->Buffered());
+    highestEndTime = std::max(highestEndTime, activeRanges.LastElement().GetEnd());
   }
 
-  double highestEndTime = 0;
+  buffered +=
+    media::TimeInterval(media::TimeUnit::FromMicroseconds(0), highestEndTime);
 
-  nsTArray<nsRefPtr<TimeRanges>> activeRanges;
-  for (uint32_t i = 0; i < mTrackBuffers.Length(); ++i) {
-    nsRefPtr<TimeRanges> r = new TimeRanges();
-    mTrackBuffers[i]->Buffered(r);
-    activeRanges.AppendElement(r);
-    highestEndTime = std::max(highestEndTime, activeRanges.LastElement()->GetEndTime());
-  }
-
-  TimeRanges* intersectionRanges = aBuffered;
-  intersectionRanges->Add(0, highestEndTime);
-
-  for (uint32_t i = 0; i < activeRanges.Length(); ++i) {
-    TimeRanges* sourceRanges = activeRanges[i];
-
-    if (IsEnded()) {
+  for (auto& range : activeRanges) {
+    if (IsEnded() && range.Length()) {
       // Set the end time on the last range to highestEndTime by adding a
       // new range spanning the current end time to highestEndTime, which
       // Normalize() will then merge with the old last range.
-      sourceRanges->Add(sourceRanges->GetEndTime(), highestEndTime);
-      sourceRanges->Normalize();
+      range +=
+        media::TimeInterval(range.GetEnd(), highestEndTime);
     }
 
-    intersectionRanges->Intersection(sourceRanges);
+    buffered.Intersection(range);
   }
 
-  MSE_DEBUG("ranges=%s", DumpTimeRanges(intersectionRanges).get());
-  return NS_OK;
+  MSE_DEBUG("ranges=%s", DumpTimeRanges(buffered).get());
+  return buffered;
 }
 
 already_AddRefed<SourceBufferDecoder>
@@ -1035,15 +1024,14 @@ MediaSourceReader::FirstDecoder(MediaData::Type aType)
   }
 
   nsRefPtr<SourceBufferDecoder> firstDecoder;
-  double lowestStartTime = PositiveInfinity<double>();
+  media::TimeUnit lowestStartTime{media::TimeUnit::FromInfinity()};
 
   for (uint32_t i = 0; i < decoders.Length(); ++i) {
-    nsRefPtr<TimeRanges> r = new TimeRanges();
-    decoders[i]->GetBuffered(r);
-    double start = r->GetStartTime();
-    if (start < 0) {
+    media::TimeIntervals r = decoders[i]->GetBuffered();
+    if (!r.Length()) {
       continue;
     }
+    media::TimeUnit start = r.GetStart();
     if (start < lowestStartTime) {
       firstDecoder = decoders[i];
       lowestStartTime = start;
@@ -1203,9 +1191,8 @@ MediaSourceReader::IsNearEnd(MediaData::Type aType, int64_t aTime)
   }
   TrackBuffer* trackBuffer =
     aType == MediaData::AUDIO_DATA ? mAudioTrack : mVideoTrack;
-  nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-  trackBuffer->Buffered(buffered);
-  return aTime >= (buffered->GetEndTime() * USECS_PER_S - EOS_FUZZ_US);
+  media::TimeIntervals buffered = trackBuffer->Buffered();
+  return aTime >= buffered.GetEnd().ToMicroseconds() - EOS_FUZZ_US;
 }
 
 int64_t
@@ -1214,10 +1201,9 @@ MediaSourceReader::LastSampleTime(MediaData::Type aType)
   ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
 
   TrackBuffer* trackBuffer =
-  aType == MediaData::AUDIO_DATA ? mAudioTrack : mVideoTrack;
-  nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-  trackBuffer->Buffered(buffered);
-  return buffered->GetEndTime() * USECS_PER_S - 1;
+    aType == MediaData::AUDIO_DATA ? mAudioTrack : mVideoTrack;
+  media::TimeIntervals buffered = trackBuffer->Buffered();
+  return buffered.GetEnd().ToMicroseconds() - 1;
 }
 
 void
@@ -1238,8 +1224,7 @@ MediaSourceReader::GetMozDebugReaderData(nsAString& aString)
     for (int32_t i = mAudioTrack->Decoders().Length() - 1; i >= 0; --i) {
       nsRefPtr<MediaDecoderReader> newReader = mAudioTrack->Decoders()[i]->GetReader();
 
-      nsRefPtr<dom::TimeRanges> ranges = new dom::TimeRanges();
-      mAudioTrack->Decoders()[i]->GetBuffered(ranges);
+      media::TimeIntervals ranges = mAudioTrack->Decoders()[i]->GetBuffered();
       result += nsPrintfCString("\t\tReader %d: %p ranges=%s active=%s size=%lld\n",
                                 i, newReader.get(), DumpTimeRanges(ranges).get(),
                                 newReader.get() == GetAudioReader() ? "true" : "false",
@@ -1252,8 +1237,7 @@ MediaSourceReader::GetMozDebugReaderData(nsAString& aString)
     for (int32_t i = mVideoTrack->Decoders().Length() - 1; i >= 0; --i) {
       nsRefPtr<MediaDecoderReader> newReader = mVideoTrack->Decoders()[i]->GetReader();
 
-      nsRefPtr<dom::TimeRanges> ranges = new dom::TimeRanges();
-      mVideoTrack->Decoders()[i]->GetBuffered(ranges);
+      media::TimeIntervals ranges = mVideoTrack->Decoders()[i]->GetBuffered();
       result += nsPrintfCString("\t\tReader %d: %p ranges=%s active=%s size=%lld\n",
                                 i, newReader.get(), DumpTimeRanges(ranges).get(),
                                 newReader.get() == GetVideoReader() ? "true" : "false",

--- a/dom/media/mediasource/MediaSourceReader.h
+++ b/dom/media/mediasource/MediaSourceReader.h
@@ -112,7 +112,7 @@ public:
   nsresult ResetDecode() override;
 
   // Acquires the decoder monitor, and is thus callable on any thread.
-  nsresult GetBuffered(dom::TimeRanges* aBuffered) override;
+  media::TimeIntervals GetBuffered() override;
 
   already_AddRefed<SourceBufferDecoder> CreateSubDecoder(const nsACString& aType,
                                                          int64_t aTimestampOffset /* microseconds */);

--- a/dom/media/mediasource/MediaSourceUtils.cpp
+++ b/dom/media/mediasource/MediaSourceUtils.cpp
@@ -6,24 +6,24 @@
 #include "MediaSourceUtils.h"
 
 #include "prlog.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "nsPrintfCString.h"
 
 namespace mozilla {
 
 nsCString
-DumpTimeRanges(dom::TimeRanges* aRanges)
+DumpTimeRanges(const media::TimeIntervals& aRanges)
 {
   nsCString dump;
 
   dump = "[";
 
-  for (uint32_t i = 0; i < aRanges->Length(); ++i) {
+  for (uint32_t i = 0; i < aRanges.Length(); ++i) {
     if (i > 0) {
       dump += ", ";
     }
-    ErrorResult dummy;
-    dump += nsPrintfCString("(%f, %f)", aRanges->Start(i, dummy), aRanges->End(i, dummy));
+    dump += nsPrintfCString("(%f, %f)",
+                            aRanges.Start(i).ToSeconds(),
+                            aRanges.End(i).ToSeconds());
   }
 
   dump += "]";

--- a/dom/media/mediasource/MediaSourceUtils.h
+++ b/dom/media/mediasource/MediaSourceUtils.h
@@ -8,14 +8,11 @@
 #define MOZILLA_MEDIASOURCEUTILS_H_
 
 #include "nsString.h"
+#include "TimeUnits.h"
 
 namespace mozilla {
 
-namespace dom {
-  class TimeRanges;
-} // namespace dom
-
-nsCString DumpTimeRanges(dom::TimeRanges* aRanges);
+nsCString DumpTimeRanges(const media::TimeIntervals& aRanges);
 
 } // namespace mozilla
 

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -146,17 +146,14 @@ SourceBuffer::GetBuffered(ErrorResult& aRv)
     aRv.Throw(NS_ERROR_DOM_INVALID_STATE_ERR);
     return nullptr;
   }
-  nsRefPtr<TimeRanges> ranges = new TimeRanges();
-  double highestEndTime = mTrackBuffer->Buffered(ranges);
-  if (mMediaSource->ReadyState() == MediaSourceReadyState::Ended) {
-    // Set the end time on the last range to highestEndTime by adding a
-    // new range spanning the current end time to highestEndTime, which
-    // Normalize() will then merge with the old last range.
-    ranges->Add(ranges->GetEndTime(), highestEndTime);
-    ranges->Normalize();
-  }
+  // We only manage a single trackbuffer in our source buffer.
+  // As such, there's no need to adjust the end of the trackbuffers as per
+  // Step 4: http://w3c.github.io/media-source/index.html#widl-SourceBuffer-buffered
+  media::TimeIntervals ranges = mTrackBuffer->Buffered();
   MSE_DEBUGV("ranges=%s", DumpTimeRanges(ranges).get());
-  return ranges.forget();
+  nsRefPtr<dom::TimeRanges> tr = new dom::TimeRanges();
+  ranges.ToTimeRanges(tr);
+  return tr.forget();
 }
 
 void
@@ -287,8 +284,8 @@ SourceBuffer::DoRangeRemoval(double aStart, double aEnd)
 {
   MSE_DEBUG("DoRangeRemoval(%f, %f)", aStart, aEnd);
   if (mTrackBuffer && !IsInfinite(aStart)) {
-    mTrackBuffer->RangeRemoval(media::Microseconds::FromSeconds(aStart),
-                               media::Microseconds::FromSeconds(aEnd));
+    mTrackBuffer->RangeRemoval(media::TimeUnit::FromSeconds(aStart),
+                               media::TimeUnit::FromSeconds(aEnd));
   }
 }
 

--- a/dom/media/mediasource/SourceBufferDecoder.cpp
+++ b/dom/media/mediasource/SourceBufferDecoder.cpp
@@ -9,7 +9,6 @@
 #include "prlog.h"
 #include "AbstractMediaDecoder.h"
 #include "MediaDecoderReader.h"
-#include "mozilla/dom/TimeRanges.h"
 
 #ifdef PR_LOGGING
 extern PRLogModuleInfo* GetMediaSourceLog();
@@ -238,24 +237,23 @@ SourceBufferDecoder::NotifyDataArrived(const char* aBuffer, uint32_t aLength, in
   mParentDecoder->NotifyDataArrived(nullptr, 0, 0);
 }
 
-nsresult
-SourceBufferDecoder::GetBuffered(dom::TimeRanges* aBuffered)
+media::TimeIntervals
+SourceBufferDecoder::GetBuffered()
 {
-  nsresult rv = mReader->GetBuffered(aBuffered);
-  if (NS_FAILED(rv)) {
-    return rv;
+  media::TimeIntervals buffered = mReader->GetBuffered();
+  if (buffered.IsInvalid()) {
+    return buffered;
   }
 
   // Adjust buffered range according to timestamp offset.
-  aBuffered->Shift((double)mTimestampOffset / USECS_PER_S);
+  buffered.Shift(media::TimeUnit::FromMicroseconds(mTimestampOffset));
 
   if (!WasTrimmed()) {
-    return NS_OK;
+    return buffered;
   }
-  nsRefPtr<dom::TimeRanges> tr = new dom::TimeRanges();
-  tr->Add(0, mTrimmedOffset);
-  aBuffered->Intersection(tr);
-  return NS_OK;
+  media::TimeInterval filter(media::TimeUnit::FromSeconds(0),
+                             media::TimeUnit::FromSeconds(mTrimmedOffset));
+  return buffered.Intersection(filter);
 }
 
 int64_t

--- a/dom/media/mediasource/SourceBufferDecoder.h
+++ b/dom/media/mediasource/SourceBufferDecoder.h
@@ -18,12 +18,6 @@ namespace mozilla {
 class MediaResource;
 class MediaDecoderReader;
 
-namespace dom {
-
-class TimeRanges;
-
-} // namespace dom
-
 class SourceBufferDecoder final : public AbstractMediaDecoder
 {
 public:
@@ -69,7 +63,7 @@ public:
 
   // Warning: this mirrors GetBuffered in MediaDecoder, but this class's base is
   // AbstractMediaDecoder, which does not supply this interface.
-  nsresult GetBuffered(dom::TimeRanges* aBuffered);
+  media::TimeIntervals GetBuffered();
 
   void SetReader(MediaDecoderReader* aReader)
   {

--- a/dom/media/mediasource/TrackBuffer.cpp
+++ b/dom/media/mediasource/TrackBuffer.cpp
@@ -276,24 +276,18 @@ class DecoderSorter
 public:
   bool LessThan(SourceBufferDecoder* aFirst, SourceBufferDecoder* aSecond) const
   {
-    nsRefPtr<dom::TimeRanges> first = new dom::TimeRanges();
-    aFirst->GetBuffered(first);
+    media::TimeIntervals first = aFirst->GetBuffered();
+    media::TimeIntervals second = aSecond->GetBuffered();
 
-    nsRefPtr<dom::TimeRanges> second = new dom::TimeRanges();
-    aSecond->GetBuffered(second);
-
-    return first->GetStartTime() < second->GetStartTime();
+    return first.GetStart() < second.GetStart();
   }
 
   bool Equals(SourceBufferDecoder* aFirst, SourceBufferDecoder* aSecond) const
   {
-    nsRefPtr<dom::TimeRanges> first = new dom::TimeRanges();
-    aFirst->GetBuffered(first);
+    media::TimeIntervals first = aFirst->GetBuffered();
+    media::TimeIntervals second = aSecond->GetBuffered();
 
-    nsRefPtr<dom::TimeRanges> second = new dom::TimeRanges();
-    aSecond->GetBuffered(second);
-
-    return first->GetStartTime() == second->GetStartTime();
+    return first.GetStart() == second.GetStart();
   }
 };
 
@@ -323,8 +317,7 @@ TrackBuffer::EvictData(double aPlaybackTime,
   // First try to evict data before the current play position, starting
   // with the oldest decoder.
   for (uint32_t i = 0; i < decoders.Length() && toEvict > 0; ++i) {
-    nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-    decoders[i]->GetBuffered(buffered);
+    media::TimeIntervals buffered = decoders[i]->GetBuffered();
 
     MSE_DEBUG("Step1. decoder=%u/%u threshold=%u toEvict=%lld",
               i, decoders.Length(), aThreshold, toEvict);
@@ -333,22 +326,24 @@ TrackBuffer::EvictData(double aPlaybackTime,
     // we apply a threshold of a few seconds back and evict data up to
     // that point.
     if (aPlaybackTime > MSE_EVICT_THRESHOLD_TIME) {
-      double time = aPlaybackTime - MSE_EVICT_THRESHOLD_TIME;
+      media::TimeUnit time = media::TimeUnit::FromSeconds(aPlaybackTime) -
+        media::TimeUnit::FromSeconds(MSE_EVICT_THRESHOLD_TIME);
       bool isActive = decoders[i] == mCurrentDecoder ||
         mParentDecoder->IsActiveReader(decoders[i]->GetReader());
-      if (!isActive && buffered->GetEndTime() < time) {
+      if (!isActive && buffered.GetEnd() < time) {
         // The entire decoder is contained before our current playback time.
         // It can be fully evicted.
         MSE_DEBUG("evicting all bufferedEnd=%f "
                   "aPlaybackTime=%f time=%f, size=%lld",
-                  buffered->GetEndTime(), aPlaybackTime, time,
+                  buffered.GetEnd().ToSeconds(), aPlaybackTime, time,
                   decoders[i]->GetResource()->GetSize());
         toEvict -= decoders[i]->GetResource()->EvictAll();
       } else {
-        int64_t playbackOffset = decoders[i]->ConvertToByteOffset(time);
+        int64_t playbackOffset =
+          decoders[i]->ConvertToByteOffset(time.ToMicroseconds());
         MSE_DEBUG("evicting some bufferedEnd=%f "
                   "aPlaybackTime=%f time=%f, playbackOffset=%lld size=%lld",
-                  buffered->GetEndTime(), aPlaybackTime, time,
+                  buffered.GetEnd().ToSeconds(), aPlaybackTime, time,
                   playbackOffset, decoders[i]->GetResource()->GetSize());
         if (playbackOffset > 0) {
           toEvict -= decoders[i]->GetResource()->EvictData(playbackOffset,
@@ -368,13 +363,12 @@ TrackBuffer::EvictData(double aPlaybackTime,
     if (decoders[i] == mCurrentDecoder) {
       continue;
     }
-    nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-    decoders[i]->GetBuffered(buffered);
+    media::TimeIntervals buffered = decoders[i]->GetBuffered();
 
     // Remove data from older decoders than the current one.
     MSE_DEBUG("evicting all "
               "bufferedStart=%f bufferedEnd=%f aPlaybackTime=%f size=%lld",
-              buffered->GetStartTime(), buffered->GetEndTime(),
+              buffered.GetStart().ToSeconds(), buffered.GetEnd().ToSeconds(),
               aPlaybackTime, decoders[i]->GetResource()->GetSize());
     toEvict -= decoders[i]->GetResource()->EvictAll();
   }
@@ -398,10 +392,9 @@ TrackBuffer::EvictData(double aPlaybackTime,
   // Find the next decoder we're likely going to play with.
   nsRefPtr<SourceBufferDecoder> nextPlayingDecoder = nullptr;
   if (playingDecoder) {
-    nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-    playingDecoder->GetBuffered(buffered);
+    media::TimeIntervals buffered = playingDecoder->GetBuffered();
     nextPlayingDecoder =
-      mParentDecoder->SelectDecoder(buffered->GetEndTime() * USECS_PER_S + 1,
+      mParentDecoder->SelectDecoder(buffered.GetEnd().ToMicroseconds() + 1,
                                     EOS_FUZZ_US,
                                     mInitializedDecoders);
   }
@@ -416,12 +409,11 @@ TrackBuffer::EvictData(double aPlaybackTime,
         decoders[i] == mCurrentDecoder) {
       continue;
     }
-    nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-    decoders[i]->GetBuffered(buffered);
+    media::TimeIntervals buffered = decoders[i]->GetBuffered();
 
     MSE_DEBUG("evicting all "
               "bufferedStart=%f bufferedEnd=%f aPlaybackTime=%f size=%lld",
-              buffered->GetStartTime(), buffered->GetEndTime(),
+              buffered.GetStart().ToSeconds(), buffered.GetEnd().ToSeconds(),
               aPlaybackTime, decoders[i]->GetResource()->GetSize());
     toEvict -= decoders[i]->GetResource()->EvictAll();
   }
@@ -431,9 +423,8 @@ TrackBuffer::EvictData(double aPlaybackTime,
   bool evicted = toEvict < (totalSize - aThreshold);
   if (evicted) {
     if (playingDecoder) {
-      nsRefPtr<dom::TimeRanges> ranges = new dom::TimeRanges();
-      playingDecoder->GetBuffered(ranges);
-      *aBufferStartTime = std::max(0.0, ranges->GetStartTime());
+      media::TimeIntervals ranges = playingDecoder->GetBuffered();
+      *aBufferStartTime = std::max(0.0, ranges.GetStart().ToSeconds());
     } else {
       // We do not currently have data to play yet.
       // Avoid evicting anymore data to minimize rebuffering time.
@@ -451,20 +442,18 @@ TrackBuffer::RemoveEmptyDecoders(nsTArray<mozilla::SourceBufferDecoder*>& aDecod
 
   // Remove decoders that have no data in them
   for (uint32_t i = 0; i < aDecoders.Length(); ++i) {
-    nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-    aDecoders[i]->GetBuffered(buffered);
+    media::TimeIntervals buffered = aDecoders[i]->GetBuffered();
     MSE_DEBUG("maybe remove empty decoders=%d "
               "size=%lld start=%f end=%f",
               i, aDecoders[i]->GetResource()->GetSize(),
-              buffered->GetStartTime(), buffered->GetEndTime());
+              buffered.GetStart().ToSeconds(), buffered.GetEnd().ToSeconds());
     if (aDecoders[i] == mCurrentDecoder ||
         mParentDecoder->IsActiveReader(aDecoders[i]->GetReader())) {
       continue;
     }
 
-    if (aDecoders[i]->GetResource()->GetSize() == 0 ||
-        buffered->GetStartTime() < 0.0 ||
-        buffered->GetEndTime() < 0.0) {
+    if (aDecoders[i]->GetResource()->GetSize() == 0 || !buffered.Length() ||
+      buffered[0].IsEmpty()) {
       MSE_DEBUG("remove empty decoders=%d", i);
       RemoveDecoder(aDecoders[i]);
     }
@@ -487,12 +476,11 @@ TrackBuffer::HasOnlyIncompleteMedia()
   if (!mCurrentDecoder) {
     return false;
   }
-  nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-  mCurrentDecoder->GetBuffered(buffered);
+  media::TimeIntervals buffered = mCurrentDecoder->GetBuffered();
   MSE_DEBUG("mCurrentDecoder.size=%lld, start=%f end=%f",
             mCurrentDecoder->GetResource()->GetSize(),
-            buffered->GetStartTime(), buffered->GetEndTime());
-  return mCurrentDecoder->GetResource()->GetSize() && !buffered->Length();
+            buffered.GetStart(), buffered.GetEnd());
+  return mCurrentDecoder->GetResource()->GetSize() && !buffered.Length();
 }
 
 void
@@ -510,23 +498,23 @@ TrackBuffer::EvictBefore(double aTime)
   }
 }
 
-double
-TrackBuffer::Buffered(dom::TimeRanges* aRanges)
+media::TimeIntervals
+TrackBuffer::Buffered()
 {
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
 
-  double highestEndTime = 0;
+  media::TimeIntervals buffered;
 
-  for (uint32_t i = 0; i < mInitializedDecoders.Length(); ++i) {
-    nsRefPtr<dom::TimeRanges> r = new dom::TimeRanges();
-    mInitializedDecoders[i]->GetBuffered(r);
-    if (r->Length() > 0) {
-      highestEndTime = std::max(highestEndTime, r->GetEndTime());
-      aRanges->Union(r, double(mParser->GetRoundingError()) / USECS_PER_S);
-    }
+  for (auto& decoder : mInitializedDecoders) {
+    buffered += decoder->GetBuffered();
+  }
+  // mParser may not be initialized yet, and will only be so if we have a
+  // buffered range.
+  if (buffered.Length()) {
+    buffered.SetFuzz(media::TimeUnit::FromMicroseconds(mParser->GetRoundingError()));
   }
 
-  return highestEndTime;
+  return buffered;
 }
 
 already_AddRefed<SourceBufferDecoder>
@@ -883,10 +871,11 @@ TrackBuffer::ContainsTime(int64_t aTime, int64_t aTolerance)
 {
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
   for (uint32_t i = 0; i < mInitializedDecoders.Length(); ++i) {
-    nsRefPtr<dom::TimeRanges> r = new dom::TimeRanges();
-    mInitializedDecoders[i]->GetBuffered(r);
-    if (r->Find(double(aTime) / USECS_PER_S,
-                double(aTolerance) / USECS_PER_S) != dom::TimeRanges::NoIndex) {
+    media::TimeUnit time{media::TimeUnit::FromMicroseconds(aTime)};
+  for (auto& decoder : mInitializedDecoders) {
+    media::TimeIntervals r = decoder->GetBuffered();
+    r.SetFuzz(media::TimeUnit::FromMicroseconds(aTolerance));
+    if (r.Contains(time)) {
       return true;
     }
   }
@@ -1026,17 +1015,17 @@ TrackBuffer::RemoveDecoder(SourceBufferDecoder* aDecoder)
 }
 
 bool
-TrackBuffer::RangeRemoval(media::Microseconds aStart,
-                          media::Microseconds aEnd)
+TrackBuffer::RangeRemoval(media::TimeUnit aStart,
+                          media::TimeUnit aEnd)
 {
   MOZ_ASSERT(NS_IsMainThread());
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
 
-  nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-  media::Microseconds bufferedEnd = media::Microseconds::FromSeconds(Buffered(buffered));
-  media::Microseconds bufferedStart = media::Microseconds::FromSeconds(buffered->GetStartTime());
+  media::TimeIntervals buffered = Buffered();
+  media::TimeUnit bufferedStart = buffered.GetStart();
+  media::TimeUnit bufferedEnd = buffered.GetEnd();
 
-  if (bufferedStart < media::Microseconds(0) || aStart > bufferedEnd || aEnd < bufferedStart) {
+  if (!buffered.Length() || aStart > bufferedEnd || aEnd < bufferedStart) {
     // Nothing to remove.
     return false;
   }
@@ -1054,18 +1043,17 @@ TrackBuffer::RangeRemoval(media::Microseconds aStart,
   if (aStart <= bufferedStart && aEnd < bufferedEnd) {
     // Evict data from beginning.
     for (size_t i = 0; i < decoders.Length(); ++i) {
-      nsRefPtr<dom::TimeRanges> buffered = new dom::TimeRanges();
-      decoders[i]->GetBuffered(buffered);
-      if (media::Microseconds::FromSeconds(buffered->GetEndTime()) < aEnd) {
+      media::TimeIntervals buffered = decoders[i]->GetBuffered();
+      if (buffered.GetEnd() < aEnd) {
         // Can be fully removed.
         MSE_DEBUG("remove all bufferedEnd=%f size=%lld",
-                  buffered->GetEndTime(),
+                  buffered.GetEnd().ToSeconds(),
                   decoders[i]->GetResource()->GetSize());
         decoders[i]->GetResource()->EvictAll();
       } else {
         int64_t offset = decoders[i]->ConvertToByteOffset(aEnd.ToSeconds());
         MSE_DEBUG("removing some bufferedEnd=%f offset=%lld size=%lld",
-                  buffered->GetEndTime(), offset,
+                  buffered.GetEnd().ToSeconds(), offset,
                   decoders[i]->GetResource()->GetSize());
         if (offset > 0) {
           decoders[i]->GetResource()->EvictData(offset, offset);
@@ -1075,11 +1063,11 @@ TrackBuffer::RangeRemoval(media::Microseconds aStart,
   } else {
     // Only trimming existing buffers.
     for (size_t i = 0; i < decoders.Length(); ++i) {
-      if (aStart <= media::Microseconds::FromSeconds(buffered->GetStartTime())) {
+      if (aStart <= buffered.GetStart()) {
         // It will be entirely emptied, can clear all data.
         decoders[i]->GetResource()->EvictAll();
       } else {
-        decoders[i]->Trim(aStart.mValue);
+        decoders[i]->Trim(aStart.ToMicroseconds());
       }
     }
   }

--- a/dom/media/mediasource/TrackBuffer.cpp
+++ b/dom/media/mediasource/TrackBuffer.cpp
@@ -870,8 +870,7 @@ bool
 TrackBuffer::ContainsTime(int64_t aTime, int64_t aTolerance)
 {
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
-  for (uint32_t i = 0; i < mInitializedDecoders.Length(); ++i) {
-    media::TimeUnit time{media::TimeUnit::FromMicroseconds(aTime)};
+  media::TimeUnit time{media::TimeUnit::FromMicroseconds(aTime)};
   for (auto& decoder : mInitializedDecoders) {
     media::TimeIntervals r = decoder->GetBuffered();
     r.SetFuzz(media::TimeUnit::FromMicroseconds(aTolerance));

--- a/dom/media/mediasource/TrackBuffer.h
+++ b/dom/media/mediasource/TrackBuffer.h
@@ -24,12 +24,6 @@ class ContainerParser;
 class MediaSourceDecoder;
 class MediaLargeByteBuffer;
 
-namespace dom {
-
-class TimeRanges;
-
-} // namespace dom
-
 class TrackBuffer final {
 public:
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(TrackBuffer);
@@ -56,10 +50,9 @@ public:
   // of the buffer through to aTime.
   void EvictBefore(double aTime);
 
-  // Returns the highest end time of all of the buffered ranges in the
-  // decoders managed by this TrackBuffer, and returns the union of the
-  // decoders buffered ranges in aRanges. This may be called on any thread.
-  double Buffered(dom::TimeRanges* aRanges);
+  // Returns the union of the decoders buffered ranges in aRanges.
+  // This may be called on any thread.
+  media::TimeIntervals Buffered();
 
   // Mark the current decoder's resource as ended, clear mCurrentDecoder and
   // reset mLast{Start,End}Timestamp.  Main thread only.
@@ -99,8 +92,8 @@ public:
   // Implementation is only partial, we can only trim a buffer.
   // Returns true if data was evicted.
   // Times are in microseconds.
-  bool RangeRemoval(mozilla::media::Microseconds aStart,
-                    mozilla::media::Microseconds aEnd);
+  bool RangeRemoval(mozilla::media::TimeUnit aStart,
+                    mozilla::media::TimeUnit aEnd);
 
   // Abort any pending appendBuffer by rejecting any pending promises.
   void AbortAppendData();

--- a/dom/media/ogg/OggReader.cpp
+++ b/dom/media/ogg/OggReader.cpp
@@ -17,7 +17,6 @@
 extern "C" {
 #include "opus/opus_multistream.h"
 }
-#include "mozilla/dom/TimeRanges.h"
 #include "mozilla/TimeStamp.h"
 #include "VorbisUtils.h"
 #include "MediaMetadataManager.h"
@@ -1859,29 +1858,31 @@ nsresult OggReader::SeekBisection(int64_t aTarget,
   return NS_OK;
 }
 
-nsresult OggReader::GetBuffered(dom::TimeRanges* aBuffered)
+media::TimeIntervals OggReader::GetBuffered()
 {
   MOZ_ASSERT(mStartTime != -1, "Need to finish metadata decode first");
   {
     mozilla::ReentrantMonitorAutoEnter mon(mMonitor);
-    if (mIsChained)
-      return NS_ERROR_FAILURE;
+    if (mIsChained) {
+      return media::TimeIntervals::Invalid();
+    }
   }
 #ifdef OGG_ESTIMATE_BUFFERED
-  return MediaDecoderReader::GetBuffered(aBuffered);
+  return MediaDecoderReader::GetBuffered();
 #else
+  media::TimeIntervals buffered;
   // HasAudio and HasVideo are not used here as they take a lock and cause
   // a deadlock. Accessing mInfo doesn't require a lock - it doesn't change
   // after metadata is read.
   if (!mInfo.HasValidMedia()) {
     // No need to search through the file if there are no audio or video tracks
-    return NS_OK;
+    return buffered;
   }
 
   AutoPinned<MediaResource> resource(mDecoder->GetResource());
   nsTArray<MediaByteRange> ranges;
   nsresult res = resource->GetCachedRanges(ranges);
-  NS_ENSURE_SUCCESS(res, res);
+  NS_ENSURE_SUCCESS(res, media::TimeIntervals::Invalid());
 
   // Traverse across the buffered byte ranges, determining the time ranges
   // they contain. MediaResource::GetNextCachedData(offset) returns -1 when
@@ -1915,7 +1916,7 @@ nsresult OggReader::GetBuffered(dom::TimeRanges* aBuffered)
                                     &page,
                                     discard);
       if (res == PAGE_SYNC_ERROR) {
-        return NS_ERROR_FAILURE;
+        return media::TimeIntervals::Invalid();
       } else if (res == PAGE_SYNC_END_OF_RANGE) {
         // Hit the end of range without reading a page, give up trying to
         // find a start time for this buffered range, skip onto the next one.
@@ -1955,7 +1956,7 @@ nsresult OggReader::GetBuffered(dom::TimeRanges* aBuffered)
         // prevents us searching through the rest of the media when we
         // may not be able to extract timestamps from it.
         SetChained(true);
-        return NS_OK;
+        return buffered;
       }
     }
 
@@ -1963,14 +1964,15 @@ nsresult OggReader::GetBuffered(dom::TimeRanges* aBuffered)
       // We were able to find a start time for that range, see if we can
       // find an end time.
       int64_t endTime = RangeEndTime(startOffset, endOffset, true);
-      if (endTime != -1) {
-        aBuffered->Add((startTime - mStartTime) / static_cast<double>(USECS_PER_S),
-                       (endTime - mStartTime) / static_cast<double>(USECS_PER_S));
+      if (endTime > startTime) {
+        buffered += media::TimeInterval(
+           media::TimeUnit::FromMicroseconds(startTime - mStartTime),
+           media::TimeUnit::FromMicroseconds(endTime - mStartTime));
       }
     }
   }
 
-  return NS_OK;
+  return buffered;
 #endif
 }
 

--- a/dom/media/ogg/OggReader.h
+++ b/dom/media/ogg/OggReader.h
@@ -19,12 +19,6 @@
 #include "mozilla/Monitor.h"
 
 namespace mozilla {
-namespace dom {
-class TimeRanges;
-}
-}
-
-namespace mozilla {
 
 // Thread safe container to store the codec information and the serial for each
 // streams.
@@ -77,7 +71,7 @@ public:
                                 MetadataTags** aTags) override;
   virtual nsRefPtr<SeekPromise>
   Seek(int64_t aTime, int64_t aEndTime) override;
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered) override;
+  virtual media::TimeIntervals GetBuffered() override;
 
   virtual bool IsMediaSeekable() override;
 

--- a/dom/media/omx/MediaOmxReader.cpp
+++ b/dom/media/omx/MediaOmxReader.cpp
@@ -8,7 +8,6 @@
 
 #include "MediaDecoderStateMachine.h"
 #include "mozilla/TimeStamp.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "MediaResource.h"
 #include "VideoUtils.h"
 #include "MediaOmxDecoder.h"

--- a/dom/media/omx/RtspMediaCodecReader.h
+++ b/dom/media/omx/RtspMediaCodecReader.h
@@ -11,10 +11,6 @@
 
 namespace mozilla {
 
-namespace dom {
-  class TimeRanges;
-}
-
 class AbstractMediaDecoder;
 class RtspMediaResource;
 
@@ -48,8 +44,8 @@ public:
   // we returned are not useful for the MediaDecodeStateMachine. Unlike the
   // ChannelMediaResource, it has a "cache" that can store the whole streaming
   // data so the |GetBuffered| function can retrieve useful time ranges.
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered) override {
-    return NS_ERROR_NOT_IMPLEMENTED;
+  virtual media::TimeIntervals GetBuffered() override {
+    return media::TimeIntervals::Invalid();
   }
 
   virtual void SetIdle() override;

--- a/dom/media/omx/RtspOmxReader.h
+++ b/dom/media/omx/RtspOmxReader.h
@@ -58,8 +58,8 @@ public:
   // we returned are not useful for the MediaDecodeStateMachine. Unlike the
   // ChannelMediaResource, it has a "cache" that can store the whole streaming
   // data so the |GetBuffered| function can retrieve useful time ranges.
-  virtual nsresult GetBuffered(mozilla::dom::TimeRanges* aBuffered) final override {
-    return NS_ERROR_NOT_IMPLEMENTED;
+  virtual media::TimeIntervals GetBuffered() final override {
+    return media::TimeIntervals::Invalid();
   }
 
   virtual void SetIdle() override;

--- a/dom/media/raw/RawReader.cpp
+++ b/dom/media/raw/RawReader.cpp
@@ -289,7 +289,7 @@ nsresult RawReader::SeekInternal(int64_t aTime)
   return NS_OK;
 }
 
-nsresult RawReader::GetBuffered(dom::TimeRanges* aBuffered)
+media::TimeIntervals RawReader::GetBuffered()
 {
-  return NS_OK;
+  return media::TimeIntervals();
 }

--- a/dom/media/raw/RawReader.h
+++ b/dom/media/raw/RawReader.h
@@ -42,7 +42,7 @@ public:
   virtual nsRefPtr<SeekPromise>
   Seek(int64_t aTime, int64_t aEndTime) override;
 
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered) override;
+  virtual media::TimeIntervals GetBuffered() override;
 
   virtual bool IsMediaSeekable() override;
 

--- a/dom/media/wave/WaveReader.cpp
+++ b/dom/media/wave/WaveReader.cpp
@@ -7,7 +7,6 @@
 #include "AbstractMediaDecoder.h"
 #include "MediaResource.h"
 #include "WaveReader.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "MediaDecoderStateMachine.h"
 #include "VideoUtils.h"
 #include "nsISeekableStream.h"
@@ -280,15 +279,12 @@ WaveReader::Seek(int64_t aTarget, int64_t aEndTime)
   }
 }
 
-static double RoundToUsecs(double aSeconds) {
-  return floor(aSeconds * USECS_PER_S) / USECS_PER_S;
-}
-
-nsresult WaveReader::GetBuffered(dom::TimeRanges* aBuffered)
+media::TimeIntervals WaveReader::GetBuffered()
 {
   if (!mInfo.HasAudio()) {
-    return NS_OK;
+    return media::TimeIntervals();
   }
+  media::TimeIntervals buffered;
   AutoPinned<MediaResource> resource(mDecoder->GetResource());
   int64_t startOffset = resource->GetNextCachedData(mWavePCMOffset);
   while (startOffset >= 0) {
@@ -300,11 +296,12 @@ nsresult WaveReader::GetBuffered(dom::TimeRanges* aBuffered)
     // We need to round the buffered ranges' times to microseconds so that they
     // have the same precision as the currentTime and duration attribute on
     // the media element.
-    aBuffered->Add(RoundToUsecs(BytesToTime(startOffset - mWavePCMOffset)),
-                   RoundToUsecs(BytesToTime(endOffset - mWavePCMOffset)));
+    buffered += media::TimeInterval(
+      media::TimeUnit::FromSeconds(BytesToTime(startOffset - mWavePCMOffset)),
+      media::TimeUnit::FromSeconds(BytesToTime(endOffset - mWavePCMOffset)));
     startOffset = resource->GetNextCachedData(endOffset);
   }
-  return NS_OK;
+  return buffered;
 }
 
 bool

--- a/dom/media/wave/WaveReader.h
+++ b/dom/media/wave/WaveReader.h
@@ -10,12 +10,6 @@
 #include "mozilla/dom/HTMLMediaElement.h"
 
 namespace mozilla {
-namespace dom {
-class TimeRanges;
-}
-}
-
-namespace mozilla {
 
 class WaveReader : public MediaDecoderReader
 {
@@ -46,7 +40,7 @@ public:
   virtual nsRefPtr<SeekPromise>
   Seek(int64_t aTime, int64_t aEndTime) override;
 
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered) override;
+  virtual media::TimeIntervals GetBuffered() override;
 
   virtual bool IsMediaSeekable() override;
 

--- a/dom/media/webm/SoftwareWebMVideoDecoder.cpp
+++ b/dom/media/webm/SoftwareWebMVideoDecoder.cpp
@@ -8,9 +8,9 @@
 #include "gfx2DGlue.h"
 #include "MediaDecoderStateMachine.h"
 #include "MediaResource.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "nsError.h"
 #include "OggReader.h"
+#include "TimeUnits.h"
 #include "VorbisUtils.h"
 #include "WebMBufferedParser.h"
 

--- a/dom/media/webm/WebMBufferedParser.cpp
+++ b/dom/media/webm/WebMBufferedParser.cpp
@@ -6,7 +6,6 @@
 
 #include "nsAlgorithm.h"
 #include "WebMBufferedParser.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "nsThreadUtils.h"
 #include <algorithm>
 

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -1115,7 +1115,6 @@ media::TimeIntervals WebMReader::GetBuffered()
         media::TimeInterval(media::TimeUnit::FromSeconds(0),
                             media::TimeUnit::FromSeconds(duration / NS_PER_S));
       return buffered;
-     }
     }
   }
 

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -10,7 +10,6 @@
 #include "SoftwareWebMVideoDecoder.h"
 #include "WebMReader.h"
 #include "WebMBufferedParser.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "VorbisUtils.h"
 #include "gfx2DGlue.h"
 #include "Layers.h"
@@ -1102,21 +1101,21 @@ nsresult WebMReader::SeekInternal(int64_t aTarget)
   return NS_OK;
 }
 
-nsresult WebMReader::GetBuffered(dom::TimeRanges* aBuffered)
+media::TimeIntervals WebMReader::GetBuffered()
 {
   MOZ_ASSERT(mStartTime != -1, "Need to finish metadata decode first");
-  if (aBuffered->Length() != 0) {
-    return NS_ERROR_FAILURE;
-  }
-
   AutoPinned<MediaResource> resource(mDecoder->GetResource());
 
+  media::TimeIntervals buffered;
   // Special case completely cached files.  This also handles local files.
   if (mContext && resource->IsDataCachedToEndOfResource(0)) {
     uint64_t duration = 0;
     if (nestegg_duration(mContext, &duration) == 0) {
-      aBuffered->Add(0, duration / NS_PER_S);
-      return NS_OK;
+      buffered +=
+        media::TimeInterval(media::TimeUnit::FromSeconds(0),
+                            media::TimeUnit::FromSeconds(duration / NS_PER_S));
+      return buffered;
+     }
     }
   }
 
@@ -1124,7 +1123,7 @@ nsresult WebMReader::GetBuffered(dom::TimeRanges* aBuffered)
   // the WebM bitstream.
   nsTArray<MediaByteRange> ranges;
   nsresult res = resource->GetCachedRanges(ranges);
-  NS_ENSURE_SUCCESS(res, res);
+  NS_ENSURE_SUCCESS(res, media::TimeIntervals::Invalid());
 
   for (uint32_t index = 0; index < ranges.Length(); index++) {
     uint64_t start, end;
@@ -1150,11 +1149,12 @@ nsresult WebMReader::GetBuffered(dom::TimeRanges* aBuffered)
         }
       }
 
-      aBuffered->Add(startTime, endTime);
+      buffered += media::TimeInterval(media::TimeUnit::FromSeconds(startTime),
+                                      media::TimeUnit::FromSeconds(endTime));
     }
   }
 
-  return NS_OK;
+  return buffered;
 }
 
 void WebMReader::NotifyDataArrived(const char* aBuffer, uint32_t aLength,

--- a/dom/media/webm/WebMReader.h
+++ b/dom/media/webm/WebMReader.h
@@ -158,7 +158,7 @@ public:
   virtual nsRefPtr<SeekPromise>
   Seek(int64_t aTime, int64_t aEndTime) override;
 
-  virtual nsresult GetBuffered(dom::TimeRanges* aBuffered) override;
+  virtual media::TimeIntervals GetBuffered() override;
   virtual void NotifyDataArrived(const char* aBuffer, uint32_t aLength,
                                  int64_t aOffset) override;
   virtual int64_t GetEvictionOffset(double aTime) override;

--- a/dom/media/wmf/WMFReader.cpp
+++ b/dom/media/wmf/WMFReader.cpp
@@ -10,7 +10,6 @@
 #include "WMFByteStream.h"
 #include "WMFSourceReaderCallback.h"
 #include "mozilla/ArrayUtils.h"
-#include "mozilla/dom/TimeRanges.h"
 #include "mozilla/dom/HTMLMediaElement.h"
 #include "mozilla/Preferences.h"
 #include "DXVA2Manager.h"


### PR DESCRIPTION
Plays nicer with the new MediaFormatReader, and is listed on BMO as a blocker (or rather, a blocker of a blocker) to enable MediaFormatReader by default. See individual commits for greater details.

Tested MP4 Videos (with and without GStreamer), WebM, WebM + MSE, MP4 + MSE (test suite) (all with both the current MP4Reader and the new MediaFormatReader), as well as OGG and WAVE files. All appears to be working as intended.