### PR TITLE
FFmpeg sec fixes

### DIFF
--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
@@ -114,8 +114,7 @@ FFmpegDataDecoder<LIBAV_VER>::Shutdown()
 #elif LIBAVCODEC_VERSION_MAJOR == 54
     avcodec_free_frame(&mFrame);
 #else
-    delete mFrame;
-    mFrame = nullptr;
+    av_freep(&mFrame);
 #endif
   }
   return NS_OK;
@@ -137,9 +136,8 @@ FFmpegDataDecoder<LIBAV_VER>::PrepareFrame()
     mFrame = avcodec_alloc_frame();
   }
 #else
-  delete mFrame;
-  mFrame = new AVFrame;
-  avcodec_get_frame_defaults(mFrame);
+  av_freep(&mFrame);
+  mFrame = avcodec_alloc_frame();
 #endif
   return mFrame;
 }

--- a/dom/media/platforms/ffmpeg/FFmpegFunctionList.h
+++ b/dom/media/platforms/ffmpeg/FFmpegFunctionList.h
@@ -17,6 +17,10 @@ AV_FUNC(av_parser_close, AV_FUNC_AVCODEC_ALL)
 AV_FUNC(av_parser_parse2, AV_FUNC_AVCODEC_ALL)
 #if LIBAVCODEC_VERSION_MAJOR <= 54 || defined(LIBAVCODEC_ALLVERSION)
 AV_FUNC(avcodec_get_frame_defaults, (AV_FUNC_53 | AV_FUNC_54))
+AV_FUNC(avcodec_alloc_frame, (AV_FUNC_53 | AV_FUNC_54))
+#endif
+#if LIBAVCODEC_VERSION_MAJOR == 54 || defined(LIBAVCODEC_ALLVERSION)
+AV_FUNC(avcodec_free_frame, AV_FUNC_54)
 #endif
 
 /* libavutil */
@@ -25,11 +29,6 @@ AV_FUNC(av_malloc, AV_FUNC_AVUTIL_ALL)
 AV_FUNC(av_freep, AV_FUNC_AVUTIL_ALL)
 
 #if defined(LIBAVCODEC_VERSION_MAJOR) || defined(LIBAVCODEC_ALLVERSION)
-#if LIBAVCODEC_VERSION_MAJOR == 54 || defined(LIBAVCODEC_ALLVERSION)
-/* libavutil v54 only */
-AV_FUNC(avcodec_alloc_frame, AV_FUNC_AVUTIL_54)
-AV_FUNC(avcodec_free_frame, AV_FUNC_AVUTIL_54)
-#endif
 #if LIBAVCODEC_VERSION_MAJOR >= 55 || defined(LIBAVCODEC_ALLVERSION)
 /* libavutil v55 and later only */
 AV_FUNC(av_frame_alloc, (AV_FUNC_AVUTIL_55 | AV_FUNC_AVUTIL_56 | AV_FUNC_AVUTIL_57))

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -372,12 +372,6 @@ FFmpegH264Decoder<LIBAV_VER>::GetCodecId(const nsACString& aMimeType)
   }
 #endif
 
-#if LIBAVCODEC_VERSION_MAJOR >= 55
-  if (aMimeType.EqualsLiteral("video/webm; codecs=vp9")) {
-    return AV_CODEC_ID_VP9;
-  }
-#endif
-
   return AV_CODEC_ID_NONE;
 }
 

--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
@@ -104,8 +104,6 @@ FFmpegRuntimeLinker::Bind(const char* aLibName)
     // Refuse any libavcodec version prior to 54.35.1.
     // (Unless media.libavcodec.allow-obsolete==true)
     Unlink();
-    LogToBrowserConsole(NS_LITERAL_STRING(
-      "libavcodec may be vulnerable or is not supported, and should be updated to play video."));
     return false;
   }
 

--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.cpp
@@ -92,8 +92,20 @@ FFmpegRuntimeLinker::Bind(const char* aLibName)
 {
   avcodec_version = (typeof(avcodec_version))PR_FindSymbol(sLinkedLib,
                                                            "avcodec_version");
-  uint32_t major, minor, micro;
-  if (!GetVersion(major, minor, micro)) {
+  uint32_t fullVersion, major, minor, micro;
+  fullVersion = GetVersion(major, minor, micro);
+  if (!fullVersion) {
+    return false;
+  }
+
+  if (micro < 100 &&
+      fullVersion < (54u << 16 | 35u << 8 | 1u) &&
+      !Preferences::GetBool("media.libavcodec.allow-obsolete", false)) {
+    // Refuse any libavcodec version prior to 54.35.1.
+    // (Unless media.libavcodec.allow-obsolete==true)
+    Unlink();
+    LogToBrowserConsole(NS_LITERAL_STRING(
+      "libavcodec may be vulnerable or is not supported, and should be updated to play video."));
     return false;
   }
 
@@ -175,17 +187,17 @@ FFmpegRuntimeLinker::Unlink()
   }
 }
 
-/* static */ bool
+/* static */ uint32_t
 FFmpegRuntimeLinker::GetVersion(uint32_t& aMajor, uint32_t& aMinor, uint32_t& aMicro)
 {
   if (!avcodec_version) {
-    return false;
+    return 0u;
   }
   uint32_t version = avcodec_version();
   aMajor = (version >> 16) & 0xff;
   aMinor = (version >> 8) & 0xff;
   aMicro = version & 0xff;
-  return true;
+  return version;
 }
 
 } // namespace mozilla

--- a/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.h
+++ b/dom/media/platforms/ffmpeg/FFmpegRuntimeLinker.h
@@ -37,7 +37,7 @@ public:
   static bool Link();
   static void Unlink();
   static already_AddRefed<PlatformDecoderModule> CreateDecoderModule();
-  static bool GetVersion(uint32_t& aMajor, uint32_t& aMinor, uint32_t& aMicro);
+  static uint32_t GetVersion(uint32_t& aMajor, uint32_t& aMinor, uint32_t& aMicro);
 
 private:
   static PRLibrary* sLinkedLib;

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -306,6 +306,9 @@ pref("media.fragmented-mp4.exposed", false);
 // decoder works on all platforms.
 pref("media.fragmented-mp4.use-blank-decoder", false);
 #endif
+#if defined(MOZ_FFMPEG)
+pref("media.libavcodec.allow-obsolete", false);
+#endif
 #ifdef MOZ_RAW
 pref("media.raw.enabled", true);
 #endif

--- a/testing/profiles/prefs_general.js
+++ b/testing/profiles/prefs_general.js
@@ -306,3 +306,6 @@ user_pref("dom.ipc.tabs.shutdownTimeoutSecs", 0);
 
 // Avoid performing Readinglist Intro during tests.
 user_pref("browser.readinglist.introShown", true);
+
+// Don't block old libavcodec libraries when testing.
+user_pref("media.libavcodec.allow-obsolete", true);


### PR DESCRIPTION
Roll up patch of all applicable sec issues with our FFmpeg code:

1) Don't use old, potentially vulnerable versions of libavcodec by default (can be enabled with a pref on those distros that have older versions).

2) Don't use libav to decode VP9.

3) Fix a possibly exploitable crash.

Tested and works as intended.