### PR TITLE
Limit number of history entries saved by SessionStore [proper]

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -781,6 +781,10 @@ pref("browser.sessionstore.max_windows_undo", 3);
 // number of crashes that can occur before the about:sessionrestore page is displayed
 // (this pref has no effect if more than 6 hours have passed since the last crash)
 pref("browser.sessionstore.max_resumed_crashes", 1);
+// number of back button session history entries to save (-1 = all of them)
+pref("browser.sessionstore.max_serialize_back", 10);
+// number of forward button session history entries to save (-1 = all of them)
+pref("browser.sessionstore.max_serialize_forward", -1);
 // restore_on_demand overrides browser.sessionstore.max_concurrent_tabs
 // and restore_hidden_tabs. When true, tabs will not be restored until they are
 // focused (also applies to tabs that aren't visible). When false, the values

--- a/browser/components/sessionstore/SessionStore.jsm
+++ b/browser/components/sessionstore/SessionStore.jsm
@@ -1861,44 +1861,59 @@ let SessionStoreInternal = {
     }
     catch (ex) { } // this could happen if we catch a tab during (de)initialization
 
+    // Limit number of back/forward button history entries to save
+    let oldest, newest;
+    let maxSerializeBack = this._prefBranch.getIntPref("sessionstore.max_serialize_back");
+    if (maxSerializeBack >= 0) {
+      oldest = Math.max(0, history.index - maxSerializeBack);
+    } else { // History.getEntryAtIndex(0, ...) is the oldest.
+      oldest = 0;
+    }
+    let maxSerializeFwd = this._prefBranch.getIntPref("sessionstore.max_serialize_forward");
+    if (maxSerializeFwd >= 0) {
+      newest = Math.min(history.count - 1, history.index + maxSerializeFwd);
+    } else { // History.getEntryAtIndex(history.count - 1, ...) is the newest.
+      newest = history.count - 1;
+    }
+
     // XXXzeniko anchor navigation doesn't reset __SS_data, so we could reuse
     //           data even when we shouldn't (e.g. Back, different anchor)
+    // Warning: this is required to save form data and scrolling position!
     if (history && browser.__SS_data &&
         browser.__SS_data.entries[history.index] &&
         browser.__SS_data.entries[history.index].url == browser.currentURI.spec &&
         history.index < this._sessionhistory_max_entries - 1 && !aFullData) {
-      tabData = browser.__SS_data;
-      tabData.index = history.index + 1;
+      try {
+        tabData.entries = browser.__SS_data.entries.slice(oldest, newest + 1);
+      }
+      catch (ex) {
+        // No errors are expected above, but we use try-catch to keep sessionstore.js safe
+        NS_ASSERT(false, "SessionStore failed to slice history from browser.__SS_data");
+      }
+
+      // Set the one-based index of the currently active tab, ensuring it isn't out of bounds
+      tabData.index = Math.min(history.index - oldest + 1, tabData.entries.length);
     }
     else if (history && history.count > 0) {
       browser.__SS_hostSchemeData = [];
       try {
-        for (var j = 0; j < history.count; j++) {
+        for (var j = oldest; j <= newest; j++) {
           let entry = this._serializeHistoryEntry(history.getEntryAtIndex(j, false),
                                                   aFullData, aTab.pinned, browser.__SS_hostSchemeData);
           tabData.entries.push(entry);
         }
-        // If we make it through the for loop, then we're ok and we should clear
-        // any indicator of brokenness.
-        delete aTab.__SS_broken_history;
       }
       catch (ex) {
         // In some cases, getEntryAtIndex will throw. This seems to be due to
         // history.count being higher than it should be. By doing this in a
         // try-catch, we'll update history to where it breaks, assert for
-        // non-release builds, and still save sessionstore.js. We'll track if
-        // we've shown the assert for this tab so we only show it once.
-        // cf. bug 669196.
-        if (!aTab.__SS_broken_history) {
-          // First Focus the window & tab we're having trouble with.
-          aTab.ownerDocument.defaultView.focus();
-          aTab.ownerDocument.defaultView.gBrowser.selectedTab = aTab;
-          NS_ASSERT(false, "SessionStore failed gathering complete history " +
-                           "for the focused window/tab. See bug 669196.");
-          aTab.__SS_broken_history = true;
-        }
+        // non-release builds, and still save sessionstore.js.
+        NS_ASSERT(false, "SessionStore failed gathering complete history " +
+                         "for the focused window/tab. See bug 669196.");
       }
-      tabData.index = history.index + 1;
+
+      // Set the one-based index of the currently active tab, ensuring it isn't out of bounds
+      tabData.index = Math.min(history.index - oldest + 1, tabData.entries.length);
 
       // make sure not to cache privacy sensitive data which shouldn't get out
       if (!aFullData)


### PR DESCRIPTION
Limit number of back/forward button history entries saved by SessionStore for each tab. 

Replaces #950.

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=943339.