### PR TITLE
Permissions: Plugins (the second part)

### DIFF
--- a/browser/components/preferences/aboutPermissions.xml
+++ b/browser/components/preferences/aboutPermissions.xml
@@ -38,9 +38,11 @@
     </content>
     <implementation>
       <constructor><![CDATA[
+        let mimeType = this.getAttribute("mimeType");
         let permString = this.getAttribute("permString");
         let menulist = document.getAnonymousElementByAttribute(this, "anonid", "plugins-menulist");
         menulist.setAttribute("id", permString + "-menulist");
+        menulist.setAttribute("mimeType", mimeType);
         menulist.setAttribute("type", permString);
         let askitem = document.getAnonymousElementByAttribute(this, "anonid", "ask");
         askitem.setAttribute("id", permString + "-0")


### PR DESCRIPTION
## Permissions Manager

Ad #637 (Add per-plugin permissions) and #764 (Permissions: Plugins (a basic part))

The suggestion (for example).
__________

### I've created the new build (x64) and tested:
__________

Reading and writing settings:
`Ask to Activate`/`Always Activate`/`Never Activate`:
__________
`about:addons`: `Plugins`
__<=>__ 
`about:permissions`: `All sites`
__________
`Page Info`: `Permissions` - `Activate Plugins`
__<=>__
`about:permissions`: `[the selected site]`
__________

__But please check it in detail (all options).__
