### PR TITLE
FFmpeg cash fix: Initialize PDM before attempting to use it

### DIFF
--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -183,6 +183,7 @@ IsFFmpegAvailable()
   if (!Preferences::GetBool("media.ffmpeg.enabled", false)) {
     return false;
   }
+  PlatformDecoderModule::Init();
   nsRefPtr<PlatformDecoderModule> m = FFmpegRuntimeLinker::CreateDecoderModule();
   return !!m;
 #endif


### PR DESCRIPTION
This will prevent a crash should FFmpeg try to use the PDM before it is initialized.