### PR TITLE
DevTools - gcli commands - console

### DIFF
--- a/toolkit/devtools/webconsole/console-commands.js
+++ b/toolkit/devtools/webconsole/console-commands.js
@@ -41,12 +41,11 @@ exports.items = [
       let toolbox = gDevTools.getToolbox(target);
 
       if (!toolbox) {
-        return gDevTools.showToolbox(target, "inspector").then((toolbox) => {
-          toolbox.toggleSplitConsole();
+        return gDevTools.showToolbox(target, "inspector").then((newToolbox) => {
+          newToolbox.toggleSplitConsole();
         });
-      } else {
-        toolbox.toggleSplitConsole();
       }
+      return toolbox.toggleSplitConsole();
     }
   },
   {
@@ -60,12 +59,12 @@ exports.items = [
     exec: function(args, context) {
       let toolbox = gDevTools.getToolbox(context.environment.target);
       if (toolbox == null) {
-        return;
+        return null;
       }
 
       let panel = toolbox.getPanel("webconsole");
       if (panel == null) {
-        return;
+        return null;
       }
 
       panel.hud.jsterm.clearOutput();
@@ -75,14 +74,16 @@ exports.items = [
     name: "console close",
     description: gcli.lookup("consolecloseDesc"),
     exec: function(args, context) {
-      return gDevTools.closeToolbox(context.environment.target);
+      // Don't return a value to GCLI
+      return gDevTools.closeToolbox(context.environment.target).then(() => {});
     }
   },
   {
     name: "console open",
     description: gcli.lookup("consoleopenDesc"),
     exec: function(args, context) {
-      return gDevTools.showToolbox(context.environment.target, "webconsole");
+      // Don't return a value to GCLI
+      return gDevTools.showToolbox(context.environment.target, "webconsole").then(() => {});
     }
   }
 ];


### PR DESCRIPTION

__Steps to reproduce:__

__1)__ Open `Developer Toolbar`

__2a)__ The command: `console open`

Throws an errors in Browser Console (e.g.):
```
No type from output of console open
```

__2b)__ The command: `console close`

Returns `true` to `Developer Toolbar`.

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1256767

---

I've created the new build (x64) and tested.
