### PR TITLE
Fix SSUAO & Navigator::GetUserAgent() regression

### DIFF
--- a/dom/base/Navigator.cpp
+++ b/dom/base/Navigator.cpp
@@ -2576,17 +2576,7 @@ Navigator::GetUserAgent(nsPIDOMWindow* aWindow, nsIURI* aURI,
                         nsAString& aUserAgent)
 {
   MOZ_ASSERT(NS_IsMainThread());
-/*
-  if (!aIsCallerChrome) {
-    const nsAdoptingString& override =
-      mozilla::Preferences::GetString("general.useragent.override");
 
-    if (override) {
-      aUserAgent = override;
-      return NS_OK;
-    }
-  }
-*/
   nsresult rv;
   nsCOMPtr<nsIHttpProtocolHandler>
     service(do_GetService(NS_NETWORK_PROTOCOL_CONTRACTID_PREFIX "http", &rv));

--- a/dom/base/Navigator.cpp
+++ b/dom/base/Navigator.cpp
@@ -2576,7 +2576,7 @@ Navigator::GetUserAgent(nsPIDOMWindow* aWindow, nsIURI* aURI,
                         nsAString& aUserAgent)
 {
   MOZ_ASSERT(NS_IsMainThread());
-
+/*
   if (!aIsCallerChrome) {
     const nsAdoptingString& override =
       mozilla::Preferences::GetString("general.useragent.override");
@@ -2586,7 +2586,7 @@ Navigator::GetUserAgent(nsPIDOMWindow* aWindow, nsIURI* aURI,
       return NS_OK;
     }
   }
-
+*/
   nsresult rv;
   nsCOMPtr<nsIHttpProtocolHandler>
     service(do_GetService(NS_NETWORK_PROTOCOL_CONTRACTID_PREFIX "http", &rv));


### PR DESCRIPTION
If general.useragent.override is defined, then Navigator::GetUserAgent() ignores SSUAO and always uses value from general.useragent.override. 

This problem did not exist in the Pale Moon 26.x. The regression probably caused by that Mozilla no longer considers SSUAO.