### PR TITLE
Add support for YUV444P pixel format in FFmpeg

### DIFF
--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -20,6 +20,7 @@
 #define AVPixelFormat PixelFormat
 #define AV_PIX_FMT_YUV420P PIX_FMT_YUV420P
 #define AV_PIX_FMT_YUVJ420P PIX_FMT_YUVJ420P
+#define AV_PIX_FMT_YUV444P PIX_FMT_YUV444P
 #define AV_PIX_FMT_NONE PIX_FMT_NONE
 #endif
 
@@ -40,9 +41,16 @@ ChoosePixelFormat(AVCodecContext* aCodecContext, const AVPixelFormat* aFormats)
 {
   FFMPEG_LOG("Choosing FFmpeg pixel format for video decoding.");
   for (; *aFormats > -1; aFormats++) {
-    if (*aFormats == AV_PIX_FMT_YUV420P || *aFormats == AV_PIX_FMT_YUVJ420P) {
-      FFMPEG_LOG("Requesting pixel format YUV420P.");
-      return AV_PIX_FMT_YUV420P;
+    switch (*aFormats) {
+      case AV_PIX_FMT_YUV444P:
+        FFMPEG_LOG("Requesting pixel format YUV444P.");
+        return AV_PIX_FMT_YUV444P;
+      case AV_PIX_FMT_YUV420P:
+      case AV_PIX_FMT_YUVJ420P:
+        FFMPEG_LOG("Requesting pixel format YUV420P.");
+        return AV_PIX_FMT_YUV420P;
+      default:
+        break;
     }
   }
 
@@ -265,22 +273,26 @@ FFmpegH264Decoder<LIBAV_VER>::DoDecodeFrame(MediaRawData* aSample,
 
     VideoData::YCbCrBuffer b;
     b.mPlanes[0].mData = mFrame->data[0];
-    b.mPlanes[0].mStride = mFrame->linesize[0];
-    b.mPlanes[0].mHeight = mFrame->height;
-    b.mPlanes[0].mWidth = mFrame->width;
-    b.mPlanes[0].mOffset = b.mPlanes[0].mSkip = 0;
-
     b.mPlanes[1].mData = mFrame->data[1];
-    b.mPlanes[1].mStride = mFrame->linesize[1];
-    b.mPlanes[1].mHeight = (mFrame->height + 1) >> 1;
-    b.mPlanes[1].mWidth = (mFrame->width + 1) >> 1;
-    b.mPlanes[1].mOffset = b.mPlanes[1].mSkip = 0;
-
     b.mPlanes[2].mData = mFrame->data[2];
+
+    b.mPlanes[0].mStride = mFrame->linesize[0];
+    b.mPlanes[1].mStride = mFrame->linesize[1];
     b.mPlanes[2].mStride = mFrame->linesize[2];
-    b.mPlanes[2].mHeight = (mFrame->height + 1) >> 1;
-    b.mPlanes[2].mWidth = (mFrame->width + 1) >> 1;
+
+    b.mPlanes[0].mOffset = b.mPlanes[0].mSkip = 0;
+    b.mPlanes[1].mOffset = b.mPlanes[1].mSkip = 0;
     b.mPlanes[2].mOffset = b.mPlanes[2].mSkip = 0;
+
+    b.mPlanes[0].mWidth = mFrame->width;
+    b.mPlanes[0].mHeight = mFrame->height;
+    if (mCodecContext->pix_fmt == AV_PIX_FMT_YUV444P) {
+      b.mPlanes[1].mWidth = b.mPlanes[2].mWidth = mFrame->width;
+      b.mPlanes[1].mHeight = b.mPlanes[2].mHeight = mFrame->height;
+    } else {
+      b.mPlanes[1].mWidth = b.mPlanes[2].mWidth = (mFrame->width + 1) >> 1;
+      b.mPlanes[1].mHeight = b.mPlanes[2].mHeight = (mFrame->height + 1) >> 1;
+    }
 
     nsRefPtr<VideoData> v = VideoData::Create(info,
                                               mImageContainer,

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -33,8 +33,8 @@ namespace mozilla
 /**
  * FFmpeg calls back to this function with a list of pixel formats it supports.
  * We choose a pixel format that we support and return it.
- * For now, we just look for YUV420P as it is the only non-HW accelerated format
- * supported by FFmpeg's H264 decoder.
+ * For now, we just look for YUV420P, YUVJ420P and YUV444 as those are the only
+ * non-HW accelerated format supported by FFmpeg's H.264 and VP9 decoder.
  */
 static AVPixelFormat
 ChoosePixelFormat(AVCodecContext* aCodecContext, const AVPixelFormat* aFormats)

--- a/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegH264Decoder.cpp
@@ -46,9 +46,11 @@ ChoosePixelFormat(AVCodecContext* aCodecContext, const AVPixelFormat* aFormats)
         FFMPEG_LOG("Requesting pixel format YUV444P.");
         return AV_PIX_FMT_YUV444P;
       case AV_PIX_FMT_YUV420P:
-      case AV_PIX_FMT_YUVJ420P:
         FFMPEG_LOG("Requesting pixel format YUV420P.");
         return AV_PIX_FMT_YUV420P;
+      case AV_PIX_FMT_YUVJ420P:
+        FFMPEG_LOG("Requesting pixel format YUVJ420P.");
+        return AV_PIX_FMT_YUVJ420P;
       default:
         break;
     }


### PR DESCRIPTION
This allows us to decode 4:4:4 videos using FFmpeg. Also fixes a potential crash point with some older versions of FFmpeg.

Tested and appears to work as intended.