### PR TITLE
Crypto Services (utils): Support for SHA224-512 (+ fix typo)

### DIFF
--- a/netwerk/base/nsICryptoHash.idl
+++ b/netwerk/base/nsICryptoHash.idl
@@ -10,7 +10,7 @@ interface nsIInputStream;
  * This interface provides crytographic hashing algorithms.
  */
 
-[scriptable, uuid(1e5b7c43-4688-45ce-92e1-77ed931e3bbe)]
+[scriptable, uuid(0a248513-dfa7-4474-8777-8c452d60dd04)]
 interface nsICryptoHash : nsISupports
 {
     /**
@@ -25,6 +25,7 @@ interface nsICryptoHash : nsISupports
     const short SHA256 = 4;  /* String value: "sha256" */
     const short SHA384 = 5;  /* String value: "sha384" */
     const short SHA512 = 6;  /* String value: "sha512" */
+    const short SHA224 = 7;  /* String value: "sha224" */
 
     /**
      * Initialize the hashing object. This method may be

--- a/services/crypto/modules/utils.js
+++ b/services/crypto/modules/utils.js
@@ -77,36 +77,6 @@ this.CryptoUtils = {
   },
 
   /**
-   * UTF-8 encode a message and perform a SHA-1 over it.
-   *
-   * @param message
-   *        (string) Buffer to perform operation on. Should be a JS string.
-   *                 It is possible to pass in a string representing an array
-   *                 of bytes. But, you probably don't want to UTF-8 encode
-   *                 such data and thus should not be using this function.
-   *
-   * @return string
-   *         Raw bytes constituting SHA-1 hash. Value is a JS string. Each
-   *         character is the byte value for that offset. Returned string
-   *         always has .length == 20.
-   */
-  UTF8AndSHA1: function UTF8AndSHA1(message) {
-    let hasher = Cc["@mozilla.org/security/hash;1"]
-                 .createInstance(Ci.nsICryptoHash);
-    hasher.init(hasher.SHA1);
-
-    return CryptoUtils.digestUTF8(message, hasher);
-  },
-
-  sha1: function sha1(message) {
-    return CommonUtils.bytesAsHex(CryptoUtils.UTF8AndSHA1(message));
-  },
-
-  sha1Base32: function sha1Base32(message) {
-    return CommonUtils.encodeBase32(CryptoUtils.UTF8AndSHA1(message));
-  },
-
-  /**
    * Produce an HMAC key object from a key string.
    */
   makeHMACKey: function makeHMACKey(str) {
@@ -180,9 +150,8 @@ this.CryptoUtils = {
                        hmacAlg=Ci.nsICryptoHMAC.SHA1, hmacLen=20) {
 
     // We don't have a default in the algo itself, as NSS does.
-    // Use the constant.
     if (!dkLen) {
-      dkLen = SYNC_KEY_DECODED_LENGTH;
+      throw new Error("dkLen should be defined");
     }
 
     function F(S, c, i, h) {
@@ -543,6 +512,48 @@ this.CryptoUtils = {
   },
 
 };
+
+/**
+ * Hashing Algorithms SHA-X.
+ * These values map directly onto the values defined
+ * in netwerk/base/nsICryptoHash.idl.
+ */
+let shaX = ["1", "256", "384", "512"];
+
+for (let shaIdx = 0, shaIdxLen = shaX.length; shaIdx < shaIdxLen; shaIdx++) {
+  let shaXIdx = shaX[shaIdx];
+
+  /**
+   * UTF-8 encode a message and perform a SHA-X over it.
+   *
+   * @param message
+   *        (string) Buffer to perform operation on. Should be a JS string.
+   *                 It is possible to pass in a string representing an array
+   *                 of bytes. But, you probably don't want to UTF-8 encode
+   *                 such data and thus should not be using this function.
+   *
+   * @return string
+   *         Raw bytes constituting SHA-X hash. Value is a JS string.
+   *         Each character is the byte value for that offset.
+   */
+  CryptoUtils["UTF8AndSHA" + shaXIdx] = function (message) {
+    let hasher = Cc["@mozilla.org/security/hash;1"]
+                 .createInstance(Ci.nsICryptoHash);
+    hasher.init(hasher["SHA" + shaXIdx]);
+
+    return CryptoUtils.digestUTF8(message, hasher);
+  };
+
+  CryptoUtils["sha" + shaXIdx] = function (message) {
+    return CommonUtils.bytesAsHex(
+        CryptoUtils["UTF8AndSHA" + shaXIdx](message));
+  };
+
+  CryptoUtils["sha" + shaXIdx + "Base32"] = function (message) {
+    return CommonUtils.encodeBase32(
+        CryptoUtils["UTF8AndSHA" + shaXIdx](message));
+  };
+}
 
 XPCOMUtils.defineLazyGetter(CryptoUtils, "_utf8Converter", function() {
   let converter = Cc["@mozilla.org/intl/scriptableunicodeconverter"]

--- a/services/crypto/modules/utils.js
+++ b/services/crypto/modules/utils.js
@@ -518,7 +518,7 @@ this.CryptoUtils = {
  * These values map directly onto the values defined
  * in netwerk/base/nsICryptoHash.idl.
  */
-let shaX = ["1", "256", "384", "512"];
+let shaX = ["1", "256", "384", "512", "224"];
 
 for (let shaIdx = 0, shaIdxLen = shaX.length; shaIdx < shaIdxLen; shaIdx++) {
   let shaXIdx = shaX[shaIdx];


### PR DESCRIPTION
## 1) Support for SHA224-512:

__An example - steps to reproduce:__

1) Open Scratchpad
2) Menu: "Environment-Browser"
3) Insert the code:
``` javascript
Components.utils.import("resource://services-common/utils.js");
Components.utils.import("resource://services-crypto/utils.js");

let str = "some characters";

let shaX = ["1", "256", "384", "512", "224"];

let alertsStr = [];
for (let shaIdx = 0, shaIdxLen = shaX.length; shaIdx < shaIdxLen; shaIdx++) {
  let shaXIdx = shaX[shaIdx];

  alertsStr.push(
      "CryptoUtils.sha" + shaXIdx + ":\n" +
      CryptoUtils["sha" + shaXIdx](str) + "\n" +
      "CryptoUtils.UTF8AndSHA" + shaXIdx + ":\n" +
      CryptoUtils["UTF8AndSHA" + shaXIdx](str) + "\n" +
      "CryptoUtils.sha" + shaXIdx + "Base32:\n" +
      CryptoUtils["sha" + shaXIdx + "Base32"](str) + "\n" +
      "CommonUtils.decodeBase32:\n" +
      CommonUtils.decodeBase32(CryptoUtils["sha" + shaXIdx + "Base32"](str)) + "\n\n"
  );
}

console.log(alertsStr.join(""));
```
4) Run

See also:
https://hg.mozilla.org/mozilla-central/rev/0123be9d2c87#l1.12

## 2) Fix typo:

__An example - steps to reproduce:__

1) Open Scratchpad
2) Menu: "Environment-Browser"
3) Insert the code:
``` javascript
Components.utils.import("resource://services-crypto/utils.js");
alert(CryptoUtils.pbkdf2Generate("phrase", "a", 4096, null));
```
4) Run

Throws an error in Browser Console:
```
Exception: ReferenceError: SYNC_KEY_DECODED_LENGTH is not defined
pbkdf2Generate@resource://services-crypto/utils.js:185:7
```
See:
https://hg.mozilla.org/mozilla-central/rev/f3741ccc800b#l9.30
(https://bugzilla.mozilla.org/show_bug.cgi?id=1333044#c16)

---

I've created the new build (x32, Windows) and tested.
