### PR TITLE
Hide non-fatal error in nsContextMenu.js

### DIFF
--- a/browser/base/content/nsContextMenu.js
+++ b/browser/base/content/nsContextMenu.js
@@ -72,7 +72,7 @@ nsContextMenu.prototype = {
                                          nsISupportsCString).data;
         }
       } catch (e) {
-        Components.utils.reportError(e);
+        // Failure to get type and content-disposition off the image is non-fatal
       }
     }
 


### PR DESCRIPTION
Cosmetic update to #778: failure to get type and content-disposition off the image is non-fatal, so let's be quiet like in [similar case](https://github.com/MoonchildProductions/Pale-Moon/blob/master/toolkit/content/contentAreaUtils.js#L123).