### PR TITLE
Don't use a FallibleTArray as backend for MediaRawData

### DIFF
--- a/dom/media/MediaData.cpp
+++ b/dom/media/MediaData.cpp
@@ -482,15 +482,13 @@ VideoData::Create(const VideoInfo& aInfo,
 // For 32-bytes aligned, use 31U.
 #define RAW_DATA_ALIGNMENT 31U
 
-#define RAW_DATA_DEFAULT_SIZE 4096
-
 MediaRawData::MediaRawData()
   : MediaData(RAW_DATA)
   , mCrypto(mCryptoInternal)
   , mData(nullptr)
   , mSize(0)
-  , mBuffer(new MediaLargeByteBuffer(RAW_DATA_DEFAULT_SIZE))
-  , mPadding(0)
+  , mBuffer(nullptr)
+  , mCapacity(0)
 {
 }
 
@@ -499,14 +497,13 @@ MediaRawData::MediaRawData(const uint8_t* aData, size_t aSize)
   , mCrypto(mCryptoInternal)
   , mData(nullptr)
   , mSize(0)
-  , mBuffer(new MediaLargeByteBuffer(RAW_DATA_DEFAULT_SIZE))
-  , mPadding(0)
+  , mBuffer(nullptr)
+  , mCapacity(0)
 {
   if (!EnsureCapacity(aSize)) {
     return;
   }
-  mBuffer->AppendElements(aData, aSize);
-  mBuffer->AppendElements(RAW_DATA_ALIGNMENT);
+  memcpy(mData, aData, aSize);
   mSize = aSize;
 }
 
@@ -525,40 +522,38 @@ MediaRawData::Clone() const
     if (!s->EnsureCapacity(mSize)) {
       return nullptr;
     }
-    s->mBuffer->AppendElements(mData, mSize);
-    s->mBuffer->AppendElements(RAW_DATA_ALIGNMENT);
+    memcpy(s->mData, mData, mSize);
     s->mSize = mSize;
   }
   return s.forget();
 }
 
+// EnsureCapacity ensures that the buffer is big enough to hold
+// aSize. It doesn't set the mSize. It's up to the caller to adjust it.
 bool
 MediaRawData::EnsureCapacity(size_t aSize)
 {
-  if (mData && mBuffer->Capacity() >= aSize + RAW_DATA_ALIGNMENT * 2) {
+  const size_t sizeNeeded = aSize + RAW_DATA_ALIGNMENT * 2;
+
+  if (mData && mCapacity >= sizeNeeded) {
     return true;
   }
-  if (!mBuffer->SetCapacity(aSize + RAW_DATA_ALIGNMENT * 2)) {
+  nsAutoArrayPtr<uint8_t> newBuffer;
+  newBuffer = new (fallible) uint8_t[sizeNeeded];
+  if (!newBuffer) {
     return false;
   }
   // Find alignment address.
   const uintptr_t alignmask = RAW_DATA_ALIGNMENT;
-  mData = reinterpret_cast<uint8_t*>(
-    (reinterpret_cast<uintptr_t>(mBuffer->Elements()) + alignmask) & ~alignmask);
-  MOZ_ASSERT(uintptr_t(mData) % (RAW_DATA_ALIGNMENT+1) == 0);
+  uint8_t* newData = reinterpret_cast<uint8_t*>(
+    (reinterpret_cast<uintptr_t>(newBuffer.get()) + alignmask) & ~alignmask);
+  MOZ_ASSERT(uintptr_t(newData) % (RAW_DATA_ALIGNMENT+1) == 0);
+  memcpy(newData, mData, mSize);
 
-  // Shift old data according to new padding.
-  uint32_t oldpadding = int32_t(mPadding);
-  mPadding = mData - mBuffer->Elements();
-  int32_t shift = int32_t(mPadding) - int32_t(oldpadding);
+  mBuffer = newBuffer.forget();
+  mCapacity = sizeNeeded;
+  mData = newData;
 
-  if (shift == 0) {
-    // Nothing to do.
-  } else if (shift > 0) {
-    mBuffer->InsertElementsAt(oldpadding, shift);
-  } else {
-    mBuffer->RemoveElementsAt(mPadding, -shift);
-  }
   return true;
 }
 
@@ -569,7 +564,7 @@ MediaRawData::~MediaRawData()
 size_t
 MediaRawData::SizeOfIncludingThis(MallocSizeOf aMallocSizeOf) const
 {
-  size_t size = aMallocSizeOf(this);
+  size += aMallocSizeOf(mBuffer.get());
 
   if (mExtraData) {
     size += mExtraData->SizeOfIncludingThis(aMallocSizeOf);
@@ -587,7 +582,6 @@ MediaRawData::CreateWriter()
 MediaRawDataWriter::MediaRawDataWriter(MediaRawData* aMediaRawData)
   : mCrypto(aMediaRawData->mCryptoInternal)
   , mTarget(aMediaRawData)
-  , mBuffer(aMediaRawData->mBuffer.get())
 {
 }
 
@@ -609,8 +603,6 @@ MediaRawDataWriter::SetSize(size_t aSize)
   if (aSize > mTarget->mSize && !EnsureSize(aSize)) {
     return false;
   }
-  // Pad our buffer.
-  mBuffer->SetLength(aSize + mTarget->mPadding + RAW_DATA_ALIGNMENT);
   mTarget->mSize = aSize;
   return true;
 }
@@ -621,7 +613,9 @@ MediaRawDataWriter::Prepend(const uint8_t* aData, size_t aSize)
   if (!EnsureSize(aSize + mTarget->mSize)) {
     return false;
   }
-  mBuffer->InsertElementsAt(mTarget->mPadding, aData, aSize);
+  // Shift the data to the right by aSize to leave room for the new data.
+  memmove(mTarget->mData + aSize, mTarget->mData, mTarget->mSize);
+  memcpy(mTarget->mData, aData, aSize);
   mTarget->mSize += aSize;
   return true;
 }
@@ -629,10 +623,12 @@ MediaRawDataWriter::Prepend(const uint8_t* aData, size_t aSize)
 bool
 MediaRawDataWriter::Replace(const uint8_t* aData, size_t aSize)
 {
+  // If aSize is smaller than our current size, we leave the buffer as is,
+  // only adjusting the reported size.
   if (!EnsureSize(aSize)) {
     return false;
   }
-  mBuffer->ReplaceElementsAt(mTarget->mPadding, mTarget->mSize, aData, aSize);
+  memcpy(mTarget->mData, aData, aSize);
   mTarget->mSize = aSize;
   return true;
 }
@@ -640,7 +636,6 @@ MediaRawDataWriter::Replace(const uint8_t* aData, size_t aSize)
 void
 MediaRawDataWriter::Clear()
 {
-  mBuffer->RemoveElementsAt(mTarget->mPadding, mTarget->mSize);
   mTarget->mSize = 0;
   mTarget->mData = nullptr;
 }

--- a/dom/media/MediaData.cpp
+++ b/dom/media/MediaData.cpp
@@ -564,12 +564,12 @@ MediaRawData::~MediaRawData()
 size_t
 MediaRawData::SizeOfIncludingThis(MallocSizeOf aMallocSizeOf) const
 {
-  size += aMallocSizeOf(mBuffer.get());
+  size_t size = aMallocSizeOf(this);
 
   if (mExtraData) {
-    size += mExtraData->SizeOfIncludingThis(aMallocSizeOf);
+    size += aMallocSizeOf(mExtraData.get());
   }
-  size += mBuffer->SizeOfIncludingThis(aMallocSizeOf);
+  size += aMallocSizeOf(mBuffer.get());
   return size;
 }
 

--- a/dom/media/MediaData.h
+++ b/dom/media/MediaData.h
@@ -345,9 +345,9 @@ class MediaRawDataWriter
 {
 public:
   // Pointer to data or null if not-yet allocated
-  uint8_t* mData;
+  uint8_t* Data();
   // Writeable size of buffer.
-  size_t mSize;
+  size_t Size();
   // Writeable reference to MediaRawData::mCryptoInternal
   CryptoSample& mCrypto;
 
@@ -360,7 +360,7 @@ public:
   bool Prepend(const uint8_t* aData, size_t aSize);
   // Replace current content with aData.
   bool Replace(const uint8_t* aData, size_t aSize);
-  // Clear the memory buffer. Will set mData and mSize to 0.
+  // Clear the memory buffer. Will set target mData and mSize to 0.
   void Clear();
 
 private:
@@ -377,9 +377,15 @@ public:
   MediaRawData(const uint8_t* aData, size_t mSize);
 
   // Pointer to data or null if not-yet allocated
-  const uint8_t* mData;
+  const uint8_t* Data() const
+  {
+    return mData;
+  }
   // Size of buffer.
-  size_t mSize;
+  size_t Size() const
+  {
+    return mSize;
+  }
 
   const CryptoSample& mCrypto;
   nsRefPtr<MediaByteBuffer> mExtraData;
@@ -402,6 +408,8 @@ private:
   // read as required by some data decoders.
   // Returns false if memory couldn't be allocated.
   bool EnsureCapacity(size_t aSize);
+  uint8_t* mData;
+  size_t mSize;
   nsRefPtr<MediaLargeByteBuffer> mBuffer;
   CryptoSample mCryptoInternal;
   uint32_t mPadding;

--- a/dom/media/MediaData.h
+++ b/dom/media/MediaData.h
@@ -368,7 +368,6 @@ private:
   explicit MediaRawDataWriter(MediaRawData* aMediaRawData);
   bool EnsureSize(size_t aSize);
   MediaRawData* mTarget;
-  nsRefPtr<MediaLargeByteBuffer> mBuffer;
 };
 
 class MediaRawData : public MediaData {
@@ -377,15 +376,9 @@ public:
   MediaRawData(const uint8_t* aData, size_t mSize);
 
   // Pointer to data or null if not-yet allocated
-  const uint8_t* Data() const
-  {
-    return mData;
-  }
+  const uint8_t* Data() const { return mData; }
   // Size of buffer.
-  size_t Size() const
-  {
-    return mSize;
-  }
+  size_t Size() const { return mSize; }
 
   const CryptoSample& mCrypto;
   nsRefPtr<MediaByteBuffer> mExtraData;
@@ -410,9 +403,9 @@ private:
   bool EnsureCapacity(size_t aSize);
   uint8_t* mData;
   size_t mSize;
-  nsRefPtr<MediaLargeByteBuffer> mBuffer;
+  nsAutoArrayPtr<uint8_t> mBuffer;
+  uint32_t mCapacity;
   CryptoSample mCryptoInternal;
-  uint32_t mPadding;
   MediaRawData(const MediaRawData&); // Not implemented
 };
 

--- a/dom/media/gmp/GMPAudioHost.cpp
+++ b/dom/media/gmp/GMPAudioHost.cpp
@@ -40,7 +40,7 @@ GMPAudioSamplesImpl::GMPAudioSamplesImpl(MediaRawData* aSample,
  , mChannels(aChannels)
  , mRate(aRate)
 {
-  mBuffer.AppendElements(aSample->mData, aSample->mSize);
+  mBuffer.AppendElements(aSample->Data(), aSample->Size());
   if (aSample->mCrypto.valid) {
     mCrypto = new GMPEncryptedBufferDataImpl(aSample->mCrypto);
   }

--- a/dom/media/platforms/agnostic/gmp/GMPVideoDecoder.cpp
+++ b/dom/media/platforms/agnostic/gmp/GMPVideoDecoder.cpp
@@ -126,13 +126,13 @@ GMPVideoDecoder::CreateFrame(MediaRawData* aSample)
   }
 
   GMPUnique<GMPVideoEncodedFrame>::Ptr frame(static_cast<GMPVideoEncodedFrame*>(ftmp));
-  err = frame->CreateEmptyFrame(aSample->mSize);
+  err = frame->CreateEmptyFrame(aSample->Size());
   if (GMP_FAILED(err)) {
     mCallback->Error();
     return nullptr;
   }
 
-  memcpy(frame->Buffer(), aSample->mData, frame->Size());
+  memcpy(frame->Buffer(), aSample->Data(), frame->Size());
 
   // Convert 4-byte NAL unit lengths to host-endian 4-byte buffer lengths to
   // suit the GMP API.

--- a/dom/media/platforms/android/AndroidDecoderModule.cpp
+++ b/dom/media/platforms/android/AndroidDecoderModule.cpp
@@ -464,7 +464,7 @@ void MediaCodecDataDecoder::DecoderLoop()
 
         void* directBuffer = frame.GetEnv()->GetDirectBufferAddress(buffer.Get());
 
-        MOZ_ASSERT(frame.GetEnv()->GetDirectBufferCapacity(buffer.Get()) >= sample->mSize,
+        MOZ_ASSERT(frame.GetEnv()->GetDirectBufferCapacity(buffer.Get()) >= sample->Size(),
           "Decoder buffer is not large enough for sample");
 
         {
@@ -473,9 +473,9 @@ void MediaCodecDataDecoder::DecoderLoop()
           mQueue.pop();
         }
 
-        PodCopy((uint8_t*)directBuffer, sample->mData, sample->mSize);
+        PodCopy((uint8_t*)directBuffer, sample->Data(), sample->Size());
 
-        res = mDecoder->QueueInputBuffer(inputIndex, 0, sample->mSize,
+        res = mDecoder->QueueInputBuffer(inputIndex, 0, sample->Size(),
                                          sample->mTime, 0);
         HANDLE_DECODER_ERROR();
 

--- a/dom/media/platforms/apple/AppleATDecoder.cpp
+++ b/dom/media/platforms/apple/AppleATDecoder.cpp
@@ -73,7 +73,7 @@ AppleATDecoder::Input(MediaRawData* aSample)
       aSample->mDuration,
       aSample->mTime,
       aSample->mKeyframe ? " keyframe" : "",
-      (unsigned long long)aSample->mSize);
+      (unsigned long long)aSample->Size());
 
   // Queue a task to perform the actual decoding on a separate thread.
   mTaskQueue->Dispatch(
@@ -222,7 +222,7 @@ AppleATDecoder::DecodeSample(MediaRawData* aSample)
   // This API insists on having packets spoon-fed to it from a callback.
   // This structure exists only to pass our state.
   PassthroughUserData userData =
-    { channels, (UInt32)aSample->mSize, aSample->mData };
+    { channels, (UInt32)aSample->Size(), aSample->Data() };
 
   // Decompressed audio buffer
   nsAutoArrayPtr<AudioDataValue> decoded(new AudioDataValue[maxDecodedSamples]);
@@ -494,8 +494,8 @@ AppleATDecoder::GetImplicitAACMagicCookie(const MediaRawData* aSample)
   }
 
   OSStatus status = AudioFileStreamParseBytes(mStream,
-                                              adtssample->mSize,
-                                              adtssample->mData,
+                                              adtssample->Size(),
+                                              adtssample->Size(),
                                               0 /* discontinuity */);
   if (status) {
     NS_WARNING("Couldn't parse sample");

--- a/dom/media/platforms/apple/AppleVDADecoder.cpp
+++ b/dom/media/platforms/apple/AppleVDADecoder.cpp
@@ -104,7 +104,7 @@ AppleVDADecoder::Input(MediaRawData* aSample)
       aSample->mTime,
       aSample->mDuration,
       aSample->mKeyframe ? " keyframe" : "",
-      aSample->mSize);
+      aSample->Size());
 
   mTaskQueue->Dispatch(
       NS_NewRunnableMethodWithArg<nsRefPtr<MediaRawData>>(
@@ -302,7 +302,7 @@ nsresult
 AppleVDADecoder::SubmitFrame(MediaRawData* aSample)
 {
   AutoCFRelease<CFDataRef> block =
-    CFDataCreate(kCFAllocatorDefault, aSample->mData, aSample->mSize);
+    CFDataCreate(kCFAllocatorDefault, aSample->Data(), aSample->Size());
   if (!block) {
     NS_ERROR("Couldn't create CFData");
     return NS_ERROR_FAILURE;

--- a/dom/media/platforms/apple/AppleVTDecoder.cpp
+++ b/dom/media/platforms/apple/AppleVTDecoder.cpp
@@ -86,7 +86,7 @@ AppleVTDecoder::Input(MediaRawData* aSample)
       aSample->mTime,
       aSample->mDuration,
       aSample->mKeyframe ? " keyframe" : "",
-      aSample->mSize);
+      aSample->Size());
 
 #ifdef LOG_MEDIA_SHA1
   SHA1Sum hash;
@@ -216,12 +216,12 @@ AppleVTDecoder::SubmitFrame(MediaRawData* aSample)
   // But note that there may be a problem keeping the samples
   // alive over multiple frames.
   rv = CMBlockBufferCreateWithMemoryBlock(kCFAllocatorDefault, // Struct allocator.
-                                          const_cast<uint8_t*>(aSample->mData),
-                                          aSample->mSize,
+                                          const_cast<uint8_t*>(aSample->Data()),
+                                          aSample->Size(),
                                           kCFAllocatorNull, // Block allocator.
                                           NULL, // Block source.
                                           0,    // Data offset.
-                                          aSample->mSize,
+                                          aSample->Size(),
                                           false,
                                           block.receive());
   if (rv != noErr) {

--- a/dom/media/platforms/ffmpeg/FFmpegAudioDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegAudioDecoder.cpp
@@ -87,8 +87,8 @@ FFmpegAudioDecoder<LIBAV_VER>::DecodePacket(MediaRawData* aSample)
   AVPacket packet;
   av_init_packet(&packet);
 
-  packet.data = const_cast<uint8_t*>(aSample->mData);
-  packet.size = aSample->mSize;
+  packet.data = const_cast<uint8_t*>(aSample->Data());
+  packet.size = aSample->Size();
 
   if (!PrepareFrame()) {
     NS_WARNING("FFmpeg audio decoder failed to allocate frame.");

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -55,8 +55,8 @@ FFmpegH264Decoder<LIBAV_VER>::DoDecodeFrame(MediaRawData* aSample)
   AVPacket packet;
   av_init_packet(&packet);
 
-  packet.data = const_cast<uint8_t*>(aSample->mData);
-  packet.size = aSample->mSize;
+  packet.data = const_cast<uint8_t*>(aSample->Data());
+  packet.size = aSample->Size();
   packet.dts = aSample->mTimecode;
   packet.pts = aSample->mTime;
   packet.flags = aSample->mKeyframe ? AV_PKT_FLAG_KEY : 0;

--- a/dom/media/platforms/gonk/GonkAudioDecoderManager.cpp
+++ b/dom/media/platforms/gonk/GonkAudioDecoderManager.cpp
@@ -109,8 +109,8 @@ GonkAudioDecoderManager::Init(MediaDataDecoderCallback* aCallback)
 status_t
 GonkAudioDecoderManager::SendSampleToOMX(MediaRawData* aSample)
 {
-  return mDecoder->Input(reinterpret_cast<const uint8_t*>(aSample->mData),
-                         aSample->mSize,
+  return mDecoder->Input(reinterpret_cast<const uint8_t*>(aSample->Data()),
+                         aSample->Size(),
                          aSample->mTime,
                          0);
 }

--- a/dom/media/platforms/gonk/GonkVideoDecoderManager.cpp
+++ b/dom/media/platforms/gonk/GonkVideoDecoderManager.cpp
@@ -447,8 +447,8 @@ GonkVideoDecoderManager::SendSampleToOMX(MediaRawData* aSample)
     QueueFrameTimeIn(aSample->mTime, aSample->mDuration);
   }
 
-  return mDecoder->Input(reinterpret_cast<const uint8_t*>(aSample->mData),
-                         aSample->mSize,
+  return mDecoder->Input(reinterpret_cast<const uint8_t*>(aSample->Data()),
+                         aSample->Size(),
                          aSample->mTime,
                          0);
 }

--- a/dom/media/platforms/wmf/WMFAudioMFTManager.cpp
+++ b/dom/media/platforms/wmf/WMFAudioMFTManager.cpp
@@ -179,8 +179,8 @@ WMFAudioMFTManager::Init()
 HRESULT
 WMFAudioMFTManager::Input(MediaRawData* aSample)
 {
-  return mDecoder->Input(aSample->mData,
-                         uint32_t(aSample->mSize),
+  return mDecoder->Input(aSample->Data(),
+                         uint32_t(aSample->Size()),
                          aSample->mTime);
 }
 

--- a/dom/media/webm/IntelWebMVideoDecoder.cpp
+++ b/dom/media/webm/IntelWebMVideoDecoder.cpp
@@ -224,7 +224,7 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
                             data,
                             length,
                             si.is_kf);
-    if (!aSample->mData) {
+    if (!aSample->Data()) {
       return false;
     }
   }

--- a/media/libstagefright/binding/Adts.cpp
+++ b/media/libstagefright/binding/Adts.cpp
@@ -37,7 +37,7 @@ Adts::ConvertSample(uint16_t aChannelCount, int8_t aFrequencyIndex,
 {
   static const int kADTSHeaderSize = 7;
 
-  size_t newSize = aSample->mSize + kADTSHeaderSize;
+  size_t newSize = aSample->Size() + kADTSHeaderSize;
 
   // ADTS header uses 13 bits for packet size.
   if (newSize >= (1 << 13) || aChannelCount > 15 ||
@@ -63,7 +63,7 @@ Adts::ConvertSample(uint16_t aChannelCount, int8_t aFrequencyIndex,
   if (aSample->mCrypto.valid) {
     if (aSample->mCrypto.plain_sizes.Length() == 0) {
       writer->mCrypto.plain_sizes.AppendElement(kADTSHeaderSize);
-      writer->mCrypto.encrypted_sizes.AppendElement(aSample->mSize - kADTSHeaderSize);
+      writer->mCrypto.encrypted_sizes.AppendElement(aSample->Size() - kADTSHeaderSize);
     } else {
       writer->mCrypto.plain_sizes[0] += kADTSHeaderSize;
     }

--- a/media/libstagefright/binding/AnnexB.cpp
+++ b/media/libstagefright/binding/AnnexB.cpp
@@ -24,18 +24,18 @@ AnnexB::ConvertSampleToAnnexB(mozilla::MediaRawData* aSample)
   if (!IsAVCC(aSample)) {
     return true;
   }
-  MOZ_ASSERT(aSample->mData);
+  MOZ_ASSERT(aSample->Data());
 
   if (!ConvertSampleTo4BytesAVCC(aSample)) {
     return false;
   }
 
-  if (aSample->mSize < 4) {
+  if (aSample->Size() < 4) {
     // Nothing to do, it's corrupted anyway.
     return true;
   }
 
-  ByteReader reader(aSample->mData, aSample->mSize);
+  ByteReader reader(aSample->Data(), aSample->Size());
 
   mozilla::Vector<uint8_t> tmp;
   ByteWriter writer(tmp);
@@ -226,7 +226,7 @@ AnnexB::ConvertSampleToAVCC(mozilla::MediaRawData* aSample)
 
   mozilla::Vector<uint8_t> nalu;
   ByteWriter writer(nalu);
-  ByteReader reader(aSample->mData, aSample->mSize);
+  ByteReader reader(aSample->Data(), aSample->Size());
 
   ParseNALUnits(writer, reader);
   nsAutoPtr<MediaRawDataWriter> samplewriter(aSample->CreateWriter());
@@ -263,7 +263,7 @@ AnnexB::ExtractExtraData(const mozilla::MediaRawData* aSample)
     // ConvertSampleToAVCC.
     nalLenSize = 4;
   }
-  ByteReader reader(aSample->mData, aSample->mSize);
+  ByteReader reader(aSample->Data(), aSample->Size());
 
   // Find SPS and PPS NALUs in AVCC data
   while (reader.Remaining() > nalLenSize) {
@@ -344,7 +344,7 @@ AnnexB::ConvertSampleTo4BytesAVCC(mozilla::MediaRawData* aSample)
   }
   mozilla::Vector<uint8_t> dest;
   ByteWriter writer(dest);
-  ByteReader reader(aSample->mData, aSample->mSize);
+  ByteReader reader(aSample->Data(), aSample->Size());
   while (reader.Remaining() > nalLenSize) {
     uint32_t nalLen;
     switch (nalLenSize) {
@@ -367,17 +367,17 @@ AnnexB::ConvertSampleTo4BytesAVCC(mozilla::MediaRawData* aSample)
 bool
 AnnexB::IsAVCC(const mozilla::MediaRawData* aSample)
 {
-  return aSample->mSize >= 3 && aSample->mExtraData &&
+  return aSample->Size() >= 3 && aSample->mExtraData &&
     aSample->mExtraData->Length() >= 7 && (*aSample->mExtraData)[0] == 1;
 }
 
 bool
 AnnexB::IsAnnexB(const mozilla::MediaRawData* aSample)
 {
-  if (aSample->mSize < 4) {
+  if (aSample->Size() < 4) {
     return false;
   }
-  uint32_t header = mozilla::BigEndian::readUint32(aSample->mData);
+  uint32_t header = mozilla::BigEndian::readUint32(aSample->Data());
   return header == 0x00000001 || (header >> 8) == 0x000001;
 }
 

--- a/media/libstagefright/binding/Index.cpp
+++ b/media/libstagefright/binding/Index.cpp
@@ -112,8 +112,8 @@ already_AddRefed<MediaRawData> SampleIterator::GetNext()
   }
 
   size_t bytesRead;
-  if (!mIndex->mSource->ReadAt(sample->mOffset, writer->mData, sample->mSize,
-                               &bytesRead) || bytesRead != sample->mSize) {
+  if (!mIndex->mSource->ReadAt(sample->mOffset, writer->Data(), sample->Size(),
+                               &bytesRead) || bytesRead != sample->Size()) {
     return nullptr;
   }
 
@@ -155,7 +155,7 @@ already_AddRefed<MediaRawData> SampleIterator::GetNext()
     } else {
       // No subsample information means the entire sample is encrypted.
       writer->mCrypto.plain_sizes.AppendElement(0);
-      writer->mCrypto.encrypted_sizes.AppendElement(sample->mSize);
+      writer->mCrypto.encrypted_sizes.AppendElement(sample->Size());
     }
   }
 


### PR DESCRIPTION
This PR heads off some potential memory inflation in MediaRawData. Also fixes build bustage for some of my local ffmpeg patches that I will be testing and submitting soon.

These patches tested and appear to work as intended on Linux.