### PR TITLE
Fix deadlocks in SharedDecoderManager

### DIFF
--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -3857,7 +3857,7 @@ void HTMLMediaElement::UpdateMediaSize(const nsIntSize& aSize)
 
 void HTMLMediaElement::UpdateInitialMediaSize(const nsIntSize& aSize)
 {
-  if (mMediaInfo.mVideo.mDisplay == nsIntSize(0, 0)) {
+  if (!mMediaInfo.HasVideo()) {
     UpdateMediaSize(aSize);
   }
 }

--- a/dom/media/platforms/SharedDecoderManager.cpp
+++ b/dom/media/platforms/SharedDecoderManager.cpp
@@ -150,9 +150,16 @@ void
 SharedDecoderManager::SetIdle(MediaDataDecoder* aProxy)
 {
   if (aProxy && mActiveProxy == aProxy) {
+    MonitorAutoLock mon(mMonitor);
     mWaitForInternalDrain = true;
-    if (NS_SUCCEEDED(mActiveProxy->Drain())) {
-      MonitorAutoLock mon(mMonitor);
+    nsresult rv;
+    {
+      // We don't want to hold the lock while calling Drain() as some
+      // platform implementations call DrainComplete() immediately.
+      MonitorAutoUnlock mon(mMonitor);
+      rv = mActiveProxy->Drain();
+    }
+    if (NS_SUCCEEDED(rv)) {
       while (mWaitForInternalDrain) {
         mon.Wait();
       }
@@ -165,13 +172,15 @@ SharedDecoderManager::SetIdle(MediaDataDecoder* aProxy)
 void
 SharedDecoderManager::DrainComplete()
 {
-  if (mWaitForInternalDrain) {
+  {
     MonitorAutoLock mon(mMonitor);
-    mWaitForInternalDrain = false;
-    mon.NotifyAll();
-  } else {
-    mActiveCallback->DrainComplete();
+    if (mWaitForInternalDrain) {
+      mWaitForInternalDrain = false;
+      mon.NotifyAll();
+      return;
+    }
   }
+  mActiveCallback->DrainComplete();
 }
 
 void

--- a/dom/media/platforms/SharedDecoderManager.cpp
+++ b/dom/media/platforms/SharedDecoderManager.cpp
@@ -150,16 +150,15 @@ void
 SharedDecoderManager::SetIdle(MediaDataDecoder* aProxy)
 {
   if (aProxy && mActiveProxy == aProxy) {
-    MonitorAutoLock mon(mMonitor);
-    mWaitForInternalDrain = true;
-    nsresult rv;
     {
+      MonitorAutoLock mon(mMonitor);
+      mWaitForInternalDrain = true;
       // We don't want to hold the lock while calling Drain() as some
       // platform implementations call DrainComplete() immediately.
-      MonitorAutoUnlock mon(mMonitor);
-      rv = mActiveProxy->Drain();
     }
+    nsresult rv = mActiveProxy->Drain();
     if (NS_SUCCEEDED(rv)) {
+      MonitorAutoLock mon(mMonitor);
       while (mWaitForInternalDrain) {
         mon.Wait();
       }

--- a/dom/media/platforms/SharedDecoderManager.h
+++ b/dom/media/platforms/SharedDecoderManager.h
@@ -56,6 +56,7 @@ private:
   SharedDecoderProxy* mActiveProxy;
   MediaDataDecoderCallback* mActiveCallback;
   nsAutoPtr<MediaDataDecoderCallback> mCallback;
+  // access protected by mMonitor
   bool mWaitForInternalDrain;
   Monitor mMonitor;
   bool mDecoderReleasedResources;


### PR DESCRIPTION
This PR should hopefully fix the hang in #920 for good (one of the commits here landed at Mozilla to fix a hang with the same stack trace). The remaining commits here are followups to that, ensuring that no other deadlocks happen in the surrounding code.

According to Mozilla, this hang was triggered only by some video formats and also varies based on the decoder being used (whether it be WMF, certain versions of FFmpeg, etc.). This would explain why the hang was difficult (or impossible) to reproduce on some systems.

Been testing on Twitch and YouTube the past couple hours and appears to work as intended.