### PR TITLE
Using "View Image" and "Save Image As" on a large canvas doesn't work (follow up)

### DIFF
--- a/browser/base/content/nsContextMenu.js
+++ b/browser/base/content/nsContextMenu.js
@@ -1210,7 +1210,7 @@ nsContextMenu.prototype = {
       var win = doc.defaultView;
       if (!win) {
         Components.utils.reportError(
-            "View Image (on the <canvas> element):\n" +
+            "Save Image As (on the <canvas> element):\n" +
             "This feature cannot be used, because it hasn't found " + 
             "an appropriate window.");
       } else {


### PR DESCRIPTION
Follow up to #933 

We cannot use the chrome window. Every blob allocated memory which has not been released after closing the window/tab. And the blob still exist within its chrome window.

---

I've created the new build (x32, Windows) and tested.
