### PR TITLE
Do not build GStreamer support by default

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -5579,7 +5579,7 @@ case "$OS_TARGET" in
 WINNT|Darwin|Android)
     ;;
 *)
-    MOZ_GSTREAMER=1
+    MOZ_GSTREAMER=
     ;;
 esac
 


### PR DESCRIPTION
Just what it says in the tin.

While I do plan to ship 27.1 with GStreamer support, it will be unused and disabled by default. If any issues are encountered, a simple pref flip can re-enable it if a user needs it.

That said, all the regressions I've encountered from not using GStreamer have already been fixed, and I've not seen any reports from users of the unstable builds (where it is already prefed off by default). So let's not build it by default on master/unstable builds anymore.