### PR TITLE
[minor fix] DevTools - Console - throws an error

### DIFF
--- a/toolkit/devtools/webconsole/console-output.js
+++ b/toolkit/devtools/webconsole/console-output.js
@@ -3135,8 +3135,8 @@ Widgets.ObjectRenderers.add({
     let target = this.message.output.toolboxTarget;
     this.toolbox = gDevTools.getToolbox(target);
     if (!this.toolbox) {
-      throw new Error("The object cannot be linked to the inspector without a " +
-        "toolbox");
+      // In cases like the browser console, there is no toolbox.
+      return;
     }
 
     // Checking that the inspector supports the node


### PR DESCRIPTION

__Steps to reproduce__

Go to (e.g.): http://www.ceskatelevize.cz/ct24#live

Throws an errors in Browser Console:
```
The object cannot be linked to the inspector without a toolbox
console-output.js:3138:0
```

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1193747

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows) and tested.
