### PR TITLE
Search engine: If no result, throws an error

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -351,6 +351,9 @@ pref("browser.search.openintab", false);
 // context menu searches open in the foreground
 pref("browser.search.context.loadInBackground", false);
 
+// if no result, add the search term so that the panel of the new UI is shown anyway
+pref("browser.search.showOneOffButtons", true);
+
 // send ping to the server to update
 pref("browser.search.update", true);
 

--- a/browser/branding/shared/pref/preferences.inc
+++ b/browser/branding/shared/pref/preferences.inc
@@ -16,7 +16,6 @@ pref("browser.getdevtools.url","https://@APO_AM_URL@/external/devtools");
 pref("browser.tabs.insertRelatedAfterCurrent", false); //use old method of tabbed browsing instead of "Chrome" style
 pref("browser.download.useDownloadDir", false); //don't use default download location as standard. ASK.
 pref("browser.search.context.loadInBackground", true); //don't swap focus to the context search tab.
-pref("browser.search.showOneOffButtons", true); //if no result, add the search term so that the panel of the new UI is shown anyway.
 pref("browser.ctrlTab.previews", true);
 pref("browser.allTabs.previews", true);
 pref("browser.urlbar.trimURLs", false); //stop being a derp, Mozilla!

--- a/browser/branding/shared/pref/preferences.inc
+++ b/browser/branding/shared/pref/preferences.inc
@@ -16,6 +16,7 @@ pref("browser.getdevtools.url","https://@APO_AM_URL@/external/devtools");
 pref("browser.tabs.insertRelatedAfterCurrent", false); //use old method of tabbed browsing instead of "Chrome" style
 pref("browser.download.useDownloadDir", false); //don't use default download location as standard. ASK.
 pref("browser.search.context.loadInBackground", true); //don't swap focus to the context search tab.
+pref("browser.search.showOneOffButtons", true); //if no result, add the search term so that the panel of the new UI is shown anyway.
 pref("browser.ctrlTab.previews", true);
 pref("browser.allTabs.previews", true);
 pref("browser.urlbar.trimURLs", false); //stop being a derp, Mozilla!


### PR DESCRIPTION
__Steps to reproduce__

1) Search engine
2) Find something without result

Throws an error in Browser Console:
```
A promise chain failed to handle a rejection. Did you forget to '.catch', or did you forget to 'return'?

See https://developer.mozilla.org/Mozilla/JavaScript_code_modules/Promise.jsm/Promise
Full Message: Component returned failure code: 0x8000ffff (NS_ERROR_UNEXPECTED) [nsIPrefBranch.getBoolPref]
Full Stack: JS frame :: resource://gre/components/nsSearchSuggestions.js :: SuggestAutoComplete.prototype.onResultsReturned :: line 79
JS frame :: resource://gre/components/nsSearchSuggestions.js :: SuggestAutoComplete.prototype._init/this._suggestionController< :: line 27
JS frame :: resource://gre/modules/SearchSuggestionController.jsm :: this.SearchSuggestionController.prototype._dedupeAndReturnResults :: line 368
JS frame :: resource://gre/modules/Promise.jsm -> resource://gre/modules/Promise-backend.js :: Handler.prototype.process :: line 867
JS frame :: resource://gre/modules/Promise.jsm -> resource://gre/modules/Promise-backend.js :: this.PromiseWalker.walkerLoop :: line 746
JS frame :: resource://gre/modules/Promise.jsm -> resource://gre/modules/Promise-backend.js :: this.PromiseWalker.scheduleWalkerLoop/< :: line 688
native frame :: <unknown filename> :: <TOP_LEVEL> :: line 0 nsSearchSuggestions.js:79:0
```

---

I've created the new build (x64) and tested.
