### PR TITLE
[Suggestion] Minor fix: Status Bar - Status Text - null

### DIFF
--- a/browser/components/statusbar/content/urlbarBindings.xml
+++ b/browser/components/statusbar/content/urlbarBindings.xml
@@ -178,8 +178,8 @@
 					this._status = aURL;
 
 					// Hide the over-link immediately if necessary.
-					if((!aURL && (XULBrowserWindow.hideOverLinkImmediately
-					   || this._hideOverLinkImmediately)) || this.focused)
+					if(!aURL && (XULBrowserWindow.hideOverLinkImmediately
+					   || this._hideOverLinkImmediately))
 					{
 						this._setOverLinkState(null);
 						return;


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/issues/700#issuecomment-262497785:

![1](https://cloud.githubusercontent.com/assets/2373486/20594614/2ea5c31e-b237-11e6-9a44-92b01026f5c3.png)

Status text is initially `null`.
___

But I'm not sure if you want it that way...

---

I've created the new build (x64) and tested.
