### PR TITLE
Minor fix - about:telemetry - throws an error

### DIFF
--- a/toolkit/content/aboutTelemetry.js
+++ b/toolkit/content/aboutTelemetry.js
@@ -460,11 +460,13 @@ let ThreadHangStats = {
     clearDivData(div);
 
     let stats = Telemetry.threadHangStats;
-    stats.forEach((thread) => {
-      div.appendChild(this.renderThread(thread));
-    });
-    if (stats.length) {
-      setHasData("thread-hang-stats-section", true);
+    if (stats) {
+      stats.forEach((thread) => {
+        div.appendChild(this.renderThread(thread));
+      });
+      if (stats.length) {
+        setHasData("thread-hang-stats-section", true);
+      }
     }
   },
 


### PR DESCRIPTION
Throws an error in Error Console:
```
Error: TypeError: stats is undefined
Source File: chrome://global/content/aboutTelemetry.js
Line: 461
```

See also:
https://github.com/MoonchildProductions/Tycho/commit/c58719d40f866a0ba619c2493e928fef8db73c5b
https://forum.palemoon.org/viewtopic.php?f=29&t=14015

---

I've created the new build (x64) and tested.
