### PR TITLE
Abstact MSE TrackBuffer

### DIFF
--- a/dom/media/TimeUnits.h
+++ b/dom/media/TimeUnits.h
@@ -142,6 +142,10 @@ public:
     MOZ_ASSERT(IsValid() && aOther.IsValid());
     return mValue.value() == aOther.mValue.value();
   }
+  bool operator != (const TimeUnit& aOther) const {
+    MOZ_ASSERT(IsValid() && aOther.IsValid());
+    return mValue.value() != aOther.mValue.value();
+  }
   bool operator >= (const TimeUnit& aOther) const {
     MOZ_ASSERT(IsValid() && aOther.IsValid());
     return mValue.value() >= aOther.mValue.value();

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -47,7 +47,7 @@ class AppendDataRunnable : public nsRunnable {
 public:
   AppendDataRunnable(SourceBuffer* aSourceBuffer,
                      MediaLargeByteBuffer* aData,
-                     double aTimestampOffset,
+                     TimeUnit aTimestampOffset,
                      uint32_t aUpdateID)
   : mSourceBuffer(aSourceBuffer)
   , mData(aData)
@@ -66,7 +66,7 @@ public:
 private:
   nsRefPtr<SourceBuffer> mSourceBuffer;
   nsRefPtr<MediaLargeByteBuffer> mData;
-  double mTimestampOffset;
+  TimeUnit mTimestampOffset;
   uint32_t mUpdateID;
 };
 
@@ -146,7 +146,7 @@ SourceBuffer::GetBuffered(ErrorResult& aRv)
     aRv.Throw(NS_ERROR_DOM_INVALID_STATE_ERR);
     return nullptr;
   }
-  media::TimeIntervals ranges = mContentManager->Buffered();
+  TimeIntervals ranges = mContentManager->Buffered();
   MSE_DEBUGV("ranges=%s", DumpTimeRanges(ranges).get());
   nsRefPtr<dom::TimeRanges> tr = new dom::TimeRanges();
   ranges.ToTimeRanges(tr);
@@ -178,8 +178,7 @@ SourceBuffer::SetAppendWindowEnd(double aAppendWindowEnd, ErrorResult& aRv)
     aRv.Throw(NS_ERROR_DOM_INVALID_STATE_ERR);
     return;
   }
-  if (IsNaN(aAppendWindowEnd) ||
-      aAppendWindowEnd <= mAppendWindowStart) {
+  if (IsNaN(aAppendWindowEnd) || aAppendWindowEnd <= mAppendWindowStart) {
     aRv.Throw(NS_ERROR_DOM_INVALID_ACCESS_ERR);
     return;
   }
@@ -278,8 +277,8 @@ SourceBuffer::DoRangeRemoval(double aStart, double aEnd)
 {
   MSE_DEBUG("DoRangeRemoval(%f, %f)", aStart, aEnd);
   if (mContentManager && !IsInfinite(aStart)) {
-    mContentManager->RangeRemoval(media::TimeUnit::FromSeconds(aStart),
-                                  media::TimeUnit::FromSeconds(aEnd));
+    mContentManager->RangeRemoval(TimeUnit::FromSeconds(aStart),
+                                  TimeUnit::FromSeconds(aEnd));
   }
 }
 
@@ -425,12 +424,12 @@ SourceBuffer::AppendData(const uint8_t* aData, uint32_t aLength, ErrorResult& aR
   MOZ_ASSERT(mAppendMode == SourceBufferAppendMode::Segments,
              "We don't handle timestampOffset for sequence mode yet");
   nsRefPtr<nsIRunnable> task =
-    new AppendDataRunnable(this, data, mTimestampOffset, mUpdateID);
+    new AppendDataRunnable(this, data, TimeUnit::FromSeconds(mTimestampOffset), mUpdateID);
   NS_DispatchToMainThread(task);
 }
 
 void
-SourceBuffer::AppendData(MediaLargeByteBuffer* aData, double aTimestampOffset,
+SourceBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset,
                          uint32_t aUpdateID)
 {
   if (!mUpdating || aUpdateID != mUpdateID) {
@@ -451,7 +450,7 @@ SourceBuffer::AppendData(MediaLargeByteBuffer* aData, double aTimestampOffset,
     return;
   }
 
-  mPendingAppend.Begin(mContentManager->AppendData(aData, aTimestampOffset * USECS_PER_S)
+  mPendingAppend.Begin(mContentManager->AppendData(aData, aTimestampOffset)
                        ->RefableThen(NS_GetCurrentThread(), __func__, this,
                                      &SourceBuffer::AppendDataCompletedWithSuccess,
                                      &SourceBuffer::AppendDataErrored));
@@ -538,13 +537,13 @@ SourceBuffer::PrepareAppend(const uint8_t* aData, uint32_t aLength, ErrorResult&
   // TODO: Make the eviction threshold smaller for audio-only streams.
   // TODO: Drive evictions off memory pressure notifications.
   // TODO: Consider a global eviction threshold  rather than per TrackBuffer.
-  double newBufferStartTime = 0.0;
+  TimeUnit newBufferStartTime;
   // Attempt to evict the amount of data we are about to add by lowering the
   // threshold.
   uint32_t toEvict =
     (mEvictionThreshold > aLength) ? mEvictionThreshold - aLength : aLength;
   Result evicted =
-    mContentManager->EvictData(mMediaSource->GetDecoder()->GetCurrentTime(),
+    mContentManager->EvictData(TimeUnit::FromSeconds(mMediaSource->GetDecoder()->GetCurrentTime()),
                                toEvict, &newBufferStartTime);
   if (evicted == Result::DATA_EVICTED) {
     MSE_DEBUG("AppendData Evict; current buffered start=%f",
@@ -552,7 +551,7 @@ SourceBuffer::PrepareAppend(const uint8_t* aData, uint32_t aLength, ErrorResult&
 
     // We notify that we've evicted from the time range 0 through to
     // the current start point.
-    mMediaSource->NotifyEvicted(0.0, newBufferStartTime);
+    mMediaSource->NotifyEvicted(0.0, newBufferStartTime.ToSeconds());
   }
 
   // See if we have enough free space to append our new data.
@@ -603,7 +602,7 @@ SourceBuffer::Evict(double aStart, double aEnd)
   if (currentTime + safety_threshold >= evictTime) {
     evictTime -= safety_threshold;
   }
-  mContentManager->EvictBefore(evictTime);
+  mContentManager->EvictBefore(TimeUnit::FromSeconds(evictTime));
 }
 
 #if defined(DEBUG)

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -146,10 +146,7 @@ SourceBuffer::GetBuffered(ErrorResult& aRv)
     aRv.Throw(NS_ERROR_DOM_INVALID_STATE_ERR);
     return nullptr;
   }
-  // We only manage a single trackbuffer in our source buffer.
-  // As such, there's no need to adjust the end of the trackbuffers as per
-  // Step 4: http://w3c.github.io/media-source/index.html#widl-SourceBuffer-buffered
-  media::TimeIntervals ranges = mTrackBuffer->Buffered();
+  media::TimeIntervals ranges = mContentManager->Buffered();
   MSE_DEBUGV("ranges=%s", DumpTimeRanges(ranges).get());
   nsRefPtr<dom::TimeRanges> tr = new dom::TimeRanges();
   ranges.ToTimeRanges(tr);
@@ -221,12 +218,9 @@ SourceBuffer::Abort(ErrorResult& aRv)
     return;
   }
   AbortBufferAppend();
-  mTrackBuffer->ResetParserState();
+  mContentManager->ResetParserState();
   mAppendWindowStart = 0;
   mAppendWindowEnd = PositiveInfinity<double>();
-  // Discard the current decoder so no new data will be added to it.
-  MSE_DEBUG("Discarding decoder");
-  mTrackBuffer->DiscardCurrentDecoder();
 }
 
 void
@@ -236,7 +230,7 @@ SourceBuffer::AbortBufferAppend()
     mPendingAppend.DisconnectIfExists();
     // TODO: Abort segment parser loop, and stream append loop algorithms.
     // cancel any pending buffer append.
-    mTrackBuffer->AbortAppendData();
+    mContentManager->AbortAppendData();
     AbortUpdating();
   }
 }
@@ -283,9 +277,9 @@ void
 SourceBuffer::DoRangeRemoval(double aStart, double aEnd)
 {
   MSE_DEBUG("DoRangeRemoval(%f, %f)", aStart, aEnd);
-  if (mTrackBuffer && !IsInfinite(aStart)) {
-    mTrackBuffer->RangeRemoval(media::TimeUnit::FromSeconds(aStart),
-                               media::TimeUnit::FromSeconds(aEnd));
+  if (mContentManager && !IsInfinite(aStart)) {
+    mContentManager->RangeRemoval(media::TimeUnit::FromSeconds(aStart),
+                                  media::TimeUnit::FromSeconds(aEnd));
   }
 }
 
@@ -295,10 +289,10 @@ SourceBuffer::Detach()
   MOZ_ASSERT(NS_IsMainThread());
   MSE_DEBUG("Detach");
   AbortBufferAppend();
-  if (mTrackBuffer) {
-    mTrackBuffer->Detach();
+  if (mContentManager) {
+     mContentManager->Detach();
   }
-  mTrackBuffer = nullptr;
+  mContentManager = nullptr;
   mMediaSource = nullptr;
 }
 
@@ -308,7 +302,7 @@ SourceBuffer::Ended()
   MOZ_ASSERT(NS_IsMainThread());
   MOZ_ASSERT(IsAttached());
   MSE_DEBUG("Ended");
-  mTrackBuffer->EndCurrentDecoder();
+  mContentManager->Ended();
 }
 
 SourceBuffer::SourceBuffer(MediaSource* aMediaSource, const nsACString& aType)
@@ -327,9 +321,9 @@ SourceBuffer::SourceBuffer(MediaSource* aMediaSource, const nsACString& aType)
   MOZ_ASSERT(aMediaSource);
   mEvictionThreshold = Preferences::GetUint("media.mediasource.eviction_threshold",
                                             75 * (1 << 20));
-  mTrackBuffer = new TrackBuffer(aMediaSource->GetDecoder(), aType);
-  MSE_DEBUG("Create mTrackBuffer=%p",
-            mTrackBuffer.get());
+  mContentManager = SourceBufferContentManager::CreateManager(aMediaSource->GetDecoder(), aType);
+  MSE_DEBUG("Create mContentManager=%p",
+            mContentManager.get());
 }
 
 SourceBuffer::~SourceBuffer()
@@ -457,14 +451,14 @@ SourceBuffer::AppendData(MediaLargeByteBuffer* aData, double aTimestampOffset,
     return;
   }
 
-  mPendingAppend.Begin(mTrackBuffer->AppendData(aData, aTimestampOffset * USECS_PER_S)
+  mPendingAppend.Begin(mContentManager->AppendData(aData, aTimestampOffset * USECS_PER_S)
                        ->RefableThen(NS_GetCurrentThread(), __func__, this,
                                      &SourceBuffer::AppendDataCompletedWithSuccess,
                                      &SourceBuffer::AppendDataErrored));
 }
 
 void
-SourceBuffer::AppendDataCompletedWithSuccess(bool aGotMedia)
+SourceBuffer::AppendDataCompletedWithSuccess(bool aHasActiveTracks)
 {
   mPendingAppend.Complete();
   if (!mUpdating) {
@@ -472,7 +466,7 @@ SourceBuffer::AppendDataCompletedWithSuccess(bool aGotMedia)
     return;
   }
 
-  if (mTrackBuffer->HasInitSegment()) {
+  if (aHasActiveTracks) {
     if (!mActive) {
       mActive = true;
       mMediaSource->SourceBufferIsActive(this);
@@ -480,9 +474,7 @@ SourceBuffer::AppendDataCompletedWithSuccess(bool aGotMedia)
     }
   }
 
-  if (aGotMedia) {
-    CheckEndTime();
-  }
+  CheckEndTime();
 
   StopUpdating();
 }
@@ -510,7 +502,7 @@ SourceBuffer::AppendError(bool aDecoderError)
     // The buffer append algorithm has been interrupted by abort().
     return;
   }
-  mTrackBuffer->ResetParserState();
+  mContentManager->ResetParserState();
 
   mUpdating = false;
 
@@ -528,6 +520,8 @@ SourceBuffer::AppendError(bool aDecoderError)
 already_AddRefed<MediaLargeByteBuffer>
 SourceBuffer::PrepareAppend(const uint8_t* aData, uint32_t aLength, ErrorResult& aRv)
 {
+  typedef SourceBufferContentManager::EvictDataResult Result;
+
   if (!IsAttached() || mUpdating) {
     aRv.Throw(NS_ERROR_DOM_INVALID_STATE_ERR);
     return nullptr;
@@ -549,10 +543,10 @@ SourceBuffer::PrepareAppend(const uint8_t* aData, uint32_t aLength, ErrorResult&
   // threshold.
   uint32_t toEvict =
     (mEvictionThreshold > aLength) ? mEvictionThreshold - aLength : aLength;
-  bool evicted =
-    mTrackBuffer->EvictData(mMediaSource->GetDecoder()->GetCurrentTime(),
-                            toEvict, &newBufferStartTime);
-  if (evicted) {
+  Result evicted =
+    mContentManager->EvictData(mMediaSource->GetDecoder()->GetCurrentTime(),
+                               toEvict, &newBufferStartTime);
+  if (evicted == Result::DATA_EVICTED) {
     MSE_DEBUG("AppendData Evict; current buffered start=%f",
               GetBufferedStart());
 
@@ -565,8 +559,8 @@ SourceBuffer::PrepareAppend(const uint8_t* aData, uint32_t aLength, ErrorResult&
   // As we can only evict once we have playable data, we must give a chance
   // to the DASH player to provide a complete media segment.
   if (aLength > mEvictionThreshold ||
-      ((mTrackBuffer->GetSize() > mEvictionThreshold - aLength) &&
-       !mTrackBuffer->HasOnlyIncompleteMedia())) {
+      ((mContentManager->GetSize() > mEvictionThreshold - aLength) &&
+       evicted != Result::CANT_EVICT)) {
     aRv.Throw(NS_ERROR_DOM_QUOTA_EXCEEDED_ERR);
     return nullptr;
   }
@@ -609,15 +603,15 @@ SourceBuffer::Evict(double aStart, double aEnd)
   if (currentTime + safety_threshold >= evictTime) {
     evictTime -= safety_threshold;
   }
-  mTrackBuffer->EvictBefore(evictTime);
+  mContentManager->EvictBefore(evictTime);
 }
 
 #if defined(DEBUG)
 void
 SourceBuffer::Dump(const char* aPath)
 {
-  if (mTrackBuffer) {
-    mTrackBuffer->Dump(aPath);
+  if (mContentManager) {
+    mContentManager->Dump(aPath);
   }
 }
 #endif
@@ -626,9 +620,9 @@ NS_IMPL_CYCLE_COLLECTION_CLASS(SourceBuffer)
 
 NS_IMPL_CYCLE_COLLECTION_UNLINK_BEGIN(SourceBuffer)
   // Tell the TrackBuffer to end its current SourceBufferResource.
-  TrackBuffer* track = tmp->mTrackBuffer;
-  if (track) {
-    track->Detach();
+  SourceBufferContentManager* manager = tmp->mContentManager;
+  if (manager) {
+    manager->Detach();
   }
   NS_IMPL_CYCLE_COLLECTION_UNLINK(mMediaSource)
 NS_IMPL_CYCLE_COLLECTION_UNLINK_END_INHERITED(DOMEventTargetHelper)

--- a/dom/media/mediasource/SourceBuffer.h
+++ b/dom/media/mediasource/SourceBuffer.h
@@ -37,6 +37,9 @@ template <typename T> class AsyncEventRunner;
 
 namespace dom {
 
+using media::TimeUnit;
+using media::TimeIntervals;
+
 class TimeRanges;
 
 class SourceBuffer final : public DOMEventTargetHelper
@@ -147,7 +150,7 @@ private:
 
   // Shared implementation of AppendBuffer overloads.
   void AppendData(const uint8_t* aData, uint32_t aLength, ErrorResult& aRv);
-  void AppendData(MediaLargeByteBuffer* aData, double aTimestampOffset,
+  void AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset,
                   uint32_t aAppendID);
 
   // Implement the "Append Error Algorithm".

--- a/dom/media/mediasource/SourceBuffer.h
+++ b/dom/media/mediasource/SourceBuffer.h
@@ -189,7 +189,7 @@ private:
   // aborted and another AppendData queued.
   uint32_t mUpdateID;
 
-  MediaPromiseRequestHolder<SourceBufferContentManager::AppendPromise> mPendingAppend;
+  MediaPromiseConsumerHolder<SourceBufferContentManager::AppendPromise> mPendingAppend;
   const nsCString mType;
 };
 

--- a/dom/media/mediasource/SourceBuffer.h
+++ b/dom/media/mediasource/SourceBuffer.h
@@ -23,6 +23,7 @@
 #include "nsISupports.h"
 #include "nsString.h"
 #include "nscore.h"
+#include "SourceBufferContentManager.h"
 
 class JSObject;
 struct JSContext;
@@ -33,7 +34,6 @@ class ErrorResult;
 class MediaLargeByteBuffer;
 class TrackBuffer;
 template <typename T> class AsyncEventRunner;
-typedef MediaPromise<bool, nsresult, /* IsExclusive = */ true> TrackBufferAppendPromise;
 
 namespace dom {
 
@@ -162,14 +162,14 @@ private:
                                                        uint32_t aLength,
                                                        ErrorResult& aRv);
 
-  void AppendDataCompletedWithSuccess(bool aValue);
+  void AppendDataCompletedWithSuccess(bool aHasActiveTracks);
   void AppendDataErrored(nsresult aError);
 
   nsRefPtr<MediaSource> mMediaSource;
 
   uint32_t mEvictionThreshold;
 
-  nsRefPtr<TrackBuffer> mTrackBuffer;
+  nsRefPtr<SourceBufferContentManager> mContentManager;
 
   double mAppendWindowStart;
   double mAppendWindowEnd;
@@ -186,7 +186,7 @@ private:
   // aborted and another AppendData queued.
   uint32_t mUpdateID;
 
-  MediaPromiseConsumerHolder<TrackBufferAppendPromise> mPendingAppend;
+  MediaPromiseRequestHolder<SourceBufferContentManager::AppendPromise> mPendingAppend;
   const nsCString mType;
 };
 

--- a/dom/media/mediasource/SourceBufferContentManager.cpp
+++ b/dom/media/mediasource/SourceBufferContentManager.cpp
@@ -1,0 +1,20 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "SourceBufferContentManager.h"
+
+namespace mozilla {
+
+already_AddRefed<SourceBufferContentManager>
+SourceBufferContentManager::CreateManager(MediaSourceDecoder* aParentDecoder,
+                                          const nsACString &aType)
+{
+  nsRefPtr<SourceBufferContentManager> manager;
+  manager = new TrackBuffer(aParentDecoder, aType);
+  return  manager.forget();
+}
+
+}

--- a/dom/media/mediasource/SourceBufferContentManager.h
+++ b/dom/media/mediasource/SourceBufferContentManager.h
@@ -16,6 +16,9 @@
 
 namespace mozilla {
 
+using media::TimeUnit;
+using media::TimeIntervals;
+
 class SourceBufferContentManager {
 public:
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(SourceBufferContentManager);
@@ -29,7 +32,7 @@ public:
   // NotifyDataArrived on the decoder to keep buffered range computation up
   // to date.  Returns false if the append failed.
   virtual nsRefPtr<AppendPromise>
-  AppendData(MediaLargeByteBuffer* aData, int64_t aTimestampOffset /* microseconds */) = 0;
+  AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset /* microseconds */) = 0;
 
   // Abort any pending AppendData.
   virtual void AbortAppendData() = 0;
@@ -41,8 +44,7 @@ public:
 
   // Runs MSE range removal algorithm.
   // http://w3c.github.io/media-source/#sourcebuffer-coded-frame-removal
-  virtual bool RangeRemoval(mozilla::media::TimeUnit aStart,
-                            mozilla::media::TimeUnit aEnd) = 0;
+  virtual bool RangeRemoval(TimeUnit aStart, TimeUnit aEnd) = 0;
 
   enum class EvictDataResult : int8_t
   {
@@ -56,10 +58,10 @@ public:
   // bytes. aBufferStartTime contains the new start time of the data after the
   // eviction.
   virtual EvictDataResult
-  EvictData(double aPlaybackTime, uint32_t aThreshold, double* aBufferStartTime) = 0;
+  EvictData(TimeUnit aPlaybackTime, uint32_t aThreshold, TimeUnit* aBufferStartTime) = 0;
 
   // Evicts data up to aTime.
-  virtual void EvictBefore(double aTime) = 0;
+  virtual void EvictBefore(TimeUnit aTime) = 0;
 
   // Returns the buffered range currently managed.
   // This may be called on any thread.

--- a/dom/media/mediasource/SourceBufferContentManager.h
+++ b/dom/media/mediasource/SourceBufferContentManager.h
@@ -1,0 +1,87 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef MOZILLA_SOURCEBUFFERCONTENTMANAGER_H_
+#define MOZILLA_SOURCEBUFFERCONTENTMANAGER_H_
+
+#include "MediaData.h"
+#include "MediaPromise.h"
+#include "MediaSourceDecoder.h"
+#include "SourceBuffer.h"
+#include "TimeUnits.h"
+#include "nsString.h"
+
+namespace mozilla {
+
+class SourceBufferContentManager {
+public:
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(SourceBufferContentManager);
+
+  typedef MediaPromise<bool, nsresult, /* IsExclusive = */ true> AppendPromise;
+
+  static already_AddRefed<SourceBufferContentManager>
+  CreateManager(MediaSourceDecoder* aParentDecoder, const nsACString& aType);
+
+  // Append data to the current decoder.  Also responsible for calling
+  // NotifyDataArrived on the decoder to keep buffered range computation up
+  // to date.  Returns false if the append failed.
+  virtual nsRefPtr<AppendPromise>
+  AppendData(MediaLargeByteBuffer* aData, int64_t aTimestampOffset /* microseconds */) = 0;
+
+  // Abort any pending AppendData.
+  virtual void AbortAppendData() = 0;
+
+  // Run MSE Reset Parser State Algorithm.
+  // 3.5.2 Reset Parser State
+  // http://w3c.github.io/media-source/#sourcebuffer-reset-parser-state
+  virtual void ResetParserState() = 0;
+
+  // Runs MSE range removal algorithm.
+  // http://w3c.github.io/media-source/#sourcebuffer-coded-frame-removal
+  virtual bool RangeRemoval(mozilla::media::TimeUnit aStart,
+                            mozilla::media::TimeUnit aEnd) = 0;
+
+  enum class EvictDataResult : int8_t
+  {
+    NO_DATA_EVICTED,
+    DATA_EVICTED,
+    CANT_EVICT,
+  };
+
+  // Evicts data up to aPlaybackTime. aThreshold is used to
+  // bound the data being evicted. It will not evict more than aThreshold
+  // bytes. aBufferStartTime contains the new start time of the data after the
+  // eviction.
+  virtual EvictDataResult
+  EvictData(double aPlaybackTime, uint32_t aThreshold, double* aBufferStartTime) = 0;
+
+  // Evicts data up to aTime.
+  virtual void EvictBefore(double aTime) = 0;
+
+  // Returns the buffered range currently managed.
+  // This may be called on any thread.
+  // Buffered must conform to http://w3c.github.io/media-source/index.html#widl-SourceBuffer-buffered
+  virtual media::TimeIntervals Buffered() = 0;
+
+  // Return the size of the data managed by this SourceBufferContentManager.
+  virtual int64_t GetSize() = 0;
+
+  // Indicate that the MediaSource parent object got into "ended" state.
+  virtual void Ended() = 0;
+
+  // The parent SourceBuffer is about to be destroyed.
+  virtual void Detach() = 0;
+
+#if defined(DEBUG)
+  virtual void Dump(const char* aPath) { }
+#endif
+
+protected:
+  virtual ~SourceBufferContentManager() { }
+};
+
+} // namespace mozilla
+#endif /* MOZILLA_SOURCEBUFFERCONTENTMANAGER_H_ */

--- a/dom/media/mediasource/TrackBuffer.cpp
+++ b/dom/media/mediasource/TrackBuffer.cpp
@@ -46,8 +46,6 @@ TrackBuffer::TrackBuffer(MediaSourceDecoder* aParentDecoder, const nsACString& a
   : mParentDecoder(aParentDecoder)
   , mType(aType)
   , mLastStartTimestamp(0)
-  , mLastTimestampOffset(0)
-  , mAdjustedTimestamp(0)
   , mIsWaitingOnCDM(false)
   , mShutdown(false)
 {
@@ -78,7 +76,7 @@ public:
     }
   }
 
-  bool NewDecoder(int64_t aTimestampOffset)
+  bool NewDecoder(TimeUnit aTimestampOffset)
   {
     nsRefPtr<SourceBufferDecoder> decoder = mOwner->NewDecoder(aTimestampOffset);
     if (!decoder) {
@@ -144,7 +142,7 @@ TrackBuffer::ContinueShutdown()
 }
 
 nsRefPtr<TrackBuffer::AppendPromise>
-TrackBuffer::AppendData(MediaLargeByteBuffer* aData, int64_t aTimestampOffset)
+TrackBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset)
 {
   MOZ_ASSERT(NS_IsMainThread());
   MOZ_ASSERT(mInitializationPromise.IsEmpty());
@@ -224,11 +222,13 @@ TrackBuffer::AppendData(MediaLargeByteBuffer* aData, int64_t aTimestampOffset)
     mLastEndTimestamp.emplace(end);
   }
 
-  if (gotMedia && start != mAdjustedTimestamp &&
-      ((start < 0 && -start < FUZZ_TIMESTAMP_OFFSET && start < mAdjustedTimestamp) ||
-       (start > 0 && (start < FUZZ_TIMESTAMP_OFFSET || start < mAdjustedTimestamp)))) {
-    AdjustDecodersTimestampOffset(mAdjustedTimestamp - start);
-    mAdjustedTimestamp = start;
+  TimeUnit starttu{TimeUnit::FromMicroseconds(start)};
+
+  if (gotMedia && starttu != mAdjustedTimestamp &&
+      ((start < 0 && -start < FUZZ_TIMESTAMP_OFFSET && starttu < mAdjustedTimestamp) ||
+       (start > 0 && (start < FUZZ_TIMESTAMP_OFFSET || starttu < mAdjustedTimestamp)))) {
+    AdjustDecodersTimestampOffset(mAdjustedTimestamp - starttu);
+    mAdjustedTimestamp = starttu;
   }
 
   if (!AppendDataToCurrentResource(aData, end - start)) {
@@ -285,25 +285,25 @@ class DecoderSorter
 public:
   bool LessThan(SourceBufferDecoder* aFirst, SourceBufferDecoder* aSecond) const
   {
-    media::TimeIntervals first = aFirst->GetBuffered();
-    media::TimeIntervals second = aSecond->GetBuffered();
+    TimeIntervals first = aFirst->GetBuffered();
+    TimeIntervals second = aSecond->GetBuffered();
 
     return first.GetStart() < second.GetStart();
   }
 
   bool Equals(SourceBufferDecoder* aFirst, SourceBufferDecoder* aSecond) const
   {
-    media::TimeIntervals first = aFirst->GetBuffered();
-    media::TimeIntervals second = aSecond->GetBuffered();
+    TimeIntervals first = aFirst->GetBuffered();
+    TimeIntervals second = aSecond->GetBuffered();
 
     return first.GetStart() == second.GetStart();
   }
 };
 
 TrackBuffer::EvictDataResult
-TrackBuffer::EvictData(double aPlaybackTime,
+TrackBuffer::EvictData(TimeUnit aPlaybackTime,
                        uint32_t aThreshold,
-                       double* aBufferStartTime)
+                       TimeUnit* aBufferStartTime)
 {
   MOZ_ASSERT(NS_IsMainThread());
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
@@ -322,11 +322,12 @@ TrackBuffer::EvictData(double aPlaybackTime,
   // Get a list of initialized decoders.
   nsTArray<SourceBufferDecoder*> decoders;
   decoders.AppendElements(mInitializedDecoders);
+  const TimeUnit evictThresholdTime{TimeUnit::FromSeconds(MSE_EVICT_THRESHOLD_TIME)};
 
   // First try to evict data before the current play position, starting
   // with the oldest decoder.
   for (uint32_t i = 0; i < decoders.Length() && toEvict > 0; ++i) {
-    media::TimeIntervals buffered = decoders[i]->GetBuffered();
+    TimeIntervals buffered = decoders[i]->GetBuffered();
 
     MSE_DEBUG("Step1. decoder=%u/%u threshold=%u toEvict=%lld",
               i, decoders.Length(), aThreshold, toEvict);
@@ -334,9 +335,8 @@ TrackBuffer::EvictData(double aPlaybackTime,
     // To ensure we don't evict data past the current playback position
     // we apply a threshold of a few seconds back and evict data up to
     // that point.
-    if (aPlaybackTime > MSE_EVICT_THRESHOLD_TIME) {
-      media::TimeUnit time = media::TimeUnit::FromSeconds(aPlaybackTime) -
-        media::TimeUnit::FromSeconds(MSE_EVICT_THRESHOLD_TIME);
+    if (aPlaybackTime > evictThresholdTime) {
+      TimeUnit time = aPlaybackTime - evictThresholdTime;
       bool isActive = decoders[i] == mCurrentDecoder ||
         mParentDecoder->IsActiveReader(decoders[i]->GetReader());
       if (!isActive && buffered.GetEnd() < time) {
@@ -344,16 +344,16 @@ TrackBuffer::EvictData(double aPlaybackTime,
         // It can be fully evicted.
         MSE_DEBUG("evicting all bufferedEnd=%f "
                   "aPlaybackTime=%f time=%f, size=%lld",
-                  buffered.GetEnd().ToSeconds(), aPlaybackTime, time,
-                  decoders[i]->GetResource()->GetSize());
+                  buffered.GetEnd().ToSeconds(), aPlaybackTime.ToSeconds(),
+                  time, decoders[i]->GetResource()->GetSize());
         toEvict -= decoders[i]->GetResource()->EvictAll();
       } else {
         int64_t playbackOffset =
           decoders[i]->ConvertToByteOffset(time.ToSeconds());
         MSE_DEBUG("evicting some bufferedEnd=%f "
                   "aPlaybackTime=%f time=%f, playbackOffset=%lld size=%lld",
-                  buffered.GetEnd().ToSeconds(), aPlaybackTime, time,
-                  playbackOffset, decoders[i]->GetResource()->GetSize());
+                  buffered.GetEnd().ToSeconds(), aPlaybackTime.ToSeconds(),
+                  time, playbackOffset, decoders[i]->GetResource()->GetSize());
         if (playbackOffset > 0) {
           toEvict -= decoders[i]->GetResource()->EvictData(playbackOffset,
                                                            playbackOffset);
@@ -373,7 +373,7 @@ TrackBuffer::EvictData(double aPlaybackTime,
     if (decoders[i] == mCurrentDecoder) {
       continue;
     }
-    media::TimeIntervals buffered = decoders[i]->GetBuffered();
+    TimeIntervals buffered = decoders[i]->GetBuffered();
 
     // Remove data from older decoders than the current one.
     MSE_DEBUG("evicting all "
@@ -403,7 +403,7 @@ TrackBuffer::EvictData(double aPlaybackTime,
   // Find the next decoder we're likely going to play with.
   nsRefPtr<SourceBufferDecoder> nextPlayingDecoder = nullptr;
   if (playingDecoder) {
-    media::TimeIntervals buffered = playingDecoder->GetBuffered();
+    TimeIntervals buffered = playingDecoder->GetBuffered();
     nextPlayingDecoder =
       mParentDecoder->SelectDecoder(buffered.GetEnd().ToMicroseconds() + 1,
                                     EOS_FUZZ_US,
@@ -420,7 +420,7 @@ TrackBuffer::EvictData(double aPlaybackTime,
         decoders[i] == mCurrentDecoder) {
       continue;
     }
-    media::TimeIntervals buffered = decoders[i]->GetBuffered();
+    TimeIntervals buffered = decoders[i]->GetBuffered();
 
     MSE_DEBUG("evicting all "
               "bufferedStart=%f bufferedEnd=%f aPlaybackTime=%f size=%lld",
@@ -435,12 +435,12 @@ TrackBuffer::EvictData(double aPlaybackTime,
   bool evicted = toEvict < (totalSize - aThreshold);
   if (evicted) {
     if (playingDecoder) {
-      media::TimeIntervals ranges = playingDecoder->GetBuffered();
-      *aBufferStartTime = std::max(0.0, ranges.GetStart().ToSeconds());
+      TimeIntervals ranges = playingDecoder->GetBuffered();
+      *aBufferStartTime = std::max(TimeUnit::FromSeconds(0), ranges.GetStart());
     } else {
       // We do not currently have data to play yet.
       // Avoid evicting anymore data to minimize rebuffering time.
-      *aBufferStartTime = 0.0;
+      *aBufferStartTime = TimeUnit::FromSeconds(0.0);
     }
   }
 
@@ -460,7 +460,7 @@ TrackBuffer::RemoveEmptyDecoders(nsTArray<mozilla::SourceBufferDecoder*>& aDecod
 
   // Remove decoders that have no data in them
   for (uint32_t i = 0; i < aDecoders.Length(); ++i) {
-    media::TimeIntervals buffered = aDecoders[i]->GetBuffered();
+    TimeIntervals buffered = aDecoders[i]->GetBuffered();
     MSE_DEBUG("maybe remove empty decoders=%d "
               "size=%lld start=%f end=%f",
               i, aDecoders[i]->GetResource()->GetSize(),
@@ -494,7 +494,7 @@ TrackBuffer::HasOnlyIncompleteMedia()
   if (!mCurrentDecoder) {
     return false;
   }
-  media::TimeIntervals buffered = mCurrentDecoder->GetBuffered();
+  TimeIntervals buffered = mCurrentDecoder->GetBuffered();
   MSE_DEBUG("mCurrentDecoder.size=%lld, start=%f end=%f",
             mCurrentDecoder->GetResource()->GetSize(),
             buffered.GetStart(), buffered.GetEnd());
@@ -502,12 +502,12 @@ TrackBuffer::HasOnlyIncompleteMedia()
 }
 
 void
-TrackBuffer::EvictBefore(double aTime)
+TrackBuffer::EvictBefore(TimeUnit aTime)
 {
   MOZ_ASSERT(NS_IsMainThread());
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
   for (uint32_t i = 0; i < mInitializedDecoders.Length(); ++i) {
-    int64_t endOffset = mInitializedDecoders[i]->ConvertToByteOffset(aTime);
+    int64_t endOffset = mInitializedDecoders[i]->ConvertToByteOffset(aTime.ToSeconds());
     if (endOffset > 0) {
       MSE_DEBUG("decoder=%u offset=%lld",
                 i, endOffset);
@@ -518,12 +518,12 @@ TrackBuffer::EvictBefore(double aTime)
   NotifyTimeRangesChanged();
 }
 
-media::TimeIntervals
+TimeIntervals
 TrackBuffer::Buffered()
 {
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
 
-  media::TimeIntervals buffered;
+  TimeIntervals buffered;
 
   for (auto& decoder : mInitializedDecoders) {
     buffered += decoder->GetBuffered();
@@ -531,14 +531,14 @@ TrackBuffer::Buffered()
   // mParser may not be initialized yet, and will only be so if we have a
   // buffered range.
   if (buffered.Length()) {
-    buffered.SetFuzz(media::TimeUnit::FromMicroseconds(mParser->GetRoundingError()));
+    buffered.SetFuzz(TimeUnit::FromMicroseconds(mParser->GetRoundingError()));
   }
 
   return buffered;
 }
 
 already_AddRefed<SourceBufferDecoder>
-TrackBuffer::NewDecoder(int64_t aTimestampOffset)
+TrackBuffer::NewDecoder(TimeUnit aTimestampOffset)
 {
   MOZ_ASSERT(NS_IsMainThread());
   MOZ_ASSERT(mParentDecoder);
@@ -546,7 +546,7 @@ TrackBuffer::NewDecoder(int64_t aTimestampOffset)
   DiscardCurrentDecoder();
 
   nsRefPtr<SourceBufferDecoder> decoder =
-    mParentDecoder->CreateSubDecoder(mType, aTimestampOffset - mAdjustedTimestamp);
+    mParentDecoder->CreateSubDecoder(mType, (aTimestampOffset - mAdjustedTimestamp).ToMicroseconds());
   if (!decoder) {
     return nullptr;
   }
@@ -890,10 +890,10 @@ bool
 TrackBuffer::ContainsTime(int64_t aTime, int64_t aTolerance)
 {
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
-  media::TimeUnit time{media::TimeUnit::FromMicroseconds(aTime)};
+  TimeUnit time{TimeUnit::FromMicroseconds(aTime)};
   for (auto& decoder : mInitializedDecoders) {
-    media::TimeIntervals r = decoder->GetBuffered();
-    r.SetFuzz(media::TimeUnit::FromMicroseconds(aTolerance));
+    TimeIntervals r = decoder->GetBuffered();
+    r.SetFuzz(TimeUnit::FromMicroseconds(aTolerance));
     if (r.Contains(time)) {
       return true;
     }
@@ -1034,15 +1034,14 @@ TrackBuffer::RemoveDecoder(SourceBufferDecoder* aDecoder)
 }
 
 bool
-TrackBuffer::RangeRemoval(media::TimeUnit aStart,
-                          media::TimeUnit aEnd)
+TrackBuffer::RangeRemoval(TimeUnit aStart, TimeUnit aEnd)
 {
   MOZ_ASSERT(NS_IsMainThread());
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
 
-  media::TimeIntervals buffered = Buffered();
-  media::TimeUnit bufferedStart = buffered.GetStart();
-  media::TimeUnit bufferedEnd = buffered.GetEnd();
+  TimeIntervals buffered = Buffered();
+  TimeUnit bufferedStart = buffered.GetStart();
+  TimeUnit bufferedEnd = buffered.GetEnd();
 
   if (!buffered.Length() || aStart > bufferedEnd || aEnd < bufferedStart) {
     // Nothing to remove.
@@ -1062,7 +1061,7 @@ TrackBuffer::RangeRemoval(media::TimeUnit aStart,
   if (aStart <= bufferedStart && aEnd < bufferedEnd) {
     // Evict data from beginning.
     for (size_t i = 0; i < decoders.Length(); ++i) {
-      media::TimeIntervals buffered = decoders[i]->GetBuffered();
+      TimeIntervals buffered = decoders[i]->GetBuffered();
       if (buffered.GetEnd() < aEnd) {
         // Can be fully removed.
         MSE_DEBUG("remove all bufferedEnd=%f size=%lld",
@@ -1100,11 +1099,11 @@ TrackBuffer::RangeRemoval(media::TimeUnit aStart,
 }
 
 void
-TrackBuffer::AdjustDecodersTimestampOffset(int32_t aOffset)
+TrackBuffer::AdjustDecodersTimestampOffset(TimeUnit aOffset)
 {
   ReentrantMonitorAutoEnter mon(mParentDecoder->GetReentrantMonitor());
   for (uint32_t i = 0; i < mDecoders.Length(); i++) {
-    mDecoders[i]->SetTimestampOffset(mDecoders[i]->GetTimestampOffset() + aOffset);
+    mDecoders[i]->SetTimestampOffset(mDecoders[i]->GetTimestampOffset() + aOffset.ToMicroseconds());
   }
 }
 

--- a/dom/media/mediasource/TrackBuffer.h
+++ b/dom/media/mediasource/TrackBuffer.h
@@ -24,10 +24,8 @@ class ContainerParser;
 class MediaSourceDecoder;
 class MediaLargeByteBuffer;
 
-class TrackBuffer final {
+class TrackBuffer final : public SourceBufferContentManager {
 public:
-  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(TrackBuffer);
-
   TrackBuffer(MediaSourceDecoder* aParentDecoder, const nsACString& aType);
 
   nsRefPtr<ShutdownPromise> Shutdown();
@@ -35,32 +33,45 @@ public:
   // Append data to the current decoder.  Also responsible for calling
   // NotifyDataArrived on the decoder to keep buffered range computation up
   // to date.  Returns false if the append failed.
-  nsRefPtr<TrackBufferAppendPromise> AppendData(MediaLargeByteBuffer* aData,
-                                                int64_t aTimestampOffset /* microseconds */);
+  nsRefPtr<AppendPromise> AppendData(MediaLargeByteBuffer* aData,
+                                     int64_t aTimestampOffset /* microseconds */) override;
 
   // Evicts data held in the current decoders SourceBufferResource from the
   // start of the buffer through to aPlaybackTime. aThreshold is used to
   // bound the data being evicted. It will not evict more than aThreshold
   // bytes. aBufferStartTime contains the new start time of the current
-  // decoders buffered data after the eviction. Returns true if data was
-  // evicted.
-  bool EvictData(double aPlaybackTime, uint32_t aThreshold, double* aBufferStartTime);
+  // decoders buffered data after the eviction.
+  EvictDataResult EvictData(double aPlaybackTime, uint32_t aThreshold, double* aBufferStartTime) override;
 
   // Evicts data held in all the decoders SourceBufferResource from the start
   // of the buffer through to aTime.
-  void EvictBefore(double aTime);
+  void EvictBefore(double aTime) override;
+
+  bool RangeRemoval(mozilla::media::TimeUnit aStart,
+                    mozilla::media::TimeUnit aEnd) override;
+
+  void AbortAppendData() override;
+
+  int64_t GetSize() override;
+
+  void ResetParserState() override;
 
   // Returns the union of the decoders buffered ranges in aRanges.
   // This may be called on any thread.
-  media::TimeIntervals Buffered();
+  media::TimeIntervals Buffered() override;
+
+  void Ended() override
+  {
+    EndCurrentDecoder();
+  }
+
+  void Detach() override;
 
   // Mark the current decoder's resource as ended, clear mCurrentDecoder and
   // reset mLast{Start,End}Timestamp.  Main thread only.
   void DiscardCurrentDecoder();
   // Mark the current decoder's resource as ended.
   void EndCurrentDecoder();
-
-  void Detach();
 
   // Returns true if an init segment has been appended.
   bool HasInitSegment();
@@ -77,42 +88,23 @@ public:
 
   void BreakCycles();
 
-  // Run MSE Reset Parser State Algorithm.
-  // 3.5.2 Reset Parser State
-  // http://w3c.github.io/media-source/#sourcebuffer-reset-parser-state
-  void ResetParserState();
-
   // Returns a reference to mInitializedDecoders, used by MediaSourceReader
   // to select decoders.
   // TODO: Refactor to a cleaner interface between TrackBuffer and MediaSourceReader.
   const nsTArray<nsRefPtr<SourceBufferDecoder>>& Decoders();
-
-  // Runs MSE range removal algorithm.
-  // http://w3c.github.io/media-source/#sourcebuffer-coded-frame-removal
-  // Implementation is only partial, we can only trim a buffer.
-  // Returns true if data was evicted.
-  // Times are in microseconds.
-  bool RangeRemoval(mozilla::media::TimeUnit aStart,
-                    mozilla::media::TimeUnit aEnd);
-
-  // Abort any pending appendBuffer by rejecting any pending promises.
-  void AbortAppendData();
-
-  // Return the size used by all decoders managed by this TrackBuffer.
-  int64_t GetSize();
 
   // Return true if we have a partial media segment being appended that is
   // currently not playable.
   bool HasOnlyIncompleteMedia();
 
 #if defined(DEBUG)
-  void Dump(const char* aPath);
+  void Dump(const char* aPath) override;
 #endif
 
 private:
   friend class DecodersToInitialize;
   friend class MetadataRecipient;
-  ~TrackBuffer();
+  virtual ~TrackBuffer();
 
   // Create a new decoder, set mCurrentDecoder to the new decoder and
   // returns it. The new decoder must be queued using QueueInitializeDecoder
@@ -215,7 +207,7 @@ private:
   bool mDecoderPerSegment;
   bool mShutdown;
 
-  MediaPromiseHolder<TrackBufferAppendPromise> mInitializationPromise;
+  MediaPromiseHolder<AppendPromise> mInitializationPromise;
   // Track our request for metadata from the reader.
   MediaPromiseConsumerHolder<MediaDecoderReader::MetadataPromise> mMetadataRequest;
 };

--- a/dom/media/mediasource/TrackBuffer.h
+++ b/dom/media/mediasource/TrackBuffer.h
@@ -34,21 +34,20 @@ public:
   // NotifyDataArrived on the decoder to keep buffered range computation up
   // to date.  Returns false if the append failed.
   nsRefPtr<AppendPromise> AppendData(MediaLargeByteBuffer* aData,
-                                     int64_t aTimestampOffset /* microseconds */) override;
+                                     TimeUnit aTimestampOffset /* microseconds */) override;
 
   // Evicts data held in the current decoders SourceBufferResource from the
   // start of the buffer through to aPlaybackTime. aThreshold is used to
   // bound the data being evicted. It will not evict more than aThreshold
   // bytes. aBufferStartTime contains the new start time of the current
   // decoders buffered data after the eviction.
-  EvictDataResult EvictData(double aPlaybackTime, uint32_t aThreshold, double* aBufferStartTime) override;
+  EvictDataResult EvictData(TimeUnit aPlaybackTime, uint32_t aThreshold, TimeUnit* aBufferStartTime) override;
 
   // Evicts data held in all the decoders SourceBufferResource from the start
   // of the buffer through to aTime.
-  void EvictBefore(double aTime) override;
+  void EvictBefore(TimeUnit aTime) override;
 
-  bool RangeRemoval(mozilla::media::TimeUnit aStart,
-                    mozilla::media::TimeUnit aEnd) override;
+  bool RangeRemoval(TimeUnit aStart, TimeUnit aEnd) override;
 
   void AbortAppendData() override;
 
@@ -111,7 +110,7 @@ private:
   // for initialization.
   // The decoder is not considered initialized until it is added to
   // mInitializedDecoders.
-  already_AddRefed<SourceBufferDecoder> NewDecoder(int64_t aTimestampOffset /* microseconds */);
+  already_AddRefed<SourceBufferDecoder> NewDecoder(TimeUnit aTimestampOffset);
 
   // Helper for AppendData, ensures NotifyDataArrived is called whenever
   // data is appended to the current decoder's SourceBufferResource.
@@ -189,11 +188,11 @@ private:
   // AppendData.  Accessed on the main thread only.
   int64_t mLastStartTimestamp;
   Maybe<int64_t> mLastEndTimestamp;
-  void AdjustDecodersTimestampOffset(int32_t aOffset);
+  void AdjustDecodersTimestampOffset(TimeUnit aOffset);
 
-  // The timestamp offset used by our current decoder, in microseconds.
-  int64_t mLastTimestampOffset;
-  int64_t mAdjustedTimestamp;
+  // The timestamp offset used by our current decoder.
+  TimeUnit mLastTimestampOffset;
+  TimeUnit mAdjustedTimestamp;
 
   // True if at least one of our decoders has encrypted content.
   bool mIsWaitingOnCDM;

--- a/dom/media/mediasource/moz.build
+++ b/dom/media/mediasource/moz.build
@@ -9,6 +9,7 @@ EXPORTS += [
     'AsyncEventRunner.h',
     'MediaSourceDecoder.h',
     'MediaSourceReader.h',
+    'SourceBufferContentManager.h',
 ]
 
 EXPORTS.mozilla.dom += [
@@ -24,6 +25,7 @@ UNIFIED_SOURCES += [
     'MediaSourceReader.cpp',
     'MediaSourceUtils.cpp',
     'SourceBuffer.cpp',
+    'SourceBufferContentManager.cpp',
     'SourceBufferDecoder.cpp',
     'SourceBufferList.cpp',
     'SourceBufferResource.cpp',


### PR DESCRIPTION
Prep work for #908.

Abstracting our MSE TrackBuffer implementation will make it easier to replace it with a different, more spec-compliant one that interfaces better with MediaFormatReader.

Lightly tested on YouTube and Vimeo and works as intended.