### PR TITLE
Revamp extension target indicators for tooltip support

### DIFF
--- a/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.dtd
+++ b/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.dtd
@@ -210,6 +210,10 @@
 <!ENTITY addon.loadingReleaseNotes.label      "Loading…">
 <!ENTITY addon.errorLoadingReleaseNotes.label "Sorry, but there was an error loading the release notes.">
 
+<!ENTITY addon.nativeIndicator.glyph          "•">
+<!ENTITY addon.nativeIndicator.tooltip        "Blue dot means a native extension directly targeting Pale Moon,
+while orange dot means a non-native extension targeting Firefox, which is still possible to run.">
+
 <!ENTITY addon.createdBy.label                "By ">
 
 <!ENTITY eula.title                           "End-User License Agreement">

--- a/toolkit/mozapps/extensions/content/extensions.css
+++ b/toolkit/mozapps/extensions/content/extensions.css
@@ -148,6 +148,7 @@ setting[type="menulist"] {
 .addon:not([notification="info"]) .info,
 .addon:not([pending]) .pending,
 .addon:not([upgrade="true"]) .update-postfix,
+.addon:not([native]) .nativeIndicator,
 .addon[active="true"] .disabled-postfix,
 .addon[pending="install"] .update-postfix,
 .addon[pending="install"] .disabled-postfix,
@@ -261,14 +262,14 @@ richlistitem:not([selected]) * {
 }
 
 /* Indicator style for extension target application */
-.addon[native] .name-container::after {
-  content: " •";
+.addon[native] .nativeIndicator {
   font-size: 150%;
-  line-height: 75%;
+  margin-top: -5pt;
+  margin-bottom: -1pt;
 }
-.addon[native="true"] .name-container::after {
+.addon[native="true"] .nativeIndicator {
   color: #3366FF;
 }
-.addon[native="false"] .name-container::after {
+.addon[native="false"] .nativeIndicator {
   color: #FF6600;
 }

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -797,6 +797,8 @@
                 <xul:label anonid="name" class="name" crop="end" flex="1"
                            xbl:inherits="value=name,tooltiptext=name"/>
                 <xul:label anonid="version" class="version"/>
+                <xul:label class="nativeIndicator" value="&addon.nativeIndicator.glyph;"
+                           tooltiptext="&addon.nativeIndicator.tooltip;"/>
                 <xul:label class="disabled-postfix" value="&addon.disabled.postfix;"/>
                 <xul:label class="update-postfix" value="&addon.update.postfix;"/>
                 <xul:spacer flex="5000"/> <!-- Necessary to make the name crop -->


### PR DESCRIPTION
 Adding a tooltip text with explanation should reduce confusion.