### PR TITLE
Permissions vs. Page Info - cookies

### DIFF
--- a/browser/base/content/pageinfo/pageInfo.xul
+++ b/browser/base/content/pageinfo/pageInfo.xul
@@ -328,6 +328,7 @@
             <radiogroup id="cookieRadioGroup" orient="horizontal">
               <radio id="cookie#1" command="cmd_cookieToggle" label="&permAllow;"/>
               <radio id="cookie#8" command="cmd_cookieToggle" label="&permAllowSession;"/>
+              <radio id="cookie#9" command="cmd_cookieToggle" label="&permAllowFirstPartyOnly;"/>              
               <radio id="cookie#2" command="cmd_cookieToggle" label="&permBlock;"/>
             </radiogroup>
           </hbox>

--- a/browser/locales/en-US/chrome/browser/pageInfo.dtd
+++ b/browser/locales/en-US/chrome/browser/pageInfo.dtd
@@ -50,23 +50,24 @@
 <!ENTITY  feedSubscribe         "Subscribe">
 <!ENTITY  feedSubscribe.accesskey "u">
 
-<!ENTITY  permTab               "Permissions">
-<!ENTITY  permTab.accesskey     "P">
-<!ENTITY  permUseDefault        "Use Default">
-<!ENTITY  permAskAlways         "Always ask">
-<!ENTITY  permAllow             "Allow">
-<!ENTITY  permAllowSession      "Allow for Session">
-<!ENTITY  permBlock             "Block">
-<!ENTITY  permissionsFor        "Permissions for:">
-<!ENTITY  permImage             "Load Images">
-<!ENTITY  permPopup             "Open Pop-up Windows">
-<!ENTITY  permCookie            "Set Cookies">
-<!ENTITY  permNotifications     "Show Notifications">
-<!ENTITY  permInstall           "Install Extensions or Themes">
-<!ENTITY  permGeo               "Share Location">
-<!ENTITY  permPlugins           "Activate Plugins">
-<!ENTITY  permFullscreen        "Enter Fullscreen">
-<!ENTITY  permPointerLock2      "Hide the Mouse Pointer">
+<!ENTITY  permTab                 "Permissions">
+<!ENTITY  permTab.accesskey       "P">
+<!ENTITY  permUseDefault          "Use Default">
+<!ENTITY  permAskAlways           "Always ask">
+<!ENTITY  permAllow               "Allow">
+<!ENTITY  permAllowSession        "Allow for Session">
+<!ENTITY  permAllowFirstPartyOnly "Allow First Party Only">
+<!ENTITY  permBlock               "Block">
+<!ENTITY  permissionsFor          "Permissions for:">
+<!ENTITY  permImage               "Load Images">
+<!ENTITY  permPopup               "Open Pop-up Windows">
+<!ENTITY  permCookie              "Set Cookies">
+<!ENTITY  permNotifications       "Show Notifications">
+<!ENTITY  permInstall             "Install Extensions or Themes">
+<!ENTITY  permGeo                 "Share Location">
+<!ENTITY  permPlugins             "Activate Plugins">
+<!ENTITY  permFullscreen          "Enter Fullscreen">
+<!ENTITY  permPointerLock2        "Hide the Mouse Pointer">
 
 <!ENTITY  permIndexedDB              "Maintain Offline Storage">
 <!ENTITY  permClearStorage           "Clear Storage">


### PR DESCRIPTION
__Steps to reproduce (e.g.):__

1) Go to http://www.palemoon.org/
2) Main menu: `Tools - Page Info - Permissions` - uncheck `Set Cookies` - `Use Default`
3) Go to `about:permissions`
4) Select the appropriate domain
5) Select `Set Cookies` - `Allow First Party Only`
6) Go back to `Tools - Page Info - Permissions`

Throws an error in Error Console:
```
Error: TypeError: radio is null
Source File: chrome://browser/content/pageinfo/permissions.js
Line: 205
```

But my patch is just a suggestion...

---

I've created the new build (x64) and tested.
