### PR TITLE
Set release notes URL in About dialog based on channel

### DIFF
--- a/browser/base/content/aboutDialog.js
+++ b/browser/base/content/aboutDialog.js
@@ -56,6 +56,15 @@ function init(aEvent)
   window.sizeToContent();
   window.moveTo((screen.availWidth / 2) - (window.outerWidth / 2), screen.availHeight / 5);
 #endif
+
+// get release notes URL from prefs
+  var formatter = Components.classes["@mozilla.org/toolkit/URLFormatterService;1"]
+                            .getService(Components.interfaces.nsIURLFormatter);
+  var releaseNotesURL = formatter.formatURLPref("app.releaseNotesURL");
+  if (releaseNotesURL != "about:blank") {
+    var relnotes = document.getElementById("releaseNotesURL");
+    relnotes.setAttribute("href", releaseNotesURL);
+  }
 }
 
 #ifdef MOZ_UPDATER

--- a/browser/base/content/aboutDialog.xul
+++ b/browser/base/content/aboutDialog.xul
@@ -106,7 +106,7 @@
       <hbox pack="center">
         <label class="text-link bottom-link" href="about:license">Licensing information</label>
         <label class="text-link bottom-link" href="about:rights">End-user rights</label>
-        <label class="text-link bottom-link" href="http://www.palemoon.org/releasenotes-ng.shtml">Release notes</label>
+        <label class="text-link bottom-link" id="releaseNotesURL">Release notes</label>
       </hbox>
       <description id="PMtrademark">&trademarkInfo.part1;</description>
     </vbox>


### PR DESCRIPTION
Original code is from [about.xhtml](http://xref.palemoon.org/palemoon-trunk/source/toolkit/content/about.xhtml) / [about.js](http://xref.palemoon.org/palemoon-trunk/source/toolkit/content/about.js)

PS: This dialog should also be properly localized, I'll prepare a separate PR.