### PR TITLE
[suggestion] Minor fix: When a WebSocket connection is active and users refreshes the page an error is logged

### DIFF
--- a/dom/base/WebSocket.cpp
+++ b/dom/base/WebSocket.cpp
@@ -2583,8 +2583,6 @@ WebSocketImpl::CancelInternal()
     return NS_OK;
   }
 
-  ConsoleError();
-
   return CloseConnection(nsIWebSocketChannel::CLOSE_GOING_AWAY);
 }
 


### PR DESCRIPTION
__Steps to reproduce:__

1. Load a page like http://superuser.com/questions/223396/mbr-boot-sector-wiping-virus-trojan/307673?noredirect=1#comment853472_307673
2. Load something else in the same tab, e.g. http://gmail.com
3. Throws an error in Browser Console:
```
The connection to ws://sockets.ny.stackexchange.com/ was interrupted while the page was loading. 
```

See:
https://forum.palemoon.org/viewtopic.php?f=29&p=108223
(it was also during this navigation)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=712329
(https://bugzilla.mozilla.org/show_bug.cgi?id=712329#c2)

---

I've created the new build (x32, Windows) and tested.
