### PR TITLE
Enable MediaFormatReader in MP4Decoder & MediaSourceReader

### DIFF
--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -27,7 +27,7 @@ namespace mozilla {
 MediaDecoderStateMachine* MP4Decoder::CreateStateMachine()
 {
   bool useFormatDecoder =
-    Preferences::GetBool("media.format-reader.mp4", false);
+    Preferences::GetBool("media.format-reader.mp4", true);
   nsRefPtr<MediaDecoderReader> reader = useFormatDecoder ?
     static_cast<MediaDecoderReader*>(new MediaFormatReader(this, new MP4Demuxer(GetResource()))) :
     static_cast<MediaDecoderReader*>(new MP4Reader(this));

--- a/dom/media/mediasource/MediaSourceReader.cpp
+++ b/dom/media/mediasource/MediaSourceReader.cpp
@@ -669,7 +669,7 @@ CreateReaderForType(const nsACString& aType, AbstractMediaDecoder* aDecoder)
        aType.LowerCaseEqualsLiteral("audio/mp4")) &&
       MP4Decoder::IsEnabled() && aDecoder) {
     bool useFormatDecoder =
-      Preferences::GetBool("media.mediasource.format-reader.mp4", false);
+      Preferences::GetBool("media.mediasource.format-reader.mp4", true);
     MediaDecoderReader* reader = useFormatDecoder ?
       static_cast<MediaDecoderReader*>(new MediaFormatReader(aDecoder, new MP4Demuxer(aDecoder->GetResource()))) :
       static_cast<MediaDecoderReader*>(new MP4Reader(aDecoder));


### PR DESCRIPTION
Just what it says in the tin. Fixes an accidental overlook on my part.

Tested and works as intended on Linux.