### PR TITLE
FFmpeg fixes

### DIFF
--- a/dom/media/platforms/PlatformDecoderModule.cpp
+++ b/dom/media/platforms/PlatformDecoderModule.cpp
@@ -166,12 +166,20 @@ PlatformDecoderModule::CreateDecoder(const TrackInfo& aConfig,
   }
 
   if (H264Converter::IsH264(aConfig)) {
-    m = new H264Converter(this,
+    nsRefPtr<H264Converter> h
+      = new H264Converter(this,
                           *aConfig.GetAsVideoInfo(),
                           aLayersBackend,
                           aImageContainer,
                           aTaskQueue,
                           aCallback);
+    const nsresult rv = h->GetLastError();
+    if (NS_SUCCEEDED(rv) || rv == NS_ERROR_NOT_INITIALIZED) {
+      // The H264Converter either successfully created the wrapped decoder,
+      // or there wasn't enough AVCC data to do so. Otherwise, there was some
+      // problem, for example WMF DLLs were missing.
+      m = h.forget();
+    }
   } else {
     m = CreateVideoDecoder(*aConfig.GetAsVideoInfo(),
                            aLayersBackend,

--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
@@ -135,7 +135,9 @@ nsresult
 FFmpegDataDecoder<LIBAV_VER>::Flush()
 {
   mTaskQueue->Flush();
-  avcodec_flush_buffers(mCodecContext);
+  if (mCodecContext) {
+    avcodec_flush_buffers(mCodecContext);
+  }
   return NS_OK;
 }
 

--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
@@ -146,7 +146,7 @@ FFmpegDataDecoder<LIBAV_VER>::Shutdown()
 {
   StaticMutexAutoLock mon(sMonitor);
 
-  if (sFFmpegInitDone) {
+  if (sFFmpegInitDone && mCodecContext) {
     avcodec_close(mCodecContext);
     av_freep(&mCodecContext);
 #if LIBAVCODEC_VERSION_MAJOR >= 55

--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
@@ -65,7 +65,7 @@ FFmpegDataDecoder<LIBAV_VER>::Init()
   FFMPEG_LOG("Initialising FFmpeg decoder.");
 
   if (!sFFmpegInitDone) {
-    av_register_all();
+    avcodec_register_all();
 #ifdef DEBUG
     av_log_set_level(AV_LOG_DEBUG);
 #endif

--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
@@ -12,6 +12,7 @@
 #include "FFmpegLog.h"
 #include "FFmpegDataDecoder.h"
 #include "prsystem.h"
+#include "FFmpegDecoderModule.h"
 
 namespace mozilla
 {
@@ -85,7 +86,11 @@ FFmpegDataDecoder<LIBAV_VER>::Init()
   mCodecContext->opaque = this;
 
   // FFmpeg takes this as a suggestion for what format to use for audio samples.
-  mCodecContext->request_sample_fmt = AV_SAMPLE_FMT_FLT;
+  uint32_t major, minor;
+  FFmpegDecoderModule<LIBAV_VER>::GetVersion(major, minor);
+  // LibAV 0.8 produces rubbish float interlaved samples, request 16 bits audio.
+  mCodecContext->request_sample_fmt = major == 53 && minor <= 34 ?
+    AV_SAMPLE_FMT_S16 : AV_SAMPLE_FMT_FLT;
 
   // FFmpeg will call back to this to negotiate a video pixel format.
   mCodecContext->get_format = ChoosePixelFormat;

--- a/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
+++ b/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
@@ -25,6 +25,15 @@ public:
     return pdm.forget();
   }
 
+  static bool
+  GetVersion(uint32_t& aMajor, uint32_t& aMinor)
+  {
+    uint32_t version = avcodec_version();
+    aMajor = (version >> 16) & 0xff;
+    aMinor = (version >> 8) & 0xff;
+    return true;
+  }
+
   FFmpegDecoderModule() {}
   virtual ~FFmpegDecoderModule() {}
 

--- a/dom/media/platforms/ffmpeg/FFmpegFunctionList.h
+++ b/dom/media/platforms/ffmpeg/FFmpegFunctionList.h
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* libavformat */
-AV_FUNC(av_register_all, 0)
-
 /* libavcodec */
 AV_FUNC(avcodec_align_dimensions2, 0)
 AV_FUNC(avcodec_get_frame_defaults, 0)
@@ -21,6 +18,7 @@ AV_FUNC(avcodec_open2, 0)
 AV_FUNC(av_init_packet, 0)
 AV_FUNC(av_dict_get, 0)
 AV_FUNC(avcodec_version, 0)
+AV_FUNC(avcodec_register_all, 0)
 
 /* libavutil */
 AV_FUNC(av_image_fill_linesizes, 0)

--- a/dom/media/platforms/ffmpeg/FFmpegFunctionList.h
+++ b/dom/media/platforms/ffmpeg/FFmpegFunctionList.h
@@ -20,6 +20,7 @@ AV_FUNC(avcodec_get_edge_width, 0)
 AV_FUNC(avcodec_open2, 0)
 AV_FUNC(av_init_packet, 0)
 AV_FUNC(av_dict_get, 0)
+AV_FUNC(avcodec_version, 0)
 
 /* libavutil */
 AV_FUNC(av_image_fill_linesizes, 0)

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -13,6 +13,7 @@
 
 #include "FFmpegH264Decoder.h"
 #include "FFmpegLog.h"
+#include "mozilla/PodOperations.h"
 
 #define GECKO_FRAME_TYPE 0x00093CC0
 
@@ -202,32 +203,34 @@ FFmpegH264Decoder<LIBAV_VER>::AllocateYUV420PVideoBuffer(
   AVCodecContext* aCodecContext, AVFrame* aFrame)
 {
   bool needAlign = aCodecContext->codec->capabilities & CODEC_CAP_DR1;
-  int edgeWidth =  needAlign ? avcodec_get_edge_width() : 0;
+  bool needEdge = !(aCodecContext->flags & CODEC_FLAG_EMU_EDGE);
+  int edgeWidth = needEdge ? avcodec_get_edge_width() : 0;
+
   int decodeWidth = aCodecContext->width + edgeWidth * 2;
-  // Make sure the decodeWidth is a multiple of 32, so a UV plane stride will be
-  // a multiple of 16. FFmpeg uses SSE2 accelerated code to copy a frame line by
-  // line.
-  decodeWidth = (decodeWidth + 31) & ~31;
   int decodeHeight = aCodecContext->height + edgeWidth * 2;
 
   if (needAlign) {
-    // Align width and height to account for CODEC_FLAG_EMU_EDGE.
-    int stride_align[AV_NUM_DATA_POINTERS];
-    avcodec_align_dimensions2(aCodecContext, &decodeWidth, &decodeHeight,
-                              stride_align);
+    // Align width and height to account for CODEC_CAP_DR1.
+    // Make sure the decodeWidth is a multiple of 64, so a UV plane stride will be
+    // a multiple of 32. FFmpeg uses SSE3 accelerated code to copy a frame line by
+    // line.
+    // VP9 decoder uses MOVAPS/VEX.256 which requires 32-bytes aligned memory.
+    decodeWidth = (decodeWidth + 63) & ~63;
+    decodeHeight = (decodeHeight + 63) & ~63;
   }
 
-  // Get strides for each plane.
-  av_image_fill_linesizes(aFrame->linesize, aCodecContext->pix_fmt,
-                          decodeWidth);
+  PodZero(&aFrame->data[0], AV_NUM_DATA_POINTERS);
+  PodZero(&aFrame->linesize[0], AV_NUM_DATA_POINTERS);
 
-  // Let FFmpeg set up its YUV plane pointers and tell us how much memory we
-  // need.
-  // Note that we're passing |nullptr| here as the base address as we haven't
-  // allocated our image yet. We will adjust |aFrame->data| below.
-  size_t allocSize =
-    av_image_fill_pointers(aFrame->data, aCodecContext->pix_fmt, decodeHeight,
-                           nullptr /* base address */, aFrame->linesize);
+  int pitch = decodeWidth;
+  int chroma_pitch  = (pitch + 1) / 2;
+  int chroma_height = (decodeHeight +1) / 2;
+
+  // Get strides for each plane.
+  aFrame->linesize[0] = pitch;
+  aFrame->linesize[1] = aFrame->linesize[2] = chroma_pitch;
+
+  size_t allocSize = pitch * decodeHeight + (chroma_pitch * chroma_height) * 2;
 
   nsRefPtr<Image> image =
     mImageContainer->CreateImage(ImageFormat::PLANAR_YCBCR);
@@ -241,18 +244,20 @@ FFmpegH264Decoder<LIBAV_VER>::AllocateYUV420PVideoBuffer(
     return -1;
   }
 
-  // Now that we've allocated our image, we can add its address to the offsets
-  // set by |av_image_fill_pointers| above. We also have to add |edgeWidth|
-  // pixels of padding here.
-  for (uint32_t i = 0; i < AV_NUM_DATA_POINTERS; i++) {
-    // The C planes are half the resolution of the Y plane, so we need to halve
-    // the edge width here.
-    uint32_t planeEdgeWidth = edgeWidth / (i ? 2 : 1);
+  int offsets[3] = {
+    0,
+    pitch * decodeHeight,
+    pitch * decodeHeight + chroma_pitch * chroma_height };
 
-    // Add buffer offset, plus a horizontal bar |edgeWidth| pixels high at the
-    // top of the frame, plus |edgeWidth| pixels from the left of the frame.
-    aFrame->data[i] += reinterpret_cast<ptrdiff_t>(
-      buffer + planeEdgeWidth * aFrame->linesize[i] + planeEdgeWidth);
+  // Add a horizontal bar |edgeWidth| pixels high at the
+  // top of the frame, plus |edgeWidth| pixels from the left of the frame.
+  int planesEdgeWidth[3] = {
+    edgeWidth * aFrame->linesize[0] + edgeWidth,
+    edgeWidth / 2 * aFrame->linesize[1] + edgeWidth / 2,
+    edgeWidth / 2 * aFrame->linesize[2] + edgeWidth / 2 };
+
+  for (uint32_t i = 0; i < 3; i++) {
+    aFrame->data[i] = buffer + offsets[i] + planesEdgeWidth[i];
   }
 
   // Unused, but needs to be non-zero to keep ffmpeg happy.

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -30,6 +30,8 @@ FFmpegH264Decoder<LIBAV_VER>::FFmpegH264Decoder(
   : FFmpegDataDecoder(aTaskQueue, GetCodecId(aConfig.mMimeType))
   , mCallback(aCallback)
   , mImageContainer(aImageContainer)
+  , mPictureWidth(aConfig.mImage.width)
+  , mPictureHeight(aConfig.mImage.height)
   , mDisplayWidth(aConfig.mDisplay.width)
   , mDisplayHeight(aConfig.mDisplay.height)
 {
@@ -47,6 +49,8 @@ FFmpegH264Decoder<LIBAV_VER>::Init()
 
   mCodecContext->get_buffer = AllocateBufferCb;
   mCodecContext->release_buffer = ReleaseBufferCb;
+  mCodecContext->width = mPictureWidth;
+  mCodecContext->height = mPictureHeight;
 
   return NS_OK;
 }

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
@@ -59,6 +59,7 @@ private:
 
   static int AllocateBufferCb(AVCodecContext* aCodecContext, AVFrame* aFrame);
   static void ReleaseBufferCb(AVCodecContext* aCodecContext, AVFrame* aFrame);
+  int64_t GetPts(const AVPacket& packet);
 
   MediaDataDecoderCallback* mCallback;
   nsRefPtr<ImageContainer> mImageContainer;

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
@@ -63,6 +63,8 @@ private:
 
   MediaDataDecoderCallback* mCallback;
   nsRefPtr<ImageContainer> mImageContainer;
+  uint32_t mPictureWidth;
+  uint32_t mPictureHeight;
   uint32_t mDisplayWidth;
   uint32_t mDisplayHeight;
 };

--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
@@ -32,6 +32,7 @@ public:
 };
 
 static const AvFormatLib sLibs[] = {
+  { "libavformat-ffmpeg.so.56", FFmpegDecoderModule<55>::Create, 55 },
   { "libavformat.so.56", FFmpegDecoderModule<55>::Create, 55 },
   { "libavformat.so.55", FFmpegDecoderModule<55>::Create, 55 },
   { "libavformat.so.54", FFmpegDecoderModule<54>::Create, 54 },

--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
@@ -18,7 +18,7 @@ namespace mozilla
 FFmpegRuntimeLinker::LinkStatus FFmpegRuntimeLinker::sLinkStatus =
   LinkStatus_INIT;
 
-struct AvFormatLib
+struct AvCodecLib
 {
   const char* Name;
   already_AddRefed<PlatformDecoderModule> (*Factory)();
@@ -31,20 +31,20 @@ public:
   static already_AddRefed<PlatformDecoderModule> Create();
 };
 
-static const AvFormatLib sLibs[] = {
-  { "libavformat-ffmpeg.so.56", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavformat.so.56", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavformat.so.55", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavformat.so.54", FFmpegDecoderModule<54>::Create, 54 },
-  { "libavformat.so.53", FFmpegDecoderModule<53>::Create, 53 },
-  { "libavformat.56.dylib", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavformat.55.dylib", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavformat.54.dylib", FFmpegDecoderModule<54>::Create, 54 },
-  { "libavformat.53.dylib", FFmpegDecoderModule<53>::Create, 53 },
+static const AvCodecLib sLibs[] = {
+  { "libavcodec-ffmpeg.so.56", FFmpegDecoderModule<55>::Create, 55 },
+  { "libavcodec.so.56", FFmpegDecoderModule<55>::Create, 55 },
+  { "libavcodec.so.55", FFmpegDecoderModule<55>::Create, 55 },
+  { "libavcodec.so.54", FFmpegDecoderModule<54>::Create, 54 },
+  { "libavcodec.so.53", FFmpegDecoderModule<53>::Create, 53 },
+  { "libavcodec.56.dylib", FFmpegDecoderModule<55>::Create, 55 },
+  { "libavcodec.55.dylib", FFmpegDecoderModule<55>::Create, 55 },
+  { "libavcodec.54.dylib", FFmpegDecoderModule<54>::Create, 54 },
+  { "libavcodec.53.dylib", FFmpegDecoderModule<53>::Create, 53 },
 };
 
 void* FFmpegRuntimeLinker::sLinkedLib = nullptr;
-const AvFormatLib* FFmpegRuntimeLinker::sLib = nullptr;
+const AvCodecLib* FFmpegRuntimeLinker::sLib = nullptr;
 
 #define AV_FUNC(func, ver) void (*func)();
 #define LIBAVCODEC_ALLVERSION
@@ -62,7 +62,7 @@ FFmpegRuntimeLinker::Link()
   MOZ_ASSERT(NS_IsMainThread());
 
   for (size_t i = 0; i < ArrayLength(sLibs); i++) {
-    const AvFormatLib* lib = &sLibs[i];
+    const AvCodecLib* lib = &sLibs[i];
     sLinkedLib = dlopen(lib->Name, RTLD_NOW | RTLD_LOCAL);
     if (sLinkedLib) {
       if (Bind(lib->Name, lib->Version)) {

--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.h
+++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.h
@@ -13,7 +13,7 @@
 namespace mozilla
 {
 
-struct AvFormatLib;
+struct AvCodecLib;
 
 class FFmpegRuntimeLinker
 {
@@ -24,7 +24,7 @@ public:
 
 private:
   static void* sLinkedLib;
-  static const AvFormatLib* sLib;
+  static const AvCodecLib* sLib;
 
   static bool Bind(const char* aLibName, uint32_t Version);
 

--- a/dom/media/platforms/wrappers/H264Converter.h
+++ b/dom/media/platforms/wrappers/H264Converter.h
@@ -39,6 +39,7 @@ public:
 
   // Return true if mimetype is H.264.
   static bool IsH264(const TrackInfo& aConfig);
+  nsresult GetLastError() const { return mLastError; }
 
 private:
   // Will create the required MediaDataDecoder if need AVCC and we have a SPS NAL.


### PR DESCRIPTION
First batch of fixes! This PR adds a method of determining the version of libavcodec that is available, removes our dependence on libavformat, and fixes several FFmpeg-related bugs and crashes. 