### PR TITLE
Don't let FFmpeg be a resource hog

### DIFF
--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -126,17 +126,20 @@ FFmpegH264Decoder<LIBAV_VER>::InitCodecContext()
   // We use the same logic as libvpx in determining the number of threads to use
   // so that we end up behaving in the same fashion when using ffmpeg as
   // we would otherwise cause various crashes (see bug 1236167)
-  int decode_threads = 2;
-  if (mCodecID != AV_CODEC_ID_VP8) {
-    if (mDisplayWidth >= 2048) {
-      decode_threads = 8;
-    } else if (mDisplayWidth >= 1024) {
-      decode_threads = 4;
-    }
+  int decode_threads = 1;
+  if (mDisplayWidth >= 2048) {
+    decode_threads = 8;
+  } else if (mDisplayWidth >= 1024) {
+    decode_threads = 4;
+  } else if (mDisplayWidth >= 320) {
+    decode_threads = 2;
   }
+
   decode_threads = std::min(decode_threads, PR_GetNumberOfProcessors());
   mCodecContext->thread_count = decode_threads;
-  mCodecContext->thread_type = FF_THREAD_SLICE | FF_THREAD_FRAME;
+  if (decode_threads > 1) {
+    mCodecContext->thread_type = FF_THREAD_SLICE | FF_THREAD_FRAME;
+  }
 
   // FFmpeg will call back to this to negotiate a video pixel format.
   mCodecContext->get_format = ChoosePixelFormat;

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -135,7 +135,8 @@ FFmpegH264Decoder<LIBAV_VER>::InitCodecContext()
     decode_threads = 2;
   }
 
-  decode_threads = std::min(decode_threads, PR_GetNumberOfProcessors());
+  decode_threads = std::min(decode_threads, PR_GetNumberOfProcessors() - 1);
+  decode_threads = std::max(decode_threads, 1);
   mCodecContext->thread_count = decode_threads;
   if (decode_threads > 1) {
     mCodecContext->thread_type = FF_THREAD_SLICE | FF_THREAD_FRAME;

--- a/media/libstagefright/frameworks/av/media/libstagefright/SampleTable.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/SampleTable.cpp
@@ -375,7 +375,7 @@ status_t SampleTable::setTimeToSampleParams(
 
 status_t SampleTable::setCompositionTimeToSampleParams(
         off64_t data_offset, size_t data_size) {
-    ALOGI("There are reordered frames present.");
+    ALOGV("There are reordered frames present.");
 
     if (mCompositionTimeDeltaEntries != NULL || data_size < 8) {
         return ERROR_MALFORMED;


### PR DESCRIPTION
Currently the FFmpeg decoder will use all available CPUs. With this PR, we'll leave one free for other tasks.

Currently, FFmpeg always creates a new thread for each video it is decoding. For small videos, we will now keep it on the current task queue (lowers RAM usage when watching short videos).

Additionally, this PR prevents libstagefright from spamming the terminal with another useless "error" message.

Tested and appears to work as intended.