### PR TITLE
Update Events/TabSelect to the current API spec

### DIFF
--- a/browser/base/content/tabbrowser.xml
+++ b/browser/base/content/tabbrowser.xml
@@ -1078,8 +1078,13 @@
             // Focus is suppressed in the event that the main browser window is minimized - focusing a tab would restore the window
             if (!this._previewMode) {
               // We've selected the new tab, so go ahead and notify listeners.
-              let event = document.createEvent("Events");
-              event.initEvent("TabSelect", true, false);
+              let event = new CustomEvent("TabSelect", {
+                bubbles: true,
+                cancelable: false,
+                detail: {
+                  previousTab: oldTab
+                }
+              });
               this.mCurrentTab.dispatchEvent(event);
 
               this._tabAttrModified(oldTab);


### PR DESCRIPTION
The previously selected tab should be [available via event.detail](https://developer.mozilla.org/docs/Web/Events/TabSelect) from within the listener callback. This will prevent [memory leak](https://forum.palemoon.org/viewtopic.php?f=12&t=14326) in extensions that use this API, such as [Quick Context 2](https://addons.mozilla.org/addon/quick-context-2/).

PS: This API update was introduced as part of https://bugzilla.mozilla.org/show_bug.cgi?id=952568