### PR TITLE
Set GStreamer pref to "false" by default

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -318,7 +318,7 @@ pref("media.webm.intel_decoder.enabled", false);
 #endif
 #endif
 #ifdef MOZ_GSTREAMER
-pref("media.gstreamer.enabled", true);
+pref("media.gstreamer.enabled", false);
 pref("media.gstreamer.enable-blacklist", true);
 #endif
 #ifdef MOZ_APPLEMEDIA


### PR DESCRIPTION
Just what it says in the tin.

I'll let this bake for a while, and let the masses test in our unstable builds. If no issues are encountered, we'll be able to remove GStreamer completely!

Note that this is dependent on PR #833 being merged and verified first.