### PR TITLE
Piggyback Quicktime support onto MP4Decoder

### DIFF
--- a/dom/media/DecoderTraits.cpp
+++ b/dom/media/DecoderTraits.cpp
@@ -360,8 +360,7 @@ IsMP4SupportedType(const nsACString& aType,
 #ifdef MOZ_OMX_DECODER
   return false;
 #else
-  bool haveAAC, haveMP3, haveH264;
-  return MP4Decoder::CanHandleMediaType(aType, aCodecs, haveAAC, haveH264, haveMP3);
+  return MP4Decoder::CanHandleMediaType(aType, aCodecs);
 #endif
 }
 #endif

--- a/dom/media/VideoUtils.cpp
+++ b/dom/media/VideoUtils.cpp
@@ -13,8 +13,11 @@
 #include "mozilla/Preferences.h"
 #include "mozilla/Base64.h"
 #include "mozilla/Telemetry.h"
+#include "mozilla/Function.h"
 #include "nsIRandomGenerator.h"
 #include "nsIServiceManager.h"
+#include "nsCharSeparatedTokenizer.h"
+#include "nsContentTypeParser.h"
 #include "MediaTaskQueue.h"
 
 #include <stdint.h>
@@ -339,6 +342,80 @@ CreateFlushableMediaDecodeTaskQueue()
   nsresult rv = NS_DispatchToMainThread(t, NS_DISPATCH_SYNC);
   NS_ENSURE_SUCCESS(rv, nullptr);
   return t->mTaskQueue.forget();
+}
+
+bool
+ParseCodecsString(const nsAString& aCodecs, nsTArray<nsString>& aOutCodecs)
+{
+  aOutCodecs.Clear();
+  bool expectMoreTokens = false;
+  nsCharSeparatedTokenizer tokenizer(aCodecs, ',');
+  while (tokenizer.hasMoreTokens()) {
+    const nsSubstring& token = tokenizer.nextToken();
+    expectMoreTokens = tokenizer.separatorAfterCurrentToken();
+    aOutCodecs.AppendElement(token);
+  }
+  if (expectMoreTokens) {
+    // Last codec name was empty
+    return false;
+  }
+  return true;
+}
+
+static bool
+CheckContentType(const nsAString& aContentType,
+                 mozilla::Function<bool(const nsAString&)> aSubtypeFilter,
+                 mozilla::Function<bool(const nsAString&)> aCodecFilter)
+{
+  nsContentTypeParser parser(aContentType);
+  nsAutoString mimeType;
+  nsresult rv = parser.GetType(mimeType);
+  if (NS_FAILED(rv) || !aSubtypeFilter(mimeType)) {
+    return false;
+  }
+
+  nsString codecsStr;
+  parser.GetParameter("codecs", codecsStr);
+  nsTArray<nsString> codecs;
+  if (!ParseCodecsString(codecsStr, codecs)) {
+    return false;
+  }
+  for (const nsString& codec : codecs) {
+    if (!aCodecFilter(codec)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+IsH264ContentType(const nsAString& aContentType)
+{
+  return CheckContentType(aContentType,
+    [](const nsAString& type) {
+      return type.EqualsLiteral("video/mp4");
+    },
+    [](const nsAString& codec) {
+      int16_t profile = 0;
+      int16_t level = 0;
+      return ExtractH264CodecDetails(codec, profile, level);
+    }
+  );
+}
+
+bool
+IsAACContentType(const nsAString& aContentType)
+{
+  return CheckContentType(aContentType,
+    [](const nsAString& type) {
+      return type.EqualsLiteral("audio/mp4") ||
+             type.EqualsLiteral("audio/x-m4a");
+    },
+    [](const nsAString& codec) {
+      return codec.EqualsLiteral("mp4a.40.2") || // MPEG4 AAC-LC
+             codec.EqualsLiteral("mp4a.40.5") || // MPEG4 HE-AAC
+             codec.EqualsLiteral("mp4a.67");     // MPEG2 AAC-LC
+    });
 }
 
 } // end namespace mozilla

--- a/dom/media/VideoUtils.cpp
+++ b/dom/media/VideoUtils.cpp
@@ -345,6 +345,15 @@ CreateFlushableMediaDecodeTaskQueue()
 }
 
 bool
+IsAACCodecString(const nsAString& aCodec)
+{
+  return
+    aCodec.EqualsLiteral("mp4a.40.2") || // MPEG4 AAC-LC
+    aCodec.EqualsLiteral("mp4a.40.5") || // MPEG4 HE-AAC
+    aCodec.EqualsLiteral("mp4a.67"); // MPEG2 AAC-LC}
+}
+
+bool
 ParseCodecsString(const nsAString& aCodecs, nsTArray<nsString>& aOutCodecs)
 {
   aOutCodecs.Clear();

--- a/dom/media/VideoUtils.h
+++ b/dom/media/VideoUtils.h
@@ -271,6 +271,15 @@ CreateMediaDecodeTaskQueue();
 already_AddRefed<FlushableMediaTaskQueue>
 CreateFlushableMediaDecodeTaskQueue();
 
+bool
+ParseCodecsString(const nsAString& aCodecs, nsTArray<nsString>& aOutCodecs);
+
+bool
+IsH264ContentType(const nsAString& aContentType);
+
+bool
+IsAACContentType(const nsAString& aContentType);
+
 } // end namespace mozilla
 
 #endif

--- a/dom/media/VideoUtils.h
+++ b/dom/media/VideoUtils.h
@@ -280,6 +280,9 @@ IsH264ContentType(const nsAString& aContentType);
 bool
 IsAACContentType(const nsAString& aContentType);
 
+bool
+IsAACCodecString(const nsAString& aCodec);
+
 } // end namespace mozilla
 
 #endif

--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -91,10 +91,11 @@ MP4Decoder::CanHandleMediaType(const nsACString& aMIMETypeExcludingCodecs,
   // Whitelist MP4 types, so they explicitly match what we encounter on
   // the web, as opposed to what we use internally (i.e. what our demuxers
   // etc output).
-  if (!aMIMETypeExcludingCodecs.EqualsASCII("audio/mp4") &&
-      !aMIMETypeExcludingCodecs.EqualsASCII("audio/x-m4a") &&
-      !aMIMETypeExcludingCodecs.EqualsASCII("video/mp4") &&
-      !aMIMETypeExcludingCodecs.EqualsASCII("video/x-m4v")) {
+  const bool isMP4Audio = aMIMETypeExcludingCodecs.EqualsASCII("audio/mp4") ||
+                          aMIMETypeExcludingCodecs.EqualsASCII("audio/x-m4a");
+  const bool isMP4Video = aMIMETypeExcludingCodecs.EqualsASCII("video/mp4") ||
+                          aMIMETypeExcludingCodecs.EqualsASCII("video/x-m4v");
+  if (!isMP4Audio && !isMP4Video) {
     return false;
   }
 
@@ -107,11 +108,10 @@ MP4Decoder::CanHandleMediaType(const nsACString& aMIMETypeExcludingCodecs,
   nsTArray<nsCString> codecMimes;
   if (aCodecs.IsEmpty()) {
     // No codecs specified. Assume AAC/H.264
-    if (aMIMETypeExcludingCodecs.EqualsLiteral("audio/mp4") ||
-        aMIMETypeExcludingCodecs.EqualsLiteral("audio/x-m4a")) {
+    if (isMP4Audio) {
       codecMimes.AppendElement(NS_LITERAL_CSTRING("audio/mp4a-latm"));
-    } else if (aMIMETypeExcludingCodecs.EqualsLiteral("video/mp4") ||
-               aMIMETypeExcludingCodecs.EqualsLiteral("video/x-m4v")) {
+    } else {
+      MOZ_ASSERT(isMP4Video);
       codecMimes.AppendElement(NS_LITERAL_CSTRING("video/avc"));
     }
   } else {
@@ -130,7 +130,9 @@ MP4Decoder::CanHandleMediaType(const nsACString& aMIMETypeExcludingCodecs,
         codecMimes.AppendElement(NS_LITERAL_CSTRING("audio/mpeg"));
         continue;
       }
-      if (IsWhitelistedH264Codec(codec)) {
+      // Note: Only accept H.264 in a video content type, not in an audio
+      // content type.
+      if (IsWhitelistedH264Codec(codec) && isMP4Video) {
         codecMimes.AppendElement(NS_LITERAL_CSTRING("video/avc"));
         continue;
       }

--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -94,7 +94,9 @@ MP4Decoder::CanHandleMediaType(const nsACString& aMIMETypeExcludingCodecs,
   const bool isMP4Audio = aMIMETypeExcludingCodecs.EqualsASCII("audio/mp4") ||
                           aMIMETypeExcludingCodecs.EqualsASCII("audio/x-m4a");
   const bool isMP4Video = aMIMETypeExcludingCodecs.EqualsASCII("video/mp4") ||
+#ifdef XP_LINUX
                           aMIMETypeExcludingCodecs.EqualsASCII("video/quicktime") ||
+#endif
                           aMIMETypeExcludingCodecs.EqualsASCII("video/x-m4v");
   if (!isMP4Audio && !isMP4Video) {
     return false;

--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -12,6 +12,7 @@
 #include "mozilla/Preferences.h"
 #include "nsCharSeparatedTokenizer.h"
 #include "nsContentTypeParser.h"
+#include "VideoUtils.h"
 #include "prlog.h"
 
 #ifdef XP_WIN
@@ -41,35 +42,7 @@ MediaDecoderStateMachine* MP4Decoder::CreateStateMachine()
 }
 
 static bool
-IsSupportedAudioCodec(const nsAString& aCodec,
-                      bool& aOutContainsAAC,
-                      bool& aOutContainsMP3)
-{
-  // AAC-LC or HE-AAC in M4A.
-  aOutContainsAAC = aCodec.EqualsASCII("mp4a.40.2") ||
-                    aCodec.EqualsASCII("mp4a.40.5");
-  if (aOutContainsAAC) {
-#ifdef XP_WIN
-    if (!Preferences::GetBool("media.use-blank-decoder") &&
-        !WMFDecoderModule::HasAAC()) {
-      return false;
-    }
-#endif
-    return true;
-  }
-#ifndef MOZ_GONK_MEDIACODEC // B2G doesn't support MP3 in MP4 yet.
-  aOutContainsMP3 = aCodec.EqualsASCII("mp3");
-  if (aOutContainsMP3) {
-    return true;
-  }
-#else
-  aOutContainsMP3 = false;
-#endif
-  return false;
-}
-
-static bool
-IsSupportedH264Codec(const nsAString& aCodec)
+IsWhitelistedH264Codec(const nsAString& aCodec)
 {
   int16_t profile = 0, level = 0;
 
@@ -108,45 +81,74 @@ IsSupportedH264Codec(const nsAString& aCodec)
 
 /* static */
 bool
-MP4Decoder::CanHandleMediaType(const nsACString& aType,
-                               const nsAString& aCodecs,
-                               bool& aOutContainsAAC,
-                               bool& aOutContainsH264,
-                               bool& aOutContainsMP3)
+MP4Decoder::CanHandleMediaType(const nsACString& aMIMETypeExcludingCodecs,
+                               const nsAString& aCodecs)
 {
   if (!IsEnabled()) {
     return false;
   }
 
-  if (aType.EqualsASCII("audio/mp4") || aType.EqualsASCII("audio/x-m4a")) {
-    return aCodecs.IsEmpty() ||
-           IsSupportedAudioCodec(aCodecs,
-                                 aOutContainsAAC,
-                                 aOutContainsMP3);
-  }
-
-  if (!aType.EqualsASCII("video/mp4")) {
+  // Whitelist MP4 types, so they explicitly match what we encounter on
+  // the web, as opposed to what we use internally (i.e. what our demuxers
+  // etc output).
+  if (!aMIMETypeExcludingCodecs.EqualsASCII("audio/mp4") &&
+      !aMIMETypeExcludingCodecs.EqualsASCII("audio/x-m4a") &&
+      !aMIMETypeExcludingCodecs.EqualsASCII("video/mp4") &&
+      !aMIMETypeExcludingCodecs.EqualsASCII("video/x-m4v")) {
     return false;
   }
 
-  // Verify that all the codecs specifed are ones that we expect that
-  // we can play.
-  nsTArray<nsString> codecs;
-  if (!ParseCodecsString(aCodecs, codecs)) {
+  #ifdef MOZ_GONK_MEDIACODEC
+  if (aMIMETypeExcludingCodecs.EqualsASCII(VIDEO_3GPP)) {
+    return Preferences::GetBool("media.gonk.enabled", false);
+  }
+#endif
+
+  nsTArray<nsCString> codecMimes;
+  if (aCodecs.IsEmpty()) {
+    // No codecs specified. Assume AAC/H.264
+    if (aMIMETypeExcludingCodecs.EqualsLiteral("audio/mp4") ||
+        aMIMETypeExcludingCodecs.EqualsLiteral("audio/x-m4a")) {
+      codecMimes.AppendElement(NS_LITERAL_CSTRING("audio/mp4a-latm"));
+    } else if (aMIMETypeExcludingCodecs.EqualsLiteral("video/mp4") ||
+               aMIMETypeExcludingCodecs.EqualsLiteral("video/x-m4v")) {
+      codecMimes.AppendElement(NS_LITERAL_CSTRING("video/avc"));
+    }
+  } else {
+    // Verify that all the codecs specified are ones that we expect that
+    // we can play.
+    nsTArray<nsString> codecs;
+    if (!ParseCodecsString(aCodecs, codecs)) {
+      return false;
+    }
+    for (const nsString& codec : codecs) {
+      if (IsAACCodecString(codec)) {
+        codecMimes.AppendElement(NS_LITERAL_CSTRING("audio/mp4a-latm"));
+        continue;
+      }
+      if (codec.EqualsLiteral("mp3")) {
+        codecMimes.AppendElement(NS_LITERAL_CSTRING("audio/mpeg"));
+        continue;
+      }
+      if (IsWhitelistedH264Codec(codec)) {
+        codecMimes.AppendElement(NS_LITERAL_CSTRING("video/avc"));
+        continue;
+      }
+      // Some unsupported codec.
+      return false;
+    }
+  }
+
+  // Verify that we have a PDM that supports the whitelisted types.
+  PlatformDecoderModule::Init();
+  nsRefPtr<PlatformDecoderModule> platform = PlatformDecoderModule::Create();
+  if (!platform) {
     return false;
   }
-  for (const nsString& codec : codecs) {
-    if (IsSupportedAudioCodec(codec,
-                              aOutContainsAAC,
-                              aOutContainsMP3)) {
-      continue;
+  for (const nsCString& codecMime : codecMimes) {
+    if (!platform->SupportsMimeType(codecMime)) {
+      return false;
     }
-    if (IsSupportedH264Codec(codec)) {
-      aOutContainsH264 = true;
-      continue;
-    }
-    // Some unsupported codec.
-    return false;
   }
 
   return true;
@@ -164,10 +166,7 @@ MP4Decoder::CanHandleMediaType(const nsAString& aContentType)
   nsString codecs;
   parser.GetParameter("codecs", codecs);
 
-  bool ignoreAAC, ignoreH264, ignoreMP3;
-  return CanHandleMediaType(NS_ConvertUTF16toUTF8(mimeType),
-                            codecs,
-                            ignoreAAC, ignoreH264, ignoreMP3);
+  return CanHandleMediaType(NS_ConvertUTF16toUTF8(mimeType), codecs);
 }
 
 static bool

--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -94,6 +94,7 @@ MP4Decoder::CanHandleMediaType(const nsACString& aMIMETypeExcludingCodecs,
   const bool isMP4Audio = aMIMETypeExcludingCodecs.EqualsASCII("audio/mp4") ||
                           aMIMETypeExcludingCodecs.EqualsASCII("audio/x-m4a");
   const bool isMP4Video = aMIMETypeExcludingCodecs.EqualsASCII("video/mp4") ||
+                          aMIMETypeExcludingCodecs.EqualsASCII("video/quicktime") ||
                           aMIMETypeExcludingCodecs.EqualsASCII("video/x-m4v");
   if (!isMP4Audio && !isMP4Video) {
     return false;

--- a/dom/media/fmp4/MP4Decoder.h
+++ b/dom/media/fmp4/MP4Decoder.h
@@ -34,6 +34,8 @@ public:
                                  bool& aOutContainsH264,
                                  bool& aOutContainsMP3);
 
+  static bool CanHandleMediaType(const nsAString& aMIMEType);
+
   // Returns true if the MP4 backend is preffed on.
   static bool IsEnabled();
 };

--- a/dom/media/fmp4/MP4Decoder.h
+++ b/dom/media/fmp4/MP4Decoder.h
@@ -28,11 +28,8 @@ public:
   // a MP4 platform decoder backend. If aCodecs is non emtpy, it is filled
   // with a comma-delimited list of codecs to check support for. Notes in
   // out params wether the codecs string contains AAC or H.264.
-  static bool CanHandleMediaType(const nsACString& aMIMEType,
-                                 const nsAString& aCodecs,
-                                 bool& aOutContainsAAC,
-                                 bool& aOutContainsH264,
-                                 bool& aOutContainsMP3);
+  static bool CanHandleMediaType(const nsACString& aMIMETypeExcludingCodecs,
+                                 const nsAString& aCodecs);
 
   static bool CanHandleMediaType(const nsAString& aMIMEType);
 

--- a/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
@@ -751,7 +751,14 @@ static bool ValidInputSize(int32_t size) {
 status_t MPEG4Extractor::parseChunk(off64_t *offset, int depth) {
     ALOGV("entering parseChunk %lld/%d", *offset, depth);
     uint32_t hdr[2];
-    if (mDataSource->readAt(*offset, hdr, 8) < 8) {
+    if (mDataSource->readAt(*offset, hdr, 4) < 4) {
+        return ERROR_IO;
+    }
+    if (!hdr[0]) {
+        *offset += 4;
+        return OK;
+    }
+    if (mDataSource->readAt(*offset + 4, hdr + 1, 4) < 4) {
         return ERROR_IO;
     }
     uint64_t chunk_size = ntohl(hdr[0]);


### PR DESCRIPTION
On Linux (where the Quicktime plugin is not available), .mov files are played using GStreamer. Since mov files are in most cases essentially an MP4, we can use our MP4Decoder to play them. This PR will allow Linux users to play mov files in the browser without needing GStreamer.

The PR is dependent on the new mozilla::Function in PR #847 and will not compile without it.

Built and tested together with #847 and appears to work as intended.