### PR TITLE
about:license - the link to about:buildconfig

### DIFF
--- a/docshell/base/nsAboutRedirector.cpp
+++ b/docshell/base/nsAboutRedirector.cpp
@@ -51,7 +51,8 @@ static RedirEntry kRedirMap[] = {
   },
   {
     "buildconfig", "chrome://global/content/buildconfig.html",
-    nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT
+    nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
+    nsIAboutModule::MAKE_LINKABLE
   },
   {
     "license", "chrome://global/content/license.html",


### PR DESCRIPTION
See:
![a](https://cloud.githubusercontent.com/assets/2373486/20245538/d064a86a-a9a3-11e6-9fb3-5d62f08a404a.png)

After click on the link (or in the context menu: "Save link as", etc.) - throws an errors in the Browser Console:
```
Security Error: Content at about:license may not load or link to about:buildconfig.
uncaught exception: Load of about:buildconfig from about:license denied. <unknown>
```

See also https://github.com/MoonchildProductions/Pale-Moon/commit/6767342dff9cef4a4bfb770e3b2a9f18c3b471e5

---

I've created the new build (x64) and tested.
