### PR TITLE
Add support for Element.insertAdjacentText() and Element.insertAdjacentElement()

### DIFF
--- a/dom/base/Element.cpp
+++ b/dom/base/Element.cpp
@@ -3378,6 +3378,53 @@ Element::InsertAdjacentHTML(const nsAString& aPosition, const nsAString& aText,
   }
 }
 
+nsINode*
+Element::InsertAdjacent(const nsAString& aWhere,
+                        nsINode* aNode,
+                        ErrorResult& aError)
+{
+  if (aWhere.LowerCaseEqualsLiteral("beforebegin")) {
+    nsCOMPtr<nsINode> parent = GetParentNode();
+    if (!parent) {
+      return nullptr;
+    }
+    parent->InsertBefore(*aNode, this, aError);
+  } else if (aWhere.LowerCaseEqualsLiteral("afterbegin")) {
+    static_cast<nsINode*>(this)->InsertBefore(*aNode, GetFirstChild(), aError);
+  } else if (aWhere.LowerCaseEqualsLiteral("beforeend")) {
+    static_cast<nsINode*>(this)->AppendChild(*aNode, aError);
+  } else if (aWhere.LowerCaseEqualsLiteral("afterend")) {
+    nsCOMPtr<nsINode> parent = GetParentNode();
+    if (!parent) {
+      return nullptr;
+    }
+    parent->InsertBefore(*aNode, GetNextSibling(), aError);
+  } else {
+    aError.Throw(NS_ERROR_DOM_SYNTAX_ERR);
+    return nullptr;
+  }
+
+  return aError.Failed() ? nullptr : aNode;
+}
+
+Element*
+Element::InsertAdjacentElement(const nsAString& aWhere,
+                               Element& aElement,
+                               ErrorResult& aError) {
+  nsINode* newNode = InsertAdjacent(aWhere, &aElement, aError);
+  MOZ_ASSERT(!newNode || newNode->IsElement());
+
+  return newNode ? newNode->AsElement() : nullptr;
+}
+
+void
+Element::InsertAdjacentText(
+  const nsAString& aWhere, const nsAString& aData, ErrorResult& aError)
+{
+  RefPtr<nsTextNode> textNode = OwnerDoc()->CreateTextNode(aData);
+  InsertAdjacent(aWhere, textNode, aError);
+}
+
 nsIEditor*
 Element::GetEditorInternal()
 {

--- a/dom/base/Element.h
+++ b/dom/base/Element.h
@@ -670,6 +670,26 @@ public:
   {
     return Matches(aSelector, aError);
   }
+
+private:
+  /**
+   * Implement the algorithm specified at
+   * https://dom.spec.whatwg.org/#insert-adjacent for both
+   * |insertAdjacentElement()| and |insertAdjacentText()| APIs.
+   */
+  nsINode* InsertAdjacent(const nsAString& aWhere,
+                          nsINode* aNode,
+                          ErrorResult& aError);
+
+public:
+  Element* InsertAdjacentElement(const nsAString& aWhere,
+                                 Element& aElement,
+                                 ErrorResult& aError);
+
+  void InsertAdjacentText(const nsAString& aWhere,
+                          const nsAString& aData,
+                          ErrorResult& aError);
+
   void SetPointerCapture(int32_t aPointerId, ErrorResult& aError)
   {
     bool activeState = false;

--- a/dom/webidl/Element.webidl
+++ b/dom/webidl/Element.webidl
@@ -67,6 +67,12 @@ interface Element : Node {
   [Pure]
   HTMLCollection getElementsByClassName(DOMString classNames);
 
+  [Throws, Pure]
+  Element? insertAdjacentElement(DOMString where, Element element); // historical
+
+  [Throws]
+  void insertAdjacentText(DOMString where, DOMString data); // historical
+
   /**
    * The ratio of font-size-inflated text font size to computed font
    * size for this element. This will query the element for its primary frame,

--- a/testing/web-platform/meta/MANIFEST.json
+++ b/testing/web-platform/meta/MANIFEST.json
@@ -18221,6 +18221,18 @@
             "timeout": "long",
             "url": "/content-security-policy/object-src/object-src-2_2.html"
           }
+        ],
+        "dom/nodes/Element-insertAdjacentElement.html": [
+          {
+            "path": "dom/nodes/Element-insertAdjacentElement.html",
+            "url": "/dom/nodes/Element-insertAdjacentElement.html"
+          }
+        ],
+        "dom/nodes/Element-insertAdjacentText.html": [
+          {
+            "path": "dom/nodes/Element-insertAdjacentText.html",
+            "url": "/dom/nodes/Element-insertAdjacentText.html"
+          }
         ]
       }
     }

--- a/testing/web-platform/meta/dom/interfaces.html.ini
+++ b/testing/web-platform/meta/dom/interfaces.html.ini
@@ -279,25 +279,25 @@
   [Document interface: xmlDoc must inherit property "queryAll" with the proper type (34)]
     expected: FAIL
 
-  [Element interface: element must inherit property "prepend" with the proper type (31)]
+  [Element interface: element must inherit property "prepend" with the proper type (33)]
     expected: FAIL
 
-  [Element interface: element must inherit property "append" with the proper type (32)]
+  [Element interface: element must inherit property "append" with the proper type (34)]
     expected: FAIL
 
-  [Element interface: element must inherit property "query" with the proper type (33)]
+  [Element interface: element must inherit property "query" with the proper type (35)]
     expected: FAIL
 
-  [Element interface: element must inherit property "queryAll" with the proper type (34)]
+  [Element interface: element must inherit property "queryAll" with the proper type (36)]
     expected: FAIL
 
-  [Element interface: element must inherit property "before" with the proper type (39)]
+  [Element interface: element must inherit property "before" with the proper type (41)]
     expected: FAIL
 
-  [Element interface: element must inherit property "after" with the proper type (40)]
+  [Element interface: element must inherit property "after" with the proper type (42)]
     expected: FAIL
 
-  [Element interface: element must inherit property "replace" with the proper type (41)]
+  [Element interface: element must inherit property "replace" with the proper type (43)]
     expected: FAIL
 
   [Attr interface: attribute textContent]

--- a/testing/web-platform/tests/dom/interfaces.html
+++ b/testing/web-platform/tests/dom/interfaces.html
@@ -307,6 +307,9 @@ interface Element : Node {
   HTMLCollection getElementsByTagName(DOMString localName);
   HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
   HTMLCollection getElementsByClassName(DOMString classNames);
+
+  Element? insertAdjacentElement(DOMString where, Element element); // historical
+  void insertAdjacentText(DOMString where, DOMString data); // historical
 };
 
 interface NamedNodeMap {

--- a/testing/web-platform/tests/dom/nodes/Element-insertAdjacentElement.html
+++ b/testing/web-platform/tests/dom/nodes/Element-insertAdjacentElement.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<div id="target"></div>
+<div id="parent"><span id=target2></span></div>
+<div id="log" style="visibility:visible"></div>
+<span id="test1"></span>
+<span id="test2"></span>
+<span id="test3"></span>
+<span id="test4"></span>
+<script>
+var target = document.getElementById("target");
+var target2 = document.getElementById("target2");
+
+test(function() {
+  assert_throws("SyntaxError", function() {
+    target.insertAdjacentElement("test", document.getElementById("test1"))
+  });
+
+  assert_throws("SyntaxError", function() {
+    target2.insertAdjacentElement("test", document.getElementById("test1"))
+  });
+}, "Inserting to an invalid location should cause a Syntax Error exception")
+
+test(function() {
+  var el = target.insertAdjacentElement("beforebegin", document.getElementById("test1"));
+  assert_equals(target.previousSibling.id, "test1");
+  assert_equals(el.id, "test1");
+
+  el = target2.insertAdjacentElement("beforebegin", document.getElementById("test1"));
+  assert_equals(target2.previousSibling.id, "test1");
+  assert_equals(el.id, "test1");
+}, "Inserted element should be target element's previous sibling for 'beforebegin' case")
+
+test(function() {
+  var el = target.insertAdjacentElement("afterbegin", document.getElementById("test2"));
+  assert_equals(target.firstChild.id, "test2");
+  assert_equals(el.id, "test2");
+
+  el = target2.insertAdjacentElement("afterbegin", document.getElementById("test2"));
+  assert_equals(target2.firstChild.id, "test2");
+  assert_equals(el.id, "test2");
+}, "Inserted element should be target element's first child for 'afterbegin' case")
+
+test(function() {
+  var el = target.insertAdjacentElement("beforeend", document.getElementById("test3"));
+  assert_equals(target.lastChild.id, "test3");
+  assert_equals(el.id, "test3");
+
+  el = target2.insertAdjacentElement("beforeend", document.getElementById("test3"));
+  assert_equals(target2.lastChild.id, "test3");
+  assert_equals(el.id, "test3");
+}, "Inserted element should be target element's last child for 'beforeend' case")
+
+test(function() {
+  var el = target.insertAdjacentElement("afterend", document.getElementById("test4"));
+  assert_equals(target.nextSibling.id, "test4");
+  assert_equals(el.id, "test4");
+
+  el = target2.insertAdjacentElement("afterend", document.getElementById("test4"));
+  assert_equals(target2.nextSibling.id, "test4");
+  assert_equals(el.id, "test4");
+}, "Inserted element should be target element's next sibling for 'afterend' case")
+
+test(function() {
+  var docElement = document.documentElement;
+  docElement.style.visibility="hidden";
+
+  assert_throws("HierarchyRequestError", function() {
+    var el = docElement.insertAdjacentElement("beforebegin", document.getElementById("test1"));
+    assert_equals(el, null);
+  });
+
+  var el = docElement.insertAdjacentElement("afterbegin", document.getElementById("test2"));
+  assert_equals(docElement.firstChild.id, "test2");
+  assert_equals(el.id, "test2");
+
+  el = docElement.insertAdjacentElement("beforeend", document.getElementById("test3"));
+  assert_equals(docElement.lastChild.id, "test3");
+  assert_equals(el.id, "test3");
+
+  assert_throws("HierarchyRequestError", function() {
+    var el = docElement.insertAdjacentElement("afterend", document.getElementById("test4"));
+    assert_equals(el, null);
+  });
+}, "Adding more than one child to document should cause a HierarchyRequestError exception")
+
+</script>

--- a/testing/web-platform/tests/dom/nodes/Element-insertAdjacentText.html
+++ b/testing/web-platform/tests/dom/nodes/Element-insertAdjacentText.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body style="visibility:hidden">
+<div id="target"></div>
+<div id="parent"><span id=target2></span></div>
+<div id="log" style="visibility:visible"></div>
+</body>
+<script>
+var target = document.getElementById("target");
+var target2 = document.getElementById("target2");
+
+test(function() {
+  assert_throws("SyntaxError", function() {
+    target.insertAdjacentText("test", "text")
+  });
+
+  assert_throws("SyntaxError", function() {
+    target2.insertAdjacentText("test", "test")
+  });
+}, "Inserting to an invalid location should cause a Syntax Error exception")
+
+test(function() {
+  target.insertAdjacentText("beforebegin", "test1");
+  assert_equals(target.previousSibling.nodeValue, "test1");
+
+  target2.insertAdjacentText("beforebegin", "test1");
+  assert_equals(target2.previousSibling.nodeValue, "test1");
+}, "Inserted text node should be target element's previous sibling for 'beforebegin' case")
+
+test(function() {
+  target.insertAdjacentText("afterbegin", "test2");
+  assert_equals(target.firstChild.nodeValue, "test2");
+
+  target2.insertAdjacentText("afterbegin", "test2");
+  assert_equals(target2.firstChild.nodeValue, "test2");
+}, "Inserted text node should be target element's first child for 'afterbegin' case")
+
+test(function() {
+  target.insertAdjacentText("beforeend", "test3");
+  assert_equals(target.lastChild.nodeValue, "test3");
+
+  target2.insertAdjacentText("beforeend", "test3");
+  assert_equals(target2.lastChild.nodeValue, "test3");
+}, "Inserted text node should be target element's last child for 'beforeend' case")
+
+test(function() {
+  target.insertAdjacentText("afterend", "test4");
+  assert_equals(target.nextSibling.nodeValue, "test4");
+
+  target2.insertAdjacentText("afterend", "test4");
+  assert_equals(target.nextSibling.nodeValue, "test4");
+}, "Inserted text node should be target element's next sibling for 'afterend' case")
+
+test(function() {
+  var docElement = document.documentElement;
+  docElement.style.visibility="hidden";
+
+  assert_throws("HierarchyRequestError", function() {
+    docElement.insertAdjacentText("beforebegin", "text1")
+  });
+
+  docElement.insertAdjacentText("afterbegin", "test2");
+  assert_equals(docElement.firstChild.nodeValue, "test2");
+
+  docElement.insertAdjacentText("beforeend", "test3");
+  assert_equals(docElement.lastChild.nodeValue, "test3");
+
+  assert_throws("HierarchyRequestError", function() {
+    docElement.insertAdjacentText("afterend", "test4")
+  });
+}, "Adding more than one child to document should cause a HierarchyRequestError exception")
+
+</script>


### PR DESCRIPTION
Ad #871 (https://forum.palemoon.org/viewtopic.php?f=29&t=14663)

__Steps to reproduce:__
Go to: https://www.dotnetperls.com/

Throws an error in Browser Console:
```
TypeError: b.insertAdjacentText is not a function
i.js:1:331
```
---

I've created the new build (x32, Windows) and tested.

See also:
https://w3c-test.org/dom/nodes/insert-adjacent.html
http://tests.caniuse.com/?feat=insert-adjacent

__But... Please you check tests (mainly the file: `interfaces.html.ini`).__