### PR TITLE
Allow access to 'sdk/ui/buttons' via require('sdk/ui')

### DIFF
--- a/toolkit/jetpack/sdk/ui.js
+++ b/toolkit/jetpack/sdk/ui.js
@@ -6,12 +6,12 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
-    'Firefox': '> 28'
+    'Firefox': '> 27'
   }
 };
 
 exports.ActionButton = require('./ui/button/action').ActionButton;
 exports.ToggleButton = require('./ui/button/toggle').ToggleButton;
-exports.Sidebar = require('./ui/sidebar').Sidebar;
-exports.Frame = require('./ui/frame').Frame;
-exports.Toolbar = require('./ui/toolbar').Toolbar;
+//exports.Sidebar = require('./ui/sidebar').Sidebar;
+//exports.Frame = require('./ui/frame').Frame;
+//exports.Toolbar = require('./ui/toolbar').Toolbar;


### PR DESCRIPTION
Some add-ons use require('sdk/ui') to access 'sdk/ui/buttons/*', we should support it.