### PR TITLE
Adjust some media prefs

### DIFF
--- a/b2g/app/b2g.js
+++ b/b2g/app/b2g.js
@@ -312,7 +312,7 @@ pref("media.cache_readahead_limit", 30);
 
 #ifdef MOZ_FMP4
 // Enable/Disable Gonk Decoder Module
-pref("media.fragmented-mp4.gonk.enabled", true);
+pref("media.gonk.enabled", true);
 #endif
 // The default number of decoded video frames that are enqueued in
 // MediaDecoderReader's mVideoQueue.

--- a/configure.in
+++ b/configure.in
@@ -5311,6 +5311,10 @@ MOZ_ARG_DISABLE_BOOL(fmp4,
     MOZ_FMP4=,
     MOZ_FMP4=1)
 
+if test -n "$MOZ_FFMPEG" -a -z "$MOZ_FMP4"; then
+    AC_MSG_ERROR([Fragmented MP4 support must be enabled if using FFmpeg])
+fi
+
 if test -n "$MOZ_FMP4"; then
     AC_DEFINE(MOZ_FMP4)
 fi;

--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -160,6 +160,9 @@ IsFFmpegAvailable()
 #ifndef MOZ_FFMPEG
   return false;
 #else
+  if (!Preferences::GetBool("media.ffmpeg.enabled", false)) {
+    return false;
+  }
   nsRefPtr<PlatformDecoderModule> m = FFmpegRuntimeLinker::CreateDecoderModule();
   return !!m;
 #endif

--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -223,7 +223,7 @@ HavePlatformMPEGDecoders()
 bool
 MP4Decoder::IsEnabled()
 {
-  return Preferences::GetBool("media.mp4.enabled") &&
+  return Preferences::GetBool("media.fragmented-mp4.enabled") &&
          HavePlatformMPEGDecoders();
 }
 

--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -49,7 +49,7 @@ IsSupportedAudioCodec(const nsAString& aCodec,
                     aCodec.EqualsASCII("mp4a.40.5");
   if (aOutContainsAAC) {
 #ifdef XP_WIN
-    if (!Preferences::GetBool("media.fragmented-mp4.use-blank-decoder") &&
+    if (!Preferences::GetBool("media.use-blank-decoder") &&
         !WMFDecoderModule::HasAAC()) {
       return false;
     }
@@ -77,7 +77,7 @@ IsSupportedH264Codec(const nsAString& aCodec)
   }
 
 #ifdef XP_WIN
-  if (!Preferences::GetBool("media.fragmented-mp4.use-blank-decoder") &&
+  if (!Preferences::GetBool("media.use-blank-decoder") &&
       !WMFDecoderModule::HasH264()) {
     return false;
   }
@@ -190,19 +190,19 @@ IsAndroidAvailable()
 static bool
 IsGonkMP4DecoderAvailable()
 {
-  return Preferences::GetBool("media.fragmented-mp4.gonk.enabled", false);
+  return Preferences::GetBool("media.gonk.enabled", false);
 }
 
 static bool
 IsGMPDecoderAvailable()
 {
-  return Preferences::GetBool("media.fragmented-mp4.gmp.enabled", false);
+  return Preferences::GetBool("media.gmp.decoder.enabled", false);
 }
 
 static bool
 HavePlatformMPEGDecoders()
 {
-  return Preferences::GetBool("media.fragmented-mp4.use-blank-decoder") ||
+  return Preferences::GetBool("media.use-blank-decoder") ||
 #ifdef XP_WIN
          // We have H.264/AAC platform decoders on Windows Vista and up.
          IsVistaOrLater() ||
@@ -220,7 +220,7 @@ HavePlatformMPEGDecoders()
 bool
 MP4Decoder::IsEnabled()
 {
-  return Preferences::GetBool("media.fragmented-mp4.enabled") &&
+  return Preferences::GetBool("media.mp4.enabled") &&
          HavePlatformMPEGDecoders();
 }
 

--- a/dom/media/gtest/TestMP4Reader.cpp
+++ b/dom/media/gtest/TestMP4Reader.cpp
@@ -30,7 +30,7 @@ public:
     , reader(new MP4Reader(decoder))
   {
     EXPECT_EQ(NS_OK, Preferences::SetBool(
-                       "media.fragmented-mp4.use-blank-decoder", true));
+                       "media.use-blank-decoder", true));
 
     EXPECT_EQ(NS_OK, resource->Open(nullptr));
     decoder->SetResource(resource);

--- a/dom/media/platforms/PlatformDecoderModule.cpp
+++ b/dom/media/platforms/PlatformDecoderModule.cpp
@@ -35,10 +35,16 @@ namespace mozilla {
 extern already_AddRefed<PlatformDecoderModule> CreateBlankDecoderModule();
 
 bool PlatformDecoderModule::sUseBlankDecoder = false;
+#ifdef MOZ_FFMPEG
 bool PlatformDecoderModule::sFFmpegDecoderEnabled = false;
+#endif
+#ifdef MOZ_GONK_MEDIACODEC
 bool PlatformDecoderModule::sGonkDecoderEnabled = false;
+#endif
+#ifdef MOZ_WIDGET_ANDROID
 bool PlatformDecoderModule::sAndroidMCDecoderEnabled = false;
 bool PlatformDecoderModule::sAndroidMCDecoderPreferred = false;
+#endif
 bool PlatformDecoderModule::sGMPDecoderEnabled = false;
 
 /* static */
@@ -54,9 +60,10 @@ PlatformDecoderModule::Init()
 
   Preferences::AddBoolVarCache(&sUseBlankDecoder,
                                "media.use-blank-decoder");
+#ifdef MOZ_FFMPEG
   Preferences::AddBoolVarCache(&sFFmpegDecoderEnabled,
                                "media.ffmpeg.enabled", false);
-
+#endif
 #ifdef MOZ_GONK_MEDIACODEC
   Preferences::AddBoolVarCache(&sGonkDecoderEnabled,
                                "media.gonk.enabled", false);

--- a/dom/media/platforms/PlatformDecoderModule.cpp
+++ b/dom/media/platforms/PlatformDecoderModule.cpp
@@ -53,23 +53,23 @@ PlatformDecoderModule::Init()
   alreadyInitialized = true;
 
   Preferences::AddBoolVarCache(&sUseBlankDecoder,
-                               "media.fragmented-mp4.use-blank-decoder");
+                               "media.use-blank-decoder");
   Preferences::AddBoolVarCache(&sFFmpegDecoderEnabled,
-                               "media.fragmented-mp4.ffmpeg.enabled", false);
+                               "media.ffmpeg.enabled", false);
 
 #ifdef MOZ_GONK_MEDIACODEC
   Preferences::AddBoolVarCache(&sGonkDecoderEnabled,
-                               "media.fragmented-mp4.gonk.enabled", false);
+                               "media.gonk.enabled", false);
 #endif
 #ifdef MOZ_WIDGET_ANDROID
   Preferences::AddBoolVarCache(&sAndroidMCDecoderEnabled,
-                               "media.fragmented-mp4.android-media-codec.enabled", false);
+                               "media.android-media-codec.enabled", false);
   Preferences::AddBoolVarCache(&sAndroidMCDecoderPreferred,
-                               "media.fragmented-mp4.android-media-codec.preferred", false);
+                               "media.android-media-codec.preferred", false);
 #endif
 
   Preferences::AddBoolVarCache(&sGMPDecoderEnabled,
-                               "media.fragmented-mp4.gmp.enabled", false);
+                               "media.gmp.decoder.enabled", false);
 
 #ifdef XP_WIN
   WMFDecoderModule::Init();

--- a/dom/media/platforms/PlatformDecoderModule.h
+++ b/dom/media/platforms/PlatformDecoderModule.h
@@ -50,7 +50,7 @@ typedef int64_t Microseconds;
 //
 // A cross-platform decoder module that discards input and produces "blank"
 // output samples exists for testing, and is created when the pref
-// "media.fragmented-mp4.use-blank-decoder" is true.
+// "media.use-blank-decoder" is true.
 class PlatformDecoderModule {
 public:
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(PlatformDecoderModule)
@@ -142,7 +142,7 @@ protected:
                      FlushableMediaTaskQueue* aAudioTaskQueue,
                      MediaDataDecoderCallback* aCallback) = 0;
 
-  // Caches pref media.fragmented-mp4.use-blank-decoder
+  // Caches pref media.use-blank-decoder
   static bool sUseBlankDecoder;
   static bool sFFmpegDecoderEnabled;
   static bool sGonkDecoderEnabled;

--- a/dom/media/platforms/PlatformDecoderModule.h
+++ b/dom/media/platforms/PlatformDecoderModule.h
@@ -142,12 +142,18 @@ protected:
                      FlushableMediaTaskQueue* aAudioTaskQueue,
                      MediaDataDecoderCallback* aCallback) = 0;
 
-  // Caches pref media.use-blank-decoder
+  // PDM pref caches...
   static bool sUseBlankDecoder;
+#ifdef MOZ_FFMPEG
   static bool sFFmpegDecoderEnabled;
+#endif
+#ifdef MOZ_GONK_MEDIACODEC
   static bool sGonkDecoderEnabled;
+#endif
+#ifdef MOZ_WIDGET_ANDROID
   static bool sAndroidMCDecoderPreferred;
   static bool sAndroidMCDecoderEnabled;
+#endif
   static bool sGMPDecoderEnabled;
 };
 

--- a/dom/media/test/test_can_play_type_mpeg.html
+++ b/dom/media/test/test_can_play_type_mpeg.html
@@ -116,17 +116,12 @@ function getPref(name) {
   return pref;
 }
 
-// Check whether we should expect the new MP4Reader-based support to work.
-function IsMP4ReaderAvailable() {
-  var prefs = getPref("media.fragmented-mp4.enabled");
-  return prefs && (IsWindowsVistaOrLater() || IsMacOSSnowLeopardOrLater());
-}
-
 var haveMp4 = (getPref("media.windows-media-foundation.enabled") && IsWindowsVistaOrLater()) ||
+               IsMacOSSnowLeopardOrLater() ||
+               IsJellyBeanOrLater() ||
                getPref("media.omx.enabled") ||
                getPref("media.gstreamer.enabled") ||
-               IsMP4ReaderAvailable();
-// TODO:  Add "getPref("media.plugins.enabled")" once MP4 works on Gingerbread.
+               getPref("media.ffmpeg.enabled");
              
 check_mp4(document.getElementById('v'), haveMp4);
 
@@ -134,6 +129,7 @@ var haveMp3 = getPref("media.directshow.enabled") ||
               (getPref("media.windows-media-foundation.enabled") && IsWindowsVistaOrLater()) ||
                getPref("media.omx.enabled") ||
                getPref("media.gstreamer.enabled") ||
+               getPref("media.ffmpeg.enabled") ||
                getPref("media.apple.mp3.enabled");
 check_mp3(document.getElementById('v'), haveMp3);
 

--- a/mobile/android/app/mobile.js
+++ b/mobile/android/app/mobile.js
@@ -560,6 +560,7 @@ pref("media.cache_readahead_limit", 30);
 pref("media.video-queue.default-size", 3);
 
 // Enable the MediaCodec PlatformDecoderModule by default.
+pref("media.fragmented-mp4.enabled", true);
 pref("media.android-media-codec.enabled", true);
 pref("media.android-media-codec.preferred", true);
 

--- a/mobile/android/app/mobile.js
+++ b/mobile/android/app/mobile.js
@@ -560,9 +560,8 @@ pref("media.cache_readahead_limit", 30);
 pref("media.video-queue.default-size", 3);
 
 // Enable the MediaCodec PlatformDecoderModule by default.
-pref("media.fragmented-mp4.enabled", true);
-pref("media.fragmented-mp4.android-media-codec.enabled", true);
-pref("media.fragmented-mp4.android-media-codec.preferred", true);
+pref("media.android-media-codec.enabled", true);
+pref("media.android-media-codec.preferred", true);
 
 // optimize images memory usage
 pref("image.mem.decodeondraw", true);

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -288,7 +288,7 @@ pref("media.decoder.heuristic.dormant.timeout", 60000);
 pref("media.directshow.enabled", true);
 #endif
 #ifdef MOZ_FMP4
-pref("media.mp4.enabled", true);
+pref("media.fragmented-mp4.enabled", true);
 #endif
 // Specifies whether the PDM can create a test decoder that
 // just outputs blank frames/audio instead of actually decoding. The blank

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -284,25 +284,25 @@ pref("media.play-stand-alone", true);
 pref("media.decoder.heuristic.dormant.enabled", true);
 pref("media.decoder.heuristic.dormant.timeout", 60000);
 
-#ifdef MOZ_WMF
-pref("media.windows-media-foundation.enabled", true);
-pref("media.windows-media-foundation.use-dxva", true);
-#endif
 #ifdef MOZ_DIRECTSHOW
 pref("media.directshow.enabled", true);
 #endif
 #ifdef MOZ_FMP4
-pref("media.fragmented-mp4.enabled", true);
-pref("media.fragmented-mp4.ffmpeg.enabled", true);
-pref("media.fragmented-mp4.gmp.enabled", false);
-// Specifies whether the fragmented MP4 parser uses a test decoder that
+pref("media.mp4.enabled", true);
+#endif
+// Specifies whether the PDM can create a test decoder that
 // just outputs blank frames/audio instead of actually decoding. The blank
 // decoder works on all platforms.
-pref("media.fragmented-mp4.use-blank-decoder", false);
+pref("media.use-blank-decoder", false);
+#ifdef MOZ_WMF
+pref("media.windows-media-foundation.enabled", true);
+pref("media.windows-media-foundation.use-dxva", true);
 #endif
 #if defined(MOZ_FFMPEG)
+pref("media.ffmpeg.enabled", true);
 pref("media.libavcodec.allow-obsolete", false);
 #endif
+pref("media.gmp.decoder.enabled", false);
 #ifdef MOZ_RAW
 pref("media.raw.enabled", true);
 #endif

--- a/testing/profiles/prefs_general.js
+++ b/testing/profiles/prefs_general.js
@@ -163,10 +163,6 @@ user_pref("media.mediasource.enabled", true);
 user_pref("media.mediasource.mp4.enabled", true);
 user_pref("media.mediasource.webm.enabled", true);
 
-#if defined(LINUX)
-user_pref("media.fragmented-mp4.ffmpeg.enabled", true);
-#endif
-
 // Enable mozContacts
 user_pref("dom.mozContacts.enabled", true);
 


### PR DESCRIPTION
Some cleanup now that we've got FFmpeg working and enabled. Changes:

1) Remove "fragmented-mp4" from pref names -- Not necessary as we can play both fragmented and regular MP4's. Also, it shortens and simplifies some of the pref names to boot.

2) Put platform-specific media pref caches behind appropriate #ifdef's.

3) Make the "media.ffmpeg.enabled" pref actually work when set to "false" (in which case GStreamer will be used again :nauseated_face: )

4) Add a test and fatal error to configure if trying to build FFmpeg support without FMP4 support.