### PR TITLE
Allow toolbarbutton-badge be styled by add-ons

### DIFF
--- a/browser/themes/linux/browser.css
+++ b/browser/themes/linux/browser.css
@@ -2154,21 +2154,6 @@ toolbar[iconsize="small"] .toolbarbutton-badge-container {
   margin: 0;
 }
 
-.toolbarbutton-badge[badge]:not([badge=""])::after {
-  /* The |content| property is set in the content stylesheet. */
-  font-size: 9px;
-  font-weight: bold;
-  padding: 0 1px;
-  color: #fff;
-  background-color: rgb(240,61,37);
-  border: 1px solid rgb(216,55,34);
-  border-radius: 2px;
-  box-shadow: 0 1px 0 rgba(0,39,121,0.77);
-  position: absolute;
-  top: 0;
-  right: 0;
-}
-
 .toolbarbutton-badge[badge]:not([badge=""]):-moz-locale-dir(rtl)::after {
   left: 2px;
   right: auto;

--- a/browser/themes/osx/browser.css
+++ b/browser/themes/osx/browser.css
@@ -2460,24 +2460,6 @@ toolbar[brighttext] #addonbar-closebutton {
     -moz-margin-end: 0;
 }
 
-.toolbarbutton-badge[badge=""] {
-    display: none;
-}
-.toolbarbutton-badge[badge]:not([badge=""])::after {
-    /* The |content| property is set in the content stylesheet. */
-    font-size: 9px;
-    font-weight: bold;
-    padding: 0 1px;
-    color: #fff;
-    background-color: rgb(240,61,37);
-    border: 1px solid rgb(216,55,34);
-    border-radius: 2px;
-    box-shadow: 0 1px 0 rgba(0,39,121,0.77);
-    position: absolute;
-    top: 0;
-    right: 0;
-}
-
 @navbarLargeIcons@ *|* > .toolbarbutton-badge[badge]:not([badge=""])::after {
     top: 1px;
     right: 1px;

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -2931,24 +2931,6 @@ toolbar[brighttext] #addonbar-closebutton {
   -moz-margin-end: 0;
 }
 
-.toolbarbutton-badge[badge=""] {
-  display: none;
-}
-.toolbarbutton-badge[badge]:not([badge=""])::after {
-  /* The |content| property is set in the content stylesheet. */
-  font-size: 9px;
-  font-weight: bold;
-  padding: 0 1px;
-  color: #fff;
-  background-color: rgb(240,61,37);
-  border: 1px solid rgb(216,55,34);
-  border-radius: 2px;
-  box-shadow: 0 1px 0 rgba(0,39,121,0.77);
-  position: absolute;
-  top: 0;
-  right: 0;
-}
-
 @navbarLargeIcons@ *|* > .toolbarbutton-badge[badge]:not([badge=""])::after {
   top: 1px;
   right: 1px;


### PR DESCRIPTION
Style for toolbarbutton-badge is already properly defined in [/toolkit/themes/windows/global/toolbarbutton.css](http://xref.palemoon.org/palemoon-trunk/source/toolkit/themes/windows/global/toolbarbutton.css#151). Second definition in browser.css is unnecessary and prevents to change style of budge from add-ons.