### PR TITLE
Make the "-disable-precompiled-startupcache" option actually work

### DIFF
--- a/toolkit/mozapps/installer/packager.py
+++ b/toolkit/mozapps/installer/packager.py
@@ -376,7 +376,8 @@ def main():
 
     # Fill startup cache
     if isinstance(formatter, OmniJarFormatter) and launcher.can_launch() \
-      and buildconfig.substs['MOZ_DISABLE_STARTUPCACHE'] != '1':
+      and buildconfig.substs['MOZ_DISABLE_STARTUPCACHE'] != '1' \
+      and buildconfig.substs['MOZ_DISABLE_PRECOMPILED_STARTUPCACHE'] != '1':
         if buildconfig.substs.get('LIBXUL_SDK'):
             gre_path = mozpath.join(buildconfig.substs['LIBXUL_DIST'],
                                          'bin')


### PR DESCRIPTION
The --disable-precompiled-startupcache configure option no longer works in v27. This PR fixes that regression.