### PR TITLE
About Dialog - missing translated links

### DIFF
--- a/browser/base/content/aboutDialog.xul
+++ b/browser/base/content/aboutDialog.xul
@@ -104,9 +104,9 @@
     </hbox>
     <vbox id="PMbottomBox">
       <hbox pack="center">
-        <label class="text-link bottom-link" href="about:license">Licensing information</label>
-        <label class="text-link bottom-link" href="about:rights">End-user rights</label>
-        <label class="text-link bottom-link" href="http://www.palemoon.org/releasenotes-ng.shtml">Release notes</label>
+        <label class="text-link bottom-link" href="about:license">&bottomLinks.license;</label>
+        <label class="text-link bottom-link" href="about:rights">&bottomLinks.rights;</label>
+        <label class="text-link bottom-link" href="http://www.palemoon.org/releasenotes-ng.shtml">&bottomLinks.releaseNotes;</label>
       </hbox>
       <description id="PMtrademark">&trademarkInfo.part1;</description>
     </vbox>

--- a/browser/locales/en-US/chrome/browser/aboutDialog.dtd
+++ b/browser/locales/en-US/chrome/browser/aboutDialog.dtd
@@ -37,6 +37,9 @@
 <!-- LOCALIZATION NOTE (bottomLinks.privacy): This is a link title that links to https://www.mozilla.org/legal/privacy/. -->
 <!ENTITY bottomLinks.privacy        "Privacy Policy">
 
+<!-- LOCALIZATION NOTE (bottomLinks.releaseNotes): This is a link title that links to http://www.palemoon.org/releasenotes-ng.shtml. -->
+<!ENTITY bottomLinks.releaseNotes   "Release notes">
+
 <!-- LOCALIZATION NOTE (update.checkingForUpdates): try to make the localized text short (see bug 596813 for screenshots). -->
 <!ENTITY update.checkingForUpdates  "Checking for updates…">
 <!-- LOCALIZATION NOTE (update.checkingAddonCompat): try to make the localized text short (see bug 596813 for screenshots). -->


### PR DESCRIPTION
If it is not intentionally...

@JustOff 
Also FYI

---

I've created the new build (x64) and tested.
