### PR TITLE
Add bits-per-second interface to MediaRecorder

### DIFF
--- a/dom/media/MediaRecorder.cpp
+++ b/dom/media/MediaRecorder.cpp
@@ -581,9 +581,17 @@ private:
 
     // Make sure the application has permission to assign AUDIO_3GPP
     if (mRecorder->mMimeType.EqualsLiteral(AUDIO_3GPP) && Check3gppPermission()) {
-      mEncoder = MediaEncoder::CreateEncoder(NS_LITERAL_STRING(AUDIO_3GPP), aTrackTypes);
+      mEncoder = MediaEncoder::CreateEncoder(NS_LITERAL_STRING(AUDIO_3GPP),
+                                             mRecorder->GetAudioBitrate(),
+                                             mRecorder->GetVideoBitrate(),
+                                             mRecorder->GetBitrate(),
+                                             aTrackTypes);
     } else {
-      mEncoder = MediaEncoder::CreateEncoder(NS_LITERAL_STRING(""), aTrackTypes);
+      mEncoder = MediaEncoder::CreateEncoder(NS_LITERAL_STRING(""),
+                                             mRecorder->GetAudioBitrate(),
+                                             mRecorder->GetVideoBitrate(),
+                                             mRecorder->GetBitrate(),
+                                             aTrackTypes);
     }
 
     if (!mEncoder) {
@@ -984,6 +992,17 @@ MediaRecorder::SetOptions(const MediaRecorderOptions& aInitDict)
                         aInitDict.mVideoBitsPerSecond.Value() : 0;
   mBitsPerSecond = aInitDict.mBitsPerSecond.WasPassed() ?
                    aInitDict.mBitsPerSecond.Value() : 0;
+  // We're not handling dynamic changes yet. Eventually we'll handle
+  // setting audio, video and/or total -- and anything that isn't set,
+  // we'll derive. Calculated versions require querying bitrates after
+  // the encoder is Init()ed. This happens only after data is
+  // available and thus requires dynamic changes.
+  //
+  // Until dynamic changes are supported, we'll be safe and err
+  // slightly high.
+  if (aInitDict.mBitsPerSecond.WasPassed() && !aInitDict.mVideoBitsPerSecond.WasPassed()) {
+    mVideoBitsPerSecond = mBitsPerSecond;
+  }
 }
 
 nsresult

--- a/dom/media/MediaRecorder.cpp
+++ b/dom/media/MediaRecorder.cpp
@@ -934,7 +934,7 @@ MediaRecorder::Constructor(const GlobalObject& aGlobal,
   }
 
   nsRefPtr<MediaRecorder> object = new MediaRecorder(aStream, ownerWindow);
-  object->SetMimeType(aInitDict.mMimeType);
+  object->SetOptions(aInitDict);
   return object.forget();
 }
 
@@ -970,8 +970,20 @@ MediaRecorder::Constructor(const GlobalObject& aGlobal,
   nsRefPtr<MediaRecorder> object = new MediaRecorder(aSrcAudioNode,
                                                      aSrcOutput,
                                                      ownerWindow);
-  object->SetMimeType(aInitDict.mMimeType);
+  object->SetOptions(aInitDict);
   return object.forget();
+}
+
+void
+MediaRecorder::SetOptions(const MediaRecorderOptions& aInitDict)
+{
+  SetMimeType(aInitDict.mMimeType);
+  mAudioBitsPerSecond = aInitDict.mAudioBitsPerSecond.WasPassed() ?
+                        aInitDict.mAudioBitsPerSecond.Value() : 0;
+  mVideoBitsPerSecond = aInitDict.mVideoBitsPerSecond.WasPassed() ?
+                        aInitDict.mVideoBitsPerSecond.Value() : 0;
+  mBitsPerSecond = aInitDict.mBitsPerSecond.WasPassed() ?
+                   aInitDict.mBitsPerSecond.Value() : 0;
 }
 
 nsresult

--- a/dom/media/MediaRecorder.h
+++ b/dom/media/MediaRecorder.h
@@ -118,6 +118,7 @@ protected:
   bool CheckPrincipal();
   // Set encoded MIME type.
   void SetMimeType(const nsString &aMimeType);
+  void SetOptions(const MediaRecorderOptions& aInitDict);
 
   MediaRecorder(const MediaRecorder& x) = delete; // prevent bad usage
   // Remove session pointer.
@@ -144,6 +145,9 @@ protected:
   // It specifies the container format as well as the audio and video capture formats.
   nsString mMimeType;
 
+  uint32_t mAudioBitsPerSecond;
+  uint32_t mVideoBitsPerSecond;
+  uint32_t mBitsPerSecond;
 private:
   // Register MediaRecorder into Document to listen the activity changes.
   void RegisterActivityObserver();

--- a/dom/media/MediaRecorder.h
+++ b/dom/media/MediaRecorder.h
@@ -104,6 +104,9 @@ public:
 
   NS_DECL_NSIDOCUMENTACTIVITY
 
+  uint32_t GetAudioBitrate() { return mAudioBitsPerSecond; }
+  uint32_t GetVideoBitrate() { return mVideoBitsPerSecond; }
+  uint32_t GetBitrate() { return mBitsPerSecond; }
 protected:
   virtual ~MediaRecorder();
 

--- a/dom/media/encoder/MediaEncoder.cpp
+++ b/dom/media/encoder/MediaEncoder.cpp
@@ -77,7 +77,9 @@ MediaEncoder::NotifyEvent(MediaStreamGraph* aGraph,
 
 /* static */
 already_AddRefed<MediaEncoder>
-MediaEncoder::CreateEncoder(const nsAString& aMIMEType, uint8_t aTrackTypes)
+MediaEncoder::CreateEncoder(const nsAString& aMIMEType, uint32_t aAudioBitrate,
+                            uint32_t aVideoBitrate, uint32_t aBitrate,
+                            uint8_t aTrackTypes)
 {
 #ifdef PR_LOGGING
   if (!gMediaEncoderLog) {
@@ -150,8 +152,15 @@ MediaEncoder::CreateEncoder(const nsAString& aMIMEType, uint8_t aTrackTypes)
   LOG(PR_LOG_DEBUG, ("Create encoder result:a[%d] v[%d] w[%d] mimeType = %s.",
                       audioEncoder != nullptr, videoEncoder != nullptr,
                       writer != nullptr, mimeType.get()));
+  if (videoEncoder && aVideoBitrate != 0) {
+    videoEncoder->SetBitrate(aVideoBitrate);
+  }
+  if (audioEncoder && aAudioBitrate != 0) {
+    audioEncoder->SetBitrate(aAudioBitrate);
+  }
   encoder = new MediaEncoder(writer.forget(), audioEncoder.forget(),
-                             videoEncoder.forget(), mimeType);
+                             videoEncoder.forget(), mimeType, aAudioBitrate,
+                             aVideoBitrate, aBitrate);
   return encoder.forget();
 }
 

--- a/dom/media/encoder/MediaEncoder.h
+++ b/dom/media/encoder/MediaEncoder.h
@@ -62,7 +62,10 @@ public :
   MediaEncoder(ContainerWriter* aWriter,
                AudioTrackEncoder* aAudioEncoder,
                VideoTrackEncoder* aVideoEncoder,
-               const nsAString& aMIMEType)
+               const nsAString& aMIMEType,
+               uint32_t aAudioBitrate,
+               uint32_t aVideoBitrate,
+               uint32_t aBitrate)
     : mWriter(aWriter)
     , mAudioEncoder(aAudioEncoder)
     , mVideoEncoder(aVideoEncoder)
@@ -96,6 +99,8 @@ public :
    * Ogg+Opus if it is empty.
    */
   static already_AddRefed<MediaEncoder> CreateEncoder(const nsAString& aMIMEType,
+                                                      uint32_t aAudioBitrate, uint32_t aVideoBitrate,
+                                                      uint32_t aBitrate,
                                                       uint8_t aTrackTypes = ContainerWriter::CREATE_AUDIO_TRACK);
   /**
    * Encodes the raw track data and returns the final container data. Assuming

--- a/dom/media/encoder/OpusTrackEncoder.cpp
+++ b/dom/media/encoder/OpusTrackEncoder.cpp
@@ -189,6 +189,10 @@ OpusTrackEncoder::Init(int aChannels, int aSamplingRate)
 
   mInitialized = (error == OPUS_OK);
 
+  if (mAudioBitrate) {
+    opus_encoder_ctl(mEncoder, OPUS_SET_BITRATE(static_cast<int>(mAudioBitrate)));
+  }
+
   mReentrantMonitor.NotifyAll();
 
   return error == OPUS_OK ? NS_OK : NS_ERROR_FAILURE;

--- a/dom/media/encoder/TrackEncoder.h
+++ b/dom/media/encoder/TrackEncoder.h
@@ -84,6 +84,8 @@ public:
     mReentrantMonitor.NotifyAll();
   }
 
+  virtual void SetBitrate(const uint32_t aBitrate) {}
+
 protected:
   /**
    * Notifies track encoder that we have reached the end of source stream, and
@@ -143,6 +145,7 @@ public:
     : TrackEncoder()
     , mChannels(0)
     , mSamplingRate(0)
+    , mAudioBitrate(0)
   {}
 
   virtual void NotifyQueuedTrackChanges(MediaStreamGraph* aGraph, TrackID aID,
@@ -171,6 +174,10 @@ public:
   */
   size_t SizeOfExcludingThis(mozilla::MallocSizeOf aMallocSizeOf) const;
 
+  virtual void SetBitrate(const uint32_t aBitrate) override
+  {
+    mAudioBitrate = aBitrate;
+  }
 protected:
   /**
    * Number of samples per channel in a pcm buffer. This is also the value of
@@ -219,6 +226,8 @@ protected:
    * A segment queue of audio track data, protected by mReentrantMonitor.
    */
   AudioSegment mRawSegment;
+
+  uint32_t mAudioBitrate;
 };
 
 class VideoTrackEncoder : public TrackEncoder
@@ -232,6 +241,7 @@ public:
     , mDisplayHeight(0)
     , mTrackRate(0)
     , mTotalFrameDuration(0)
+    , mVideoBitrate(0)
   {}
 
   /**
@@ -247,6 +257,10 @@ public:
   */
   size_t SizeOfExcludingThis(mozilla::MallocSizeOf aMallocSizeOf) const;
 
+  virtual void SetBitrate(const uint32_t aBitrate) override
+  {
+    mVideoBitrate = aBitrate;
+  }
 protected:
   /**
    * Initialized the video encoder. In order to collect the value of width and
@@ -312,6 +326,8 @@ protected:
    * A segment queue of audio track data, protected by mReentrantMonitor.
    */
   VideoSegment mRawSegment;
+
+  uint32_t mVideoBitrate;
 };
 
 }

--- a/dom/media/encoder/VP8TrackEncoder.cpp
+++ b/dom/media/encoder/VP8TrackEncoder.cpp
@@ -24,7 +24,7 @@ PRLogModuleInfo* gVP8TrackEncoderLog;
 #define VP8LOG(msg, ...)
 #endif
 
-#define DEFAULT_BITRATE 2500 // in kbit/s
+#define DEFAULT_BITRATE_BPS 2500000
 #define DEFAULT_ENCODE_FRAMERATE 30
 
 using namespace mozilla::layers;
@@ -93,7 +93,9 @@ VP8TrackEncoder::Init(int32_t aWidth, int32_t aHeight, int32_t aDisplayWidth,
   config.g_h = mFrameHeight;
   // TODO: Maybe we should have various aFrameRate bitrate pair for each devices?
   // or for different platform
-  config.rc_target_bitrate = DEFAULT_BITRATE; // in kbit/s
+
+  // rc_target_bitrate needs kbit/s
+  config.rc_target_bitrate = (mVideoBitrate != 0 ? mVideoBitrate : DEFAULT_BITRATE_BPS)/1000;
 
   // Setting the time base of the codec
   config.g_timebase.num = 1;

--- a/dom/media/encoder/VorbisTrackEncoder.cpp
+++ b/dom/media/encoder/VorbisTrackEncoder.cpp
@@ -62,9 +62,12 @@ VorbisTrackEncoder::Init(int aChannels, int aSamplingRate)
 
   int ret = 0;
   vorbis_info_init(&mVorbisInfo);
+  double quality = mAudioBitrate ? (double)mAudioBitrate/aSamplingRate :
+                   BASE_QUALITY;
 
+  printf("quality %f \n", quality);
   ret = vorbis_encode_init_vbr(&mVorbisInfo, mChannels, mSamplingRate,
-                               BASE_QUALITY);
+                               quality);
 
   mInitialized = (ret == 0);
 

--- a/dom/media/test/manifest.js
+++ b/dom/media/test/manifest.js
@@ -106,6 +106,11 @@ var gMediaRecorderTests = [
   { name:"detodos.opus", type:"audio/ogg; codecs=opus", duration:2.9135 }
 ];
 
+// Used by video media recorder tests
+var gMediaRecorderVideoTests = [
+  { name:"seek.webm", type:"video/webm", width:320, height:240, duration:3.966 },
+];
+
 // These are files that we want to make sure we can play through.  We can
 // also check metadata.  Put files of the same type together in this list so if
 // something crashes we have some idea of which backend is responsible.

--- a/dom/media/test/mochitest.ini
+++ b/dom/media/test/mochitest.ini
@@ -406,6 +406,8 @@ skip-if = (toolkit == 'android' && processor == 'x86') #x86 only bug 914439
 [test_media_sniffer.html]
 skip-if = (toolkit == 'android' && processor == 'x86') #x86 only bug 914439
 [test_mediarecorder_avoid_recursion.html]
+[test_mediarecorder_bitrate.html]
+skip-if = (toolkit == 'gonk' || android_version == '10') # B2G emulator is too slow to run this without timing out and Android doesn't like the seek.webm
 [test_mediarecorder_creation.html]
 [test_mediarecorder_creation_fail.html]
 [test_mediarecorder_getencodeddata.html]

--- a/dom/media/test/test_mediarecorder_bitrate.html
+++ b/dom/media/test/test_mediarecorder_bitrate.html
@@ -1,0 +1,131 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Test MediaRecorder Bitrate</title>
+  <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>
+  <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
+  <script type="text/javascript" src="manifest.js"></script>
+</head>
+<body>
+<pre id="test">
+<script class="testbody" type="text/javascript">
+var manager = new MediaTestManager;
+var results = [];
+
+/**
+ * Starts a test on every media recorder file included to check that
+ * the bitrate control works
+ */
+function startTest(test, token) {
+  manager.started(token);
+  runTest(test, token, 1000000);
+  runTest(test, token, 100000);
+}
+
+function runTest(test, token, bitrate) {
+  var element = document.createElement('video');
+  var expectedMimeType = test.type.substring(0, test.type.indexOf(';'));
+
+  element.token = token;
+
+  element.src = test.name;
+  element.test = test;
+  element.stream = element.mozCaptureStreamUntilEnded();
+
+  var mediaRecorder = new MediaRecorder(element.stream , {videoBitsPerSecond: bitrate});
+  var onStopFired = false;
+  var onDataAvailableFired = false;
+  var encoded_size = 0;
+
+  mediaRecorder.onerror = function () {
+    ok(false, 'Unexpected onerror callback fired');
+  };
+
+  mediaRecorder.onwarning = function () {
+    ok(false, 'Unexpected onwarning callback fired');
+  };
+
+  // This handler verifies that only a single onstop event handler is fired.
+  mediaRecorder.onstop = function () {
+    if (onStopFired) {
+      ok(false, 'onstop unexpectedly fired more than once');
+    } else {
+      onStopFired = true;
+
+      // ondataavailable should always fire before onstop
+      if (onDataAvailableFired) {
+        ok(true, 'onstop fired after ondataavailable');
+        info("test " + test.name + " encoded@" + bitrate + "=" + encoded_size);
+        if (results[test.name]) {
+          var big, small, temp;
+          big = {};
+	  big.bitrate = bitrate;
+	  big.size = encoded_size;
+	  small = results[test.name];
+	  // Don't assume the order that these will finish in
+	  if (results[test.name].bitrate > bitrate) {
+	    temp = big;
+	    big = small;
+	    small = temp;
+	  }
+	  // Ensure there is a big enough difference in the encoded
+	  // sizes
+          ok(small.size*1.25 < big.size,
+	     test.name + ' encoded@' + big.bitrate + '=' + big.size +
+	     ' > encoded@' + small.bitrate + '=' + small.size);
+          manager.finished(token);
+        } else {
+	  results[test.name] = {};
+	  results[test.name].bitrate = bitrate;
+          results[test.name].size = encoded_size;
+        }
+      } else {
+        ok(false, 'onstop fired without an ondataavailable event first');
+      }
+    }
+  };
+
+  // This handler verifies that only a single ondataavailable event handler
+  // is fired with the blob generated having greater than zero size
+  // and a correct mime type.
+  mediaRecorder.ondataavailable = function (evt) {
+    if (onDataAvailableFired) {
+      ok(false, 'ondataavailable unexpectedly fired more than once');
+    } else {
+      onDataAvailableFired = true;
+
+      ok(evt instanceof BlobEvent,
+         'Events fired from ondataavailable should be BlobEvent');
+      is(evt.type, 'dataavailable',
+         'Event type should dataavailable');
+      ok(evt.data.size > 0,
+         'Blob data received should be greater than zero');
+      encoded_size = evt.data.size;
+
+      // onstop should not have fired before ondataavailable
+      if (onStopFired) {
+        ok(false, 'ondataavailable unexpectedly fired later than onstop');
+        manager.finished(token);
+      }
+    }
+  };
+
+  element.preload = "metadata";
+
+  element.onloadedmetadata = function () {
+    element.onloadedmetadata = null;
+    mediaRecorder.start();
+    is(mediaRecorder.state, 'recording',
+     'Media recorder should be recording');
+    is(mediaRecorder.stream, element.stream,
+     'Media recorder stream = element stream at the start of recording');
+
+    element.play();
+  }
+}
+
+manager.runTests(gMediaRecorderVideoTests, startTest);
+</script>
+</pre>
+</body>
+</html>

--- a/dom/webidl/MediaRecorder.webidl
+++ b/dom/webidl/MediaRecorder.webidl
@@ -51,4 +51,7 @@ interface MediaRecorder : EventTarget {
 
 dictionary MediaRecorderOptions {
   DOMString mimeType = ""; // Default encoding mimeType.
+  unsigned long audioBitsPerSecond;
+  unsigned long videoBitsPerSecond;
+  unsigned long bitsPerSecond;
 };


### PR DESCRIPTION
Listed on BMO as a blocker (of a blocker) for enabling FFmpeg. I can confirm that it compiles with no problems, but unfortunately I do not have a mic or camera to be able to test. Sorry :(

For reference:
BMO: [1161276](https://bugzilla.mozilla.org/show_bug.cgi?id=1161276)
MDN: [MediaRecorder Web API](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder)
MDN: [Using the MediaStream Recording API](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream_Recording_API/Using_the_MediaStream_Recording_API)