### PR TITLE
Don't use GStreamer for media mochitests

### DIFF
--- a/dom/media/mediasource/test/test_BufferingWait.html
+++ b/dom/media/mediasource/test/test_BufferingWait.html
@@ -41,14 +41,14 @@ runWithMSE(function(ms, v) {
       /* Note - Missing |46712, 67833 - 46712| segment here corresponding to (0.8, 1.2] */
       /* Note - Missing |67833, 88966 - 67833| segment here corresponding to (1.2, 1.6]  */
       loadSegment.bind(null, sb, new Uint8Array(arrayBuffer, 88966))).then(function() {
-        var promise = waitUntilTime(0.7);
+        var promise = waitUntilTime(0.27);
         info("Playing video. It should play for a bit, then fire 'waiting'");
         v.play();
         return promise;
       }).then(function() {
         window.firstStop = Date.now();
         loadSegment(sb, new Uint8Array(arrayBuffer, 46712, 67833 - 46712));
-        return waitUntilTime(1.0);
+        return waitUntilTime(0.66);
       }).then(function() {
         var waitDuration = (Date.now() - window.firstStop) / 1000;
         ok(waitDuration < 15, "Should not spend an inordinate amount of time buffering: " + waitDuration);

--- a/dom/media/test/test_can_play_type_mpeg.html
+++ b/dom/media/test/test_can_play_type_mpeg.html
@@ -44,14 +44,12 @@ function check_mp4(v, enabled) {
   check("video/mp4; codecs=\"avc1.42001E, mp4a.40.2\"", "probably");
   check("video/mp4; codecs=\"avc1.58A01E, mp4a.40.2\"", "probably");
   
-  const ProbablyIfNotLinux = !IsLinuxGStreamer() ? "probably" : "";
-  
   // H.264 Main Profile Level 3.0, AAC-LC
   check("video/mp4; codecs=\"avc1.4D401E, mp4a.40.2\"", "probably");
   // H.264 Main Profile Level 3.1, AAC-LC
-  check("video/mp4; codecs=\"avc1.4D401F, mp4a.40.2\"", ProbablyIfNotLinux);
+  check("video/mp4; codecs=\"avc1.4D401F, mp4a.40.2\"", "probably");
   // H.264 Main Profile Level 4.0, AAC-LC
-  check("video/mp4; codecs=\"avc1.4D4028, mp4a.40.2\"", ProbablyIfNotLinux);
+  check("video/mp4; codecs=\"avc1.4D4028, mp4a.40.2\"", "probably");
   // H.264 High Profile Level 3.0, AAC-LC
   check("video/mp4; codecs=\"avc1.64001E, mp4a.40.2\"", "probably");
   // H.264 High Profile Level 3.1, AAC-LC
@@ -70,10 +68,10 @@ function check_mp4(v, enabled) {
   check("audio/x-m4a; codecs=mp4a.40.2", "probably");
 
   // HE-AAC v1
-  check("audio/mp4; codecs=\"mp4a.40.5\"", ProbablyIfNotLinux);
-  check("audio/mp4; codecs=mp4a.40.5", ProbablyIfNotLinux);
-  check("audio/x-m4a; codecs=\"mp4a.40.5\"", ProbablyIfNotLinux);
-  check("audio/x-m4a; codecs=mp4a.40.5", ProbablyIfNotLinux);
+  check("audio/mp4; codecs=\"mp4a.40.5\"", "probably");
+  check("audio/mp4; codecs=mp4a.40.5", "probably");
+  check("audio/x-m4a; codecs=\"mp4a.40.5\"", "probably");
+  check("audio/x-m4a; codecs=mp4a.40.5", "probably");
   
 }
 
@@ -116,11 +114,6 @@ function getPref(name) {
     pref = SpecialPowers.getBoolPref(name);
   } catch(ex) { }
   return pref;
-}
-
-function IsLinuxGStreamer() {
-  return /Linux/.test(navigator.userAgent) &&
-         getPref("media.gstreamer.enabled");
 }
 
 // Check whether we should expect the new MP4Reader-based support to work.

--- a/testing/profiles/prefs_general.js
+++ b/testing/profiles/prefs_general.js
@@ -163,6 +163,13 @@ user_pref("media.mediasource.enabled", true);
 user_pref("media.mediasource.mp4.enabled", true);
 user_pref("media.mediasource.webm.enabled", true);
 
+// Enable fragmented MP4 parser for testing
+user_pref("media.fragmented-mp4.exposed", true);
+
+#if defined(LINUX)
+user_pref("media.fragmented-mp4.ffmpeg.enabled", true);
+#endif
+
 // Enable mozContacts
 user_pref("dom.mozContacts.enabled", true);
 

--- a/testing/web-platform/meta/media-source/mediasource-addsourcebuffer.html.ini
+++ b/testing/web-platform/meta/media-source/mediasource-addsourcebuffer.html.ini
@@ -2,11 +2,9 @@
   type: testharness
   [Test addSourceBuffer() with AAC and H.264]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 
   [Test addSourceBuffer() with AAC and H.264 in separate SourceBuffers]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 

--- a/testing/web-platform/meta/media-source/mediasource-append-buffer.html.ini
+++ b/testing/web-platform/meta/media-source/mediasource-append-buffer.html.ini
@@ -1,4 +1,4 @@
 [mediasource-append-buffer.html]
   type: testharness
   disabled:
-    if (os == "win") and (version != "5.1.2600"): https://bugzilla.mozilla.org/show_bug.cgi?id=1143650
+    if (os == "linux") or ((os == "win") and (version != "5.1.2600")): https://bugzilla.mozilla.org/show_bug.cgi?id=1143650

--- a/testing/web-platform/meta/media-source/mediasource-buffered.html.ini
+++ b/testing/web-platform/meta/media-source/mediasource-buffered.html.ini
@@ -2,7 +2,6 @@
   type: testharness
   [Demuxed content with different lengths]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 
   [Muxed tracks with different lengths]

--- a/testing/web-platform/meta/media-source/mediasource-config-change-mp4-av-framesize.html.ini
+++ b/testing/web-platform/meta/media-source/mediasource-config-change-mp4-av-framesize.html.ini
@@ -2,6 +2,5 @@
   type: testharness
   [Tests mp4 frame size changes in multiplexed content.]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 

--- a/testing/web-platform/meta/media-source/mediasource-config-change-mp4-av-video-bitrate.html.ini
+++ b/testing/web-platform/meta/media-source/mediasource-config-change-mp4-av-video-bitrate.html.ini
@@ -2,6 +2,5 @@
   type: testharness
   [Tests mp4 video bitrate changes in multiplexed content.]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 

--- a/testing/web-platform/meta/media-source/mediasource-config-change-mp4-v-bitrate.html.ini
+++ b/testing/web-platform/meta/media-source/mediasource-config-change-mp4-v-bitrate.html.ini
@@ -2,6 +2,5 @@
   type: testharness
   [Tests mp4 video-only bitrate changes.]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 

--- a/testing/web-platform/meta/media-source/mediasource-config-change-mp4-v-framerate.html.ini
+++ b/testing/web-platform/meta/media-source/mediasource-config-change-mp4-v-framerate.html.ini
@@ -2,6 +2,5 @@
   type: testharness
   [Tests mp4 video-only frame rate changes.]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 

--- a/testing/web-platform/meta/media-source/mediasource-config-change-mp4-v-framesize.html.ini
+++ b/testing/web-platform/meta/media-source/mediasource-config-change-mp4-v-framesize.html.ini
@@ -2,6 +2,5 @@
   type: testharness
   [Tests mp4 video-only frame size changes.]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 

--- a/testing/web-platform/meta/media-source/mediasource-is-type-supported.html.ini
+++ b/testing/web-platform/meta/media-source/mediasource-is-type-supported.html.ini
@@ -23,12 +23,10 @@
 
   [Test valid MP4 type "video/mp4;codecs="avc1.4d001e""]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 
   [Test valid MP4 type "video/mp4;codecs="avc1.42001e""]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 
   [Test valid MP4 type "audio/mp4;codecs="mp4a.40.2""]
@@ -37,7 +35,6 @@
 
   [Test valid MP4 type "audio/mp4;codecs="mp4a.40.5""]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 
   [Test valid MP4 type "audio/mp4;codecs="mp4a.67""]
@@ -49,17 +46,14 @@
 
   [Test valid MP4 type "video/mp4;codecs="avc1.4d001e,mp4a.40.2""]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 
   [Test valid MP4 type "video/mp4;codecs="mp4a.40.2 , avc1.4d001e ""]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 
   [Test valid MP4 type "video/mp4;codecs="avc1.4d001e,mp4a.40.5""]
     expected:
-      if os == "linux": FAIL
       if (os == "win") and (version == "5.1.2600"): FAIL
 
   [Test valid WebM type "AUDIO/WEBM;CODECS="vorbis""]


### PR DESCRIPTION
Just what it says in the tin.

Note that this does not guarantee that we will necessarily pass these tests (some of them are outdated and need updating), but they can now actually be used on Linux with FFmpeg (using GStreamer would cause an automatic fail).