### PR TITLE
[regression] Minor fix: Only list the updater's update history in about:support if it's actually built

### DIFF
--- a/toolkit/content/aboutSupport.xhtml
+++ b/toolkit/content/aboutSupport.xhtml
@@ -97,6 +97,7 @@
           </tr>
 
 #ifndef ANDROID
+#ifdef MOZ_UPDATER
           <tr class="no-copy">
             <th class="column">
               &aboutSupport.appBasicsUpdateHistory;
@@ -108,6 +109,7 @@
               </button>
             </td>
           </tr>
+#endif
 #endif
 
 #ifdef MOZ_UPDATER


### PR DESCRIPTION
Beta versions etc. - throws an error in Browser Console after click on the button "Show Update History":
```
TypeError: Cc['@mozilla.org/updates/update-prompt;1'] is undefined aboutSupport.js:617:8
```

See https://github.com/MoonchildProductions/Pale-Moon/commit/9ee5b4daa15afb44d3014a8273438c43d398ad96

---

I've created the new build (x64) and tested.
