### PR TITLE
Permissions: Notifications (+ follow up)

### DIFF
--- a/browser/base/content/pageinfo/pageInfo.xul
+++ b/browser/base/content/pageinfo/pageInfo.xul
@@ -340,6 +340,7 @@
             <checkbox id="desktop-notificationDef" command="cmd_desktop-notificationDef" label="&permUseDefault;"/>
             <spacer flex="1"/>
             <radiogroup id="desktop-notificationRadioGroup" orient="horizontal">
+              <radio id="desktop-notification#0" command="cmd_desktop-notificationToggle" label="&permAskAlways;"/>
               <radio id="desktop-notification#1" command="cmd_desktop-notificationToggle" label="&permAllow;"/>
               <radio id="desktop-notification#2" command="cmd_desktop-notificationToggle" label="&permBlock;"/>
             </radiogroup>

--- a/browser/base/content/pageinfo/permissions.js
+++ b/browser/base/content/pageinfo/permissions.js
@@ -4,8 +4,13 @@
 
 const UNKNOWN = nsIPermissionManager.UNKNOWN_ACTION;   // 0
 const ALLOW = nsIPermissionManager.ALLOW_ACTION;       // 1
-const BLOCK = nsIPermissionManager.DENY_ACTION;        // 2
+const DENY = nsIPermissionManager.DENY_ACTION;         // 2
 const SESSION = nsICookiePermission.ACCESS_SESSION;    // 8
+
+const IMAGE_DENY = 2;
+
+const COOKIE_DENY = 2;
+const COOKIE_SESSION = 2;
 
 const nsIQuotaManager = Components.interfaces.nsIQuotaManager;
 
@@ -16,45 +21,54 @@ var gUsageRequest;
 var gPermObj = {
   image: function getImageDefaultPermission()
   {
-    if (gPrefs.getIntPref("permissions.default.image") == 2)
-      return BLOCK;
+    if (gPrefs.getIntPref("permissions.default.image") == IMAGE_DENY) {
+      return DENY;
+    }
+    return ALLOW;
+  },
+  popup: function getPopupDefaultPermission()
+  {
+    if (gPrefs.getBoolPref("dom.disable_open_during_load")) {
+      return DENY;
+    }
     return ALLOW;
   },
   cookie: function getCookieDefaultPermission()
   {
-    if (gPrefs.getIntPref("network.cookie.cookieBehavior") == 2)
-      return BLOCK;
-
-    if (gPrefs.getIntPref("network.cookie.lifetimePolicy") == 2)
+    if (gPrefs.getIntPref("network.cookie.cookieBehavior") == COOKIE_DENY) {
+      return DENY;
+    }
+    if (gPrefs.getIntPref("network.cookie.lifetimePolicy") == COOKIE_SESSION) {
       return SESSION;
+    }
     return ALLOW;
   },
   "desktop-notification": function getNotificationDefaultPermission()
   {
-    return BLOCK;
-  },
-  popup: function getPopupDefaultPermission()
-  {
-    if (gPrefs.getBoolPref("dom.disable_open_during_load"))
-      return BLOCK;
-    return ALLOW;
+    if (!gPrefs.getBoolPref("dom.webnotifications.enabled")) {
+      return DENY;
+    }
+    return UNKNOWN;
   },
   install: function getInstallDefaultPermission()
   {
-    try {
-      if (!gPrefs.getBoolPref("xpinstall.whitelist.required"))
-        return ALLOW;
+    if (Services.prefs.getBoolPref("xpinstall.whitelist.required")) {
+      return DENY;
     }
-    catch (e) {
-    }
-    return BLOCK;
+    return ALLOW;
   },
   geo: function getGeoDefaultPermissions()
   {
-    return BLOCK;
+    if (!gPrefs.getBoolPref("geo.enabled")) {
+      return DENY;
+    }
+    return ALLOW;
   },
   indexedDB: function getIndexedDBDefaultPermissions()
   {
+    if (!gPrefs.getBoolPref("dom.indexedDB.enabled")) {
+      return DENY;
+    }
     return UNKNOWN;
   },
   plugins: function getPluginsDefaultPermissions()
@@ -63,11 +77,17 @@ var gPermObj = {
   },
   fullscreen: function getFullscreenDefaultPermissions()
   {
+    if (!gPrefs.getBoolPref("full-screen-api.enabled")) {
+      return DENY;
+    }
     return UNKNOWN;  
   },
   pointerLock: function getPointerLockPermissions()
   {
-    return BLOCK;
+    if (!gPrefs.getBoolPref("full-screen-api.pointer-lock.enabled")) {
+      return DENY;
+    }
+    return ALLOW;
   },
 };
 

--- a/browser/components/preferences/aboutPermissions.xul
+++ b/browser/components/preferences/aboutPermissions.xul
@@ -170,6 +170,27 @@
         </vbox>
       </hbox>
 
+      <!-- Desktop Notifications -->
+      <hbox id="desktop-notification-pref-item"
+            class="pref-item" align="top">
+        <image class="pref-icon" type="desktop-notification"/>
+        <vbox>
+          <label class="pref-title" value="&desktop-notification.label;"/>
+          <hbox>
+            <menulist id="desktop-notification-menulist"
+                      class="pref-menulist"
+                      type="desktop-notification"
+                      oncommand="AboutPermissions.onPermissionCommand(event);">
+              <menupopup>
+                <menuitem id="desktop-notification-0" value="0" label="&permission.alwaysAsk;"/>
+                <menuitem id="desktop-notification-1" value="1" label="&permission.allow;"/>
+                <menuitem id="desktop-notification-2" value="2" label="&permission.block;"/>
+              </menupopup>
+            </menulist>
+          </hbox>
+        </vbox>
+      </hbox>
+
       <!-- Addons Blocking -->
       <hbox id="install-pref-item"
             class="pref-item" align="top">

--- a/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
+++ b/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
@@ -33,6 +33,8 @@
 <!ENTITY cookie.manage                   "Manage Cookies…">
 <!ENTITY cookie.removeAll                "Remove All Cookies">
 
+<!ENTITY desktop-notification.label      "Show Notifications">
+
 <!ENTITY install.label                   "Install Extensions or Themes">
 
 <!ENTITY geo.label                       "Share Location">

--- a/browser/themes/linux/preferences/aboutPermissions.css
+++ b/browser/themes/linux/preferences/aboutPermissions.css
@@ -82,6 +82,9 @@
 .pref-icon[type="cookie"] {
   list-style-image: url(chrome://global/skin/icons/question-64.png);
 }
+.pref-icon[type="desktop-notification"] {
+  list-style-image: url(chrome://browser/skin/notification-64.png);
+}
 .pref-icon[type="install"] {
   list-style-image: url(chrome://mozapps/skin/extensions/extensionGeneric.png);
 }

--- a/browser/themes/osx/preferences/aboutPermissions.css
+++ b/browser/themes/osx/preferences/aboutPermissions.css
@@ -85,6 +85,9 @@
 .pref-icon[type="cookie"] {
   list-style-image: url(chrome://global/skin/icons/question-64.png);
 }
+.pref-icon[type="desktop-notification"] {
+  list-style-image: url(chrome://browser/skin/notification-64.png);
+}
 .pref-icon[type="install"] {
   list-style-image: url(chrome://mozapps/skin/extensions/extensionGeneric.png);
 }

--- a/browser/themes/windows/preferences/aboutPermissions.css
+++ b/browser/themes/windows/preferences/aboutPermissions.css
@@ -85,6 +85,9 @@
 .pref-icon[type="cookie"] {
   list-style-image: url(chrome://global/skin/icons/question-64.png);
 }
+.pref-icon[type="desktop-notification"] {
+  list-style-image: url(chrome://browser/skin/notification-64.png);
+}
 .pref-icon[type="install"] {
   list-style-image: url(chrome://mozapps/skin/extensions/extensionGeneric.png);
 }

--- a/dom/notification/Notification.cpp
+++ b/dom/notification/Notification.cpp
@@ -759,9 +759,9 @@ Notification::GetPermissionInternal(nsISupports* aGlobal, ErrorResult& aRv)
   nsCOMPtr<nsIPermissionManager> permissionManager =
     services::GetPermissionManager();
 
-  permissionManager->TestPermissionFromPrincipal(principal,
-                                                 "desktop-notification",
-                                                 &permission);
+  permissionManager->TestExactPermissionFromPrincipal(principal,
+                                                      "desktop-notification",
+                                                      &permission);
 
   // Convert the result to one of the enum types.
   switch (permission) {


### PR DESCRIPTION
## Permissions Manager

Ad:
#642 (Add desktop notifications permissions)
Follow up to #675

---

The suggestion (for example).

__It is necessary to test all options!__

__Notifications:__

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1192458

An example: http://demo.codeforgeek.com/notification/

__Storage (for future use):__

See also https://github.com/MoonchildProductions/Pale-Moon/issues/760

---

I've created the new build (x64) and tested.
