### PR TITLE
[Suggestion] Minor fix: about:support - Show Update History (BuildID == null)

### DIFF
--- a/toolkit/mozapps/update/content/history.js
+++ b/toolkit/mozapps/update/content/history.js
@@ -37,7 +37,7 @@ var gUpdateHistory = {
         var element = document.createElementNS(NS_XUL, "update");
         this._view.appendChild(element);
         element.name = bundle.getFormattedString("updateFullName", 
-          [update.name, update.buildID]);
+          [update.name, (update.buildID ? update.buildID : "-")]);
         element.type = bundle.getString("updateType_" + update.type);
         element.installDate = this._formatDate(update.installDate);
         if (update.detailsURL)


### PR DESCRIPTION

If update page does not return any `BuildID`:

e.g. (Pale Moon):
```
<?xml version="1.0"?>
<updates>
<update type="major" displayVersion="27.0.1 (x64)" appVersion="27.0.1"
extensionVersion="27.0.1"
detailsURL="http://www.palemoon.org/releasenotes.shtml"
showNeverForVersion="true">
</update>
</updates>
```

vs. e.g. (Firefox):
```
<?xml version="1.0"?>
<updates>
<update type="minor" displayVersion="50.0.1" appVersion="50.0.1"
platformVersion="50.0.1" buildID="20161123182536"
detailsURL="https://www.mozilla.org/cs/firefox/50.0.1/releasenotes/">
</update>
</updates>
```

...in `about:support` - `Show Update History` (`BuildID` == `null` / undefined):
![before](https://cloud.githubusercontent.com/assets/2373486/20768243/7b0e8406-b73d-11e6-8bdd-c740a8fefac3.png)

Suggestion - after this PR:
![after](https://cloud.githubusercontent.com/assets/2373486/20768247/7ed1e736-b73d-11e6-884a-cb4e0eca3530.png)

See also https://github.com/MoonchildProductions/Pale-Moon/commit/62a1fc4a524983ce43f069f29f18c385a74ec08a#diff-4717b3aa656d5a8e379361cad2c39ea2R2366

---

I've created the new build (x64) and tested.
