### PR TITLE
Permissions: Plugins (a basic part)

### DIFF
--- a/browser/components/preferences/aboutPermissions.css
+++ b/browser/components/preferences/aboutPermissions.css
@@ -5,3 +5,7 @@
 .site {
   -moz-binding: url("chrome://browser/content/preferences/aboutPermissions.xml#site");
 }
+
+.pluginPermission {
+  -moz-binding: url("chrome://browser/content/preferences/aboutPermissions.xml#pluginPermission");
+}

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -520,8 +520,7 @@ let AboutPermissions = {
       permissionEntries.push(permissionEntry);
       this._supportedPermissions.push(permString);
       this._noGlobalDeny.push(permString);
-      Object.defineProperty(PermissionDefaults, permString,
-      {
+      Object.defineProperty(PermissionDefaults, permString, {
         get: function() {
                return this.isClickToPlay()
                       ? PermissionDefaults.UNKNOWN

--- a/browser/components/preferences/aboutPermissions.xml
+++ b/browser/components/preferences/aboutPermissions.xml
@@ -68,8 +68,7 @@
                                  .getService(Components.interfaces.nsIBlocklistService);
           let mimeType = this.getAttribute("mimeType");
           let tags = pluginHost.getPluginTags();
-          let blocklistState = Components.interfaces
-              .nsIBlocklistService.STATE_NOT_BLOCKED;
+          let blocklistState = Components.interfaces.nsIBlocklistService.STATE_NOT_BLOCKED;
           for (let plugin of tags) {
             if (plugin.getMimeTypes()[0] == mimeType) {
               blocklistState = blocklistService.getPluginBlocklistState(plugin);

--- a/browser/components/preferences/aboutPermissions.xml
+++ b/browser/components/preferences/aboutPermissions.xml
@@ -3,7 +3,11 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<!DOCTYPE bindings>
+<!DOCTYPE bindings [
+<!ENTITY % aboutPermissionsDTD SYSTEM "chrome://browser/locale/preferences/aboutPermissions.dtd" >
+%aboutPermissionsDTD;
+]>
+
 <bindings xmlns="http://www.mozilla.org/xbl"
           xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
           xmlns:xbl="http://www.mozilla.org/xbl">
@@ -14,5 +18,69 @@
         <xul:label xbl:inherits="value,selected" class="site-domain" crop="end" flex="1"/>
       </xul:hbox>
     </content>
+  </binding>
+
+  <binding id="pluginPermission">
+    <content>
+      <xul:hbox flex="1" align="baseline">
+        <xul:label xbl:inherits="value=label"/>
+        <xul:spacer flex="1"/>
+        <xul:menulist anonid="plugins-menulist"
+                      class="pref-menulist"
+                      oncommand="AboutPermissions.onPermissionCommand(event);">
+          <xul:menupopup>
+            <xul:menuitem anonid="ask" value="0" label="&permission.alwaysAsk;"/>
+            <xul:menuitem anonid="allow" value="1" label="&permission.allow;"/>
+            <xul:menuitem anonid="block" value="2" label="&permission.block;"/>
+          </xul:menupopup>
+        </xul:menulist>
+      </xul:hbox>
+    </content>
+    <implementation>
+      <constructor><![CDATA[
+        let permString = this.getAttribute("permString");
+        let menulist = document.getAnonymousElementByAttribute(this, "anonid", "plugins-menulist");
+        menulist.setAttribute("id", permString + "-menulist");
+        menulist.setAttribute("type", permString);
+        let askitem = document.getAnonymousElementByAttribute(this, "anonid", "ask");
+        askitem.setAttribute("id", permString + "-0")
+        let allowitem = document.getAnonymousElementByAttribute(this, "anonid", "allow");
+        allowitem.setAttribute("id", permString + "-1")
+        let blockitem = document.getAnonymousElementByAttribute(this, "anonid", "block");
+        blockitem.setAttribute("id", permString + "-2")
+        ]]>
+      </constructor>
+      <method name="isClickToPlay">
+        <body><![CDATA[
+          let pluginHost = Components.classes["@mozilla.org/plugin/host;1"]
+              .getService(Components.interfaces.nsIPluginHost);
+          let mimeType = this.getAttribute("mimeType");
+          return (pluginHost.getStateForType(mimeType)
+              == Components.interfaces.nsIPluginTag.STATE_CLICKTOPLAY);
+        ]]>
+        </body>
+      </method>
+      <method name="isBlocklisted">
+        <body><![CDATA[
+          let pluginHost = Components.classes["@mozilla.org/plugin/host;1"]
+                           .getService(Components.interfaces.nsIPluginHost);
+          let blocklistService = Components.classes["@mozilla.org/extensions/blocklist;1"]
+                                 .getService(Components.interfaces.nsIBlocklistService);
+          let mimeType = this.getAttribute("mimeType");
+          let tags = pluginHost.getPluginTags();
+          let blocklistState = Components.interfaces
+              .nsIBlocklistService.STATE_NOT_BLOCKED;
+          for (let plugin of tags) {
+            if (plugin.getMimeTypes()[0] == mimeType) {
+              blocklistState = blocklistService.getPluginBlocklistState(plugin);
+              break;
+            }
+          }
+          return (blocklistState == Components.interfaces.nsIBlocklistService.STATE_VULNERABLE_UPDATE_AVAILABLE ||
+                  blocklistState == Components.interfaces.nsIBlocklistService.STATE_VULNERABLE_NO_UPDATE);
+        ]]>
+        </body>
+      </method>
+    </implementation>
   </binding>
 </bindings>

--- a/browser/components/preferences/aboutPermissions.xul
+++ b/browser/components/preferences/aboutPermissions.xul
@@ -238,18 +238,7 @@
         <image class="pref-icon" type="plugins"/>
         <vbox>
           <label class="pref-title" value="&plugins.label;"/>
-          <hbox>
-            <menulist id="plugins-menulist"
-                      class="pref-menulist"
-                      type="plugins"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
-              <menupopup>
-                <menuitem id="plugins-0" value="0" label="&permission.alwaysAsk;"/>
-                <menuitem id="plugins-1" value="1" label="&permission.allow;"/>
-                <menuitem id="plugins-2" value="2" label="&permission.block;"/>
-              </menupopup>
-            </menulist>
-          </hbox>
+          <vbox id="plugins-box"/>
         </vbox>
       </hbox>
 

--- a/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.properties
+++ b/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.properties
@@ -11,3 +11,4 @@ visitCount=#1 visit;#1 visits
 # See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
 passwordsCount=#1 password is stored for this website.;#1 passwords are stored for this website.
 cookiesCount=#1 cookie is set for this website.;#1 cookies are set for this website.
+pluginBlocklisted=This plugin poses a security risk and cannot be set to Allow for all sites.


### PR DESCRIPTION
## Permissions Manager

Ad #637 (Add per-plugin permissions)

The suggestion (for example).
__________

__What doesn't it do?__
__________
`about:addons`: `Plugins`
__<=__
`about:permissions`: `All sites` - write settings (yet resolved: `disabled="true"`)
__________

### I've created the new build (x64) and tested:
__________

Reading and writing settings:
`Ask to Activate`/`Always Activate`/`Never Activate`:
__________
`about:addons`: `Plugins`
__=>__ 
`about:permissions`: `All sites`
__________
`Page Info`: `Permissions` - `Activate Plugins`
__<=>__
`about:permissions`: `[the selected site]`
__________
__But please check it in detail (all options).__
Also, if you want better formatting...
