### PR TITLE
Canvas: The bars of fractions, radicals etc. are not visible at some zoom levels (follow up)

### DIFF
--- a/dom/canvas/CanvasRenderingContext2D.cpp
+++ b/dom/canvas/CanvasRenderingContext2D.cpp
@@ -2440,9 +2440,9 @@ ValidateRect(double& aX, double& aY, double& aWidth, double& aHeight)
     aY -= aHeight;
   }
   return true;
- }
+}
  
- void
+void
 CanvasRenderingContext2D::ClearRect(double x, double y, double w,
                                     double h)
 {

--- a/gfx/2d/PathHelpers.h
+++ b/gfx/2d/PathHelpers.h
@@ -321,9 +321,14 @@ extern UserDataKey sDisablePixelSnapping;
  * boundaries.)  If on the other hand you stroking the rect with an odd valued
  * stroke width then the edges of the stroke will be antialiased (assuming an
  * AntialiasMode that does antialiasing).
+ *
+ * Empty snaps are those which result in a rectangle of 0 area.  If they are
+ * disallowed, an axis is left unsnapped if the rounding process results in a
+ * length of 0.
  */
 inline bool UserToDevicePixelSnapped(Rect& aRect, const DrawTarget& aDrawTarget,
-                                     bool aAllowScaleOr90DegreeRotate = false)
+                                     bool aAllowScaleOr90DegreeRotate = false,
+                                     bool aAllowEmptySnaps = true)
 {
   if (aDrawTarget.GetUserData(&sDisablePixelSnapping)) {
     return false;
@@ -352,8 +357,18 @@ inline bool UserToDevicePixelSnapped(Rect& aRect, const DrawTarget& aDrawTarget,
   // We actually only need to check one of p2 and p4, since an affine
   // transform maps parallelograms to parallelograms.
   if (p2 == Point(p1.x, p3.y) || p2 == Point(p3.x, p1.y)) {
-      p1.Round();
-      p3.Round();
+      Point p1r = p1;
+      Point p3r = p3;
+      p1r.Round();
+      p3r.Round();
+      if (aAllowEmptySnaps || p1r.x != p3r.x) {
+          p1.x = p1r.x;
+          p3.x = p3r.x;
+      }
+      if (aAllowEmptySnaps || p1r.y != p3r.y) {
+          p1.y = p1r.y;
+          p3.y = p3r.y;
+      }
 
       aRect.MoveTo(Point(std::min(p1.x, p3.x), std::min(p1.y, p3.y)));
       aRect.SizeTo(Size(std::max(p1.x, p3.x) - aRect.X(),
@@ -369,9 +384,11 @@ inline bool UserToDevicePixelSnapped(Rect& aRect, const DrawTarget& aDrawTarget,
  * aRect is not transformed to device space.
  */
 inline void MaybeSnapToDevicePixels(Rect& aRect, const DrawTarget& aDrawTarget,
-                                    bool aIgnoreScale = false)
+                                    bool aAllowScaleOr90DegreeRotate = false,
+                                    bool aAllowEmptySnaps = true)
 {
-  if (UserToDevicePixelSnapped(aRect, aDrawTarget, aIgnoreScale)) {
+  if (UserToDevicePixelSnapped(aRect, aDrawTarget,
+                               aAllowScaleOr90DegreeRotate, aAllowEmptySnaps)) {
     // Since UserToDevicePixelSnapped returned true we know there is no
     // rotation/skew in 'mat', so we can just use TransformBounds() here.
     Matrix mat = aDrawTarget.GetTransform();

--- a/layout/base/nsLayoutUtils.cpp
+++ b/layout/base/nsLayoutUtils.cpp
@@ -7808,6 +7808,21 @@ Rect NSRectToSnappedRect(const nsRect& aRect, double aAppUnitsPerPixel,
   return rect;
 }
 
+// Similar to a snapped rect, except an axis is left unsnapped if the snapping
+// process results in a length of 0.
+Rect NSRectToNonEmptySnappedRect(const nsRect& aRect, double aAppUnitsPerPixel,
+                                 const gfx::DrawTarget& aSnapDT)
+{
+  // Note that by making aAppUnitsPerPixel a double we're doing floating-point
+  // division using a larger type and avoiding rounding error.
+  Rect rect(Float(aRect.x / aAppUnitsPerPixel),
+            Float(aRect.y / aAppUnitsPerPixel),
+            Float(aRect.width / aAppUnitsPerPixel),
+            Float(aRect.height / aAppUnitsPerPixel));
+  MaybeSnapToDevicePixels(rect, aSnapDT, true, false);
+  return rect;
+}
+
 void StrokeLineWithSnapping(const nsPoint& aP1, const nsPoint& aP2,
                             int32_t aAppUnitsPerDevPixel,
                             DrawTarget& aDrawTarget,

--- a/layout/base/nsLayoutUtils.h
+++ b/layout/base/nsLayoutUtils.h
@@ -2668,6 +2668,17 @@ gfx::Rect NSRectToRect(const nsRect& aRect, double aAppUnitsPerPixel);
 gfx::Rect NSRectToSnappedRect(const nsRect& aRect, double aAppUnitsPerPixel,
                               const gfx::DrawTarget& aSnapDT);
 
+/**
+* Converts, where possible, an nsRect in app units to a Moz2D Rect in pixels
+* (whether those are device pixels or CSS px depends on what the caller
+*  chooses to pass as aAppUnitsPerPixel).
+*
+* If snapping results in a rectangle with zero width or height, the affected
+* coordinates are left unsnapped
+*/
+gfx::Rect NSRectToNonEmptySnappedRect(const nsRect& aRect, double aAppUnitsPerPixel,
+                                      const gfx::DrawTarget& aSnapDT);
+
 void StrokeLineWithSnapping(const nsPoint& aP1, const nsPoint& aP2,
                             int32_t aAppUnitsPerDevPixel,
                             gfx::DrawTarget& aDrawTarget,

--- a/layout/mathml/nsMathMLFrame.cpp
+++ b/layout/mathml/nsMathMLFrame.cpp
@@ -362,9 +362,10 @@ void nsDisplayMathMLBar::Paint(nsDisplayListBuilder* aBuilder,
 {
   // paint the bar with the current text color
   DrawTarget* drawTarget = aCtx->GetDrawTarget();
-  Rect rect = NSRectToSnappedRect(mRect + ToReferenceFrame(),
-                                  mFrame->PresContext()->AppUnitsPerDevPixel(),
-                                  *drawTarget);
+  Rect rect =
+    NSRectToNonEmptySnappedRect(mRect + ToReferenceFrame(),
+                                mFrame->PresContext()->AppUnitsPerDevPixel(),
+                                *drawTarget);
   ColorPattern color(ToDeviceColor(
                        mFrame->GetVisitedDependentColor(eCSSProperty_color)));
   drawTarget->FillRect(rect, color);

--- a/layout/reftests/mathml/radicalbar-1.html
+++ b/layout/reftests/mathml/radicalbar-1.html
@@ -1,0 +1,48 @@
+<!doctype html>
+  <html>
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="visible">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-1a.html
+++ b/layout/reftests/mathml/radicalbar-1a.html
@@ -1,0 +1,48 @@
+<!doctype html>
+  <html reftest-zoom=".5">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="visible">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-1b.html
+++ b/layout/reftests/mathml/radicalbar-1b.html
@@ -1,0 +1,48 @@
+<!doctype html>
+  <html reftest-zoom=".4">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="visible">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-1c.html
+++ b/layout/reftests/mathml/radicalbar-1c.html
@@ -1,0 +1,48 @@
+<!doctype html>
+  <html reftest-zoom=".3">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="visible">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-1d.html
+++ b/layout/reftests/mathml/radicalbar-1d.html
@@ -1,0 +1,48 @@
+<!doctype html>
+  <html reftest-zoom=".2">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="visible">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-2.html
+++ b/layout/reftests/mathml/radicalbar-2.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html>
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="visible">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-2a.html
+++ b/layout/reftests/mathml/radicalbar-2a.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html reftest-zoom="0.5">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="visible">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-2b.html
+++ b/layout/reftests/mathml/radicalbar-2b.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html reftest-zoom="0.4">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="visible">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-2c.html
+++ b/layout/reftests/mathml/radicalbar-2c.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html reftest-zoom="0.3">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="visible">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-2d.html
+++ b/layout/reftests/mathml/radicalbar-2d.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html reftest-zoom="0.2">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="hidden">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="visible">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-3.html
+++ b/layout/reftests/mathml/radicalbar-3.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html>
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="visible">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-3a.html
+++ b/layout/reftests/mathml/radicalbar-3a.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html reftest-zoom="0.5">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="visible">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-3b.html
+++ b/layout/reftests/mathml/radicalbar-3b.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html reftest-zoom="0.4">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="visible">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-3c.html
+++ b/layout/reftests/mathml/radicalbar-3c.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html reftest-zoom="0.3">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="visible">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/radicalbar-3d.html
+++ b/layout/reftests/mathml/radicalbar-3d.html
@@ -1,0 +1,47 @@
+<!doctype html>
+  <html reftest-zoom="0.2">
+  <head>
+    <!-- Default to invisible text -->
+    <style type="text/css" media="screen, print">
+      .hidden {
+        color: white;
+      }
+      .visible {
+        color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Nest successive radicals and test that the horizontal bar of one of them is drawn.
+         Because the comparison is for inequality with about:blank, at most one can be visible -->
+    <math>
+      <mrow>
+        <msqrt class="hidden">
+          <mspace width="1em" height="1em" />
+          <msqrt class="hidden">
+            <mspace width="1em" height="1em" />
+            <msqrt class="hidden">
+              <mspace width="1em" height="1em" />
+              <msqrt class="hidden">
+                <mspace width="1em" height="1em" />
+                <msqrt class="visible">
+                  <mspace width="1em" height="1em" />
+                  <msqrt class="hidden">
+                    <mspace width="1em" height="1em" />
+                    <msqrt class="hidden">
+                      <mspace width="20em" height="1em" />
+                    </msqrt>
+                  </msqrt>
+                </msqrt>
+              </msqrt>
+            </msqrt>
+          </msqrt>
+        </msqrt>
+      </mrow>
+    </math>
+
+    <!-- Block out all but the horizontal bar of the visible radical -->
+    <div style="position: absolute; top: 5px; left: 0px;
+                width: 20em; height: 10em; background: white;"></div>
+  </body>
+</html>

--- a/layout/reftests/mathml/reftest.list
+++ b/layout/reftests/mathml/reftest.list
@@ -361,3 +361,18 @@ random-if(winWidget&&!/^Windows\x20NT\x205\.1/.test(http.oscpu)) == mfrac-D-2.ht
 == mfrac-E-1.html mfrac-E-1-ref.html
 test-pref(dom.webcomponents.enabled,true) == shadow-dom-1.html shadow-dom-1-ref.html
 pref(font.size.inflation.emPerLine,25) == font-inflation-1.html font-inflation-1-ref.html
+!= radicalbar-1.html about:blank
+!= radicalbar-1a.html about:blank
+!= radicalbar-1b.html about:blank
+!= radicalbar-1c.html about:blank
+!= radicalbar-1d.html about:blank
+!= radicalbar-2.html about:blank
+!= radicalbar-2a.html about:blank
+!= radicalbar-2b.html about:blank
+!= radicalbar-2c.html about:blank
+!= radicalbar-2d.html about:blank
+!= radicalbar-3.html about:blank
+!= radicalbar-3a.html about:blank
+!= radicalbar-3b.html about:blank
+!= radicalbar-3c.html about:blank
+!= radicalbar-3d.html about:blank


### PR DESCRIPTION
The bars of fractions, radicals etc. are not visible at some zoom levels:

![27 1 2](https://cloud.githubusercontent.com/assets/2373486/23739820/0b4182ca-04a1-11e7-94a2-6608473e4006.png)

vs.

![27 2 0](https://cloud.githubusercontent.com/assets/2373486/23739824/0f2a691a-04a1-11e7-848f-b968f8f4aa9f.png)

Follow up (style clean up):
#946 

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1011020
(https://bugzilla.mozilla.org/show_bug.cgi?id=1165896)

---

I've created the new build (x32, Windows) and tested.
