### PR TITLE
Properly handle add-on name in case it localized

### DIFF
--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -5227,7 +5227,7 @@ AddonInstall.prototype = {
     this.updateAddonURIs();
 
     this.addon._install = this;
-    this.name = this.addon.selectedLocale.name;
+    this.name = this.addon.selectedLocale.name || this.addon.defaultLocale.name;
     this.type = this.addon.type;
     this.version = this.addon.version;
 
@@ -5356,7 +5356,7 @@ AddonInstall.prototype = {
     this.updateAddonURIs();
 
     this.addon._install = this;
-    this.name = this.addon.selectedLocale.name;
+    this.name = this.addon.selectedLocale.name || this.addon.defaultLocale.name;
     this.type = this.addon.type;
     this.version = this.addon.version;
 
@@ -6038,8 +6038,9 @@ AddonInstall.createUpdate = function AI_createUpdate(aCallback, aAddon, aUpdate)
     install.initLocalInstall(aCallback);
   }
   else {
-    install.initAvailableDownload(aAddon.selectedLocale.name, aAddon.type,
-                                  aAddon.icons, aUpdate.version, aCallback);
+    install.initAvailableDownload(aAddon.selectedLocale.name ?
+                                  aAddon.selectedLocale.name : aAddon.defaultLocale.name,
+                                  aAddon.type, aAddon.icons, aUpdate.version, aCallback);
   }
 };
 


### PR DESCRIPTION
This resolves following exceptions when addons.palemoon.org provides no data:

1) If install.rdf contains '<em:localized>' blocks without '<em:name>' (it's rather common situation), then corresponding add-on displays 'null' instead of real extension name.
2) If install.rdf contains '<em:localized>' block for en-US without '<em:name>' (this is uncommon, but allowed), then corresponding add-on can't be installed at all.

See also https://github.com/Pale-Moon-Addons-Team/phoebus/issues/42.