### PR TITLE
Permissions: Notifications (+ follow up) (fixed merge conflict)

### DIFF
--- a/browser/base/content/pageinfo/pageInfo.xul
+++ b/browser/base/content/pageinfo/pageInfo.xul
@@ -340,6 +340,7 @@
             <checkbox id="desktop-notificationDef" command="cmd_desktop-notificationDef" label="&permUseDefault;"/>
             <spacer flex="1"/>
             <radiogroup id="desktop-notificationRadioGroup" orient="horizontal">
+              <radio id="desktop-notification#0" command="cmd_desktop-notificationToggle" label="&permAskAlways;"/>
               <radio id="desktop-notification#1" command="cmd_desktop-notificationToggle" label="&permAllow;"/>
               <radio id="desktop-notification#2" command="cmd_desktop-notificationToggle" label="&permBlock;"/>
             </radiogroup>

--- a/browser/base/content/pageinfo/permissions.js
+++ b/browser/base/content/pageinfo/permissions.js
@@ -4,8 +4,13 @@
 
 const UNKNOWN = nsIPermissionManager.UNKNOWN_ACTION;   // 0
 const ALLOW = nsIPermissionManager.ALLOW_ACTION;       // 1
-const BLOCK = nsIPermissionManager.DENY_ACTION;        // 2
+const DENY = nsIPermissionManager.DENY_ACTION;         // 2
 const SESSION = nsICookiePermission.ACCESS_SESSION;    // 8
+
+const IMAGE_DENY = 2;
+
+const COOKIE_DENY = 2;
+const COOKIE_SESSION = 2;
 
 const nsIQuotaManager = Components.interfaces.nsIQuotaManager;
 
@@ -16,45 +21,54 @@ var gUsageRequest;
 var gPermObj = {
   image: function getImageDefaultPermission()
   {
-    if (gPrefs.getIntPref("permissions.default.image") == 2)
-      return BLOCK;
+    if (gPrefs.getIntPref("permissions.default.image") == IMAGE_DENY) {
+      return DENY;
+    }
+    return ALLOW;
+  },
+  popup: function getPopupDefaultPermission()
+  {
+    if (gPrefs.getBoolPref("dom.disable_open_during_load")) {
+      return DENY;
+    }
     return ALLOW;
   },
   cookie: function getCookieDefaultPermission()
   {
-    if (gPrefs.getIntPref("network.cookie.cookieBehavior") == 2)
-      return BLOCK;
-
-    if (gPrefs.getIntPref("network.cookie.lifetimePolicy") == 2)
+    if (gPrefs.getIntPref("network.cookie.cookieBehavior") == COOKIE_DENY) {
+      return DENY;
+    }
+    if (gPrefs.getIntPref("network.cookie.lifetimePolicy") == COOKIE_SESSION) {
       return SESSION;
+    }
     return ALLOW;
   },
   "desktop-notification": function getNotificationDefaultPermission()
   {
-    return BLOCK;
-  },
-  popup: function getPopupDefaultPermission()
-  {
-    if (gPrefs.getBoolPref("dom.disable_open_during_load"))
-      return BLOCK;
-    return ALLOW;
+    if (!gPrefs.getBoolPref("dom.webnotifications.enabled")) {
+      return DENY;
+    }
+    return UNKNOWN;
   },
   install: function getInstallDefaultPermission()
   {
-    try {
-      if (!gPrefs.getBoolPref("xpinstall.whitelist.required"))
-        return ALLOW;
+    if (Services.prefs.getBoolPref("xpinstall.whitelist.required")) {
+      return DENY;
     }
-    catch (e) {
-    }
-    return BLOCK;
+    return ALLOW;
   },
   geo: function getGeoDefaultPermissions()
   {
-    return BLOCK;
+    if (!gPrefs.getBoolPref("geo.enabled")) {
+      return DENY;
+    }
+    return ALLOW;
   },
   indexedDB: function getIndexedDBDefaultPermissions()
   {
+    if (!gPrefs.getBoolPref("dom.indexedDB.enabled")) {
+      return DENY;
+    }
     return UNKNOWN;
   },
   plugins: function getPluginsDefaultPermissions()
@@ -63,11 +77,17 @@ var gPermObj = {
   },
   fullscreen: function getFullscreenDefaultPermissions()
   {
+    if (!gPrefs.getBoolPref("full-screen-api.enabled")) {
+      return DENY;
+    }
     return UNKNOWN;  
   },
   pointerLock: function getPointerLockPermissions()
   {
-    return BLOCK;
+    if (!gPrefs.getBoolPref("full-screen-api.pointer-lock.enabled")) {
+      return DENY;
+    }
+    return ALLOW;
   },
 };
 

--- a/browser/base/content/pageinfo/permissions.js
+++ b/browser/base/content/pageinfo/permissions.js
@@ -154,9 +154,9 @@ function initRow(aPartId)
 
   var checkbox = document.getElementById(aPartId + "Def");
   var command  = document.getElementById("cmd_" + aPartId + "Toggle");
-  // Geolocation and PointerLock permission consumers use testExactPermission, not testPermission.
+  // Desktop Notification, Geolocation and PointerLock permission consumers use testExactPermission, not testPermission.
   var perm;
-  if (aPartId == "geo" || aPartId == "pointerLock")
+  if (aPartId == "desktop-notification" || aPartId == "geo" || aPartId == "pointerLock")
     perm = permissionManager.testExactPermission(gPermURI, aPartId);
   else
     perm = permissionManager.testPermission(gPermURI, aPartId);
@@ -343,7 +343,7 @@ function initPluginsRow() {
 
   let entries = [{name: item[1], permission: item[0]} for (item of permissionMap)];
   entries.sort(function(a, b) {
-    return a.name < b.name ? -1 : (a.name == b.name ? 0 : 1);
+    return ((a.name < b.name) ? -1 : (a.name == b.name ? 0 : 1));
   });
 
   let permissionEntries = [

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -39,7 +39,7 @@ let gVisitStmt = gPlacesDatabase.createAsyncStatement(
  * Permission types that should be tested with testExactPermission, as opposed
  * to testPermission. This is based on what consumers use to test these permissions.
  */
-let TEST_EXACT_PERM_TYPES = ["desktop-notification", "geo"];
+let TEST_EXACT_PERM_TYPES = ["desktop-notification", "geo", "pointerLock"];
 
 /**
  * Site object represents a single site, uniquely identified by a host.
@@ -456,8 +456,11 @@ let AboutPermissions = {
    */
   _noGlobalDeny: [],
 
-  _stringBundle: Services.strings.
-                 createBundle("chrome://browser/locale/preferences/aboutPermissions.properties"),
+  _stringBundleBrowser: Services.strings.
+      createBundle("chrome://browser/locale/browser.properties"),
+
+  _stringBundleAboutPermissions: Services.strings.
+      createBundle("chrome://browser/locale/preferences/aboutPermissions.properties"),
 
   /**
    * Called on page load.
@@ -977,7 +980,9 @@ let AboutPermissions = {
         let pluginPermissionEntry = document.getElementById(aType + "-entry");
         if (pluginPermissionEntry.isBlocklisted()) {
           permissionMenulist.disabled = true;
-          permissionMenulist.setAttribute("tooltiptext", AboutPermissions._stringBundle.GetStringFromName("pluginBlocklisted"));
+          permissionMenulist.setAttribute("tooltiptext",
+              AboutPermissions._stringBundleAboutPermissions
+              .GetStringFromName("pluginBlocklisted"));
         } else {
           permissionMenulist.disabled = false;
           permissionMenulist.removeAttribute("tooltiptext");
@@ -991,6 +996,14 @@ let AboutPermissions = {
         document.getElementById(aType + "-9").hidden = false;
       } else if (aType.startsWith("plugin")) {
         document.getElementById(aType + "-0").disabled = false;
+        let pluginPermissionEntry = document.getElementById(aType + "-entry");
+        let permString = pluginPermissionEntry.getAttribute("permString");
+        let name = pluginPermissionEntry.getAttribute("label");
+        if (permString.startsWith("plugin-vulnerable:")) {
+          name += " \u2014 " + AboutPermissions._stringBundleBrowser
+                  .GetStringFromName("pluginActivateVulnerable.label");
+          pluginPermissionEntry.setAttribute("label", name);
+        }
       }
       let result = {};
       permissionValue = this._selectedSite.getPermission(aType, result) ?
@@ -1056,7 +1069,8 @@ let AboutPermissions = {
 
   updateVisitCount: function() {
     this._selectedSite.getVisitCount(function(aCount) {
-      let visitForm = AboutPermissions._stringBundle.GetStringFromName("visitCount");
+      let visitForm = AboutPermissions._stringBundleAboutPermissions
+                      .GetStringFromName("visitCount");
       let visitLabel = PluralForm.get(aCount, visitForm)
                                   .replace("#1", aCount);
       document.getElementById("site-visit-count").value = visitLabel;
@@ -1071,7 +1085,8 @@ let AboutPermissions = {
     }
 
     let passwordsCount = this._selectedSite.logins.length;
-    let passwordsForm = this._stringBundle.GetStringFromName("passwordsCount");
+    let passwordsForm = this._stringBundleAboutPermissions
+                        .GetStringFromName("passwordsCount");
     let passwordsLabel = PluralForm.get(passwordsCount, passwordsForm)
                                    .replace("#1", passwordsCount);
 
@@ -1109,7 +1124,8 @@ let AboutPermissions = {
     }
 
     let cookiesCount = this._selectedSite.cookies.length;
-    let cookiesForm = this._stringBundle.GetStringFromName("cookiesCount");
+    let cookiesForm = this._stringBundleAboutPermissions
+                      .GetStringFromName("cookiesCount");
     let cookiesLabel = PluralForm.get(cookiesCount, cookiesForm)
                                  .replace("#1", cookiesCount);
 

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -456,11 +456,11 @@ let AboutPermissions = {
    */
   _noGlobalDeny: [],
 
-  _stringBundleBrowser: Services.strings.
-      createBundle("chrome://browser/locale/browser.properties"),
+  _stringBundleBrowser: Services.strings
+      .createBundle("chrome://browser/locale/browser.properties"),
 
-  _stringBundleAboutPermissions: Services.strings.
-      createBundle("chrome://browser/locale/preferences/aboutPermissions.properties"),
+  _stringBundleAboutPermissions: Services.strings
+      .createBundle("chrome://browser/locale/preferences/aboutPermissions.properties"),
 
   /**
    * Called on page load.

--- a/browser/components/preferences/aboutPermissions.xul
+++ b/browser/components/preferences/aboutPermissions.xul
@@ -170,6 +170,27 @@
         </vbox>
       </hbox>
 
+      <!-- Desktop Notifications -->
+      <hbox id="desktop-notification-pref-item"
+            class="pref-item" align="top">
+        <image class="pref-icon" type="desktop-notification"/>
+        <vbox>
+          <label class="pref-title" value="&desktop-notification.label;"/>
+          <hbox>
+            <menulist id="desktop-notification-menulist"
+                      class="pref-menulist"
+                      type="desktop-notification"
+                      oncommand="AboutPermissions.onPermissionCommand(event);">
+              <menupopup>
+                <menuitem id="desktop-notification-0" value="0" label="&permission.alwaysAsk;"/>
+                <menuitem id="desktop-notification-1" value="1" label="&permission.allow;"/>
+                <menuitem id="desktop-notification-2" value="2" label="&permission.block;"/>
+              </menupopup>
+            </menulist>
+          </hbox>
+        </vbox>
+      </hbox>
+
       <!-- Addons Blocking -->
       <hbox id="install-pref-item"
             class="pref-item" align="top">

--- a/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
+++ b/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
@@ -33,6 +33,8 @@
 <!ENTITY cookie.manage                   "Manage Cookies…">
 <!ENTITY cookie.removeAll                "Remove All Cookies">
 
+<!ENTITY desktop-notification.label      "Show Notifications">
+
 <!ENTITY install.label                   "Install Extensions or Themes">
 
 <!ENTITY geo.label                       "Share Location">

--- a/browser/themes/linux/preferences/aboutPermissions.css
+++ b/browser/themes/linux/preferences/aboutPermissions.css
@@ -82,6 +82,9 @@
 .pref-icon[type="cookie"] {
   list-style-image: url(chrome://global/skin/icons/question-64.png);
 }
+.pref-icon[type="desktop-notification"] {
+  list-style-image: url(chrome://browser/skin/notification-64.png);
+}
 .pref-icon[type="install"] {
   list-style-image: url(chrome://mozapps/skin/extensions/extensionGeneric.png);
 }

--- a/browser/themes/osx/preferences/aboutPermissions.css
+++ b/browser/themes/osx/preferences/aboutPermissions.css
@@ -85,6 +85,9 @@
 .pref-icon[type="cookie"] {
   list-style-image: url(chrome://global/skin/icons/question-64.png);
 }
+.pref-icon[type="desktop-notification"] {
+  list-style-image: url(chrome://browser/skin/notification-64.png);
+}
 .pref-icon[type="install"] {
   list-style-image: url(chrome://mozapps/skin/extensions/extensionGeneric.png);
 }

--- a/browser/themes/windows/preferences/aboutPermissions.css
+++ b/browser/themes/windows/preferences/aboutPermissions.css
@@ -85,6 +85,9 @@
 .pref-icon[type="cookie"] {
   list-style-image: url(chrome://global/skin/icons/question-64.png);
 }
+.pref-icon[type="desktop-notification"] {
+  list-style-image: url(chrome://browser/skin/notification-64.png);
+}
 .pref-icon[type="install"] {
   list-style-image: url(chrome://mozapps/skin/extensions/extensionGeneric.png);
 }

--- a/dom/notification/Notification.cpp
+++ b/dom/notification/Notification.cpp
@@ -759,9 +759,9 @@ Notification::GetPermissionInternal(nsISupports* aGlobal, ErrorResult& aRv)
   nsCOMPtr<nsIPermissionManager> permissionManager =
     services::GetPermissionManager();
 
-  permissionManager->TestPermissionFromPrincipal(principal,
-                                                 "desktop-notification",
-                                                 &permission);
+  permissionManager->TestExactPermissionFromPrincipal(principal,
+                                                      "desktop-notification",
+                                                      &permission);
 
   // Convert the result to one of the enum types.
   switch (permission) {


### PR DESCRIPTION
Ad #803 

## Permissions Manager

Ad:
#642 (Add desktop notifications permissions)
Follow up to #675 (#764, #801)

---

The suggestion (for example).

__It is necessary to test all options!__

__Notifications:__

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1192458

An example: http://demo.codeforgeek.com/notification/

__Storage (for future use):__

See also https://github.com/MoonchildProductions/Pale-Moon/issues/760

---

I've created the new build (x64) and tested.
