### PR TITLE
Add a type-erased callable wrapper (mozilla::Function) to MFBT.

### DIFF
--- a/dom/workers/WorkerPrivate.cpp
+++ b/dom/workers/WorkerPrivate.cpp
@@ -5898,7 +5898,7 @@ WorkerPrivate::ReportError(JSContext* aCx, const char* aMessage,
 
 int32_t
 WorkerPrivate::SetTimeout(JSContext* aCx,
-                          Function* aHandler,
+                          dom::Function* aHandler,
                           const nsAString& aStringHandler,
                           int32_t aTimeout,
                           const Sequence<JS::Value>& aArguments,

--- a/mfbt/Function.h
+++ b/mfbt/Function.h
@@ -1,0 +1,113 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* A type-erased callable wrapper. */
+
+#ifndef mozilla_Function_h
+#define mozilla_Function_h
+
+#include "mozilla/Attributes.h"  // for MOZ_IMPLICIT
+#include "mozilla/Move.h"
+#include "mozilla/UniquePtr.h"
+
+// |Function<Signature>| is a wrapper that can hold any type of callable
+// object that can be invoked in a way that's compatible with |Signature|.
+// The standard "type erasure" technique is used to avoid the type of the
+// wrapper depending on the concrete type of the wrapped callable.
+//
+// Supported callable types include non-member functions, static member
+// functions, and function objects (that is to say, objects with an overloaded
+// call operator; this includes C++11 lambdas). Member functions aren't
+// directly supported; they first need to be wrapped into a function object
+// using |std::mem_fn()| or an equivalent.
+//
+// |Signature| is a type of the form |ReturnType(Arguments...)|. Syntactically,
+// this is a function type; it's not used in any way other than serving as a
+// vehicle to encode the return and argument types into a single type.
+//
+// |Function| is default-constructible. A default-constructed instance is
+// considered "empty". Invoking an empty instance is undefined behaviour.
+// An empty instance can be populated with a callable by assigning to it.
+//
+// This class is intended to provide functionality similar to the C++11
+// standard library class |std::function|.
+
+namespace mozilla {
+
+namespace detail {
+
+template<typename ReturnType, typename... Arguments>
+class FunctionImplBase
+{
+public:
+  virtual ~FunctionImplBase() {}
+  virtual ReturnType call(Arguments... arguments) = 0;
+};
+
+template <typename Callable, typename ReturnType, typename... Arguments>
+class FunctionImpl : public FunctionImplBase<ReturnType, Arguments...>
+{
+public:
+  explicit FunctionImpl(const Callable& aCallable) : mCallable(aCallable) {}
+
+  ReturnType call(Arguments... aArguments) override
+  {
+    return mCallable(Forward<Arguments>(aArguments)...);
+  }
+private:
+  Callable mCallable;
+};
+
+} // namespace detail
+
+// The primary template is never defined. As |Signature| is required to be
+// of the form |ReturnType(Arguments...)|, we only define a partial
+// specialization that matches this form. This allows us to use |ReturnType|
+// and |Arguments| in the definition of the specialization without having to
+// introspect |Signature|.
+template<typename Signature>
+class Function;
+
+template<typename ReturnType, typename... Arguments>
+class Function<ReturnType(Arguments...)>
+{
+public:
+  Function() {}
+
+  // This constructor is implicit to match the interface of |std::function|.
+  template <typename Callable>
+  MOZ_IMPLICIT Function(const Callable& aCallable)
+    : mImpl(MakeUnique<detail::FunctionImpl<Callable, ReturnType, Arguments...>>(aCallable))
+  {}
+
+  // Move constructor and move assingment operator.
+  // These should be generated automatically, but MSVC doesn't do that yet.
+  Function(Function&& aOther) : mImpl(Move(aOther.mImpl)) {}
+  Function& operator=(Function&& aOther) {
+    mImpl = Move(aOther.mImpl);
+    return *this;
+  }
+
+  template <typename Callable>
+  Function& operator=(const Callable& aCallable)
+  {
+    mImpl = MakeUnique<detail::FunctionImpl<Callable, ReturnType, Arguments...>>(aCallable);
+    return *this;
+  }
+
+  ReturnType operator()(Arguments... aArguments) const
+  {
+    MOZ_ASSERT(mImpl);
+    return mImpl->call(Forward<Arguments>(aArguments)...);
+  }
+private:
+  // TODO: Consider implementing a small object optimization.
+  UniquePtr<detail::FunctionImplBase<ReturnType, Arguments...>> mImpl;
+};
+
+} // namespace mozilla
+
+#endif /* mozilla_Function_h */

--- a/mfbt/Function.h
+++ b/mfbt/Function.h
@@ -155,10 +155,11 @@ public:
     return *this;
   }
 
-  ReturnType operator()(Arguments... aArguments) const
+  template<typename... Args>
+  ReturnType operator()(Args&&... aArguments) const
   {
     MOZ_ASSERT(mImpl);
-    return mImpl->call(Forward<Arguments>(aArguments)...);
+    return mImpl->call(Forward<Args>(aArguments)...);
   }
 private:
   // TODO: Consider implementing a small object optimization.

--- a/mfbt/Function.h
+++ b/mfbt/Function.h
@@ -44,21 +44,78 @@ class FunctionImplBase
 {
 public:
   virtual ~FunctionImplBase() {}
-  virtual ReturnType call(Arguments... arguments) = 0;
+  virtual ReturnType call(Arguments... aArguments) = 0;
 };
 
+// Normal Callable Object.
 template <typename Callable, typename ReturnType, typename... Arguments>
 class FunctionImpl : public FunctionImplBase<ReturnType, Arguments...>
 {
+  public:
+    explicit FunctionImpl(const Callable& aCallable)
+      : mCallable(aCallable) {}
+
+    ReturnType call(Arguments... aArguments) override
+    {
+      return mCallable(Forward<Arguments>(aArguments)...);
+    }
+  private:
+    Callable mCallable;
+};
+
+// Base class for passing pointer to member function.
+template <typename Callable, typename ReturnType, typename... Arguments>
+class MemberFunctionImplBase : public FunctionImplBase<ReturnType, Arguments...>
+{
 public:
-  explicit FunctionImpl(const Callable& aCallable) : mCallable(aCallable) {}
+  explicit MemberFunctionImplBase(const Callable& aCallable)
+    : mCallable(aCallable) {}
 
   ReturnType call(Arguments... aArguments) override
   {
-    return mCallable(Forward<Arguments>(aArguments)...);
+    return callInternal(Forward<Arguments>(aArguments)...);
   }
 private:
+  template<typename ThisType, typename... Args>
+  ReturnType callInternal(ThisType* aThis, Args&&... aArguments)
+  {
+    return (aThis->*mCallable)(Forward<Args>(aArguments)...);
+  }
+
+  template<typename ThisType, typename... Args>
+  ReturnType callInternal(ThisType&& aThis, Args&&... aArguments)
+  {
+    return (aThis.*mCallable)(Forward<Args>(aArguments)...);
+  }
   Callable mCallable;
+};
+
+// For non-const member function specialization of FunctionImpl.
+template <typename ThisType, typename... Args, typename ReturnType, typename... Arguments>
+class FunctionImpl<ReturnType(ThisType::*)(Args...),
+                   ReturnType, Arguments...>
+  : public MemberFunctionImplBase<ReturnType(ThisType::*)(Args...),
+                                  ReturnType, Arguments...>
+{
+public:
+  explicit FunctionImpl(ReturnType(ThisType::*aMemberFunc)(Args...))
+    : MemberFunctionImplBase<ReturnType(ThisType::*)(Args...),
+                             ReturnType, Arguments...>(aMemberFunc)
+  {}
+};
+
+// For const member function specialization of FunctionImpl.
+template <typename ThisType, typename... Args, typename ReturnType, typename... Arguments>
+class FunctionImpl<ReturnType(ThisType::*)(Args...) const,
+                   ReturnType, Arguments...>
+  : public MemberFunctionImplBase<ReturnType(ThisType::*)(Args...) const,
+                                  ReturnType, Arguments...>
+{
+public:
+  explicit FunctionImpl(ReturnType(ThisType::*aConstMemberFunc)(Args...) const)
+    : MemberFunctionImplBase<ReturnType(ThisType::*)(Args...) const,
+                             ReturnType, Arguments...>(aConstMemberFunc)
+  {}
 };
 
 } // namespace detail

--- a/mfbt/moz.build
+++ b/mfbt/moz.build
@@ -34,6 +34,7 @@ EXPORTS.mozilla = [
     'EnumeratedArray.h',
     'EnumSet.h',
     'FloatingPoint.h',
+    'Function.h',
     'GuardObjects.h',
     'HashFunctions.h',
     'IntegerPrintfMacros.h',

--- a/mfbt/tests/TestFunction.cpp
+++ b/mfbt/tests/TestFunction.cpp
@@ -23,7 +23,10 @@ struct ConvertibleToInt
 int increment(int arg) { return arg + 1; }
 
 struct S {
+  S() {}
   static int increment(int arg) { return arg + 1; }
+  int decrement(int arg) { return arg - 1;}
+  int sum(int arg1, int arg2) const { return arg1 + arg2;}
 };
 
 struct Incrementor {
@@ -82,6 +85,21 @@ TestReassignment()
   CHECK(f(42) == 44);
 }
 
+static void
+TestMemberFunction()
+{
+  Function<int(S&, int)> f = &S::decrement;
+  S s;
+  CHECK((f(s, 1) == 0));
+}
+
+static void
+TestConstMemberFunction()
+{
+  Function<int(const S*, int, int)> f = &S::sum;
+  const S s;
+  CHECK((f(&s, 1, 1) == 2));
+}
 int
 main()
 {
@@ -91,5 +109,7 @@ main()
   TestLambda();
   TestDefaultConstructionAndAssignmentLater();
   TestReassignment();
+  TestMemberFunction();
+  TestConstMemberFunction();
   return 0;
 }

--- a/mfbt/tests/TestFunction.cpp
+++ b/mfbt/tests/TestFunction.cpp
@@ -1,0 +1,95 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+   /* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "mozilla/Assertions.h"
+#include "mozilla/Function.h"
+
+using mozilla::Function;
+
+#define CHECK(c) \
+  do { \
+    bool cond = !!(c); \
+    MOZ_RELEASE_ASSERT(cond, "Failed assertion: " #c); \
+  } while (false)
+
+struct ConvertibleToInt
+{
+  operator int() const { return 42; }
+};
+
+int increment(int arg) { return arg + 1; }
+
+struct S {
+  static int increment(int arg) { return arg + 1; }
+};
+
+struct Incrementor {
+  int operator()(int arg) { return arg + 1; }
+};
+
+static void
+TestNonmemberFunction()
+{
+  Function<int(int)> f = &increment;
+  CHECK(f(42) == 43);
+}
+
+static void
+TestStaticMemberFunction()
+{
+  Function<int(int)> f = &S::increment;
+  CHECK(f(42) == 43);
+}
+
+static void
+TestFunctionObject()
+{
+  Function<int(int)> f = Incrementor();
+  CHECK(f(42) == 43);
+}
+
+static void
+TestLambda()
+{
+  // Test non-capturing lambda
+  Function<int(int)> f = [](int arg){ return arg + 1; };
+  CHECK(f(42) == 43);
+
+  // Test capturing lambda
+  int one = 1;
+  Function<int(int)> g = [one](int arg){ return arg + one; };
+  CHECK(g(42) == 43);
+}
+
+static void
+TestDefaultConstructionAndAssignmentLater()
+{
+  Function<int(int)> f;  // allowed
+  // Would get an assertion if we tried calling f now.
+  f = &increment;
+  CHECK(f(42) == 43);
+}
+
+static void
+TestReassignment()
+{
+  Function<int(int)> f = &increment;
+  CHECK(f(42) == 43);
+  f = [](int arg){ return arg + 2; };
+  CHECK(f(42) == 44);
+}
+
+int
+main()
+{
+  TestNonmemberFunction();
+  TestStaticMemberFunction();
+  TestFunctionObject();
+  TestLambda();
+  TestDefaultConstructionAndAssignmentLater();
+  TestReassignment();
+  return 0;
+}

--- a/mfbt/tests/moz.build
+++ b/mfbt/tests/moz.build
@@ -17,6 +17,7 @@ CppUnitTests([
     'TestEndian',
     'TestEnumSet',
     'TestFloatingPoint',
+    'TestFunction',
     'TestIntegerPrintfMacros',
     'TestJSONWriter',
     'TestMacroArgs',


### PR DESCRIPTION
This PR adds a new function that a media-related patch depends on. Mozilla explains this better than I can, so deferring to BMO on this:

[Bug 1198451](https://bugzilla.mozilla.org/show_bug.cgi?id=1198451)
[Bug 1212745](https://bugzilla.mozilla.org/show_bug.cgi?id=1212745)

Verified builds and appears to work.