### PR TITLE
Minor fix: Some sites - throws an errors

### DIFF
--- a/browser/base/content/browser-plugins.js
+++ b/browser/base/content/browser-plugins.js
@@ -182,6 +182,8 @@ var gPluginHandler = {
 
     let shouldShowNotification = false;
     let browser = gBrowser.getBrowserForDocument(doc.defaultView.top.document);
+    if (!browser)
+      return;
 
     switch (eventType) {
       case "PluginCrashed":


### PR DESCRIPTION
__Steps to reproduce (e.g.)__

Go to: `data:text/html,Bye!`

Throws an errors in Browser Console:
```
TypeError: aBrowser is null browser.js:3927:8
TypeError: aTab is null tabbrowser.xml:2254:10
```

See also https://bugzilla.mozilla.org/show_bug.cgi?id=957922

---

I've created the new build (x64) and tested.
