### PR TITLE
Fix invisible links in About dialog (unstable branding)

### DIFF
--- a/browser/branding/unstable/content/aboutDialog.css
+++ b/browser/branding/unstable/content/aboutDialog.css
@@ -34,6 +34,10 @@
   color: #909090;
 }
 
+#detailsBox > description > .text-link {
+  color: #994D00;
+}
+
 #PMtrademark {
   font-size: xx-small;
   text-align: center;


### PR DESCRIPTION
![palemoon_2017-01-12_19-48-49](https://cloud.githubusercontent.com/assets/340855/21901395/3554274c-d900-11e6-8e7f-bc46fe21d308.png)
