### PR TITLE
Silence "error" message in MPEG4Extractor

### DIFF
--- a/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
@@ -1507,7 +1507,7 @@ status_t MPEG4Extractor::parseChunk(off64_t *offset, int depth) {
                         mLastTrack->meta->findInt32(kKeyHeight, &height)) {
                     mLastTrack->meta->setInt32(kKeyMaxInputSize, width * height * 3 / 2);
                 } else {
-                    ALOGE("No width or height, assuming worst case 1080p");
+                    ALOGV("No width or height, assuming worst case 1080p");
                     mLastTrack->meta->setInt32(kKeyMaxInputSize, 3110400);
                 }
             }


### PR DESCRIPTION
The "error" message "No width or height, assuming worst case 1080p" appears in the terminal all the time when not using GStreamer to play MP4. This message serves no purpose anymore and just clutters up the terminal window (it's a remnant of when we were more dependent on libstagefright).