### PR TITLE
FFmpeg fixes

### DIFF
--- a/dom/media/platforms/ffmpeg/FFmpegAudioDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegAudioDecoder.cpp
@@ -35,6 +35,22 @@ FFmpegAudioDecoder<LIBAV_VER>::Init()
   return NS_OK;
 }
 
+void
+FFmpegAudioDecoder<LIBAV_VER>::InitCodecContext()
+{
+  MOZ_ASSERT(mCodecContext);
+  // We do not want to set this value to 0 as FFmpeg by default will
+  // use the number of cores, which with our mozlibavutil get_cpu_count
+  // isn't implemented.
+  mCodecContext->thread_count = 1;
+  // FFmpeg takes this as a suggestion for what format to use for audio samples.
+  uint32_t major, minor;
+  FFmpegRuntimeLinker::GetVersion(major, minor);
+  // LibAV 0.8 produces rubbish float interleaved samples, request 16 bits audio.
+  mCodecContext->request_sample_fmt =
+    (major == 53) ? AV_SAMPLE_FMT_S16 : AV_SAMPLE_FMT_FLT;
+}
+
 static AudioDataValue*
 CopyAndPackAudio(AVFrame* aFrame, uint32_t aNumChannels, uint32_t aNumAFrames)
 {

--- a/dom/media/platforms/ffmpeg/FFmpegAudioDecoder.h
+++ b/dom/media/platforms/ffmpeg/FFmpegAudioDecoder.h
@@ -28,6 +28,7 @@ public:
   virtual nsresult Init() override;
   virtual nsresult Input(MediaRawData* aSample) override;
   virtual nsresult Drain() override;
+  void InitCodecContext() override;
   static AVCodecID GetCodecId(const nsACString& aMimeType);
 
 private:

--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
@@ -12,7 +12,7 @@
 #include "FFmpegLog.h"
 #include "FFmpegDataDecoder.h"
 #include "prsystem.h"
-#include "FFmpegDecoderModule.h"
+#include "FFmpegRuntimeLinker.h"
 
 namespace mozilla
 {
@@ -84,7 +84,7 @@ FFmpegDataDecoder<LIBAV_VER>::Init()
 
   // FFmpeg takes this as a suggestion for what format to use for audio samples.
   uint32_t major, minor;
-  FFmpegDecoderModule<LIBAV_VER>::GetVersion(major, minor);
+  FFmpegRuntimeLinker::GetVersion(major, minor);
   // LibAV 0.8 produces rubbish float interleaved samples, request 16 bits audio.
   mCodecContext->request_sample_fmt = major == 53 ?
     AV_SAMPLE_FMT_S16 : AV_SAMPLE_FMT_FLT;

--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
@@ -27,39 +27,13 @@ FFmpegDataDecoder<LIBAV_VER>::FFmpegDataDecoder(FlushableMediaTaskQueue* aTaskQu
   , mFrame(NULL)
   , mExtraData(nullptr)
   , mCodecID(aCodecID)
-  , mCodecParser(nullptr)
 {
   MOZ_COUNT_CTOR(FFmpegDataDecoder);
-  if (mCodecParser) {
-    av_parser_close(mCodecParser);
-    mCodecParser = nullptr;
-  }
 }
 
 FFmpegDataDecoder<LIBAV_VER>::~FFmpegDataDecoder()
 {
   MOZ_COUNT_DTOR(FFmpegDataDecoder);
-}
-
-/**
- * FFmpeg calls back to this function with a list of pixel formats it supports.
- * We choose a pixel format that we support and return it.
- * For now, we just look for YUV420P as it is the only non-HW accelerated format
- * supported by FFmpeg's H264 decoder.
- */
-static PixelFormat
-ChoosePixelFormat(AVCodecContext* aCodecContext, const PixelFormat* aFormats)
-{
-  FFMPEG_LOG("Choosing FFmpeg pixel format for video decoding.");
-  for (; *aFormats > -1; aFormats++) {
-    if (*aFormats == PIX_FMT_YUV420P || *aFormats == PIX_FMT_YUVJ420P) {
-      FFMPEG_LOG("Requesting pixel format YUV420P.");
-      return PIX_FMT_YUV420P;
-    }
-  }
-
-  NS_WARNING("FFmpeg does not share any supported pixel formats.");
-  return PIX_FMT_NONE;
 }
 
 nsresult
@@ -82,19 +56,7 @@ FFmpegDataDecoder<LIBAV_VER>::Init()
 
   mCodecContext->opaque = this;
 
-  // FFmpeg takes this as a suggestion for what format to use for audio samples.
-  uint32_t major, minor;
-  FFmpegRuntimeLinker::GetVersion(major, minor);
-  // LibAV 0.8 produces rubbish float interleaved samples, request 16 bits audio.
-  mCodecContext->request_sample_fmt = major == 53 ?
-    AV_SAMPLE_FMT_S16 : AV_SAMPLE_FMT_FLT;
-
-  // FFmpeg will call back to this to negotiate a video pixel format.
-  mCodecContext->get_format = ChoosePixelFormat;
-
-  mCodecContext->thread_count = PR_GetNumberOfProcessors();
-  mCodecContext->thread_type = FF_THREAD_SLICE | FF_THREAD_FRAME;
-  mCodecContext->thread_safe_callbacks = false;
+  InitCodecContext();
 
   if (mExtraData) {
     mCodecContext->extradata_size = mExtraData->Length();
@@ -124,11 +86,6 @@ FFmpegDataDecoder<LIBAV_VER>::Init()
       mCodecContext->sample_fmt != AV_SAMPLE_FMT_S16P) {
     NS_WARNING("FFmpeg audio decoder outputs unsupported audio format.");
     return NS_ERROR_FAILURE;
-  }
-
-  mCodecParser = av_parser_init(mCodecID);
-  if (mCodecParser) {
-    mCodecParser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
   }
 
   FFMPEG_LOG("FFmpeg init successful.");

--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.h
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.h
@@ -38,6 +38,7 @@ public:
   static AVCodec* FindAVCodec(AVCodecID aCodec);
 
 protected:
+  virtual void InitCodecContext() {}
   AVFrame*        PrepareFrame();
 
   FlushableMediaTaskQueue* mTaskQueue;
@@ -45,7 +46,6 @@ protected:
   AVFrame*        mFrame;
   nsRefPtr<MediaByteBuffer> mExtraData;
   AVCodecID mCodecID;
-  AVCodecParserContext* mCodecParser;
 
 private:
   static bool sFFmpegInitDone;

--- a/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
+++ b/dom/media/platforms/ffmpeg/FFmpegDecoderModule.h
@@ -25,15 +25,6 @@ public:
     return pdm.forget();
   }
 
-  static bool
-  GetVersion(uint32_t& aMajor, uint32_t& aMinor)
-  {
-    uint32_t version = avcodec_version();
-    aMajor = (version >> 16) & 0xff;
-    aMinor = (version >> 8) & 0xff;
-    return true;
-  }
-
   FFmpegDecoderModule() {}
   virtual ~FFmpegDecoderModule() {}
 

--- a/dom/media/platforms/ffmpeg/FFmpegFunctionList.h
+++ b/dom/media/platforms/ffmpeg/FFmpegFunctionList.h
@@ -16,11 +16,9 @@ AV_FUNC(avcodec_alloc_context3, 0)
 AV_FUNC(avcodec_get_edge_width, 0)
 AV_FUNC(avcodec_open2, 0)
 AV_FUNC(av_init_packet, 0)
-AV_FUNC(av_dict_get, 0)
 AV_FUNC(av_parser_init, 0)
 AV_FUNC(av_parser_close, 0)
 AV_FUNC(av_parser_parse2, 0)
-AV_FUNC(avcodec_version, 0)
 AV_FUNC(avcodec_register_all, 0)
 
 /* libavutil */

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -84,8 +84,6 @@ FFmpegH264Decoder<LIBAV_VER>::Init()
   nsresult rv = FFmpegDataDecoder::Init();
   NS_ENSURE_SUCCESS(rv, rv);
 
-  mCodecContext->get_buffer = AllocateBufferCb;
-  mCodecContext->release_buffer = ReleaseBufferCb;
   mCodecContext->width = mPictureWidth;
   mCodecContext->height = mPictureHeight;
 
@@ -250,122 +248,6 @@ FFmpegH264Decoder<LIBAV_VER>::DecodeFrame(MediaRawData* aSample)
       mTaskQueue->IsEmpty()) {
     mCallback->InputExhausted();
   }
-}
-
-/* static */ int
-FFmpegH264Decoder<LIBAV_VER>::AllocateBufferCb(AVCodecContext* aCodecContext,
-                                               AVFrame* aFrame)
-{
-  MOZ_ASSERT(aCodecContext->codec_type == AVMEDIA_TYPE_VIDEO);
-
-  FFmpegH264Decoder* self =
-    static_cast<FFmpegH264Decoder*>(aCodecContext->opaque);
-
-  switch (aCodecContext->pix_fmt) {
-  case PIX_FMT_YUV420P:
-    return self->AllocateYUV420PVideoBuffer(aCodecContext, aFrame);
-  default:
-    return avcodec_default_get_buffer(aCodecContext, aFrame);
-  }
-}
-
-/* static */ void
-FFmpegH264Decoder<LIBAV_VER>::ReleaseBufferCb(AVCodecContext* aCodecContext,
-                                              AVFrame* aFrame)
-{
-  switch (aCodecContext->pix_fmt) {
-    case PIX_FMT_YUV420P: {
-      Image* image = static_cast<Image*>(aFrame->opaque);
-      if (image) {
-        image->Release();
-      }
-      for (uint32_t i = 0; i < AV_NUM_DATA_POINTERS; i++) {
-        aFrame->data[i] = nullptr;
-      }
-      break;
-    }
-    default:
-      avcodec_default_release_buffer(aCodecContext, aFrame);
-      break;
-  }
-}
-
-int
-FFmpegH264Decoder<LIBAV_VER>::AllocateYUV420PVideoBuffer(
-  AVCodecContext* aCodecContext, AVFrame* aFrame)
-{
-  bool needAlign = aCodecContext->codec->capabilities & CODEC_CAP_DR1;
-  bool needEdge = !(aCodecContext->flags & CODEC_FLAG_EMU_EDGE);
-  int edgeWidth = needEdge ? avcodec_get_edge_width() : 0;
-
-  int decodeWidth = aCodecContext->width + edgeWidth * 2;
-  int decodeHeight = aCodecContext->height + edgeWidth * 2;
-
-  if (needAlign) {
-    // Align width and height to account for CODEC_CAP_DR1.
-    // Make sure the decodeWidth is a multiple of 64, so a UV plane stride will be
-    // a multiple of 32. FFmpeg uses SSE3 accelerated code to copy a frame line by
-    // line.
-    // VP9 decoder uses MOVAPS/VEX.256 which requires 32-bytes aligned memory.
-    decodeWidth = (decodeWidth + 63) & ~63;
-    decodeHeight = (decodeHeight + 63) & ~63;
-  }
-
-  PodZero(&aFrame->data[0], AV_NUM_DATA_POINTERS);
-  PodZero(&aFrame->linesize[0], AV_NUM_DATA_POINTERS);
-
-  int pitch = decodeWidth;
-  int chroma_pitch  = (pitch + 1) / 2;
-  int chroma_height = (decodeHeight +1) / 2;
-
-  // Get strides for each plane.
-  aFrame->linesize[0] = pitch;
-  aFrame->linesize[1] = aFrame->linesize[2] = chroma_pitch;
-
-  size_t allocSize = pitch * decodeHeight + (chroma_pitch * chroma_height) * 2;
-
-  nsRefPtr<Image> image =
-    mImageContainer->CreateImage(ImageFormat::PLANAR_YCBCR);
-  PlanarYCbCrImage* ycbcr = static_cast<PlanarYCbCrImage*>(image.get());
-  uint8_t* buffer = ycbcr->AllocateAndGetNewBuffer(allocSize + 64);
-  // FFmpeg requires a 16/32 bytes-aligned buffer, align it on 64 to be safe
-  buffer = reinterpret_cast<uint8_t*>((reinterpret_cast<uintptr_t>(buffer) + 63) & ~63);
-
-  if (!buffer) {
-    NS_WARNING("Failed to allocate buffer for FFmpeg video decoding");
-    return -1;
-  }
-
-  int offsets[3] = {
-    0,
-    pitch * decodeHeight,
-    pitch * decodeHeight + chroma_pitch * chroma_height };
-
-  // Add a horizontal bar |edgeWidth| pixels high at the
-  // top of the frame, plus |edgeWidth| pixels from the left of the frame.
-  int planesEdgeWidth[3] = {
-    edgeWidth * aFrame->linesize[0] + edgeWidth,
-    edgeWidth / 2 * aFrame->linesize[1] + edgeWidth / 2,
-    edgeWidth / 2 * aFrame->linesize[2] + edgeWidth / 2 };
-
-  for (uint32_t i = 0; i < 3; i++) {
-    aFrame->data[i] = buffer + offsets[i] + planesEdgeWidth[i];
-  }
-
-  aFrame->extended_data = aFrame->data;
-  aFrame->width = aCodecContext->width;
-  aFrame->height = aCodecContext->height;
-
-  aFrame->opaque = static_cast<void*>(image.forget().take());
-
-  aFrame->type = FF_BUFFER_TYPE_USER;
-  aFrame->reordered_opaque = aCodecContext->reordered_opaque;
-#if LIBAVCODEC_VERSION_MAJOR == 53
-  if (aCodecContext->pkt) {
-    aFrame->pkt_pts = aCodecContext->pkt->pts;
-  }
-#endif
-  return 0;
 }
 
 nsresult

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -115,7 +115,19 @@ FFmpegH264Decoder<LIBAV_VER>::InitCodecContext()
   mCodecContext->width = mPictureWidth;
   mCodecContext->height = mPictureHeight;
 
-  mCodecContext->thread_count = PR_GetNumberOfProcessors();
+  // We use the same logic as libvpx in determining the number of threads to use
+  // so that we end up behaving in the same fashion when using ffmpeg as
+  // we would otherwise cause various crashes (see bug 1236167)
+  int decode_threads = 2;
+  if (mCodecID != AV_CODEC_ID_VP8) {
+    if (mDisplayWidth >= 2048) {
+      decode_threads = 8;
+    } else if (mDisplayWidth >= 1024) {
+      decode_threads = 4;
+    }
+  }
+  decode_threads = std::min(decode_threads, PR_GetNumberOfProcessors());
+  mCodecContext->thread_count = decode_threads;
   mCodecContext->thread_type = FF_THREAD_SLICE | FF_THREAD_FRAME;
 
   // FFmpeg will call back to this to negotiate a video pixel format.

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
@@ -42,6 +42,7 @@ public:
   virtual nsresult Input(MediaRawData* aSample) override;
   virtual nsresult Drain() override;
   virtual nsresult Flush() override;
+  void InitCodecContext() override;
   static AVCodecID GetCodecId(const nsACString& aMimeType);
 
 private:
@@ -66,6 +67,9 @@ private:
   uint32_t mPictureHeight;
   uint32_t mDisplayWidth;
   uint32_t mDisplayHeight;
+
+  // Parser used for VP8 and VP9 decoding.
+  AVCodecParserContext* mCodecParser;
 
   class PtsCorrectionContext {
   public:

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.h
@@ -60,9 +60,6 @@ private:
   int AllocateYUV420PVideoBuffer(AVCodecContext* aCodecContext,
                                  AVFrame* aFrame);
 
-  static int AllocateBufferCb(AVCodecContext* aCodecContext, AVFrame* aFrame);
-  static void ReleaseBufferCb(AVCodecContext* aCodecContext, AVFrame* aFrame);
-
   MediaDataDecoderCallback* mCallback;
   nsRefPtr<ImageContainer> mImageContainer;
   uint32_t mPictureWidth;

--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
@@ -4,13 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <dlfcn.h>
-
 #include "FFmpegRuntimeLinker.h"
 #include "mozilla/ArrayUtils.h"
 #include "FFmpegLog.h"
-
-#define NUM_ELEMENTS(X) (sizeof(X) / sizeof((X)[0]))
+#include "prlink.h"
 
 namespace mozilla
 {
@@ -18,35 +15,33 @@ namespace mozilla
 FFmpegRuntimeLinker::LinkStatus FFmpegRuntimeLinker::sLinkStatus =
   LinkStatus_INIT;
 
-struct AvCodecLib
-{
-  const char* Name;
-  already_AddRefed<PlatformDecoderModule> (*Factory)();
-  uint32_t Version;
-};
-
 template <int V> class FFmpegDecoderModule
 {
 public:
   static already_AddRefed<PlatformDecoderModule> Create();
 };
 
-static const AvCodecLib sLibs[] = {
-  { "libavcodec-ffmpeg.so.56", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavcodec.so.56", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavcodec.so.55", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavcodec.so.54", FFmpegDecoderModule<54>::Create, 54 },
-  { "libavcodec.so.53", FFmpegDecoderModule<53>::Create, 53 },
-  { "libavcodec.56.dylib", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavcodec.55.dylib", FFmpegDecoderModule<55>::Create, 55 },
-  { "libavcodec.54.dylib", FFmpegDecoderModule<54>::Create, 54 },
-  { "libavcodec.53.dylib", FFmpegDecoderModule<53>::Create, 53 },
+static const char* sLibs[] = {
+#if defined(XP_DARWIN)
+  "libavcodec.56.dylib",
+  "libavcodec.55.dylib",
+  "libavcodec.54.dylib",
+  "libavcodec.53.dylib",
+#else
+  "libavcodec-ffmpeg.so.56",
+  "libavcodec.so.56",
+  "libavcodec.so.55",
+  "libavcodec.so.54",
+  "libavcodec.so.53",
+#endif
 };
 
-void* FFmpegRuntimeLinker::sLinkedLib = nullptr;
-const AvCodecLib* FFmpegRuntimeLinker::sLib = nullptr;
+PRLibrary* FFmpegRuntimeLinker::sLinkedLib = nullptr;
+const char* FFmpegRuntimeLinker::sLib = nullptr;
+static unsigned (*avcodec_version)() = nullptr;
 
 #define AV_FUNC(func, ver) void (*func)();
+
 #define LIBAVCODEC_ALLVERSION
 #include "FFmpegFunctionList.h"
 #undef LIBAVCODEC_ALLVERSION
@@ -62,10 +57,13 @@ FFmpegRuntimeLinker::Link()
   MOZ_ASSERT(NS_IsMainThread());
 
   for (size_t i = 0; i < ArrayLength(sLibs); i++) {
-    const AvCodecLib* lib = &sLibs[i];
-    sLinkedLib = dlopen(lib->Name, RTLD_NOW | RTLD_LOCAL);
+    const char* lib = sLibs[i];
+    PRLibSpec lspec;
+    lspec.type = PR_LibSpec_Pathname;
+    lspec.value.pathname = lib;
+    sLinkedLib = PR_LoadLibraryWithFlags(lspec, PR_LD_NOW | PR_LD_LOCAL);
     if (sLinkedLib) {
-      if (Bind(lib->Name, lib->Version)) {
+      if (Bind(lib)) {
         sLib = lib;
         sLinkStatus = LinkStatus_SUCCEEDED;
         return true;
@@ -77,7 +75,7 @@ FFmpegRuntimeLinker::Link()
 
   FFMPEG_LOG("H264/AAC codecs unsupported without [");
   for (size_t i = 0; i < ArrayLength(sLibs); i++) {
-    FFMPEG_LOG("%s %s", i ? "," : "", sLibs[i].Name);
+    FFMPEG_LOG("%s %s", i ? "," : "", sLibs[i]);
   }
   FFMPEG_LOG(" ]\n");
 
@@ -88,12 +86,23 @@ FFmpegRuntimeLinker::Link()
 }
 
 /* static */ bool
-FFmpegRuntimeLinker::Bind(const char* aLibName, uint32_t Version)
+FFmpegRuntimeLinker::Bind(const char* aLibName)
 {
+  avcodec_version = (typeof(avcodec_version))PR_FindSymbol(sLinkedLib,
+                                                           "avcodec_version");
+  uint32_t major, minor;
+  if (!GetVersion(major, minor)) {
+    return false;
+  }
+  if (major > 55) {
+    // All major greater than 56 currently use the same ABI as 55.
+    major = 55;
+  }
+
 #define LIBAVCODEC_ALLVERSION
 #define AV_FUNC(func, ver)                                                     \
-  if (ver == 0 || ver == Version) {                                            \
-    if (!(func = (typeof(func))dlsym(sLinkedLib, #func))) {                    \
+  if (ver == 0 || ver == major) {                                              \
+    if (!(func = (typeof(func))PR_FindSymbol(sLinkedLib, #func))) {            \
       FFMPEG_LOG("Couldn't load function " #func " from %s.", aLibName);       \
       return false;                                                            \
     }                                                                          \
@@ -110,7 +119,17 @@ FFmpegRuntimeLinker::CreateDecoderModule()
   if (!Link()) {
     return nullptr;
   }
-  nsRefPtr<PlatformDecoderModule> module = sLib->Factory();
+  uint32_t major, minor;
+  if (!GetVersion(major, minor)) {
+    return  nullptr;
+  }
+
+  nsRefPtr<PlatformDecoderModule> module;
+  switch (major) {
+    case 53: module = FFmpegDecoderModule<53>::Create(); break;
+    case 54: module = FFmpegDecoderModule<54>::Create(); break;
+    default: module = FFmpegDecoderModule<55>::Create(); break;
+  }
   return module.forget();
 }
 
@@ -118,11 +137,24 @@ FFmpegRuntimeLinker::CreateDecoderModule()
 FFmpegRuntimeLinker::Unlink()
 {
   if (sLinkedLib) {
-    dlclose(sLinkedLib);
+    PR_UnloadLibrary(sLinkedLib);
     sLinkedLib = nullptr;
     sLib = nullptr;
     sLinkStatus = LinkStatus_INIT;
+    avcodec_version = nullptr;
   }
+}
+
+/* static */ bool
+FFmpegRuntimeLinker::GetVersion(uint32_t& aMajor, uint32_t& aMinor)
+{
+  if (!avcodec_version) {
+    return false;
+  }
+  uint32_t version = avcodec_version();
+  aMajor = (version >> 16) & 0xff;
+  aMinor = (version >> 8) & 0xff;
+  return true;
 }
 
 } // namespace mozilla

--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
@@ -75,7 +75,7 @@ FFmpegRuntimeLinker::Link()
 
   FFMPEG_LOG("H264/AAC codecs unsupported without [");
   for (size_t i = 0; i < ArrayLength(sLibs); i++) {
-    FFMPEG_LOG("%s %s", i ? "," : "", sLibs[i]);
+    FFMPEG_LOG("%s %s", i ? "," : " ", sLibs[i]);
   }
   FFMPEG_LOG(" ]\n");
 

--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.h
+++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.h
@@ -10,10 +10,10 @@
 #include "PlatformDecoderModule.h"
 #include <stdint.h>
 
+struct PRLibrary;
+
 namespace mozilla
 {
-
-struct AvCodecLib;
 
 class FFmpegRuntimeLinker
 {
@@ -21,12 +21,13 @@ public:
   static bool Link();
   static void Unlink();
   static already_AddRefed<PlatformDecoderModule> CreateDecoderModule();
+  static bool GetVersion(uint32_t& aMajor, uint32_t& aMinor);
 
 private:
-  static void* sLinkedLib;
-  static const AvCodecLib* sLib;
+  static PRLibrary* sLinkedLib;
+  static const char* sLib;
 
-  static bool Bind(const char* aLibName, uint32_t Version);
+  static bool Bind(const char* aLibName);
 
   static enum LinkStatus {
     LinkStatus_INIT = 0,


### PR DESCRIPTION
A few fixes leading up to adding support for FFmpeg 3.x/libavcodec56 & 57:

No longer rely on the library name to determine the version of libavcodec that is available. This lays the groundwork for simplifying how the external libavcodec and libavutil libs are linked (more to come on this).

Let FFmpeg manage its own memory allocation -- The API provided for overriding memory allocation has been deprecated for a long time, and was removed in libavcodec57.

Fix some potential codec initialization issues.

Reduce the number of threads that are used by the FFmpeg video decoder.

Tested and appears to be working as intended.