### PR TITLE
[suggestion] DevTools - Debugger - Source Map (if not found)

### DIFF
--- a/toolkit/devtools/server/actors/script.js
+++ b/toolkit/devtools/server/actors/script.js
@@ -5450,7 +5450,7 @@ ThreadSources.prototype = {
 
     let fetching = fetch(aAbsSourceMapURL, { loadFromCache: false })
       .then(({ content }) => {
-        let map = new SourceMapConsumer(content);
+        let map = new SourceMapConsumer(content, aAbsSourceMapURL);
         this._setSourceMapRoot(map, aAbsSourceMapURL, aSourceURL);
         return map;
       })

--- a/toolkit/devtools/server/actors/stylesheets.js
+++ b/toolkit/devtools/server/actors/stylesheets.js
@@ -645,7 +645,7 @@ let StyleSheetActor = protocol.ActorClass({
 
       let map = fetch(url, { loadFromCache: false, window: this.window })
         .then(({content}) => {
-          let map = new SourceMapConsumer(content);
+          let map = new SourceMapConsumer(content, url);
           this._setSourceMapRoot(map, url, this.href);
           this._sourceMap = promise.resolve(map);
 

--- a/toolkit/devtools/sourcemap/SourceMap.jsm
+++ b/toolkit/devtools/sourcemap/SourceMap.jsm
@@ -61,10 +61,18 @@ define('source-map/source-map-consumer', ['require', 'exports', 'module' ,  'sou
    *
    * [0]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#
    */
-  function SourceMapConsumer(aSourceMap) {
+  function SourceMapConsumer(aSourceMap, aUrl) {
     var sourceMap = aSourceMap;
     if (typeof aSourceMap === 'string') {
-      sourceMap = JSON.parse(aSourceMap.replace(/^\)\]\}'/, ''));
+      var _sourceMap = aSourceMap.replace(/^\)\]\}'/, '');
+      try {
+        sourceMap = JSON.parse(_sourceMap);
+      } catch (e) {
+        var _error = e.name + ": " + e.message + "\n\n" +
+                     (aUrl ? "URL:\n" + aUrl + "\n\n" : "") +
+                     "Content:\n" + _sourceMap;
+        throw new Error(_error);
+      }
     }
 
     var version = util.getArg(sourceMap, 'version');

--- a/toolkit/devtools/sourcemap/SourceMap.jsm
+++ b/toolkit/devtools/sourcemap/SourceMap.jsm
@@ -68,9 +68,14 @@ define('source-map/source-map-consumer', ['require', 'exports', 'module' ,  'sou
       try {
         sourceMap = JSON.parse(_sourceMap);
       } catch (e) {
+        var _contentMaxChars = 1024;
+        var _content = (_sourceMap.length > _contentMaxChars)
+                           ? _sourceMap.slice(0, _contentMaxChars - 1) + "\n[...]"
+                           : _sourceMap;
         var _error = e.name + ": " + e.message + "\n\n" +
                      (aUrl ? "URL:\n" + aUrl + "\n\n" : "") +
-                     "Content:\n" + _sourceMap;
+                     "Content (the first " + _contentMaxChars + " characters):\n" +
+                     _content + "\n";
         throw new Error(_error);
       }
     }

--- a/toolkit/devtools/sourcemap/source-map.js
+++ b/toolkit/devtools/sourcemap/source-map.js
@@ -1179,10 +1179,18 @@ define('source-map/source-map-consumer', ['require', 'exports', 'module' ,  'sou
    *
    * [0]: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?pli=1#
    */
-  function SourceMapConsumer(aSourceMap) {
+  function SourceMapConsumer(aSourceMap, aUrl) {
     var sourceMap = aSourceMap;
     if (typeof aSourceMap === 'string') {
-      sourceMap = JSON.parse(aSourceMap.replace(/^\)\]\}'/, ''));
+      var _sourceMap = aSourceMap.replace(/^\)\]\}'/, '');
+      try {
+        sourceMap = JSON.parse(_sourceMap);
+      } catch (e) {
+        var _error = e.name + ": " + e.message + "\n\n" +
+                     (aUrl ? "URL:\n" + aUrl + "\n\n" : "") +
+                     "Content:\n" + _sourceMap;
+        throw new Error(_error);
+      }
     }
 
     var version = util.getArg(sourceMap, 'version');

--- a/toolkit/devtools/sourcemap/source-map.js
+++ b/toolkit/devtools/sourcemap/source-map.js
@@ -1186,9 +1186,14 @@ define('source-map/source-map-consumer', ['require', 'exports', 'module' ,  'sou
       try {
         sourceMap = JSON.parse(_sourceMap);
       } catch (e) {
+        var _contentMaxChars = 1024;
+        var _content = (_sourceMap.length > _contentMaxChars)
+                           ? _sourceMap.slice(0, _contentMaxChars - 1) + "\n[...]"
+                           : _sourceMap;
         var _error = e.name + ": " + e.message + "\n\n" +
                      (aUrl ? "URL:\n" + aUrl + "\n\n" : "") +
-                     "Content:\n" + _sourceMap;
+                     "Content (the first " + _contentMaxChars + " characters):\n" +
+                     _content + "\n";
         throw new Error(_error);
       }
     }


### PR DESCRIPTION
Ad https://forum.palemoon.org/viewtopic.php?f=29&p=101092#p101095
(see also http://ivanvanderbyl.com/debugging-sourcemaps/)

__Steps to reproduce:__
\- Go to: https://chiru.no/ (for the file with the FLAC stream (only))
or
\- Go to: https://print.photobucket.com/
\- Opening the Developer Tools (the script debugger), throws an errors in Browser Console:

Before this change:
```
ThreadSources.prototype._fetchSourceMap threw an exception:
SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data
Stack: SourceMapConsumer@resource://gre/modules/devtools/SourceMap.jsm:67:19
ThreadSources.prototype._fetchSourceMap/fetching
<@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/server/actors/script.js:5453:19
Handler.prototype.process@resource://gre/modules/Promise.jsm
-> resource://gre/modules/Promise-backend.js:867:23
this.PromiseWalker.walkerLoop@resource://gre/modules/Promise.jsm
-> resource://gre/modules/Promise-backend.js:746:7
this.PromiseWalker.scheduleWalkerLoop/<@resource://gre/modules/Promise.jsm
-> resource://gre/modules/Promise-backend.js:688:37
EventLoop.prototype.enter@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/server/actors/script.js:371:5
ThreadActor.prototype._pushThreadPause@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/server/actors/script.js:580:5
ThreadActor.prototype.onAttach@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/server/actors/script.js:692:7
DSC_onPacket@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/server/main.js:1450:15
LocalDebuggerTransport.prototype.send/<@resource://gre/modules/devtools/dbg-client.jsm
-> resource://gre/modules/devtools/transport/transport.js:561:11
makeInfallible/<@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/DevToolsUtils.js:82:14
makeInfallible/<@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/DevToolsUtils.js:82:14
Line: 67, column: 181 DevToolsUtils.js:58:0
```

After this change (errors improvements):
```
ThreadSources.prototype._fetchSourceMap threw an exception: Error:
SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data

URL:
https://chiru.no/play/codecs/js/aurora.js.map

Content (the first 1024 characters):
<html>
<head><title>404 Not Found</title></head>
<body bgcolor="white">
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>

Stack: SourceMapConsumer@resource://gre/modules/devtools/SourceMap.jsm:74:15
...
```

See also:

https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Checking_that_the_fetch_was_successful
"a 404 does not constitute a network error"

and

Last bad: Firefox 51.0a1 (2016-09-12)
Built from https://hg.mozilla.org/mozilla-central/rev/cfdb7af3af2e92e95f71ca2f1672bf5433beeb89

First good: Firefox 51.0a1 (2016-09-13)
Built from https://hg.mozilla.org/mozilla-central/rev/f5d043ce6d36a3c461cbd829d4a4a38394b7c436

Pushlog
http://hg.mozilla.org/mozilla-central/pushloghtml?fromchange=cfdb7af3af2e92e95f71ca2f1672bf5433beeb89&tochange=f5d043ce6d36a3c461cbd829d4a4a38394b7c436

__But... There are too many changes (in debugger).__

---

The suggestion (for example).

---

__It does not solve the original problem (`https://chiru.no/` : opening the Developer Tools - the script debugger - completely breaks the audio):__

Last bad: Firefox 52.0a1 (2016-10-26)
Built from https://hg.mozilla.org/mozilla-central/rev/f9f3cc95d7282f1fd83f66dd74acbcdbfe821915

First good: Firefox 52.0a1 (2016-10-27)
Built from https://hg.mozilla.org/mozilla-central/rev/3f4c3a3cabaf94958834d3a8935adfb4a887942d

Pushlog
http://hg.mozilla.org/mozilla-central/pushloghtml?fromchange=f9f3cc95d7282f1fd83f66dd74acbcdbfe821915&tochange=3f4c3a3cabaf94958834d3a8935adfb4a887942d

I don't see a suspicious change... :-/

---

__You add the label `Devtools`, please.__

---

I've created the new build (x64) and tested.
