### PR TITLE
Fix potential crash & video stall in MFR

### DIFF
--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -924,6 +924,10 @@ MediaFormatReader::WaitForData(MediaData::Type aType)
   TrackType trackType = aType == MediaData::VIDEO_DATA ?
     TrackType::kVideoTrack : TrackType::kAudioTrack;
   auto& decoder = GetDecoderData(trackType);
+  if (!decoder.mWaitingForData) {
+    // We aren't waiting for data any longer.
+    return WaitForDataPromise::CreateAndResolve(decoder.mType, __func__);
+  }
   nsRefPtr<WaitForDataPromise> p = decoder.mWaitingPromise.Ensure(__func__);
   ScheduleUpdate(trackType);
   return p;

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -1271,7 +1271,8 @@ void MediaFormatReader::ReleaseMediaResources()
 {
   // Before freeing a video codec, all video buffers needed to be released
   // even from graphics pipeline.
-  VideoFrameContainer* container = mDecoder->GetVideoFrameContainer();
+  VideoFrameContainer* container =
+    mDecoder ? mDecoder->GetVideoFrameContainer() : nullptr;
   if (container) {
     container->ClearCurrentFrame();
   }

--- a/dom/media/platforms/wrappers/H264Converter.cpp
+++ b/dom/media/platforms/wrappers/H264Converter.cpp
@@ -94,6 +94,7 @@ H264Converter::Drain()
   if (mDecoder) {
     return mDecoder->Drain();
   }
+  mCallback->DrainComplete();
   return mLastError;
 }
 


### PR DESCRIPTION
This PR prevents MSE streams from stalling (i.e. not playing, buffering forever, or never loading at all), and also fixes a potential crash point in MediaFormatReader.

Works as intended, and appears to fix #908 during my testing (will push out a new unstable build once this is merged for the people who reported the problem to confirm).