### PR TITLE
Revamp extension target indicators for tooltip support (alternative)

### DIFF
--- a/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.dtd
+++ b/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.dtd
@@ -210,6 +210,9 @@
 <!ENTITY addon.loadingReleaseNotes.label      "Loading…">
 <!ENTITY addon.errorLoadingReleaseNotes.label "Sorry, but there was an error loading the release notes.">
 
+<!ENTITY addon.nativeAddon                    "This add-on directly targeting Pale Moon">
+<!ENTITY addon.compatAddon                    "This add-on targeting Firefox, but compatible with Pale Moon">
+
 <!ENTITY addon.createdBy.label                "By ">
 
 <!ENTITY eula.title                           "End-User License Agreement">

--- a/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.dtd
+++ b/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.dtd
@@ -210,8 +210,8 @@
 <!ENTITY addon.loadingReleaseNotes.label      "Loading…">
 <!ENTITY addon.errorLoadingReleaseNotes.label "Sorry, but there was an error loading the release notes.">
 
-<!ENTITY addon.nativeAddon                    "This add-on directly targeting Pale Moon">
-<!ENTITY addon.compatAddon                    "This add-on targeting Firefox, but compatible with Pale Moon">
+<!ENTITY addon.nativeAddon                    "This add-on directly targets Pale Moon">
+<!ENTITY addon.compatAddon                    "This add-on targets Mozilla Firefox and runs in compatibility mode">
 
 <!ENTITY addon.createdBy.label                "By ">
 

--- a/toolkit/mozapps/extensions/content/extensions.css
+++ b/toolkit/mozapps/extensions/content/extensions.css
@@ -264,9 +264,9 @@ richlistitem:not([selected]) * {
 
 /* Indicator style for extension target application */
 .addon[native] .nativeIndicator {
-  font-size: 120%;
+  font-size: 150%;
   margin-top: -5pt;
-  margin-bottom: 1pt;
+  margin-bottom: -1pt;
 }
 .addon[native][active="false"] .nativeIndicator {
   opacity: 0.4;

--- a/toolkit/mozapps/extensions/content/extensions.css
+++ b/toolkit/mozapps/extensions/content/extensions.css
@@ -148,6 +148,8 @@ setting[type="menulist"] {
 .addon:not([notification="info"]) .info,
 .addon:not([pending]) .pending,
 .addon:not([upgrade="true"]) .update-postfix,
+.addon:not([native="true"]) .nativeAddon,
+.addon:not([native="false"]) .compatAddon,
 .addon[active="true"] .disabled-postfix,
 .addon[pending="install"] .update-postfix,
 .addon[pending="install"] .disabled-postfix,
@@ -261,14 +263,17 @@ richlistitem:not([selected]) * {
 }
 
 /* Indicator style for extension target application */
-.addon[native] .name-container::after {
-  content: " •";
-  font-size: 150%;
-  line-height: 75%;
+.addon[native] .nativeIndicator {
+  font-size: 120%;
+  margin-top: -5pt;
+  margin-bottom: 1pt;
 }
-.addon[native="true"] .name-container::after {
+.addon[native][active="false"] .nativeIndicator {
+  opacity: 0.4;
+}
+.addon[native] .nativeAddon {
   color: #3366FF;
 }
-.addon[native="false"] .name-container::after {
+.addon[native] .compatAddon {
   color: #FF6600;
 }

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -797,8 +797,8 @@
                 <xul:label anonid="name" class="name" crop="end" flex="1"
                            xbl:inherits="value=name,tooltiptext=name"/>
                 <xul:label anonid="version" class="version"/>
-				<xul:label class="nativeIndicator nativeAddon" value="•" tooltiptext="&addon.nativeAddon;"/>
-				<xul:label class="nativeIndicator compatAddon" value="•" tooltiptext="&addon.compatAddon;"/>
+                <xul:label class="nativeIndicator nativeAddon" value="•" tooltiptext="&addon.nativeAddon;"/>
+                <xul:label class="nativeIndicator compatAddon" value="•" tooltiptext="&addon.compatAddon;"/>
                 <xul:label class="disabled-postfix" value="&addon.disabled.postfix;"/>
                 <xul:label class="update-postfix" value="&addon.update.postfix;"/>
                 <xul:spacer flex="5000"/> <!-- Necessary to make the name crop -->

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -797,6 +797,8 @@
                 <xul:label anonid="name" class="name" crop="end" flex="1"
                            xbl:inherits="value=name,tooltiptext=name"/>
                 <xul:label anonid="version" class="version"/>
+				<xul:label class="nativeIndicator nativeAddon" value="•" tooltiptext="&addon.nativeAddon;"/>
+				<xul:label class="nativeIndicator compatAddon" value="•" tooltiptext="&addon.compatAddon;"/>
                 <xul:label class="disabled-postfix" value="&addon.disabled.postfix;"/>
                 <xul:label class="update-postfix" value="&addon.update.postfix;"/>
                 <xul:spacer flex="5000"/> <!-- Necessary to make the name crop -->


### PR DESCRIPTION
Alternative to #741:

- Different tooltips for native and compatible addons
- Indicator itself isn't supposed to be locale dependent
- Added transparency to indicator for disabled addons
~~- Size of indicator reduced from 150% to 120%~~