### PR TITLE
Restyle extension target indicators

### DIFF
--- a/toolkit/mozapps/extensions/content/extensions.css
+++ b/toolkit/mozapps/extensions/content/extensions.css
@@ -268,9 +268,8 @@ richlistitem:not([selected]) * {
 
 /* Indicator style for extension target application */
 .addon[native] .nativeIndicator {
-  font-size: 150%;
-  margin-top: -5pt;
-  margin-bottom: -1pt;
+  margin-left: 5pt;
+  padding-bottom: 1pt;
 }
 .addon[native][active="false"] .nativeIndicator {
   opacity: 0.4;

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -845,8 +845,8 @@
                 <xul:label anonid="name" class="name" crop="end" flex="1"
                            xbl:inherits="value=name,tooltiptext=name"/>
                 <xul:label anonid="version" class="version"/>
-                <xul:label class="nativeIndicator nativeAddon" value="•" tooltiptext="&addon.nativeAddon;"/>
-                <xul:label class="nativeIndicator compatAddon" value="•" tooltiptext="&addon.compatAddon;"/>
+                <xul:label class="nativeIndicator nativeAddon" value="●" tooltiptext="&addon.nativeAddon;"/>
+                <xul:label class="nativeIndicator compatAddon" value="●" tooltiptext="&addon.compatAddon;"/>
                 <xul:label class="disabled-postfix" value="&addon.disabled.postfix;"/>
                 <xul:label class="update-postfix" value="&addon.update.postfix;"/>
                 <xul:spacer flex="5000"/> <!-- Necessary to make the name crop -->


### PR DESCRIPTION
The ASCII bullet symbol has been replaced with a Unicode circle character. It's larger than the bullet by default, which makes it more appropriate as a glyph without need for resizing anything. This fixes ugly alignment on Linux and should make it consistent regardless of applied theme.

![preview](http://i.imgur.com/Y7gFg9Y.gif)