### PR TITLE
Resolve confusion between Flash and VLC plugins

### DIFF
--- a/dom/plugins/base/nsPluginTags.cpp
+++ b/dom/plugins/base/nsPluginTags.cpp
@@ -201,7 +201,11 @@ void nsPluginTag::InitMime(const char* const* aMimeTypes,
         mIsJavaPlugin = true;
         break;
       case nsPluginHost::eSpecialType_Flash:
-        mIsFlashPlugin = true;
+        // VLC sometimes claims to implement the Flash MIME type, and we want
+        // to allow users to control that separately from Adobe Flash.
+        if (Name().EqualsLiteral("Shockwave Flash")) {
+          mIsFlashPlugin = true;
+        }  
         break;
       case nsPluginHost::eSpecialType_None:
       default:

--- a/dom/plugins/base/nsPluginTags.h
+++ b/dom/plugins/base/nsPluginTags.h
@@ -83,6 +83,8 @@ public:
 
   bool HasSameNameAndMimes(const nsPluginTag *aPluginTag) const;
   nsCString GetNiceFileName();
+  
+  nsCString Name() const { return mName; }
 
   bool IsFromExtension() const;
 


### PR DESCRIPTION
Plugin permissions are confused between Flash and the VLC plugins. Fix this by checking that the plugin name for the special Flash plugin is "Shockwave Flash", which is true of Adobe Flash but not replacement plugins such as VLC or even gnash. This causes other plugins to have their own pref tag so that users can enable/disable them separately.

https://bugzilla.mozilla.org/show_bug.cgi?id=1293062