### PR TITLE
[suggestion] Page Info: The cipher name -> The cipher suite

### DIFF
--- a/browser/base/content/pageinfo/security.js
+++ b/browser/base/content/pageinfo/security.js
@@ -55,7 +55,6 @@ var security = {
         cAName : issuerName,
         encryptionAlgorithm : undefined,
         encryptionStrength : undefined,
-        encryptionSuite : undefined,
         version: undefined,
         isBroken : isBroken,
         isMixed : isMixed,
@@ -66,9 +65,8 @@ var security = {
 
       var version;
       try {
-        retval.encryptionAlgorithm = status.cipherName; //FIXME: contains suite.
+        retval.encryptionAlgorithm = status.cipherSuite;
         retval.encryptionStrength = status.secretKeyLength;
-        retval.encryptionSuite = status.cipherName; //status.cipherSuite
         version = status.protocolVersion;
       }
       catch (e) {
@@ -96,7 +94,6 @@ var security = {
         cAName : "",
         encryptionAlgorithm : "",
         encryptionStrength : 0,
-        encryptionSuite : "",
         version: "",
         isBroken : isBroken,
         isMixed : isMixed,
@@ -269,7 +266,7 @@ function securityOnLoad() {
 
   if (info.isBroken) {
     if (info.isMixed) {
-    hdr = pkiBundle.getString("pageInfo_MixedContent");
+      hdr = pkiBundle.getString("pageInfo_MixedContent");
     } else {
       hdr = pkiBundle.getFormattedString("pageInfo_BrokenEncryption",
                                          [info.encryptionAlgorithm,


### PR DESCRIPTION
I propose to add this information...

Before:
![_before](https://cloud.githubusercontent.com/assets/2373486/23343592/5bd2a768-fc6e-11e6-9f09-32dbbcb74e78.png)

After:
![_after](https://cloud.githubusercontent.com/assets/2373486/23343593/61bc3d9c-fc6e-11e6-834e-3e9d0e853cf1.png)

See:
https://github.com/MoonchildProductions/Tycho/commit/b47b094d9811e49b23d4bd7b0a48f266d511f925

Ugly... The mainly, important information :-)

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=886752

\+ style clean up

---

I've created the new build (x32, Windows) and tested.
