### PR TITLE
Add an equivalent of std::make_pair for mozilla::Pair

### DIFF
--- a/mfbt/Pair.h
+++ b/mfbt/Pair.h
@@ -166,6 +166,18 @@ public:
 
   Pair(const Pair& aOther) = default;
 
+  Pair& operator=(Pair&& aOther)
+  {
+    MOZ_ASSERT(this != &aOther, "Self-moves are prohibited");
+
+    first() = Move(aOther.first());
+    second() = Move(aOther.second());
+
+    return *this;
+  }
+
+  Pair& operator=(const Pair& aOther) = default;
+
   /** The A instance. */
   using Base::first;
   /** The B instance. */

--- a/mfbt/Pair.h
+++ b/mfbt/Pair.h
@@ -164,6 +164,8 @@ public:
     : Base(Move(aOther.first()), Move(aOther.second()))
   { }
 
+  Pair(const Pair& aOther) = default;
+
   /** The A instance. */
   using Base::first;
   /** The B instance. */
@@ -171,9 +173,6 @@ public:
 
   /** Swap this pair with another pair. */
   void swap(Pair& aOther) { Base::swap(aOther); }
-
-private:
-  Pair(const Pair&) = delete;
 };
 
 template<typename A, class B>

--- a/mfbt/Pair.h
+++ b/mfbt/Pair.h
@@ -160,6 +160,10 @@ public:
     : Base(Forward<AArg>(aA), Forward<BArg>(aB))
   {}
 
+  Pair(Pair&& aOther)
+    : Base(Move(aOther.first()), Move(aOther.second()))
+  { }
+
   /** The A instance. */
   using Base::first;
   /** The B instance. */
@@ -177,6 +181,26 @@ void
 Swap(Pair<A, B>& aX, Pair<A, B>& aY)
 {
   aX.swap(aY);
+}
+
+/**
+ * MakePair allows you to construct a Pair instance using type inference. A call
+ * like this:
+ *
+ *   MakePair(Foo(), Bar())
+ *
+ * will return a Pair<Foo, Bar>.
+ */
+template<typename A, typename B>
+Pair<typename RemoveCV<typename RemoveReference<A>::Type>::Type,
+     typename RemoveCV<typename RemoveReference<B>::Type>::Type>
+MakePair(A&& aA, B&& aB)
+{
+  return
+    Pair<typename RemoveCV<typename RemoveReference<A>::Type>::Type,
+         typename RemoveCV<typename RemoveReference<B>::Type>::Type>(
+             Forward<A>(aA),
+             Forward<B>(aB));
 }
 
 } // namespace mozilla

--- a/mfbt/tests/TestPair.cpp
+++ b/mfbt/tests/TestPair.cpp
@@ -75,5 +75,9 @@ main()
   static_assert(IsSame<decltype(MakePair(constA, constB)), Pair<A, B>>::value,
                 "MakePair should strip CV-qualifiers");
 
+  // Check that copy assignment and move assignment work.
+  a = constA;
+  a = A(0);
+
   return 0;
 }

--- a/mfbt/tests/TestPair.cpp
+++ b/mfbt/tests/TestPair.cpp
@@ -5,7 +5,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "mozilla/Pair.h"
+#include "mozilla/TypeTraits.h"
 
+using mozilla::IsSame;
+using mozilla::MakePair;
 using mozilla::Pair;
 
 // Sizes aren't part of the guaranteed Pair interface, but we want to verify our
@@ -59,5 +62,18 @@ struct OtherEmpty : EmptyClass { explicit OtherEmpty(int aI) : EmptyClass(aI) {}
 int
 main()
 {
+  A a(0);
+  B b(0);
+  const A constA(0);
+  const B constB(0);
+
+  // Check that MakePair generates Pair objects of the correct types.
+  static_assert(IsSame<decltype(MakePair(A(0), B(0))), Pair<A, B>>::value,
+                "MakePair should strip rvalue references");
+  static_assert(IsSame<decltype(MakePair(a, b)), Pair<A, B>>::value,
+                "MakePair should strip lvalue references");
+  static_assert(IsSame<decltype(MakePair(constA, constB)), Pair<A, B>>::value,
+                "MakePair should strip CV-qualifiers");
+
   return 0;
 }


### PR DESCRIPTION
Not exactly media-related in itself, but is required for the next batch of FFmpeg fixes. Is a port of bug [1142366](https://bugzilla.mozilla.org/show_bug.cgi?id=1142366) and its 2 followups: [1142376](https://bugzilla.mozilla.org/show_bug.cgi?id=1142376) and [1143077](https://bugzilla.mozilla.org/show_bug.cgi?id=1143077).

Compiles and tests (in-tree) successfully.