### PR TITLE
Avoid TypeError in 'sdk/context-menu' caused by bad e10s code

### DIFF
--- a/toolkit/jetpack/sdk/context-menu.js
+++ b/toolkit/jetpack/sdk/context-menu.js
@@ -686,21 +686,22 @@ function remoteItemRequest({ target: { messageManager } }) {
   if (items.length == 0)
     return;
 
-  messageManager.sendAsyncMessage("sdk/contextmenu/createitems", {
-    items,
-    addon: ADDON,
-  });
-}
-
 // Context menu support in e10s via https://bugzilla.mozilla.org/show_bug.cgi?id=1060138
 // led to the TypeError in FF38 - https://bugzilla.mozilla.org/show_bug.cgi?id=1130830
 // In FF39+ context-menu.js was rewritten from scratch with processes, but it's not our way.
-// Let's disable it for now, it looks safe, though to rollback #1060138 would be better.
+// Let's do extra check it for now, though to rollback #1060138 would be better.
 
-//MessageManager.addMessageListener('sdk/contextmenu/requestitems', remoteItemRequest);
+  if (messageManager && messageManager.sendAsyncMessage && messageManager.sendAsyncMessage typeof "function") {
+    messageManager.sendAsyncMessage("sdk/contextmenu/createitems", {
+      items,
+      addon: ADDON,
+    });
+  }
+}
+MessageManager.addMessageListener('sdk/contextmenu/requestitems', remoteItemRequest);
 
 when(function() {
-//  MessageManager.removeMessageListener('sdk/contextmenu/requestitems', remoteItemRequest);
+  MessageManager.removeMessageListener('sdk/contextmenu/requestitems', remoteItemRequest);
   contentContextMenu.destroy();
 });
 

--- a/toolkit/jetpack/sdk/context-menu.js
+++ b/toolkit/jetpack/sdk/context-menu.js
@@ -691,10 +691,16 @@ function remoteItemRequest({ target: { messageManager } }) {
     addon: ADDON,
   });
 }
-MessageManager.addMessageListener('sdk/contextmenu/requestitems', remoteItemRequest);
+
+// Context menu support in e10s via https://bugzilla.mozilla.org/show_bug.cgi?id=1060138
+// led to the TypeError in FF38 - https://bugzilla.mozilla.org/show_bug.cgi?id=1130830
+// In FF39+ context-menu.js was rewritten from scratch with processes, but it's not our way.
+// Let's disable it for now, it looks safe, though to rollback #1060138 would be better.
+
+//MessageManager.addMessageListener('sdk/contextmenu/requestitems', remoteItemRequest);
 
 when(function() {
-  MessageManager.removeMessageListener('sdk/contextmenu/requestitems', remoteItemRequest);
+//  MessageManager.removeMessageListener('sdk/contextmenu/requestitems', remoteItemRequest);
   contentContextMenu.destroy();
 });
 

--- a/toolkit/jetpack/sdk/context-menu.js
+++ b/toolkit/jetpack/sdk/context-menu.js
@@ -691,7 +691,7 @@ function remoteItemRequest({ target: { messageManager } }) {
 // In FF39+ context-menu.js was rewritten from scratch with processes, but it's not our way.
 // Let's do extra check it for now, though to rollback #1060138 would be better.
 
-  if (messageManager && messageManager.sendAsyncMessage && messageManager.sendAsyncMessage typeof "function") {
+  if (messageManager && messageManager.sendAsyncMessage && typeof messageManager.sendAsyncMessage === "function") {
     messageManager.sendAsyncMessage("sdk/contextmenu/createitems", {
       items,
       addon: ADDON,


### PR DESCRIPTION
Context menu support in e10s via https://bugzilla.mozilla.org/show_bug.cgi?id=1060138 led to the TypeError in FF38 - https://bugzilla.mozilla.org/show_bug.cgi?id=1130830

In FF39+ context-menu.js was rewritten from scratch with processes, but it's not our way.

Let's do extra check it for now, though to rollback #1060138 would be better.