### PR TITLE
Silence compiler warnings in JXR decoder

### DIFF
--- a/image/decoders/nsJXRDecoder.cpp
+++ b/image/decoders/nsJXRDecoder.cpp
@@ -147,6 +147,7 @@ nsJXRDecoder::nsJXRDecoder(RasterImage* aImage, bool hasBeenDecoded) : Decoder(a
     m_numAvailableBands(0),
     m_currentTileRow(0),
     m_currentSubBand(0),
+    m_startedDecodingSubband(false),
     m_skippedTileRows(false),
     m_alphaBitDepth(0),
     m_outPixelFormat(pfNone),


### PR DESCRIPTION
As discussed in #105.

I didn't compile with GCC so maybe @trav90 will want to confirm they are all gone first (or maybe it just isn't worth a separate compile).