### PR TITLE
Remove use of decoder's monitor in MFR::ResetDecode()

### DIFF
--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -938,8 +938,6 @@ MediaFormatReader::ResetDecode()
 {
   MOZ_ASSERT(OnTaskQueue());
 
-  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
-
   mAudioSeekRequest.DisconnectIfExists();
   mVideoSeekRequest.DisconnectIfExists();
   mSeekPromise.RejectIfExists(NS_OK, __func__);

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -1240,6 +1240,15 @@ MediaFormatReader::GetBuffered()
     }
     intervals = mCachedTimeRanges;
   } else {
+    if (OnTaskQueue()) {
+      // Ensure we have up to date buffered time range.
+      if (HasVideo()) {
+        UpdateReceivedNewData(TrackType::kVideoTrack);
+      }
+      if (HasAudio()) {
+        UpdateReceivedNewData(TrackType::kAudioTrack);
+      }
+    }
     if (HasVideo()) {
       MonitorAutoLock lock(mVideo.mMonitor);
       videoti = mVideo.mTimeRanges;


### PR DESCRIPTION
This prevents a potential deadlock and appears to improve the hangs reported in #920.

Has been lightly tested by Tobin on both Linux and Windows, but probably should have some more testing done by those who have experienced the hang before pushing out a point release.