### PR TITLE
Use nsRefPtr in Element::InsertAdjacentTest

### DIFF
--- a/dom/base/Element.cpp
+++ b/dom/base/Element.cpp
@@ -3421,7 +3421,7 @@ void
 Element::InsertAdjacentText(
   const nsAString& aWhere, const nsAString& aData, ErrorResult& aError)
 {
-  RefPtr<nsTextNode> textNode = OwnerDoc()->CreateTextNode(aData);
+  nsRefPtr<nsTextNode> textNode = OwnerDoc()->CreateTextNode(aData);
   InsertAdjacent(aWhere, textNode, aError);
 }
 


### PR DESCRIPTION
Mozilla renaming at work again.

This PR fixes build bustage on Linux caused by commit 43f79b1 and resolves #880.

