### PR TITLE
Revert "Disable audio track when using combined track sourcebuffer"

### DIFF
--- a/dom/media/mediasource/MediaSourceReader.cpp
+++ b/dom/media/mediasource/MediaSourceReader.cpp
@@ -1114,11 +1114,6 @@ MediaSourceReader::ReadMetadata(MediaInfo* aInfo, MetadataTags** aTags)
               mAudioSourceDecoder->GetReader()->GetDecoder()->GetMediaDuration());
   }
 
-  if (mAudioTrack == mVideoTrack) {
-    NS_WARNING("Combined audio/video sourcebuffer, this is an unsupported "
-               "configuration, only using video track");
-    mAudioTrack = nullptr;
-  }
   if (mVideoTrack) {
     MOZ_ASSERT(mVideoTrack->IsReady());
     mVideoSourceDecoder = mVideoTrack->Decoders()[0];


### PR DESCRIPTION
This reverts commit a38b1a6 and seems to resolve #702.

This should also apply cleanly to the 27RelBranch once it's been verified working on Windows.