### PR TITLE
Canvas: Added support for ellipse (+ fix a hang/crashes problem, check the canvas rects)

### DIFF
--- a/dom/canvas/CanvasRenderingContext2D.cpp
+++ b/dom/canvas/CanvasRenderingContext2D.cpp
@@ -2413,11 +2413,44 @@ CanvasRenderingContext2D::UpdateFilter()
 // rects
 //
 
-void
+static bool
+ValidateRect(double& aX, double& aY, double& aWidth, double& aHeight)
+{
+
+  // bug 1018527
+  // The values of canvas API input are in double precision, but Moz2D APIs are
+  // using float precision. Bypass canvas API calls when the input is out of
+  // float precision to avoid precision problem
+  if (!std::isfinite((float)aX) | !std::isfinite((float)aY) |
+      !std::isfinite((float)aWidth) | !std::isfinite((float)aHeight)) {
+    return false;
+  }
+
+  // bug 1074733
+  // The canvas spec does not forbid rects with negative w or h, so given
+  // corners (x, y), (x+w, y), (x+w, y+h), and (x, y+h) we must generate
+  // the appropriate rect by flipping negative dimensions. This prevents
+  // draw targets from receiving "empty" rects later on.
+  if (aWidth < 0) {
+    aWidth = -aWidth;
+    aX -= aWidth;
+  }
+  if (aHeight < 0) {
+    aHeight = -aHeight;
+    aY -= aHeight;
+  }
+  return true;
+ }
+ 
+ void
 CanvasRenderingContext2D::ClearRect(double x, double y, double w,
                                     double h)
 {
   if (!mTarget) {
+    return;
+  }
+
+  if (!ValidateRect(x, y, w, h)) {
     return;
   }
 
@@ -2431,6 +2464,10 @@ CanvasRenderingContext2D::FillRect(double x, double y, double w,
                                    double h)
 {
   const ContextState &state = CurrentState();
+
+  if (!ValidateRect(x, y, w, h)) {
+    return;
+  }
 
   if (state.patternStyles[Style::FILL]) {
     CanvasPattern::RepeatMode repeat =
@@ -2503,6 +2540,10 @@ CanvasRenderingContext2D::StrokeRect(double x, double y, double w,
   mgfx::Rect bounds;
 
   if (!w && !h) {
+    return;
+  }
+
+  if (!ValidateRect(x, y, w, h)) {
     return;
   }
 
@@ -2891,6 +2932,22 @@ CanvasRenderingContext2D::Rect(double x, double y, double w, double h)
     mDSPathBuilder->LineTo(mTarget->GetTransform() * Point(x, y + h));
     mDSPathBuilder->Close();
   }
+}
+
+void
+CanvasRenderingContext2D::Ellipse(double aX, double aY, double aRadiusX, double aRadiusY,
+                                  double aRotation, double aStartAngle, double aEndAngle,
+                                  bool aAnticlockwise, ErrorResult& aError)
+{
+  if (aRadiusX < 0.0 || aRadiusY < 0.0) {
+    aError.Throw(NS_ERROR_DOM_INDEX_SIZE_ERR);
+    return;
+  }
+
+  EnsureWritablePath();
+
+  ArcToBezier(this, Point(aX, aY), Size(aRadiusX, aRadiusY), aStartAngle, aEndAngle,
+              aAnticlockwise, aRotation);
 }
 
 void
@@ -4217,6 +4274,13 @@ CanvasRenderingContext2D::DrawImage(const HTMLImageOrCanvasOrVideoElement& image
   }
 
   MOZ_ASSERT(optional_argc == 0 || optional_argc == 2 || optional_argc == 6);
+
+  if (optional_argc == 6) {
+    if (!ValidateRect(sx, sy, sw, sh) ||
+        !ValidateRect(dx, dy, dw, dh)) {
+      return;
+    }
+  }
 
   RefPtr<SourceSurface> srcSurf;
   gfx::IntSize imgSize;
@@ -5631,6 +5695,22 @@ CanvasPath::Arc(double x, double y, double radius,
   EnsurePathBuilder();
 
   ArcToBezier(this, Point(x, y), Size(radius, radius), startAngle, endAngle, anticlockwise);
+}
+
+void
+CanvasPath::Ellipse(double x, double y, double radiusX, double radiusY,
+                    double rotation, double startAngle, double endAngle,
+                    bool anticlockwise, ErrorResult& error)
+{
+  if (radiusX < 0.0 || radiusY < 0.0) {
+    error.Throw(NS_ERROR_DOM_INDEX_SIZE_ERR);
+    return;
+  }
+
+  EnsurePathBuilder();
+
+  ArcToBezier(this, Point(x, y), Size(radiusX, radiusY), startAngle, endAngle,
+              anticlockwise, rotation);
 }
 
 void

--- a/dom/canvas/CanvasRenderingContext2D.h
+++ b/dom/canvas/CanvasRenderingContext2D.h
@@ -82,6 +82,9 @@ public:
   void Arc(double x, double y, double radius,
            double startAngle, double endAngle, bool anticlockwise,
            ErrorResult& error);
+  void Ellipse(double x, double y, double radiusX, double radiusY,
+               double rotation, double startAngle, double endAngle,
+               bool anticlockwise, ErrorResult& error);
 
   void LineTo(const gfx::Point& aPoint);
   void BezierTo(const gfx::Point& aCP1,
@@ -406,6 +409,9 @@ public:
   void Rect(double x, double y, double w, double h);
   void Arc(double x, double y, double radius, double startAngle,
            double endAngle, bool anticlockwise, mozilla::ErrorResult& error);
+  void Ellipse(double aX, double aY, double aRadiusX, double aRadiusY,
+               double aRotation, double aStartAngle, double aEndAngle,
+               bool aAnticlockwise, ErrorResult& aError);
 
   void GetMozCurrentTransform(JSContext* cx,
                               JS::MutableHandle<JSObject*> result,

--- a/dom/canvas/test/test_canvas.html
+++ b/dom/canvas/test/test_canvas.html
@@ -21464,7 +21464,7 @@ function test_getImageData_after_zero_canvas() {
 }
 </script>
 
-<p>Canvas test: zero_dimensions_image_data</p>
+<p>Canvas test: linedash</p>
 <canvas id="c687" width="150" height="50"></canvas>
 <script type="text/javascript">
 
@@ -21536,6 +21536,16 @@ function test_linedash() {
   isPixel(ctx, 105, 40, 0, 255, 0, 255, 0);
   isPixel(ctx, 90, 35, 0, 0, 0, 0, 0);
   isPixel(ctx, 90, 25, 0, 255, 0, 255, 0);
+
+  // Ensure that all zeros or negative pattern does not cause error state in context, see bug 1169609
+  ctx.setLineDash([0, 0]);
+  ctx.strokeRect(130.5, 10.5, 10, 10);
+  ctx.setLineDash([-1]);
+  ctx.strokeRect(130.5, 10.5, 10, 10);
+  isPixel(ctx, 135, 15, 0, 0, 0, 0, 0);
+  ctx.fillStyle = '#00FF00';
+  ctx.fillRect(130, 10, 10, 10);
+  isPixel(ctx, 135, 15, 0, 255, 0, 255, 0);
 }
 </script>
 
@@ -21582,10 +21592,945 @@ isPixel(ctx, 50,25, 0,255,0,255, 0);
 
 </script>
 
+<!-- [[[ test_2d.clearRect.testdoubleprecision.html ]]] -->
+
+<p>Canvas test: 2d.clearRect.testdoubleprecision</p>
+<canvas id="c690" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_clearRect_testdoubleprecision() {
+  var canvas = document.getElementById('c690');
+  ctx = canvas.getContext('2d');
+  ctx.setTransform(1, 1, 1, 1, 0, 0);
+  ctx.clearRect(-1.79e+308, 0, 1.79e+308, 8);
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.angle.1.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.angle.1</p>
+<!-- Testing: ellipse() draws pi/2 .. -pi anticlockwise correctly -->
+<canvas id="c690" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_angle_1() {
+
+var canvas = document.getElementById('c690');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.fillStyle = '#f00';
+ctx.beginPath();
+ctx.moveTo(100, 0);
+ctx.ellipse(100, 0, 150, 100, 0, Math.PI/2, -Math.PI, true);
+ctx.fill();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.angle.2.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.angle.2</p>
+<!-- Testing: ellipse() draws -3pi/2 .. -pi anticlockwise correctly -->
+<canvas id="c691" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_angle_2() {
+
+var canvas = document.getElementById('c691');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.fillStyle = '#f00';
+ctx.beginPath();
+ctx.moveTo(100, 0);
+ctx.ellipse(100, 0, 150, 100, 0, -3*Math.PI/2, -Math.PI, true);
+ctx.fill();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.angle.3.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.angle.3</p>
+<!-- Testing: ellipse() wraps angles mod 2pi when anticlockwise and end > start+2pi -->
+<canvas id="c692" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_angle_3() {
+
+var canvas = document.getElementById('c692');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.fillStyle = '#f00';
+ctx.beginPath();
+ctx.moveTo(100, 0);
+ctx.ellipse(100, 0, 150, 100, 0, (512+1/2)*Math.PI, (1024-1)*Math.PI, true);
+ctx.fill();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.angle.4.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.angle.4</p>
+<!-- Testing: ellipse() draws a full circle when clockwise and end > start+2pi -->
+<canvas id="c693" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_angle_4() {
+
+var canvas = document.getElementById('c693');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.fillStyle = '#0f0';
+ctx.beginPath();
+ctx.moveTo(50, 25);
+ctx.ellipse(50, 25, 60, 50, 0, (512+1/2)*Math.PI, (1024-1)*Math.PI, false);
+ctx.fill();
+isPixel(ctx, 1,1, 0,255,0,255, 0);
+isPixel(ctx, 98,1, 0,255,0,255, 0);
+isPixel(ctx, 1,48, 0,255,0,255, 0);
+isPixel(ctx, 98,48, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.angle.5.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.angle.5</p>
+<!-- Testing: ellipse() wraps angles mod 2pi when clockwise and start > end+2pi -->
+<canvas id="c694" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_angle_5() {
+
+var canvas = document.getElementById('c694');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.fillStyle = '#f00';
+ctx.beginPath();
+ctx.moveTo(100, 0);
+ctx.ellipse(100, 0, 150, 100, 0, (1024-1)*Math.PI, (512+1/2)*Math.PI, false);
+ctx.fill();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.angle.6.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.angle.6</p>
+<!-- Testing: ellipse() draws a full circle when anticlockwise and start > end+2pi -->
+<canvas id="c695" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_angle_6() {
+
+var canvas = document.getElementById('c695');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.fillStyle = '#0f0';
+ctx.beginPath();
+ctx.moveTo(50, 25);
+ctx.ellipse(50, 25, 60, 50, 0, (1024-1)*Math.PI, (512+1/2)*Math.PI, true);
+ctx.fill();
+isPixel(ctx, 1,1, 0,255,0,255, 0);
+isPixel(ctx, 98,1, 0,255,0,255, 0);
+isPixel(ctx, 1,48, 0,255,0,255, 0);
+isPixel(ctx, 98,48, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.empty.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.empty</p>
+<!-- Testing: ellipse() with an empty path does not draw a straight line to the start point -->
+<canvas id="c696" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_empty() {
+
+var canvas = document.getElementById('c696');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 50;
+ctx.strokeStyle = '#f00';
+ctx.beginPath();
+ctx.ellipse(200, 25, 5, 5, 0, 0, 2*Math.PI, true);
+ctx.stroke();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.end.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.end</p>
+<!-- Testing: ellipse() adds the end point of the ellipse to the subpath -->
+<canvas id="c697" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_end() {
+
+var canvas = document.getElementById('c697');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 50;
+ctx.strokeStyle = '#0f0';
+ctx.beginPath();
+ctx.moveTo(-100, 0);
+ctx.ellipse(-100, 0, 25, 25, 0, -Math.PI/2, Math.PI/2, true);
+ctx.lineTo(100, 25);
+ctx.stroke();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.negative.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.negative</p>
+<!-- Testing: ellipse() with negative radius throws INDEX_SIZE_ERR -->
+<canvas id="c698" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_negative() {
+
+var canvas = document.getElementById('c698');
+var ctx = canvas.getContext('2d');
+
+var _thrown = undefined;
+try {
+  ctx.ellipse(0, 0, -1, 0, 0, -Math.PI/2, Math.PI/2, true);
+} catch (e) { _thrown = e }; ok(_thrown && _thrown.name == "IndexSizeError" && _thrown.code == DOMException.INDEX_SIZE_ERR, "should throw IndexSizeError");
+
+try {
+  ctx.ellipse(0, 0, 0, -1, 0, -Math.PI/2, Math.PI/2, true);
+} catch (e) { _thrown = e }; ok(_thrown && _thrown.name == "IndexSizeError" && _thrown.code == DOMException.INDEX_SIZE_ERR, "should throw IndexSizeError");
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.nonempty.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.nonempty</p>
+<!-- Testing: ellipse() with a non-empty path does draw a straight line to the start point -->
+<canvas id="c699" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_nonempty() {
+
+var canvas = document.getElementById('c699');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 50;
+ctx.strokeStyle = '#0f0';
+ctx.beginPath();
+ctx.moveTo(0, 25);
+ctx.ellipse(200, 25, 5, 2, 0, 0, 2*Math.PI, true);
+ctx.stroke();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.bezierCurveTo.nonfinite.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.nonfinite</p>
+<!-- Testing: bezierCurveTo() with Infinity/NaN is ignored -->
+<canvas id="c700" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_nonfinite() {
+
+var canvas = document.getElementById('c700');
+var ctx = canvas.getContext('2d');
+
+var _thrown_outer = false;
+try {
+
+ctx.moveTo(0, 0);
+ctx.lineTo(100, 0);
+ctx.ellipse(Infinity, 25, 0, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(-Infinity, 25, 0, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(NaN, 25, 0, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, 0, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, -Infinity, 0, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, NaN, 50, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, Infinity, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, -Infinity, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, NaN, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, Infinity, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, -Infinity, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, NaN, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, 0, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, 0, -Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, 0, NaN, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, 0, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, 0, 0, -Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, 0, 0, NaN, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, 0, 0, 0, Infinity, false);
+ctx.ellipse(50, 25, 0, 0, 0, 0, -Infinity, false);
+ctx.ellipse(50, 25, 0, 0, 0, 0, NaN, false);
+ctx.ellipse(Infinity, Infinity, 0, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, Infinity, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, Infinity, Infinity, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, Infinity, Infinity, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, Infinity, Infinity, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, Infinity, Infinity, Infinity, Infinity, Infinity, false);
+ctx.ellipse(Infinity, Infinity, Infinity, Infinity, Infinity, 0, Infinity, false);
+ctx.ellipse(Infinity, Infinity, Infinity, Infinity, 0, Infinity, Infinity, false);
+ctx.ellipse(Infinity, Infinity, Infinity, 0, Infinity, Infinity, Infinity, false);
+ctx.ellipse(Infinity, Infinity, 0, Infinity, Infinity, Infinity, Infinity, false);
+ctx.ellipse(Infinity, 25, Infinity, Infinity, Infinity, Infinity, Infinity, false);
+ctx.ellipse(50, Infinity, Infinity, Infinity, Infinity, Infinity, Infinity, false);
+ctx.ellipse(Infinity, Infinity, Infinity, Infinity, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, Infinity, 0, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, 0, Infinity, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, Infinity, Infinity, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, Infinity, Infinity, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, Infinity, Infinity, 0, 0, Infinity, false);
+ctx.ellipse(Infinity, Infinity, Infinity, 0, Infinity, 0, Infinity, false);
+ctx.ellipse(Infinity, Infinity, 0, Infinity, Infinity, 0, Infinity, false);
+ctx.ellipse(Infinity, 25, Infinity, Infinity, Infinity, 0, Infinity, false);
+ctx.ellipse(50, Infinity, Infinity, Infinity, Infinity, 0, Infinity, false);
+ctx.ellipse(Infinity, Infinity, Infinity, 0, 0, Infinity, Infinity, false);
+ctx.ellipse(Infinity, Infinity, 0, Infinity, 0, Infinity, Infinity, false);
+ctx.ellipse(Infinity, 25, Infinity, Infinity, 0, Infinity, Infinity, false);
+ctx.ellipse(50, Infinity, Infinity, Infinity, 0, Infinity, Infinity, false);
+ctx.ellipse(Infinity, Infinity, 50, 0, Infinity, Infinity, Infinity, false);
+ctx.ellipse(Infinity, 25, Infinity, 0, Infinity, Infinity, Infinity, false);
+ctx.ellipse(50, Infinity, Infinity, 0, Infinity, Infinity, Infinity, false);
+ctx.ellipse(Infinity, 25, 50, Infinity, Infinity, Infinity, Infinity, false);
+ctx.ellipse(50, Infinity, 50, Infinity, Infinity, Infinity, Infinity, false);
+ctx.ellipse(50, 25, Infinity, Infinity, Infinity, Infinity, Infinity, false);
+ctx.ellipse(Infinity, Infinity, Infinity, 0, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, 0, Infinity, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, Infinity, Infinity, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, Infinity, Infinity, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, Infinity, 0, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, 0, Infinity, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, Infinity, Infinity, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, Infinity, Infinity, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, 0, 0, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, Infinity, 0, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, Infinity, 0, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, 0, Infinity, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, 0, Infinity, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, 25, Infinity, Infinity, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, Infinity, 0, 0, 0, Infinity, false);
+ctx.ellipse(Infinity, Infinity, 0, Infinity, 0, 0, Infinity, false);
+ctx.ellipse(Infinity, 25, Infinity, Infinity, 0, 0, Infinity, false);
+ctx.ellipse(50, Infinity, Infinity, Infinity, 0, 0, Infinity, false);
+ctx.ellipse(Infinity, Infinity, 0, 0, Infinity, 0, Infinity, false);
+ctx.ellipse(Infinity, 25, Infinity, 0, Infinity, 0, Infinity, false);
+ctx.ellipse(50, Infinity, Infinity, 0, Infinity, 0, Infinity, false);
+ctx.ellipse(Infinity, 25, 0, Infinity, Infinity, 0, Infinity, false);
+ctx.ellipse(50, Infinity, 0, Infinity, Infinity, 0, Infinity, false);
+ctx.ellipse(50, 25, Infinity, Infinity, Infinity, 0, Infinity, false);
+ctx.ellipse(Infinity, Infinity, 0, 0, 0, Infinity, Infinity, false);
+ctx.ellipse(Infinity, 25, Infinity, 0, 0, Infinity, Infinity, false);
+ctx.ellipse(50, Infinity, Infinity, 0, 0, Infinity, Infinity, false);
+ctx.ellipse(Infinity, 25, 0, Infinity, 0, Infinity, Infinity, false);
+ctx.ellipse(50, Infinity, 0, Infinity, 0, Infinity, Infinity, false);
+ctx.ellipse(50, 25, Infinity, Infinity, 0, Infinity, Infinity, false);
+ctx.ellipse(Infinity, 25, 0, 0, Infinity, Infinity, Infinity, false);
+ctx.ellipse(50, Infinity, 0, 0, Infinity, Infinity, Infinity, false);
+ctx.ellipse(50, 25, Infinity, 0, Infinity, Infinity, Infinity, false);
+ctx.ellipse(50, 25, 50, Infinity, Infinity, Infinity, Infinity, false);
+ctx.ellipse(Infinity, Infinity, 0, Infinity, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, Infinity, Infinity, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, Infinity, Infinity, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, 0, 0, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, Infinity, 0, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, Infinity, 0, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, 0, Infinity, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, 0, Infinity, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, Infinity, Infinity, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, 0, 0, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, Infinity, 0, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, Infinity, 0, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, 0, Infinity, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, 0, Infinity, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, 25, Infinity, Infinity, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, 0, 0, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, 0, 0, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, 25, Infinity, 0, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, Infinity, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, Infinity, 0, 0, 0, 0, Infinity, false);
+ctx.ellipse(Infinity, 25, Infinity, 0, 0, 0, Infinity, false);
+ctx.ellipse(50, Infinity, Infinity, 0, 0, 0, Infinity, false);
+ctx.ellipse(Infinity, 25, 0, Infinity, 0, 0, Infinity, false);
+ctx.ellipse(50, Infinity, 0, Infinity, 0, 0, Infinity, false);
+ctx.ellipse(50, 25, Infinity, Infinity, 0, 0, Infinity, false);
+ctx.ellipse(Infinity, 25, 0, 0, Infinity, 0, Infinity, false);
+ctx.ellipse(50, Infinity, 0, 0, Infinity, 0, Infinity, false);
+ctx.ellipse(50, 25, Infinity, 0, Infinity, 0, Infinity, false);
+ctx.ellipse(50, 25, 0, Infinity, Infinity, 0, Infinity, false);
+ctx.ellipse(Infinity, 25, 0, 0, 0, Infinity, Infinity, false);
+ctx.ellipse(50, Infinity, 0, 0, 0, Infinity, Infinity, false);
+ctx.ellipse(50, 25, Infinity, 0, 0, Infinity, Infinity, false);
+ctx.ellipse(50, 25, 0, Infinity, 0, Infinity, Infinity, false);
+ctx.ellipse(50, 25, 0, 0, Infinity, Infinity, Infinity, false);
+ctx.ellipse(Infinity, 25, Infinity, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, Infinity, 0, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, 0, Infinity, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, 0, Infinity, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, Infinity, Infinity, 0, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, 0, 0, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, 0, 0, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, Infinity, 0, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, Infinity, Infinity, 0, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, 0, 0, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, Infinity, 0, 0, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, 25, Infinity, 0, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, Infinity, 0, Infinity, 2 * Math.PI, false);
+ctx.ellipse(50, 25, 0, 0, Infinity, Infinity, 2 * Math.PI, false);
+ctx.ellipse(Infinity, 25, 0, 0, 0, 0, Infinity, false);
+ctx.ellipse(50, Infinity, 0, 0, 0, 0, Infinity, false);
+ctx.ellipse(50, 25, Infinity, 0, 0, 0, Infinity, false);
+ctx.ellipse(50, 25, 0, Infinity, 0, 0, Infinity, false);
+ctx.ellipse(50, 25, 0, 0, Infinity, 0, Infinity, false);
+ctx.ellipse(50, 25, 0, 0, 0, Infinity, Infinity, false);
+ctx.lineTo(100, 50);
+ctx.lineTo(0, 50);
+ctx.fillStyle = '#0f0';
+ctx.fill();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+isPixel(ctx, 90,45, 0,255,0,255, 0);
+
+} catch (e) {
+    _thrown_outer = true;
+}
+ok(!_thrown_outer, ctx.canvas.id + ' should not throw exception');
+
+
+}
+</script>
+
+
+<!-- [[[ test_2d.path.ellipse.scale.1.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.scale.1</p>
+<!-- Testing: Non-uniformly scaled ellipse are the right shape -->
+<canvas id="c701" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_scale_1() {
+
+var canvas = document.getElementById('c701');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.scale(2, 0.5);
+ctx.fillStyle = '#0f0';
+ctx.beginPath();
+var hypothenuse = Math.sqrt(50 * 50 + 25 * 25);
+var tolerance = 0.5;
+var radius = hypothenuse + tolerance;
+ctx.ellipse(25, 50, radius, radius, 0, 0, 2*Math.PI, false);
+ctx.fill();
+ctx.fillStyle = '#f00';
+ctx.beginPath();
+ctx.moveTo(-25, 50);
+ctx.ellipse(-25, 50, 24, 34, 0, 0, 2 * Math.PI, false);
+ctx.moveTo(75, 50);
+ctx.ellipse(75, 50, 24, 34, 0, 0, 2 * Math.PI, false);
+ctx.moveTo(25, -25);
+ctx.ellipse(25, -25, 34, 24, 0, 0, 2 * Math.PI, false);
+ctx.moveTo(25, 125);
+ctx.ellipse(25, -25, 34, 24, 0, 0, 2 * Math.PI, false);
+ctx.fill();
+
+isPixel(ctx, 0,0, 0,255,0,255, 0);
+isPixel(ctx, 50,0, 0,255,0,255, 0);
+isPixel(ctx, 99,0, 0,255,0,255, 0);
+isPixel(ctx, 0,25, 0,255,0,255, 0);
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+isPixel(ctx, 99,25, 0,255,0,255, 0);
+isPixel(ctx, 0,49, 0,255,0,255, 0);
+isPixel(ctx, 50,49, 0,255,0,255, 0);
+isPixel(ctx, 99,49, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.scale.2.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.scale.2</p>
+<!-- Testing: Highly scaled ellipse are the right shape -->
+<canvas id="c702" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_scale_2() {
+
+var canvas = document.getElementById('c702');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.scale(100, 100);
+ctx.strokeStyle = '#0f0';
+ctx.lineWidth = 1.2;
+ctx.beginPath();
+ctx.ellipse(0, 0, 0.6, 1, 0, 0, Math.PI/2, false);
+ctx.ellipse(0, 0, 1, 0.6, 0, 0, Math.PI/2, false);
+ctx.stroke();
+
+isPixel(ctx, 1,1, 0,255,0,255, 0);
+isPixel(ctx, 50,1, 0,255,0,255, 0);
+isPixel(ctx, 98,1, 0,255,0,255, 0);
+isPixel(ctx, 1,25, 0,255,0,255, 0);
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+isPixel(ctx, 98,25, 0,255,0,255, 0);
+isPixel(ctx, 1,48, 0,255,0,255, 0);
+isPixel(ctx, 50,48, 0,255,0,255, 0);
+isPixel(ctx, 98,48, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.selfintersect.1.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.selfintersect.1</p>
+<!-- Testing: ellipse() with lineWidth > 2*radius is drawn sensibly -->
+<canvas id="c703" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_selfintersect_1() {
+
+var canvas = document.getElementById('c703');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 200;
+ctx.strokeStyle = '#f00';
+ctx.beginPath();
+ctx.ellipse(100, 50, 35, 25, 0, 0, -Math.PI/2, true);
+ctx.stroke();
+ctx.beginPath();
+ctx.ellipse(0, 0, 35, 25, 0, 0, -Math.PI/2, true);
+ctx.stroke();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.selfintersect.2.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.selfintersect.2</p>
+<!-- Testing: ellipse() with lineWidth > 2*radius is drawn sensibly -->
+<canvas id="c704" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_selfintersect_2() {
+
+var canvas = document.getElementById('c704');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 180;
+ctx.strokeStyle = '#0f0';
+ctx.beginPath();
+ctx.ellipse(-50, 50, 25, 25, 0, 0, -Math.PI/2, true);
+ctx.stroke();
+ctx.beginPath();
+ctx.ellipse(100, 0, 25, 25, 0, 0, -Math.PI/2, true);
+ctx.stroke();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+isPixel(ctx, 90,10, 0,255,0,255, 0);
+isPixel(ctx, 97,1, 0,255,0,255, 0);
+isPixel(ctx, 97,2, 0,255,0,255, 0);
+isPixel(ctx, 97,3, 0,255,0,255, 0);
+isPixel(ctx, 2,48, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.shape.1.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.shape.1</p>
+<!-- Testing: ellipse() from 0 to pi does not draw anything in the wrong half -->
+<canvas id="c705" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_shape_1() {
+
+var canvas = document.getElementById('c705');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 50;
+ctx.strokeStyle = '#f00';
+ctx.beginPath();
+ctx.ellipse(50, 50, 40, 60, 0, 0, Math.PI, false);
+ctx.stroke();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+isPixel(ctx, 1,1, 0,255,0,255, 0);
+isPixel(ctx, 98,1, 0,255,0,255, 0);
+isPixel(ctx, 1,48, 0,255,0,255, 0);
+isPixel(ctx, 20,48, 0,255,0,255, 0);
+isPixel(ctx, 98,48, 0,255,0,255, 0);
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.shape.2.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.shape.2</p>
+<!-- Testing: ellipse() from 0 to pi draws stuff in the right half -->
+<canvas id="c706" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_shape_2() {
+
+var canvas = document.getElementById('c706');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 100;
+ctx.strokeStyle = '#0f0';
+ctx.beginPath();
+ctx.ellipse(50, 50, 30, 15, 0, 0, Math.PI, true);
+ctx.stroke();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+isPixel(ctx, 1,1, 0,255,0,255, 0);
+isPixel(ctx, 98,1, 0,255,0,255, 0);
+isPixel(ctx, 1,48, 0,255,0,255, 0);
+isPixel(ctx, 20,48, 0,255,0,255, 0);
+isPixel(ctx, 98,48, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.shape.3.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.shape.3</p>
+<!-- Testing: ellipse() from 0 to -pi/2 draws stuff in the right quadrant -->
+<canvas id="c707" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_shape_3() {
+
+var canvas = document.getElementById('c707');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 150;
+ctx.strokeStyle = '#0f0';
+ctx.beginPath();
+ctx.ellipse(-50, 50, 100, 200, 0, 0, -Math.PI/2, true);
+ctx.stroke();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+isPixel(ctx, 1,1, 0,255,0,255, 0);
+isPixel(ctx, 98,1, 0,255,0,255, 0);
+isPixel(ctx, 1,48, 0,255,0,255, 0);
+isPixel(ctx, 98,48, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.shape.4.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.shape.4</p>
+<!-- Testing: ellipse() from 0 to 5pi does not draw crazy things -->
+<canvas id="c708" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_shape_4() {
+
+var canvas = document.getElementById('c708');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 200;
+ctx.strokeStyle = '#f00';
+ctx.beginPath();
+ctx.ellipse(300, 0, 100, 200, 0, 0, 5*Math.PI, false);
+ctx.stroke();
+isPixel(ctx, 50,25, 0,255,0,255, 0);
+isPixel(ctx, 1,1, 0,255,0,255, 0);
+isPixel(ctx, 98,1, 0,255,0,255, 0);
+isPixel(ctx, 1,48, 0,255,0,255, 0);
+isPixel(ctx, 98,48, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.twopie.1.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.twopie.1</p>
+<!-- Testing: ellipse() draws nothing when end = start + 2pi-e and anticlockwise -->
+<canvas id="c709" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_twopie_1() {
+
+var canvas = document.getElementById('c709');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.strokeStyle = '#f00';
+ctx.lineWidth = 100;
+ctx.beginPath();
+ctx.ellipse(50, 25, 50, 60, 0, 0, 2*Math.PI - 1e-4, true);
+ctx.stroke();
+isPixel(ctx, 50,20, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.twopie.2.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.twopie.2</p>
+<!-- Testing: ellipse() draws a full ellipse when end = start + 2pi-e and clockwise -->
+<canvas id="c710" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_twopie_2() {
+
+var canvas = document.getElementById('c710');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.strokeStyle = '#0f0';
+ctx.lineWidth = 100;
+ctx.beginPath();
+ctx.ellipse(50, 25, 50, 30, 0, 0, 2*Math.PI - 1e-4, false);
+ctx.stroke();
+isPixel(ctx, 50,20, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.twopie.3.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.twopie.3</p>
+<!-- Testing: ellipse() draws a full circle when end = start + 2pi+e and anticlockwise -->
+<canvas id="c711" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_twopie_3() {
+
+var canvas = document.getElementById('c711');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.strokeStyle = '#0f0';
+ctx.lineWidth = 100;
+ctx.beginPath();
+ctx.ellipse(50, 25, 50, 25, 0, 0, 2*Math.PI + 1e-4, true);
+ctx.stroke();
+isPixel(ctx, 50,20, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.twopie.4.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.twopie.4</p>
+<!-- Testing: ellipse() draws nothing when end = start + 2pi+e and clockwise -->
+<canvas id="c712" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_twopie_4() {
+
+var canvas = document.getElementById('c712');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00';
+ctx.fillRect(0, 0, 100, 50);
+ctx.strokeStyle = '#0f0';
+ctx.lineWidth = 100;
+ctx.beginPath();
+ctx.ellipse(50, 25, 50, 25, 0, 0, 2*Math.PI + 1e-4, false);
+ctx.stroke();
+isPixel(ctx, 50,20, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.zero.1.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.zero.1</p>
+<!-- Testing: ellipse() draws nothing when startAngle = endAngle and anticlockwise -->
+<canvas id="c713" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_zero_1() {
+
+var canvas = document.getElementById('c713');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.strokeStyle = '#f00';
+ctx.lineWidth = 100;
+ctx.beginPath();
+ctx.ellipse(50, 25, 50, 25, 0, 0, 0, true);
+ctx.stroke();
+isPixel(ctx, 50,20, 0,255,0,255, 0);
+
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.zero.2.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.zero.2</p>
+<!-- Testing: ellipse() draws nothing when startAngle = endAngle and clockwise -->
+<canvas id="c714" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+
+function test_2d_path_ellipse_zero_2() {
+
+var canvas = document.getElementById('c714');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.strokeStyle = '#f00';
+ctx.lineWidth = 100;
+ctx.beginPath();
+ctx.ellipse(50, 25, 50, 25, 0, 0, 0, true);
+ctx.stroke();
+isPixel(ctx, 50,20, 0,255,0,255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.zeroradius.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.zeroradius</p>
+<!-- Testing: ellipse() with zero radius draws a line to the start point -->
+<canvas id="c715" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_zeroradius() {
+
+var canvas = document.getElementById('c715');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#f00'
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 50;
+ctx.strokeStyle = '#0f0';
+ctx.beginPath();
+ctx.moveTo(0, 25);
+ctx.ellipse(200, 25, 0, 0, 0, 0, Math.PI, true);
+ctx.stroke();
+
+isPixel(ctx, 50, 25, 0, 255, 0, 255, 0);
+
+
+}
+</script>
+
+<!-- [[[ test_2d.path.ellipse.rotate.html ]]] -->
+
+<p>Canvas test: 2d.path.ellipse.rotate</p>
+<!-- Testing: ellipse() with a rotation angle works -->
+<canvas id="c716" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+<script>
+
+function test_2d_path_ellipse_rotate() {
+
+var canvas = document.getElementById('c716');
+var ctx = canvas.getContext('2d');
+
+ctx.fillStyle = '#0f0';
+ctx.fillRect(0, 0, 100, 50);
+ctx.lineWidth = 5;
+ctx.strokeStyle = '#f00';
+ctx.beginPath();
+ctx.ellipse(50, 25, 50, 25, Math.PI/4, 0, 2 * Math.PI, false);
+ctx.stroke();
+ctx.beginPath();
+ctx.ellipse(50, 25, 50, 25, -Math.PI/4, 0, 2 * Math.PI, false);
+ctx.stroke();
+isPixel(ctx, 50, 25, 0,255,0,255, 0);
+isPixel(ctx, 48,1, 0,255,0,255, 0);
+isPixel(ctx, 98,24, 0,255,0,255, 0);
+isPixel(ctx, 48,48, 0,255,0,255, 0);
+isPixel(ctx, 24,48, 0,255,0,255, 0);
+}
+</script>
+
 <script>
 
 function asyncTestsDone() {
 	if (isDone_test_2d_drawImage_animated_apng &&
+		isDone_test_2d_pattern_animated_gif &&
 		isDone_test_2d_drawImage_animated_gif) {
 		SimpleTest.finish();
 	} else {
@@ -24886,6 +25831,155 @@ try {
   ok(false, "unexpected exception thrown in: test_type_replace");
  }
  
+ //run the asynchronous tests
+ try {
+  test_2d_path_ellipse_angle_1();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_angle_1");
+ }
+ try {
+  test_2d_path_ellipse_angle_2();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_angle_2");
+ }
+ try {
+  test_2d_path_ellipse_angle_3();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_angle_3");
+ }
+ try {
+  test_2d_path_ellipse_angle_4();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_angle_4");
+ }
+ try {
+  test_2d_path_ellipse_angle_5();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_angle_5");
+ }
+ try {
+  test_2d_path_ellipse_angle_6();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_angle_6");
+ }
+ try {
+  test_2d_path_ellipse_empty();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_empty");
+ }
+ try {
+  test_2d_path_ellipse_end();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_end");
+ }
+ try {
+  test_2d_path_ellipse_negative();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_negative");
+ }
+ try {
+  test_2d_path_ellipse_nonempty();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_nonempty");
+ }
+ try {
+  test_2d_path_ellipse_nonfinite();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_nonfinite");
+ }
+ try {
+  test_2d_path_ellipse_scale_1();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_scale_1");
+ }
+ try {
+  test_2d_path_ellipse_scale_2();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_scale_2");
+ }
+ try {
+  test_2d_path_ellipse_selfintersect_1();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_selfintersect_1");
+ }
+ try {
+  test_2d_path_ellipse_selfintersect_2();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_selfintersect_2");
+ }
+ try {
+  test_2d_path_ellipse_shape_1();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_shape_1");
+ }
+ try {
+  test_2d_path_ellipse_shape_2();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_shape_2");
+ }
+ try {
+  test_2d_path_ellipse_shape_3();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_shape_3");
+ }
+ try {
+  test_2d_path_ellipse_shape_4();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_shape_4");
+ }
+ try {
+  test_2d_path_ellipse_twopie_1();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_twopie_1");
+ }
+ try {
+  test_2d_path_ellipse_twopie_2();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_twopie_2");
+ }
+ try {
+  test_2d_path_ellipse_twopie_3();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_twopie_3");
+ }
+ try {
+  test_2d_path_ellipse_twopie_4();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_twopie_4");
+ }
+ try {
+  test_2d_path_ellipse_zero_1();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_zero_1");
+ }
+ try {
+  test_2d_path_ellipse_zero_2();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_zero_2");
+ }
+ try {
+  test_2d_path_ellipse_zeroradius();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_zeroradius");
+ }
+ try {
+  test_2d_path_ellipse_rotate();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_2d_path_ellipse_rotate");
+ }
+ try {
+  // run this test last since it replaces the getContext method
+  test_type_replace();
+ } catch (e) {
+  ok(false, "unexpected exception thrown in: test_type_replace");
+ }
+ try {
+   test_2d_clearRect_testdoubleprecision();
+ } catch(e) {
+   throw e;
+   ok(false, "unexpected exception thrown in: test_2d_clearRect_testdoubleprecision");
+ }
+
  //run the asynchronous tests
  try {
   test_2d_drawImage_animated_apng();

--- a/dom/webidl/CanvasRenderingContext2D.webidl
+++ b/dom/webidl/CanvasRenderingContext2D.webidl
@@ -279,7 +279,9 @@ interface CanvasPathMethods {
 
   [Throws, LenientFloat]
   void arc(double x, double y, double radius, double startAngle, double endAngle, optional boolean anticlockwise = false); 
-// NOT IMPLEMENTED  [LenientFloat] void ellipse(double x, double y, double radiusX, double radiusY, double rotation, double startAngle, double endAngle, boolean anticlockwise);
+
+  [Throws, LenientFloat]
+  void ellipse(double x, double y, double radiusX, double radiusY, double rotation, double startAngle, double endAngle, optional boolean anticlockwise = false);
 };
 
 interface CanvasGradient {

--- a/gfx/2d/HelpersCairo.h
+++ b/gfx/2d/HelpersCairo.h
@@ -261,11 +261,18 @@ SetCairoStrokeOptions(cairo_t* aCtx, const StrokeOptions& aStrokeOptions)
   if (aStrokeOptions.mDashPattern) {
     // Convert array of floats to array of doubles
     std::vector<double> dashes(aStrokeOptions.mDashLength);
+    bool nonZero = false;
     for (size_t i = 0; i < aStrokeOptions.mDashLength; ++i) {
+      if (aStrokeOptions.mDashPattern[i] != 0) {
+        nonZero = true;
+      }
       dashes[i] = aStrokeOptions.mDashPattern[i];
     }
-    cairo_set_dash(aCtx, &dashes[0], aStrokeOptions.mDashLength,
-                   aStrokeOptions.mDashOffset);
+    // Avoid all-zero patterns that would trigger the CAIRO_STATUS_INVALID_DASH context error state.
+    if (nonZero) {
+      cairo_set_dash(aCtx, &dashes[0], aStrokeOptions.mDashLength,
+                     aStrokeOptions.mDashOffset);
+    }
   }
 
   cairo_set_line_join(aCtx, GfxLineJoinToCairoLineJoin(aStrokeOptions.mLineJoin));

--- a/layout/reftests/canvas/1074733-1-ref.html
+++ b/layout/reftests/canvas/1074733-1-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      function bodyonload() {
+        var canvas=document.getElementById('test');
+        var ctx = canvas.getContext("2d");
+        ctx.fillStyle = 'green';
+        ctx.fillRect(-1, 50, 151, 50); // left at -1
+        ctx.fillStyle = 'red';
+        ctx.rect(-1, 100, 151, 50); // left at -1
+        ctx.fill();
+        ctx.fillStyle = 'blue';
+        ctx.fillRect(0, 150, 150, 50); // left at 0
+      }
+    </script>
+  </head>
+  <body onload="bodyonload();">
+    <canvas id="test" width="200" height="200"></canvas>
+  </body>
+</html>
+

--- a/layout/reftests/canvas/1074733-1.html
+++ b/layout/reftests/canvas/1074733-1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <script type="text/javascript">
+      function bodyonload() {
+        var canvas=document.getElementById('test');
+        var ctx = canvas.getContext("2d");
+        ctx.fillStyle = 'green';
+        ctx.fillRect(150, 50, -151, 50); // left at -1
+        ctx.fillStyle = 'red';
+        ctx.rect(150, 100, -151, 50); // left at -1
+        ctx.fill();
+        ctx.fillStyle = 'blue';
+        ctx.fillRect(150, 150, -150, 50); // left at 0
+      }
+    </script>
+  </head>
+  <body onload="bodyonload();">
+    <canvas id="test" width="200" height="200"></canvas>
+  </body>
+</html>
+

--- a/layout/reftests/canvas/reftest.list
+++ b/layout/reftests/canvas/reftest.list
@@ -102,5 +102,5 @@ fails-if(OSX==1006) == 672646-alpha-radial-gradient.html 672646-alpha-radial-gra
 fuzzy-if(azureQuartz,2,128) fuzzy-if(d2d,12,21) == 784573-1.html 784573-1-ref.html
 
 == 802658-1.html 802658-1-ref.html
-
+== 1074733-1.html 1074733-1-ref.html
 == 1151821-1.html 1151821-1-ref.html

--- a/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativedest.html.ini
+++ b/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativedest.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.negativedest.html]
-  type: testharness
-  [Negative destination width/height represents the correct rectangle]
-    expected: FAIL
-

--- a/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativedir.html.ini
+++ b/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativedir.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.negativedir.html]
-  type: testharness
-  [Negative dimensions do not affect the direction of the image]
-    expected: FAIL
-

--- a/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativesource.html.ini
+++ b/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.negativesource.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.negativesource.html]
-  type: testharness
-  [Negative source width/height represents the correct rectangle]
-    expected: FAIL
-

--- a/testing/web-platform/meta/XMLHttpRequest/send-redirect-bogus-sync.htm.ini
+++ b/testing/web-platform/meta/XMLHttpRequest/send-redirect-bogus-sync.htm.ini
@@ -14,4 +14,3 @@
 
   [XMLHttpRequest: send() - Redirects (bogus Location header; sync) (303: tel:1234567890)]
     expected: FAIL
-

--- a/testing/web-platform/meta/html/dom/interfaces.html.ini
+++ b/testing/web-platform/meta/html/dom/interfaces.html.ini
@@ -1959,9 +1959,6 @@
   [CanvasRenderingContext2D interface: operation arcTo(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double)]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: operation ellipse(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,boolean)]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "width" with the proper type (1)]
     expected: FAIL
 
@@ -2050,12 +2047,6 @@
     expected: FAIL
 
   [CanvasRenderingContext2D interface: calling arcTo(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "ellipse" with the proper type (79)]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: calling ellipse(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,boolean) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
     expected: FAIL
 
   [TextMetrics interface: attribute actualBoundingBoxLeft]
@@ -2152,9 +2143,6 @@
     expected: FAIL
 
   [Path2D interface: operation arcTo(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double)]
-    expected: FAIL
-
-  [Path2D interface: operation ellipse(unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,unrestricted double,boolean)]
     expected: FAIL
 
   [DataTransfer interface object length]


### PR DESCRIPTION
An example:
[canvas-tests.zip](https://github.com/MoonchildProductions/Pale-Moon/files/828770/canvas-tests.zip)

Also:
http://www.corehtml5canvas.com/code-live/
https://html5test.com/ (385 vs. 383 points)

---

#### !! This page (an example) hangs browser (Pale Moon 27.1.2): !!:
https://bugzilla.mozilla.org/attachment.cgi?id=8638365

---

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=910138
https://bugzilla.mozilla.org/show_bug.cgi?id=1187210
https://bugzilla.mozilla.org/show_bug.cgi?id=1185636
https://bugzilla.mozilla.org/show_bug.cgi?id=1169609
https://bugzilla.mozilla.org/show_bug.cgi?id=1143317

https://bugzilla.mozilla.org/show_bug.cgi?id=1074733
https://bugzilla.mozilla.org/show_bug.cgi?id=1018527

---

I've created the new build (x32, Windows) and tested.

---

__I suggest trying on Linux (https://bugzilla.mozilla.org/show_bug.cgi?id=1169609)__
__and you add the label `Verification needed`, please.__
