### PR TITLE
Minor fix: DevTools - Network

### DIFF
--- a/toolkit/devtools/netmonitor/netmonitor-view.js
+++ b/toolkit/devtools/netmonitor/netmonitor-view.js
@@ -1797,7 +1797,14 @@ RequestsMenuView.prototype = Heritage.extend(WidgetMethods, {
     if (!aItemsArray.length) {
       return 0;
     }
-    return aItemsArray.reduce((prev, curr) => prev + curr.attachment.contentSize || 0, 0);
+
+    let result = 0;
+    aItemsArray.forEach(item => {
+      let size = item.attachment.contentSize;
+      result += (typeof size == "number") ? size : 0;
+    });
+
+    return result;
   },
 
   /**

--- a/toolkit/devtools/webconsole/network-monitor.js
+++ b/toolkit/devtools/webconsole/network-monitor.js
@@ -344,7 +344,10 @@ NetworkResponseListener.prototype = {
 
     if (!response.mimeType || !NetworkHelper.isTextMimeType(response.mimeType)) {
       response.encoding = "base64";
-      response.text = btoa(response.text);
+      try {
+        response.text = btoa(response.text);
+      }
+      catch (ex) { }
     }
 
     if (response.mimeType && this.request.contentCharset) {


### PR DESCRIPTION
__Steps to reproduce (e.g.):__

1) Open `DevTools` - `Network`
2) Go to https://www.google.com/maps/@37.3565066,-122.0322134,13z

Throws an errors in Browser Console:
```
TypeError: Cannot convert string to ByteString because
the character at index 0 has value 63377 which is greater than 255.
network-monitor.js:347:22
```

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1240959

---

I've created the new build (x64) and tested.
