### PR TITLE
DevTools - Debugger - Breakpoints - add from the context menu

### DIFF
--- a/toolkit/devtools/debugger/debugger-panes.js
+++ b/toolkit/devtools/debugger/debugger-panes.js
@@ -1017,7 +1017,7 @@ SourcesView.prototype = Heritage.extend(WidgetMethods, {
    */
   _onCmdAddBreakpoint: function(e) {
     let actor = DebuggerView.Sources.selectedValue;
-    let line = (e && e.sourceEvent.target.tagName == 'menuitem' ?
+    let line = (DebuggerView.clickedLine ?
                 DebuggerView.clickedLine + 1 :
                 DebuggerView.editor.getCursor().line + 1);
     let location = { actor, line };
@@ -1038,7 +1038,7 @@ SourcesView.prototype = Heritage.extend(WidgetMethods, {
    */
   _onCmdAddConditionalBreakpoint: function(e) {
     let actor = DebuggerView.Sources.selectedValue;
-    let line = (e && e.sourceEvent.target.tagName == 'menuitem' ?
+    let line = (DebuggerView.clickedLine ?
                 DebuggerView.clickedLine + 1 :
                 DebuggerView.editor.getCursor().line + 1);
     let location = { actor, line };

--- a/toolkit/devtools/debugger/debugger-view.js
+++ b/toolkit/devtools/debugger/debugger-view.js
@@ -257,6 +257,10 @@ let DebuggerView = {
         }
       }
     });
+
+    this.editor.on("cursorActivity", () => {
+      this.clickedLine = null;
+    });
   },
 
   /**

--- a/toolkit/devtools/sourceeditor/debugger.js
+++ b/toolkit/devtools/sourceeditor/debugger.js
@@ -132,6 +132,14 @@ function addBreakpoint(ctx, line, cond) {
     let meta = dbginfo.get(ed);
     let info = cm.lineInfo(line);
 
+    // The line does not exist in the editor. This is harmless, the
+    // architecture calling this assumes the editor will handle this
+    // gracefully, and make sure breakpoints exist when they need to.
+    if (!info) {
+      return;
+    }
+
+    // XXX: why is `info` null when breaking on page reload?
     ed.addMarker(line, "breakpoints", "breakpoint");
     meta.breakpoints[line] = { condition: cond };
 


### PR DESCRIPTION

__Steps to reproduce:__

Fail add breakpoint (i.e. conditional) from the context menu:

![1](https://cloud.githubusercontent.com/assets/2373486/21286196/a30f6322-c44d-11e6-8978-1a28713c1c3e.png)

Throws a error in Browser Console:
```
Handler function threw an exception: TypeError: info is null
Stack: _addBreakpoint@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/sourceeditor/debugger.js:138:5
addBreakpoint/<@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/sourceeditor/debugger.js:154:37
makeInfallible/<@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/DevToolsUtils.js:82:14
EventLoop.prototype.enter@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/server/actors/script.js:371:5
ThreadActor.prototype._pushThreadPause@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/server/actors/script.js:580:5
ThreadActor.prototype.onInterrupt@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/server/actors/script.js:1402:7
DSC_onPacket@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/server/main.js:1450:15
LocalDebuggerTransport.prototype.send/<@resource://gre/modules/devtools/dbg-client.jsm
-> resource://gre/modules/devtools/transport/transport.js:561:11
makeInfallible/<@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/DevToolsUtils.js:82:14
makeInfallible/<@resource://gre/modules/jetpack/toolkit/loader.js
-> resource://gre/modules/devtools/DevToolsUtils.js:82:14
Line: 138, column: 41 DevToolsUtils.js:58:0
```

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1251823
https://bugzilla.mozilla.org/show_bug.cgi?id=1200798
(https://hg.mozilla.org/mozilla-central/rev/0e47cb064701#l131.12)

---

__You add the label `Devtools`, please.__

---

I've created the new build (x64) and tested.
