### PR TITLE
Improve ergonomics and efficiency of AbstractThread

### DIFF
--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -6,7 +6,6 @@
 
 #include "AbstractThread.h"
 
-#include "MediaTaskQueue.h"
 #include "nsThreadUtils.h"
 
 #include "mozilla/ClearOnShutdown.h"
@@ -18,25 +17,10 @@ StaticRefPtr<AbstractThread> sMainThread;
 
 template<>
 nsresult
-AbstractThreadImpl<MediaTaskQueue>::Dispatch(already_AddRefed<nsIRunnable> aRunnable)
-{
-  RefPtr<nsIRunnable> r(aRunnable);
-  return mTarget->ForceDispatch(r);
-}
-
-template<>
-nsresult
 AbstractThreadImpl<nsIThread>::Dispatch(already_AddRefed<nsIRunnable> aRunnable)
 {
   nsCOMPtr<nsIRunnable> r = aRunnable;
   return mTarget->Dispatch(r, NS_DISPATCH_NORMAL);
-}
-
-template<>
-bool
-AbstractThreadImpl<MediaTaskQueue>::IsCurrentThreadIn()
-{
-  return mTarget->IsCurrentThreadIn();
 }
 
 template<>

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -36,6 +36,14 @@ public:
   virtual bool IsCurrentThreadIn() = 0;
 
   template<typename TargetType> static AbstractThread* Create(TargetType* aTarget);
+
+  // Convenience method for getting an AbstractThread for the main thread.
+  //
+  // EnsureMainThreadSingleton must be called on the main thread before any
+  // other threads that might use MainThread() are spawned.
+  static AbstractThread* MainThread();
+  static void EnsureMainThreadSingleton();
+
 protected:
   virtual ~AbstractThread() {}
 };

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -1333,7 +1333,7 @@ void MediaDecoder::ApplyStateToStateMachine(PlayState aState)
         mSeekRequest.Begin(ProxyMediaCall(mDecoderStateMachine->TaskQueue(),
                                           mDecoderStateMachine.get(), __func__,
                                           &MediaDecoderStateMachine::Seek, mRequestedSeekTarget)
-          ->RefableThen(NS_GetCurrentThread(), __func__, this,
+          ->RefableThen(AbstractThread::MainThread(), __func__, this,
                         &MediaDecoder::OnSeekResolved, &MediaDecoder::OnSeekRejected));
         mRequestedSeekTarget.Reset();
         break;

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -619,6 +619,7 @@ MediaDecoder::MediaDecoder() :
   MOZ_COUNT_CTOR(MediaDecoder);
   MOZ_ASSERT(NS_IsMainThread());
   MediaMemoryTracker::AddMediaDecoder(this);
+  AbstractThread::EnsureMainThreadSingleton();
 #ifdef PR_LOGGING
   if (!gMediaDecoderLog) {
     gMediaDecoderLog = PR_NewLogModule("MediaDecoder");

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -2568,10 +2568,9 @@ MediaDecoderStateMachine::FinishShutdown()
   // dispatch an event to the main thread to release the decoder and
   // state machine.
   DECODER_LOG("Shutting down state machine task queue");
-  nsCOMPtr<nsIThread> mainThread;
-  NS_GetMainThread(getter_AddRefs(mainThread));
   RefPtr<DecoderDisposer> disposer = new DecoderDisposer(mDecoder, this);
-  TaskQueue()->BeginShutdown()->Then(mainThread.get(), __func__, disposer.get(),
+  TaskQueue()->BeginShutdown()->Then(AbstractThread::MainThread(), __func__,
+                                     disposer.get(),
                                      &DecoderDisposer::OnTaskQueueShutdown,
                                      &DecoderDisposer::OnTaskQueueShutdown);
 }

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -451,7 +451,7 @@ SourceBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset,
   }
 
   mPendingAppend.Begin(mContentManager->AppendData(aData, aTimestampOffset)
-                       ->RefableThen(NS_GetCurrentThread(), __func__, this,
+                       ->RefableThen(AbstractThread::MainThread(), __func__, this,
                                      &SourceBuffer::AppendDataCompletedWithSuccess,
                                      &SourceBuffer::AppendDataErrored));
 }

--- a/dom/media/omx/MediaOmxReader.cpp
+++ b/dom/media/omx/MediaOmxReader.cpp
@@ -185,9 +185,7 @@ MediaOmxReader::Shutdown()
 
   // Wait for the superclass to finish tearing things down before releasing
   // the decoder on the main thread.
-  nsCOMPtr<nsIThread> mt;
-  NS_GetMainThread(getter_AddRefs(mt));
-  p->Then(mt.get(), __func__, this, &MediaOmxReader::ReleaseDecoder, &MediaOmxReader::ReleaseDecoder);
+  p->Then(AbstractThread::MainThread(), __func__, this, &MediaOmxReader::ReleaseDecoder, &MediaOmxReader::ReleaseDecoder);
 
   return p;
 }


### PR DESCRIPTION
Followup to #930.

This PR removes wapper-style AbstractThreads and allows callers to pass an AbstractThread directly to promise APIs.

Been streaming Twitch and YouTube for the past several hours and appears to be working as intended.