### PR TITLE
Various FFmpeg fixes

### DIFF
--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
@@ -60,23 +60,15 @@ ChoosePixelFormat(AVCodecContext* aCodecContext, const PixelFormat* aFormats)
 nsresult
 FFmpegDataDecoder<LIBAV_VER>::Init()
 {
-  StaticMutexAutoLock mon(sMonitor);
-
   FFMPEG_LOG("Initialising FFmpeg decoder.");
 
-  if (!sFFmpegInitDone) {
-    avcodec_register_all();
-#ifdef DEBUG
-    av_log_set_level(AV_LOG_DEBUG);
-#endif
-    sFFmpegInitDone = true;
-  }
-
-  AVCodec* codec = avcodec_find_decoder(mCodecID);
+  AVCodec* codec = FindAVCodec(mCodecID);
   if (!codec) {
     NS_WARNING("Couldn't find ffmpeg decoder");
     return NS_ERROR_FAILURE;
   }
+
+  StaticMutexAutoLock mon(sMonitor);
 
   if (!(mCodecContext = avcodec_alloc_context3(codec))) {
     NS_WARNING("Couldn't init ffmpeg context");
@@ -184,6 +176,20 @@ FFmpegDataDecoder<LIBAV_VER>::PrepareFrame()
   avcodec_get_frame_defaults(mFrame);
 #endif
   return mFrame;
+}
+
+/* static */ AVCodec*
+FFmpegDataDecoder<LIBAV_VER>::FindAVCodec(AVCodecID aCodec)
+{
+  StaticMutexAutoLock mon(sMonitor);
+  if (!sFFmpegInitDone) {
+    avcodec_register_all();
+#ifdef DEBUG
+    av_log_set_level(AV_LOG_DEBUG);
+#endif
+    sFFmpegInitDone = true;
+  }
+  return avcodec_find_decoder(aCodec);
 }
 
 } // namespace mozilla

--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.h
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.h
@@ -35,6 +35,8 @@ public:
   virtual nsresult Drain() override = 0;
   virtual nsresult Shutdown() override;
 
+  static AVCodec* FindAVCodec(AVCodecID aCodec);
+
 protected:
   AVFrame*        PrepareFrame();
 

--- a/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
+++ b/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
@@ -62,8 +62,13 @@ public:
 
   virtual bool SupportsMimeType(const nsACString& aMimeType) override
   {
-    return FFmpegAudioDecoder<V>::GetCodecId(aMimeType) != AV_CODEC_ID_NONE ||
-      FFmpegH264Decoder<V>::GetCodecId(aMimeType) != AV_CODEC_ID_NONE;
+    AVCodecID audioCodec = FFmpegAudioDecoder<V>::GetCodecId(aMimeType);
+    AVCodecID videoCodec = FFmpegH264Decoder<V>::GetCodecId(aMimeType);
+    if (audioCodec == AV_CODEC_ID_NONE && videoCodec == AV_CODEC_ID_NONE) {
+      return false;
+    }
+    AVCodecID codec = audioCodec != AV_CODEC_ID_NONE ? audioCodec : videoCodec;
+    return !!FFmpegDataDecoder<V>::FindAVCodec(codec);
   }
 
   virtual ConversionRequired

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -105,6 +105,13 @@ FFmpegH264Decoder<LIBAV_VER>::DoDecodeFrame(MediaRawData* aSample)
   packet.flags = aSample->mKeyframe ? AV_PKT_FLAG_KEY : 0;
   packet.pos = aSample->mOffset;
 
+  // LibAV provides no API to retrieve the decoded sample's duration.
+  // (FFmpeg >= 1.0 provides av_frame_get_pkt_duration)
+  // As such we instead use a map using the dts as key that we will retrieve
+  // later.
+  // The map will have a typical size of 16 entry.
+  mDurationMap.Insert(aSample->mTimecode, aSample->mDuration);
+
   if (!PrepareFrame()) {
     NS_WARNING("FFmpeg h264 decoder failed to allocate frame.");
     mCallback->Error();
@@ -135,6 +142,19 @@ FFmpegH264Decoder<LIBAV_VER>::DoDecodeFrame(MediaRawData* aSample)
     int64_t pts = mPtsContext.GuessCorrectPts(mFrame->pkt_pts, mFrame->pkt_dts);
     FFMPEG_LOG("Got one frame output with pts=%lld opaque=%lld",
                pts, mCodecContext->reordered_opaque);
+    // Retrieve duration from dts.
+    // We use the first entry found matching this dts (this is done to
+    // handle damaged file with multiple frames with the same dts)
+
+    int64_t duration;
+    if (!mDurationMap.Find(mFrame->pkt_dts, duration)) {
+      NS_WARNING("Unable to retrieve duration from map");
+      duration = aSample->mDuration;
+      // dts are probably incorrectly reported ; so clear the map as we're
+      // unlikely to find them in the future anyway. This also guards
+      // against the map becoming extremely big.
+      mDurationMap.Clear();
+    }
 
     VideoInfo info;
     info.mDisplay = nsIntSize(mDisplayWidth, mDisplayHeight);
@@ -162,7 +182,7 @@ FFmpegH264Decoder<LIBAV_VER>::DoDecodeFrame(MediaRawData* aSample)
                                               mImageContainer,
                                               aSample->mOffset,
                                               pts,
-                                              aSample->mDuration,
+                                              duration,
                                               b,
                                               !!mFrame->key_frame,
                                               -1,
@@ -336,6 +356,7 @@ nsresult
 FFmpegH264Decoder<LIBAV_VER>::Flush()
 {
   mPtsContext.Reset();
+  mDurationMap.Clear();
   nsresult rv = FFmpegDataDecoder::Flush();
   // Even if the above fails we may as well clear our frame queue.
   return rv;

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -21,6 +21,45 @@ typedef mozilla::layers::PlanarYCbCrImage PlanarYCbCrImage;
 namespace mozilla
 {
 
+FFmpegH264Decoder<LIBAV_VER>::PtsCorrectionContext::PtsCorrectionContext()
+  : mNumFaultyPts(0)
+  , mNumFaultyDts(0)
+  , mLastPts(INT64_MIN)
+  , mLastDts(INT64_MIN)
+{
+}
+
+int64_t
+FFmpegH264Decoder<LIBAV_VER>::PtsCorrectionContext::GuessCorrectPts(int64_t aPts, int64_t aDts)
+{
+  int64_t pts = AV_NOPTS_VALUE;
+
+  if (aDts != int64_t(AV_NOPTS_VALUE)) {
+    mNumFaultyDts += aDts <= mLastDts;
+    mLastDts = aDts;
+  }
+  if (aPts != int64_t(AV_NOPTS_VALUE)) {
+    mNumFaultyPts += aPts <= mLastPts;
+    mLastPts = aPts;
+  }
+  if ((mNumFaultyPts <= mNumFaultyDts || aDts == int64_t(AV_NOPTS_VALUE)) &&
+      aPts != int64_t(AV_NOPTS_VALUE)) {
+    pts = aPts;
+  } else {
+    pts = aDts;
+  }
+  return pts;
+}
+
+void
+FFmpegH264Decoder<LIBAV_VER>::PtsCorrectionContext::Reset()
+{
+  mNumFaultyPts = 0;
+  mNumFaultyDts = 0;
+  mLastPts = INT64_MIN;
+  mLastDts = INT64_MIN;
+}
+
 FFmpegH264Decoder<LIBAV_VER>::FFmpegH264Decoder(
   FlushableMediaTaskQueue* aTaskQueue, MediaDataDecoderCallback* aCallback,
   const VideoInfo& aConfig,
@@ -51,20 +90,6 @@ FFmpegH264Decoder<LIBAV_VER>::Init()
   mCodecContext->height = mPictureHeight;
 
   return NS_OK;
-}
-
-int64_t
-FFmpegH264Decoder<LIBAV_VER>::GetPts(const AVPacket& packet)
-{
-#if LIBAVCODEC_VERSION_MAJOR == 53
-  if (mFrame->pkt_pts == 0) {
-    return mFrame->pkt_dts;
-  } else {
-    return mFrame->pkt_pts;
-  }
-#else
-  return mFrame->pkt_pts;
-#endif
 }
 
 FFmpegH264Decoder<LIBAV_VER>::DecodeResult
@@ -107,7 +132,7 @@ FFmpegH264Decoder<LIBAV_VER>::DoDecodeFrame(MediaRawData* aSample)
 
   // If we've decoded a frame then we need to output it
   if (decoded) {
-    int64_t pts = GetPts(packet);
+    int64_t pts = mPtsContext.GuessCorrectPts(mFrame->pkt_pts, mFrame->pkt_dts);
     FFMPEG_LOG("Got one frame output with pts=%lld opaque=%lld",
                pts, mCodecContext->reordered_opaque);
 
@@ -310,6 +335,7 @@ FFmpegH264Decoder<LIBAV_VER>::Drain()
 nsresult
 FFmpegH264Decoder<LIBAV_VER>::Flush()
 {
+  mPtsContext.Reset();
   nsresult rv = FFmpegDataDecoder::Flush();
   // Even if the above fails we may as well clear our frame queue.
   return rv;

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -15,8 +15,6 @@
 #include "FFmpegLog.h"
 #include "mozilla/PodOperations.h"
 
-#define GECKO_FRAME_TYPE 0x00093CC0
-
 typedef mozilla::layers::Image Image;
 typedef mozilla::layers::PlanarYCbCrImage PlanarYCbCrImage;
 
@@ -264,15 +262,19 @@ FFmpegH264Decoder<LIBAV_VER>::AllocateYUV420PVideoBuffer(
     aFrame->data[i] = buffer + offsets[i] + planesEdgeWidth[i];
   }
 
-  // Unused, but needs to be non-zero to keep ffmpeg happy.
-  aFrame->type = GECKO_FRAME_TYPE;
-
   aFrame->extended_data = aFrame->data;
   aFrame->width = aCodecContext->width;
   aFrame->height = aCodecContext->height;
 
   aFrame->opaque = static_cast<void*>(image.forget().take());
 
+  aFrame->type = FF_BUFFER_TYPE_USER;
+  aFrame->reordered_opaque = aCodecContext->reordered_opaque;
+#if LIBAVCODEC_VERSION_MAJOR == 53
+  if (aCodecContext->pkt) {
+    aFrame->pkt_pts = aCodecContext->pkt->pts;
+  }
+#endif
   return 0;
 }
 

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -164,7 +164,7 @@ FFmpegH264Decoder<LIBAV_VER>::DoDecodeFrame(MediaRawData* aSample)
                                               pts,
                                               aSample->mDuration,
                                               b,
-                                              aSample->mKeyframe,
+                                              !!mFrame->key_frame,
                                               -1,
                                               gfx::IntRect(0, 0, mCodecContext->width, mCodecContext->height));
     if (!v) {

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
@@ -8,6 +8,8 @@
 #define __FFmpegH264Decoder_h__
 
 #include "FFmpegDataDecoder.h"
+#include "mozilla/Pair.h"
+#include "nsTArray.h"
 
 namespace mozilla
 {
@@ -81,6 +83,42 @@ private:
   };
 
   PtsCorrectionContext mPtsContext;
+
+  class DurationMap {
+  public:
+    typedef Pair<int64_t, int64_t> DurationElement;
+
+    // Insert Dts and Duration pair at the end of our map.
+    void Insert(int64_t aDts, int64_t aDuration)
+    {
+      mMap.AppendElement(MakePair(aDts, aDuration));
+    }
+    // Sets aDuration matching aDts and remove it from the map if found.
+    // The element returned is the first one found.
+    // Returns true if found, false otherwise.
+    bool Find(int64_t aDts, int64_t& aDuration)
+    {
+      for (uint32_t i = 0; i < mMap.Length(); i++) {
+        DurationElement& element = mMap[i];
+        if (element.first() == aDts) {
+          aDuration = element.second();
+          mMap.RemoveElementAt(i);
+          return true;
+        }
+      }
+      return false;
+    }
+    // Remove all elements of the map.
+    void Clear()
+    {
+      mMap.Clear();
+    }
+
+  private:
+    nsAutoTArray<DurationElement, 16> mMap;
+  };
+
+  DurationMap mDurationMap;
 };
 
 } // namespace mozilla

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
@@ -59,7 +59,6 @@ private:
 
   static int AllocateBufferCb(AVCodecContext* aCodecContext, AVFrame* aFrame);
   static void ReleaseBufferCb(AVCodecContext* aCodecContext, AVFrame* aFrame);
-  int64_t GetPts(const AVPacket& packet);
 
   MediaDataDecoderCallback* mCallback;
   nsRefPtr<ImageContainer> mImageContainer;
@@ -67,6 +66,21 @@ private:
   uint32_t mPictureHeight;
   uint32_t mDisplayWidth;
   uint32_t mDisplayHeight;
+
+  class PtsCorrectionContext {
+  public:
+    PtsCorrectionContext();
+    int64_t GuessCorrectPts(int64_t aPts, int64_t aDts);
+    void Reset();
+
+  private:
+    int64_t mNumFaultyPts; /// Number of incorrect PTS values so far
+    int64_t mNumFaultyDts; /// Number of incorrect DTS values so far
+    int64_t mLastPts;       /// PTS of the last frame
+    int64_t mLastDts;       /// DTS of the last frame
+  };
+
+  PtsCorrectionContext mPtsContext;
 };
 
 } // namespace mozilla


### PR DESCRIPTION
This PR fixes a few more problems with our FFmpeg support, most notably we will now throw an error instead of crashing if we try to use a codec that FFmpeg was not compiled with (i.e. with disable-nonfree).

Tested on Youtube, Twitch, and others and appears to work as intended.