### PR TITLE
Fix packaging of debug builds when tests are not enabled

### DIFF
--- a/b2g/installer/package-manifest.in
+++ b/b2g/installer/package-manifest.in
@@ -635,7 +635,7 @@
 @BINPATH@/components/EngineeringModeAPI.js
 @BINPATH@/components/EngineeringModeService.js
 
-#ifdef MOZ_DEBUG
+#if defined(ENABLE_TESTS) && defined(MOZ_DEBUG)
 @BINPATH@/components/TestInterfaceJS.js
 @BINPATH@/components/TestInterfaceJS.manifest
 #endif

--- a/browser/installer/package-manifest.in
+++ b/browser/installer/package-manifest.in
@@ -631,7 +631,7 @@
 @RESPATH@/components/MozKeyboard.js
 @RESPATH@/components/InputMethod.manifest
 
-#ifdef MOZ_DEBUG
+#if defined(ENABLE_TESTS) && defined(MOZ_DEBUG)
 @RESPATH@/components/TestInterfaceJS.js
 @RESPATH@/components/TestInterfaceJS.manifest
 #endif

--- a/mobile/android/installer/package-manifest.in
+++ b/mobile/android/installer/package-manifest.in
@@ -440,7 +440,7 @@
 @BINPATH@/components/dom_webspeechsynth.xpt
 #endif
 
-#ifdef MOZ_DEBUG
+#if defined(ENABLE_TESTS) && defined(MOZ_DEBUG)
 @BINPATH@/components/TestInterfaceJS.js
 @BINPATH@/components/TestInterfaceJS.manifest
 #endif


### PR DESCRIPTION
Just what it says in the tin.

Resolves #888.