### PR TITLE
Implement a new media TailDispatcher

### DIFF
--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -6,6 +6,7 @@
 
 #include "AbstractThread.h"
 
+#include "MediaTaskQueue.h"
 #include "nsThreadUtils.h"
 
 #include "mozilla/ClearOnShutdown.h"
@@ -27,7 +28,9 @@ template<>
 bool
 AbstractThreadImpl<nsIThread>::IsCurrentThreadIn()
 {
-  return NS_GetCurrentThread() == mTarget;
+  bool in = NS_GetCurrentThread() == mTarget;
+  MOZ_ASSERT_IF(in, MediaTaskQueue::GetCurrentQueue() == nullptr);
+  return in;
 }
 
 AbstractThread*

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -20,6 +20,7 @@ template<>
 nsresult
 AbstractThreadImpl<nsIThread>::Dispatch(already_AddRefed<nsIRunnable> aRunnable)
 {
+  MediaTaskQueue::AssertInTailDispatchIfNeeded();
   nsCOMPtr<nsIRunnable> r = aRunnable;
   return mTarget->Dispatch(r, NS_DISPATCH_NORMAL);
 }

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -38,16 +38,15 @@ AbstractThread::MainThread()
 }
 
 void
-AbstractThread::EnsureMainThreadSingleton()
+AbstractThread::InitStatics()
 {
   MOZ_ASSERT(NS_IsMainThread());
-  if (!sMainThread) {
-    nsCOMPtr<nsIThread> mainThread;
-    NS_GetMainThread(getter_AddRefs(mainThread));
-    MOZ_DIAGNOSTIC_ASSERT(mainThread);
-    sMainThread = AbstractThread::Create(mainThread.get());
-    ClearOnShutdown(&sMainThread);
-  }
+  MOZ_ASSERT(!sMainThread);
+  nsCOMPtr<nsIThread> mainThread;
+  NS_GetMainThread(getter_AddRefs(mainThread));
+  MOZ_DIAGNOSTIC_ASSERT(mainThread);
+  sMainThread = AbstractThread::Create(mainThread.get());
+  ClearOnShutdown(&sMainThread);
 }
 
 } // namespace mozilla

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -34,6 +34,20 @@ AbstractThreadImpl<nsIThread>::IsCurrentThreadIn()
   return in;
 }
 
+void
+AbstractThread::MaybeTailDispatch(already_AddRefed<nsIRunnable> aRunnable,
+                                  bool aAssertDispatchSuccess)
+{
+  MediaTaskQueue* currentQueue = MediaTaskQueue::GetCurrentQueue();
+  if (currentQueue && currentQueue->RequiresTailDispatch()) {
+    currentQueue->TailDispatcher().AddTask(this, Move(aRunnable), aAssertDispatchSuccess);
+  } else {
+    nsresult rv = Dispatch(Move(aRunnable));
+    MOZ_DIAGNOSTIC_ASSERT(!aAssertDispatchSuccess || NS_SUCCEEDED(rv));
+    unused << rv;
+  }
+}
+
 AbstractThread*
 AbstractThread::MainThread()
 {

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -63,7 +63,7 @@ AbstractThread::InitStatics()
   nsCOMPtr<nsIThread> mainThread;
   NS_GetMainThread(getter_AddRefs(mainThread));
   MOZ_DIAGNOSTIC_ASSERT(mainThread);
-  sMainThread = AbstractThread::Create(mainThread.get());
+  sMainThread = new AbstractThreadImpl<nsIThread>(mainThread.get());
   ClearOnShutdown(&sMainThread);
 }
 

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -23,10 +23,10 @@ namespace mozilla {
  * nsIEventTarget for this purpose. This class encapsulates the specifics of
  * the structures we might use here and provides a consistent interface.
  *
- * Use AbstractThread::Create() to instantiate an AbstractThread. Note that
- * if you use different types than the ones currently supported (MediaTaskQueue
- * and nsIThread), you'll need to implement the relevant guts in
- * AbstractThread.cpp to avoid linkage errors.
+ * At present, the supported AbstractThread implementations are MediaTaskQueue
+ * and AbstractThread::MainThread. If you add support for another thread that is
+ * not the MainThread, you'll need to figure out how to make it unique such that
+ * comparing AbstractThread pointers is equivalent to comparing nsIThread pointers.
  */
 class AbstractThread
 {
@@ -39,8 +39,6 @@ public:
   // a thread that requires runnables to be dispatched with tail dispatch.
   void MaybeTailDispatch(already_AddRefed<nsIRunnable> aRunnable,
                          bool aAssertDispatchSuccess = true);
-
-  template<typename TargetType> static AbstractThread* Create(TargetType* aTarget);
 
   // Convenience method for getting an AbstractThread for the main thread.
   static AbstractThread* MainThread();
@@ -61,13 +59,6 @@ public:
   virtual bool IsCurrentThreadIn();
 private:
   nsRefPtr<TargetType> mTarget;
-};
-
-template<typename TargetType>
-AbstractThread*
-AbstractThread::Create(TargetType* aTarget)
-{
-  return new AbstractThreadImpl<TargetType>(aTarget);
 };
 
 } // namespace mozilla

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -35,6 +35,11 @@ public:
   virtual nsresult Dispatch(already_AddRefed<nsIRunnable> aRunnable) = 0;
   virtual bool IsCurrentThreadIn() = 0;
 
+  // Convenience method for dispatching a runnable when we may be running on
+  // a thread that requires runnables to be dispatched with tail dispatch.
+  void MaybeTailDispatch(already_AddRefed<nsIRunnable> aRunnable,
+                         bool aAssertDispatchSuccess = true);
+
   template<typename TargetType> static AbstractThread* Create(TargetType* aTarget);
 
   // Convenience method for getting an AbstractThread for the main thread.

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -38,11 +38,10 @@ public:
   template<typename TargetType> static AbstractThread* Create(TargetType* aTarget);
 
   // Convenience method for getting an AbstractThread for the main thread.
-  //
-  // EnsureMainThreadSingleton must be called on the main thread before any
-  // other threads that might use MainThread() are spawned.
   static AbstractThread* MainThread();
-  static void EnsureMainThreadSingleton();
+
+  // Must be called exactly once during startup.
+  static void InitStatics();
 
 protected:
   virtual ~AbstractThread() {}

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -120,6 +120,8 @@ void
 MediaDecoder::InitStatics()
 {
   AbstractThread::InitStatics();
+
+  MediaTaskQueue::InitStatics();
 }
 
 NS_IMPL_ISUPPORTS(MediaMemoryTracker, nsIMemoryReporter)

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -116,6 +116,12 @@ public:
 
 StaticRefPtr<MediaMemoryTracker> MediaMemoryTracker::sUniqueInstance;
 
+void
+MediaDecoder::InitStatics()
+{
+  AbstractThread::InitStatics();
+}
+
 NS_IMPL_ISUPPORTS(MediaMemoryTracker, nsIMemoryReporter)
 
 NS_IMPL_ISUPPORTS(MediaDecoder, nsIObserver)
@@ -606,7 +612,6 @@ MediaDecoder::MediaDecoder() :
   MOZ_COUNT_CTOR(MediaDecoder);
   MOZ_ASSERT(NS_IsMainThread());
   MediaMemoryTracker::AddMediaDecoder(this);
-  AbstractThread::EnsureMainThreadSingleton();
 #ifdef PR_LOGGING
   if (!gMediaDecoderLog) {
     gMediaDecoderLog = PR_NewLogModule("MediaDecoder");

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -290,6 +290,9 @@ public:
     PLAY_STATE_SHUTDOWN
   };
 
+  // Must be called exactly once, on the main thread, during startup.
+  static void InitStatics();
+
   MediaDecoder();
 
   // Reset the decoder and notify the media element that

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -797,6 +797,7 @@ MediaDecoderStateMachine::OnAudioDecoded(AudioData* aAudioSample)
 void
 MediaDecoderStateMachine::Push(AudioData* aSample)
 {
+  MOZ_ASSERT(OnTaskQueue());
   MOZ_ASSERT(aSample);
   // TODO: Send aSample to MSG and recalculate readystate before pushing,
   // otherwise AdvanceFrame may pop the sample before we have a chance
@@ -814,6 +815,7 @@ MediaDecoderStateMachine::Push(AudioData* aSample)
 void
 MediaDecoderStateMachine::Push(VideoData* aSample)
 {
+  MOZ_ASSERT(OnTaskQueue());
   MOZ_ASSERT(aSample);
   // TODO: Send aSample to MSG and recalculate readystate before pushing,
   // otherwise AdvanceFrame may pop the sample before we have a chance
@@ -1176,6 +1178,7 @@ void MediaDecoderStateMachine::StopPlayback()
 
 void MediaDecoderStateMachine::MaybeStartPlayback()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   if (IsPlaying()) {
     // Logging this case is really spammy - don't do it.
@@ -1232,6 +1235,7 @@ void MediaDecoderStateMachine::UpdatePlaybackPositionInternal(int64_t aTime)
 
 void MediaDecoderStateMachine::UpdatePlaybackPosition(int64_t aTime)
 {
+  MOZ_ASSERT(OnTaskQueue());
   UpdatePlaybackPositionInternal(aTime);
 
   bool fragmentEnded = mFragmentEndTime >= 0 && GetMediaTime() >= mFragmentEndTime;
@@ -1727,6 +1731,7 @@ MediaDecoderStateMachine::SetReaderIdle()
 void
 MediaDecoderStateMachine::DispatchDecodeTasksIfNeeded()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
 
   if (mState != DECODER_STATE_DECODING &&
@@ -2168,6 +2173,7 @@ MediaDecoderStateMachine::OnMetadataNotRead(ReadMetadataFailureReason aReason)
 void
 MediaDecoderStateMachine::EnqueueLoadedMetadataEvent()
 {
+  MOZ_ASSERT(OnTaskQueue());
   nsAutoPtr<MediaInfo> info(new MediaInfo());
   *info = mInfo;
   MediaDecoderEventVisibility visibility = mSentLoadedMetadataEvent?
@@ -2182,6 +2188,7 @@ MediaDecoderStateMachine::EnqueueLoadedMetadataEvent()
 void
 MediaDecoderStateMachine::EnqueueFirstFrameLoadedEvent()
 {
+  MOZ_ASSERT(OnTaskQueue());
   nsAutoPtr<MediaInfo> info(new MediaInfo());
   *info = mInfo;
   MediaDecoderEventVisibility visibility = mSentFirstFrameLoadedEvent?

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -244,7 +244,8 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
   mDisabledHardwareAcceleration(false),
   mDecodingFrozenAtStateDecoding(false),
   mSentLoadedMetadataEvent(false),
-  mSentFirstFrameLoadedEvent(false)
+  mSentFirstFrameLoadedEvent(false),
+  mSentPlaybackEndedEvent(false)
 {
   MOZ_COUNT_CTOR(MediaDecoderStateMachine);
   NS_ASSERTION(NS_IsMainThread(), "Should be on main thread.");
@@ -1303,6 +1304,9 @@ void MediaDecoderStateMachine::SetState(State aState)
               gMachineStateStr[mState], gMachineStateStr[aState]);
 
   mState = aState;
+
+  // Clear state-scoped state.
+  mSentPlaybackEndedEvent = false;
 }
 
 void MediaDecoderStateMachine::SetVolume(double volume)
@@ -2703,21 +2707,18 @@ nsresult MediaDecoderStateMachine::RunStateMachine()
 
       StopAudioThread();
 
-      if (mDecoder->GetState() == MediaDecoder::PLAY_STATE_PLAYING) {
+      if (mDecoder->GetState() == MediaDecoder::PLAY_STATE_PLAYING &&
+          !mSentPlaybackEndedEvent)
+      {
         int64_t clockTime = std::max(mAudioEndTime, mVideoFrameEndTime);
         clockTime = std::max(int64_t(0), std::max(clockTime, mEndTime));
         UpdatePlaybackPosition(clockTime);
 
-        {
-          // Wait for the state change is completed in the main thread,
-          // otherwise we might see |mDecoder->GetState() == MediaDecoder::PLAY_STATE_PLAYING|
-          // in next loop and send |MediaDecoder::PlaybackEnded| again to trigger 'ended'
-          // event twice in the media element.
-          ReentrantMonitorAutoExit exitMon(mDecoder->GetReentrantMonitor());
-          nsCOMPtr<nsIRunnable> event =
-            NS_NewRunnableMethod(mDecoder, &MediaDecoder::PlaybackEnded);
-          NS_DispatchToMainThread(event, NS_DISPATCH_SYNC);
-        }
+        nsCOMPtr<nsIRunnable> event =
+          NS_NewRunnableMethod(mDecoder, &MediaDecoder::PlaybackEnded);
+        NS_DispatchToMainThread(event, NS_DISPATCH_NORMAL);
+
+        mSentPlaybackEndedEvent = true;
       }
       return NS_OK;
     }

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -780,6 +780,7 @@ protected:
 
       void Ensure(mozilla::TimeStamp& aTarget)
       {
+        MOZ_ASSERT(mSelf->OnTaskQueue());
         if (IsScheduled() && mTarget <= aTarget) {
           return;
         }

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -328,6 +328,22 @@ public:
 
   void NotifyDataArrived(const char* aBuffer, uint32_t aLength, int64_t aOffset);
 
+  // Returns the tail dispatcher associated with TaskQueue(), which will fire
+  // its tasks when the current task completes. May only be called when running
+  // in TaskQueue().
+  TaskDispatcher& TailDispatcher()
+  {
+    MOZ_ASSERT(OnTaskQueue());
+    return TaskQueue()->TailDispatcher();
+  }
+
+  // Convenience method to perform a tail dispatch.
+  void TailDispatch(AbstractThread* aThread,
+                    already_AddRefed<nsIRunnable> aTask)
+  {
+    TailDispatcher().AddTask(aThread, Move(aTask));
+  }
+
   // Returns the state machine task queue.
   MediaTaskQueue* TaskQueue() const { return mTaskQueue; }
 
@@ -789,7 +805,7 @@ protected:
         mRequest.Begin(mMediaTimer->WaitUntil(mTarget, __func__)->RefableThen(
           mSelf->TaskQueue(), __func__, mSelf,
           &MediaDecoderStateMachine::OnDelayedSchedule,
-          &MediaDecoderStateMachine::NotReached));
+          &MediaDecoderStateMachine::NotReached, mSelf->TailDispatcher()));
       }
 
       void CompleteRequest()
@@ -879,17 +895,17 @@ protected:
     return mTarget.IsValid();
   }
 
-  void Resolve(bool aAtEnd, const char* aCallSite)
+  void Resolve(bool aAtEnd, const char* aCallSite, TaskDispatcher& aDispatcher)
   {
     mTarget.Reset();
     MediaDecoder::SeekResolveValue val(aAtEnd, mTarget.mEventVisibility);
-    mPromise.Resolve(val, aCallSite);
+    mPromise.Resolve(val, aCallSite, aDispatcher);
   }
 
-  void RejectIfExists(const char* aCallSite)
+  void RejectIfExists(const char* aCallSite, TaskDispatcher& aDispatcher)
   {
     mTarget.Reset();
-    mPromise.RejectIfExists(true, aCallSite);
+    mPromise.RejectIfExists(true, aCallSite, aDispatcher);
   }
 
   ~SeekJob()

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -1213,6 +1213,8 @@ protected:
   // to decode any audio/video since the MediaDecoder will trigger a seek
   // operation soon.
   bool mSentFirstFrameLoadedEvent;
+
+  bool mSentPlaybackEndedEvent;
 };
 
 } // namespace mozilla;

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -311,8 +311,6 @@ public:
                                          ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod,
                                          TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
-    MutexAutoLock lock(mMutex);
-
     // {Refable,}Then() rarely dispatch directly - they do so only in the case
     // where the promise has already been resolved by the time {Refable,}Then()
     // is invoked. This case is rare, but it _can_ happen, which makes it a ripe
@@ -322,6 +320,7 @@ public:
     // infrequently.
     aDispatcher.AssertIsTailDispatcherIfRequired();
 
+    MutexAutoLock lock(mMutex);
     MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveConsumer);
     mHaveConsumer = true;
     nsRefPtr<ThenValueBase> thenValue = new ThenValue<ThisType, ResolveMethodType, RejectMethodType>(

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -10,6 +10,7 @@
 #include "prlog.h"
 
 #include "AbstractThread.h"
+#include "TaskDispatcher.h"
 
 #include "nsTArray.h"
 #include "nsThreadUtils.h"
@@ -74,18 +75,20 @@ public:
   class Private;
 
   static nsRefPtr<MediaPromise>
-  CreateAndResolve(ResolveValueType aResolveValue, const char* aResolveSite)
+  CreateAndResolve(ResolveValueType aResolveValue, const char* aResolveSite,
+                   TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     nsRefPtr<typename MediaPromise::Private> p = new MediaPromise::Private(aResolveSite);
-    p->Resolve(aResolveValue, aResolveSite);
+    p->Resolve(aResolveValue, aResolveSite, aDispatcher);
     return Move(p);
   }
 
   static nsRefPtr<MediaPromise>
-  CreateAndReject(RejectValueType aRejectValue, const char* aRejectSite)
+  CreateAndReject(RejectValueType aRejectValue, const char* aRejectSite,
+                  TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     nsRefPtr<typename MediaPromise::Private> p = new MediaPromise::Private(aRejectSite);
-    p->Reject(aRejectValue, aRejectSite);
+    p->Reject(aRejectValue, aRejectSite, aDispatcher);
     return Move(p);
   }
 
@@ -171,7 +174,8 @@ protected:
 
     explicit ThenValueBase(const char* aCallSite) : mCallSite(aCallSite) {}
 
-    virtual void Dispatch(MediaPromise *aPromise) = 0;
+    virtual void Dispatch(MediaPromise *aPromise,
+                          TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>()) = 0;
 
   protected:
     virtual void DoResolve(ResolveValueType aResolveValue) = 0;
@@ -219,7 +223,7 @@ protected:
       , mResolveMethod(aResolveMethod)
       , mRejectMethod(aRejectMethod) {}
 
-    void Dispatch(MediaPromise *aPromise) override
+    void Dispatch(MediaPromise *aPromise, TaskDispatcher& aDispatcher) override
     {
       aPromise->mMutex.AssertCurrentThreadOwns();
       MOZ_ASSERT(!aPromise->IsPending());
@@ -230,16 +234,12 @@ protected:
       PROMISE_LOG("%s Then() call made from %s [Runnable=%p, Promise=%p, ThenValue=%p]",
                   resolved ? "Resolving" : "Rejecting", ThenValueBase::mCallSite,
                   runnable.get(), aPromise, this);
-      nsresult rv = mResponseTarget->Dispatch(runnable.forget());
 
-      // NB: mDisconnected is only supposed to be accessed on the dispatch
-      // thread. However, we require the consumer to have disconnected any
-      // oustanding promise requests _before_ initiating shutdown on the
-      // thread or task queue. So the only non-buggy scenario for dispatch
-      // failing involves the target thread being unable to manipulate the
-      // ThenValue (since it's been disconnected), so it's safe to read here.
-      MOZ_DIAGNOSTIC_ASSERT(NS_SUCCEEDED(rv) || Consumer::mDisconnected);
-      unused << rv;
+      // Promise consumers are allowed to disconnect the Consumer object and
+      // then shut down the thread or task queue that the promise result would
+      // be dispatched on. So we unfortunately can't assert that promise
+      // dispatch succeeds. :-(
+      aDispatcher.AddTask(mResponseTarget, runnable.forget(), /* aAssertDispatchSuccess = */ false);
     }
 
 #ifdef DEBUG
@@ -308,9 +308,20 @@ public:
 
   template<typename ThisType, typename ResolveMethodType, typename RejectMethodType>
   already_AddRefed<Consumer> RefableThen(AbstractThread* aResponseThread, const char* aCallSite, ThisType* aThisVal,
-                                         ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod)
+                                         ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod,
+                                         TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     MutexAutoLock lock(mMutex);
+
+    // {Refable,}Then() rarely dispatch directly - they do so only in the case
+    // where the promise has already been resolved by the time {Refable,}Then()
+    // is invoked. This case is rare, but it _can_ happen, which makes it a ripe
+    // target for race bugs. So we do an extra assertion here to make sure our
+    // caller is using tail dispatch correctly no matter what, rather than
+    // relying on the assertion in Dispatch(), which may be called extremely
+    // infrequently.
+    aDispatcher.AssertIsTailDispatcherIfRequired();
+
     MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveConsumer);
     mHaveConsumer = true;
     nsRefPtr<ThenValueBase> thenValue = new ThenValue<ThisType, ResolveMethodType, RejectMethodType>(
@@ -318,7 +329,7 @@ public:
     PROMISE_LOG("%s invoking Then() [this=%p, thenValue=%p, aThisVal=%p, isPending=%d]",
                 aCallSite, this, thenValue.get(), aThisVal, (int) IsPending());
     if (!IsPending()) {
-      thenValue->Dispatch(this);
+      thenValue->Dispatch(this, aDispatcher);
     } else {
       mThenValues.AppendElement(thenValue);
     }
@@ -328,14 +339,16 @@ public:
 
   template<typename ThisType, typename ResolveMethodType, typename RejectMethodType>
   void Then(AbstractThread* aResponseThread, const char* aCallSite, ThisType* aThisVal,
-            ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod)
+            ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod,
+            TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     nsRefPtr<Consumer> c =
-      RefableThen(aResponseThread, aCallSite, aThisVal, aResolveMethod, aRejectMethod);
+      RefableThen(aResponseThread, aCallSite, aThisVal, aResolveMethod, aRejectMethod, aDispatcher);
     return;
   }
 
-  void ChainTo(already_AddRefed<Private> aChainedPromise, const char* aCallSite)
+  void ChainTo(already_AddRefed<Private> aChainedPromise, const char* aCallSite,
+               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     MutexAutoLock lock(mMutex);
     MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveConsumer);
@@ -344,7 +357,7 @@ public:
     PROMISE_LOG("%s invoking Chain() [this=%p, chainedPromise=%p, isPending=%d]",
                 aCallSite, this, chainedPromise.get(), (int) IsPending());
     if (!IsPending()) {
-      ForwardTo(chainedPromise);
+      ForwardTo(chainedPromise, aDispatcher);
     } else {
       mChainedPromises.AppendElement(chainedPromise);
     }
@@ -352,27 +365,27 @@ public:
 
 protected:
   bool IsPending() { return mResolveValue.isNothing() && mRejectValue.isNothing(); }
-  void DispatchAll()
+  void DispatchAll(TaskDispatcher& aDispatcher)
   {
     mMutex.AssertCurrentThreadOwns();
     for (size_t i = 0; i < mThenValues.Length(); ++i) {
-      mThenValues[i]->Dispatch(this);
+      mThenValues[i]->Dispatch(this, aDispatcher);
     }
     mThenValues.Clear();
 
     for (size_t i = 0; i < mChainedPromises.Length(); ++i) {
-      ForwardTo(mChainedPromises[i]);
+      ForwardTo(mChainedPromises[i], aDispatcher);
     }
     mChainedPromises.Clear();
   }
 
-  void ForwardTo(Private* aOther)
+  void ForwardTo(Private* aOther, TaskDispatcher& aDispatcher)
   {
     MOZ_ASSERT(!IsPending());
     if (mResolveValue.isSome()) {
-      aOther->Resolve(mResolveValue.ref(), "<chained promise>");
+      aOther->Resolve(mResolveValue.ref(), "<chained promise>", aDispatcher);
     } else {
-      aOther->Reject(mRejectValue.ref(), "<chained promise>");
+      aOther->Reject(mRejectValue.ref(), "<chained promise>", aDispatcher);
     }
   }
 
@@ -400,22 +413,24 @@ class MediaPromise<ResolveValueT, RejectValueT, IsExclusive>::Private
 public:
   explicit Private(const char* aCreationSite) : MediaPromise(aCreationSite) {}
 
-  void Resolve(ResolveValueT aResolveValue, const char* aResolveSite)
+  void Resolve(ResolveValueT aResolveValue, const char* aResolveSite,
+               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     MutexAutoLock lock(mMutex);
     MOZ_ASSERT(IsPending());
     PROMISE_LOG("%s resolving MediaPromise (%p created at %s)", aResolveSite, this, mCreationSite);
     mResolveValue.emplace(aResolveValue);
-    DispatchAll();
+    DispatchAll(aDispatcher);
   }
 
-  void Reject(RejectValueT aRejectValue, const char* aRejectSite)
+  void Reject(RejectValueT aRejectValue, const char* aRejectSite,
+              TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     MutexAutoLock lock(mMutex);
     MOZ_ASSERT(IsPending());
     PROMISE_LOG("%s rejecting MediaPromise (%p created at %s)", aRejectSite, this, mCreationSite);
     mRejectValue.emplace(aRejectValue);
-    DispatchAll();
+    DispatchAll(aDispatcher);
   }
 };
 
@@ -476,40 +491,44 @@ public:
   }
 
   void Resolve(typename PromiseType::ResolveValueType aResolveValue,
-               const char* aMethodName)
+               const char* aMethodName,
+               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     if (mMonitor) {
       mMonitor->AssertCurrentThreadOwns();
     }
     MOZ_ASSERT(mPromise);
-    mPromise->Resolve(aResolveValue, aMethodName);
+    mPromise->Resolve(aResolveValue, aMethodName, aDispatcher);
     mPromise = nullptr;
   }
 
   void ResolveIfExists(typename PromiseType::ResolveValueType aResolveValue,
-                       const char* aMethodName)
+                       const char* aMethodName,
+                       TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     if (!IsEmpty()) {
-      Resolve(aResolveValue, aMethodName);
+      Resolve(aResolveValue, aMethodName, aDispatcher);
     }
   }
 
   void Reject(typename PromiseType::RejectValueType aRejectValue,
-              const char* aMethodName)
+              const char* aMethodName,
+              TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     if (mMonitor) {
       mMonitor->AssertCurrentThreadOwns();
     }
     MOZ_ASSERT(mPromise);
-    mPromise->Reject(aRejectValue, aMethodName);
+    mPromise->Reject(aRejectValue, aMethodName, aDispatcher);
     mPromise = nullptr;
   }
 
   void RejectIfExists(typename PromiseType::RejectValueType aRejectValue,
-                      const char* aMethodName)
+                      const char* aMethodName,
+                      TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
   {
     if (!IsEmpty()) {
-      Reject(aRejectValue, aMethodName);
+      Reject(aRejectValue, aMethodName, aDispatcher);
     }
   }
 
@@ -645,13 +664,12 @@ private:
 
 template<typename PromiseType>
 static nsRefPtr<PromiseType>
-ProxyInternal(AbstractThread* aTarget, MethodCallBase<PromiseType>* aMethodCall, const char* aCallerName)
+ProxyInternal(AbstractThread* aTarget, MethodCallBase<PromiseType>* aMethodCall, const char* aCallerName,
+              TaskDispatcher& aDispatcher)
 {
   nsRefPtr<typename PromiseType::Private> p = new (typename PromiseType::Private)(aCallerName);
   nsRefPtr<ProxyRunnable<PromiseType>> r = new ProxyRunnable<PromiseType>(p, aMethodCall);
-  nsresult rv = aTarget->Dispatch(r.forget());
-  MOZ_DIAGNOSTIC_ASSERT(NS_SUCCEEDED(rv));
-  unused << rv;
+  aDispatcher.AddTask(aTarget, r.forget());
   return Move(p);
 }
 
@@ -660,31 +678,34 @@ ProxyInternal(AbstractThread* aTarget, MethodCallBase<PromiseType>* aMethodCall,
 template<typename PromiseType, typename ThisType>
 static nsRefPtr<PromiseType>
 ProxyMediaCall(AbstractThread* aTarget, ThisType* aThisVal, const char* aCallerName,
-               nsRefPtr<PromiseType>(ThisType::*aMethod)())
+               nsRefPtr<PromiseType>(ThisType::*aMethod)(),
+               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
 {
   typedef detail::MethodCallWithNoArgs<PromiseType, ThisType> MethodCallType;
   MethodCallType* methodCall = new MethodCallType(aThisVal, aMethod);
-  return detail::ProxyInternal(aTarget, methodCall, aCallerName);
+  return detail::ProxyInternal(aTarget, methodCall, aCallerName, aDispatcher);
 }
 
 template<typename PromiseType, typename ThisType, typename Arg1Type>
 static nsRefPtr<PromiseType>
 ProxyMediaCall(AbstractThread* aTarget, ThisType* aThisVal, const char* aCallerName,
-               nsRefPtr<PromiseType>(ThisType::*aMethod)(Arg1Type), Arg1Type aArg1)
+               nsRefPtr<PromiseType>(ThisType::*aMethod)(Arg1Type), Arg1Type aArg1,
+               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
 {
   typedef detail::MethodCallWithOneArg<PromiseType, ThisType, Arg1Type> MethodCallType;
   MethodCallType* methodCall = new MethodCallType(aThisVal, aMethod, aArg1);
-  return detail::ProxyInternal(aTarget, methodCall, aCallerName);
+  return detail::ProxyInternal(aTarget, methodCall, aCallerName, aDispatcher);
 }
 
 template<typename PromiseType, typename ThisType, typename Arg1Type, typename Arg2Type>
 static nsRefPtr<PromiseType>
 ProxyMediaCall(AbstractThread* aTarget, ThisType* aThisVal, const char* aCallerName,
-               nsRefPtr<PromiseType>(ThisType::*aMethod)(Arg1Type, Arg2Type), Arg1Type aArg1, Arg2Type aArg2)
+               nsRefPtr<PromiseType>(ThisType::*aMethod)(Arg1Type, Arg2Type), Arg1Type aArg1, Arg2Type aArg2,
+               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
 {
   typedef detail::MethodCallWithTwoArgs<PromiseType, ThisType, Arg1Type, Arg2Type> MethodCallType;
   MethodCallType* methodCall = new MethodCallType(aThisVal, aMethod, aArg1, aArg2);
-  return detail::ProxyInternal(aTarget, methodCall, aCallerName);
+  return detail::ProxyInternal(aTarget, methodCall, aCallerName, aDispatcher);
 }
 
 #undef PROMISE_LOG

--- a/dom/media/MediaQueue.h
+++ b/dom/media/MediaQueue.h
@@ -176,7 +176,7 @@ private:
       , mTarget(aOther.mTarget)
     {
     }
-    RefPtr<nsIRunnable> mRunnable;
+    nsCOMPtr<nsIRunnable> mRunnable;
     RefPtr<MediaTaskQueue> mTarget;
   };
 
@@ -185,7 +185,8 @@ private:
   void NotifyPopListeners() {
     for (uint32_t i = 0; i < mPopListeners.Length(); i++) {
       Listener& l = mPopListeners[i];
-      l.mTarget->Dispatch(l.mRunnable);
+      nsCOMPtr<nsIRunnable> r = l.mRunnable;
+      l.mTarget->MaybeTailDispatch(r.forget());
     }
   }
 

--- a/dom/media/MediaStreamGraph.cpp
+++ b/dom/media/MediaStreamGraph.cpp
@@ -278,7 +278,8 @@ MediaStreamGraphImpl::UpdateBufferSufficiencyState(SourceMediaStream* aStream)
   }
 
   for (uint32_t i = 0; i < runnables.Length(); ++i) {
-    runnables[i].mTarget->Dispatch(runnables[i].mRunnable);
+    nsCOMPtr<nsIRunnable> r = runnables[i].mRunnable;
+    runnables[i].mTarget->MaybeTailDispatch(r.forget(), /* aAssertDispatchSuccess = */ false);
   }
 }
 
@@ -2498,7 +2499,8 @@ SourceMediaStream::DispatchWhenNotEnoughBuffered(TrackID aID,
   MutexAutoLock lock(mMutex);
   TrackData* data = FindDataForTrack(aID);
   if (!data) {
-    aSignalQueue->Dispatch(aSignalRunnable);
+    nsCOMPtr<nsIRunnable> r = aSignalRunnable;
+    aSignalQueue->MaybeTailDispatch(r.forget());
     return;
   }
 
@@ -2507,7 +2509,8 @@ SourceMediaStream::DispatchWhenNotEnoughBuffered(TrackID aID,
       data->mDispatchWhenNotEnough.AppendElement()->Init(aSignalQueue, aSignalRunnable);
     }
   } else {
-    aSignalQueue->Dispatch(aSignalRunnable);
+    nsCOMPtr<nsIRunnable> r = aSignalRunnable;
+    aSignalQueue->MaybeTailDispatch(r.forget());
   }
 }
 

--- a/dom/media/MediaStreamGraph.h
+++ b/dom/media/MediaStreamGraph.h
@@ -855,7 +855,7 @@ protected:
     }
 
     nsRefPtr<MediaTaskQueue> mTarget;
-    RefPtr<nsIRunnable> mRunnable;
+    nsCOMPtr<nsIRunnable> mRunnable;
   };
   enum TrackCommands {
     TRACK_CREATE = MediaStreamListener::TRACK_EVENT_CREATED,

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -23,6 +23,7 @@ MediaTaskQueue::InitStatics()
 MediaTaskQueue::MediaTaskQueue(TemporaryRef<SharedThreadPool> aPool)
   : mPool(aPool)
   , mQueueMonitor("MediaTaskQueue::Queue")
+  , mTailDispatcher(nullptr)
   , mIsRunning(false)
   , mIsShutdown(false)
   , mIsFlushing(false)
@@ -42,6 +43,14 @@ MediaTaskQueue::Dispatch(TemporaryRef<nsIRunnable> aRunnable)
 {
   MonitorAutoLock mon(mQueueMonitor);
   return DispatchLocked(aRunnable, AbortIfFlushing);
+}
+
+TaskDispatcher&
+MediaTaskQueue::TailDispatcher()
+{
+  MOZ_ASSERT(IsCurrentThreadIn());
+  MOZ_ASSERT(mTailDispatcher);
+  return *mTailDispatcher;
 }
 
 nsresult

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -297,4 +297,19 @@ MediaTaskQueue::Runner::Run()
   return NS_OK;
 }
 
+#ifdef DEBUG
+void
+TaskDispatcher::AssertIsTailDispatcherIfRequired()
+{
+  MediaTaskQueue* currentQueue = MediaTaskQueue::GetCurrentQueue();
+
+  // NB: Make sure not to use the TailDispatcher() accessor, since that
+  // asserts IsCurrentThreadIn(), which acquires the queue monitor, which
+  // triggers a deadlock during shutdown between the queue monitor and the
+  // MediaPromise monitor.
+  MOZ_ASSERT_IF(currentQueue && currentQueue->RequiresTailDispatch(),
+                this == currentQueue->mTailDispatcher);
+}
+#endif
+
 } // namespace mozilla

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -167,6 +167,7 @@ protected:
   MediaTaskQueue* mQueue;
   };
 
+  friend class TaskDispatcher;
   TaskDispatcher* mTailDispatcher;
 
   // True if we've dispatched an event to the pool to execute events from

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -104,7 +104,7 @@ public:
   bool IsEmpty();
 
   // Returns true if the current thread is currently running a Runnable in
-  // the task queue. This is for debugging/validation purposes only.
+  // the task queue.
   bool IsCurrentThreadIn() override;
 
 protected:
@@ -141,7 +141,12 @@ protected:
   // The thread currently running the task queue. We store a reference
   // to this so that IsCurrentThreadIn() can tell if the current thread
   // is the thread currently running in the task queue.
-  RefPtr<nsIThread> mRunningThread;
+  //
+  // This may be read on any thread, but may only be written on mRunningThread.
+  // The thread can't die while we're running in it, and we only use it for
+  // pointer-comparison with the current thread anyway - so we make it atomic
+  // and don't refcount it.
+  Atomic<nsIThread*> mRunningThread;
 
   // RAII class that gets instantiated for each dispatched task.
   class AutoTaskGuard : public AutoTaskDispatcher
@@ -156,10 +161,16 @@ protected:
 
       MOZ_ASSERT(sCurrentQueueTLS.get() == nullptr);
       sCurrentQueueTLS.set(aQueue);
+
+      MOZ_ASSERT(mQueue->mRunningThread == nullptr);
+      mQueue->mRunningThread = NS_GetCurrentThread();
     }
 
     ~AutoTaskGuard()
     {
+      MOZ_ASSERT(mQueue->mRunningThread == NS_GetCurrentThread());
+      mQueue->mRunningThread = nullptr;
+
       sCurrentQueueTLS.set(nullptr);
       mQueue->mTailDispatcher = nullptr;
     }
@@ -167,7 +178,6 @@ protected:
   MediaTaskQueue* mQueue;
   };
 
-  friend class TaskDispatcher;
   TaskDispatcher* mTailDispatcher;
 
   // True if we've dispatched an event to the pool to execute events from

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -38,7 +38,7 @@ public:
   // if the caller is not running in a MediaTaskQueue.
   static MediaTaskQueue* GetCurrentQueue() { return sCurrentQueueTLS.get(); }
 
-  explicit MediaTaskQueue(TemporaryRef<SharedThreadPool> aPool);
+  explicit MediaTaskQueue(TemporaryRef<SharedThreadPool> aPool, bool aRequireTailDispatch = false);
 
   nsresult Dispatch(TemporaryRef<nsIRunnable> aRunnable);
 
@@ -47,6 +47,31 @@ public:
   //
   // May only be called when running within the task queue it is invoked up.
   TaskDispatcher& TailDispatcher();
+
+  // Returns true if this task queue requires all dispatches performed by its
+  // tasks to go through the tail dispatcher.
+  bool RequiresTailDispatch() { return mRequireTailDispatch; }
+
+#ifdef DEBUG
+  static void AssertInTailDispatchIfNeeded()
+  {
+    // See if we're currently running in a task queue that asserts tail
+    // dispatch.
+    MediaTaskQueue* currentQueue = MediaTaskQueue::GetCurrentQueue();
+    if (!currentQueue || !currentQueue->RequiresTailDispatch()) {
+      return;
+    }
+
+    // This is a bit tricky. The only moment when we're running in a task queue
+    // but don't have mTailDispatcher set is precisely the moment that we're
+    // doing tail dispatch (i.e. when AutoTaskGuard's destructor has already
+    // run and AutoTaskDispatcher's destructor is currently running).
+    MOZ_ASSERT(!currentQueue->mTailDispatcher,
+               "Not allowed to dispatch tasks directly from this task queue - use TailDispatcher()");
+  }
+#else
+  static void AssertInTailDispatchIfNeeded() {}
+#endif
 
   // For AbstractThread.
   nsresult Dispatch(already_AddRefed<nsIRunnable> aRunnable) override
@@ -154,6 +179,10 @@ protected:
 
   // True if we're flushing; we reject new tasks if we're flushing.
   bool mIsFlushing;
+
+  // True if we want to require that every task dispatched from tasks running in
+  // this queue go through our queue's tail dispatcher.
+  bool mRequireTailDispatch;
 
   class Runner : public nsRunnable {
   public:

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -14,6 +14,7 @@
 #include "SharedThreadPool.h"
 #include "nsThreadUtils.h"
 #include "MediaPromise.h"
+#include "TaskDispatcher.h"
 
 class nsIRunnable;
 
@@ -40,6 +41,12 @@ public:
   explicit MediaTaskQueue(TemporaryRef<SharedThreadPool> aPool);
 
   nsresult Dispatch(TemporaryRef<nsIRunnable> aRunnable);
+
+  // Returns a TaskDispatcher that will dispatch its tasks when the currently-
+  // running tasks pops off the stack.
+  //
+  // May only be called when running within the task queue it is invoked up.
+  TaskDispatcher& TailDispatcher();
 
   // For AbstractThread.
   nsresult Dispatch(already_AddRefed<nsIRunnable> aRunnable) override
@@ -112,13 +119,16 @@ protected:
   RefPtr<nsIThread> mRunningThread;
 
   // RAII class that gets instantiated for each dispatched task.
-  class AutoTaskGuard
+  class AutoTaskGuard : public AutoTaskDispatcher
   {
   public:
-    explicit AutoTaskGuard(MediaTaskQueue* aQueue)
+    explicit AutoTaskGuard(MediaTaskQueue* aQueue) : mQueue(aQueue)
     {
       // NB: We don't hold the lock to aQueue here. Don't do anything that
       // might require it.
+      MOZ_ASSERT(!mQueue->mTailDispatcher);
+      mQueue->mTailDispatcher = this;
+
       MOZ_ASSERT(sCurrentQueueTLS.get() == nullptr);
       sCurrentQueueTLS.set(aQueue);
     }
@@ -126,8 +136,13 @@ protected:
     ~AutoTaskGuard()
     {
       sCurrentQueueTLS.set(nullptr);
+      mQueue->mTailDispatcher = nullptr;
     }
+  private:
+  MediaTaskQueue* mQueue;
   };
+
+  TaskDispatcher* mTailDispatcher;
 
   // True if we've dispatched an event to the pool to execute events from
   // the queue.

--- a/dom/media/TaskDispatcher.h
+++ b/dom/media/TaskDispatcher.h
@@ -69,6 +69,7 @@ public:
       nsCOMPtr<nsIRunnable> r = new TaskGroupRunnable(Move(group));
       nsresult rv = thread->Dispatch(r.forget());
       MOZ_DIAGNOSTIC_ASSERT(!assertDispatchSuccess || NS_SUCCEEDED(rv));
+      unused << assertDispatchSuccess;
       unused << rv;
     }
   }

--- a/dom/media/TaskDispatcher.h
+++ b/dom/media/TaskDispatcher.h
@@ -1,0 +1,147 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#if !defined(TaskDispatcher_h_)
+#define TaskDispatcher_h_
+
+#include "AbstractThread.h"
+
+#include "mozilla/UniquePtr.h"
+#include "mozilla/unused.h"
+
+#include "nsISupportsImpl.h"
+#include "nsTArray.h"
+#include "nsThreadUtils.h"
+
+namespace mozilla {
+
+/*
+ * A classic approach to cross-thread communication is to dispatch asynchronous
+ * runnables to perform updates on other threads. This generally works well, but
+ * there are sometimes reasons why we might want to delay the actual dispatch of
+ * these tasks until a specified moment. At present, this is primarily useful to
+ * ensure that mirrored state gets updated atomically - but there may be other
+ * applications as well.
+ *
+ * TaskDispatcher is a general abstract class that accepts tasks and dispatches
+ * them at some later point. These groups of tasks are per-target-thread, and
+ * contain separate queues for two kinds of tasks - "state change tasks" (which
+ * run first, and are intended to be used to update the value held by mirrors),
+ * and regular tasks, which are other arbitrary operations that the are gated
+ * to run after all the state changes have completed.
+ */
+class TaskDispatcher
+{
+public:
+  TaskDispatcher() {}
+  virtual ~TaskDispatcher() {}
+
+  virtual void AddStateChangeTask(AbstractThread* aThread,
+                                  already_AddRefed<nsIRunnable> aRunnable) = 0;
+  virtual void AddTask(AbstractThread* aThread,
+                       already_AddRefed<nsIRunnable> aRunnable,
+                       bool aAssertDispatchSuccess = true) = 0;
+};
+
+/*
+ * AutoTaskDispatcher is a stack-scoped TaskDispatcher implementation that fires
+ * its queued tasks when it is popped off the stack.
+ */
+class MOZ_STACK_CLASS AutoTaskDispatcher : public TaskDispatcher
+{
+public:
+  AutoTaskDispatcher() {}
+  ~AutoTaskDispatcher()
+  {
+    for (size_t i = 0; i < mTaskGroups.Length(); ++i) {
+      UniquePtr<PerThreadTaskGroup> group(Move(mTaskGroups[i]));
+      nsRefPtr<AbstractThread> thread = group->mThread;
+      bool assertDispatchSuccess = group->mAssertDispatchSuccess;
+      nsCOMPtr<nsIRunnable> r = new TaskGroupRunnable(Move(group));
+      nsresult rv = thread->Dispatch(r.forget());
+      MOZ_DIAGNOSTIC_ASSERT(!assertDispatchSuccess || NS_SUCCEEDED(rv));
+      unused << rv;
+    }
+  }
+
+  void AddStateChangeTask(AbstractThread* aThread,
+                          already_AddRefed<nsIRunnable> aRunnable) override
+  {
+    EnsureTaskGroup(aThread).mStateChangeTasks.AppendElement(aRunnable);
+  }
+
+  void AddTask(AbstractThread* aThread,
+               already_AddRefed<nsIRunnable> aRunnable,
+               bool aAssertDispatchSuccess) override
+  {
+    PerThreadTaskGroup& group = EnsureTaskGroup(aThread);
+    group.mRegularTasks.AppendElement(aRunnable);
+
+    // The task group needs to assert dispatch success if any of the runnables
+    // it's dispatching want to assert it.
+    group.mAssertDispatchSuccess = group.mAssertDispatchSuccess || aAssertDispatchSuccess;
+  }
+
+private:
+
+  struct PerThreadTaskGroup
+  {
+  public:
+    explicit PerThreadTaskGroup(AbstractThread* aThread)
+      : mThread(aThread), mAssertDispatchSuccess(false)
+    {
+      MOZ_COUNT_CTOR(PerThreadTaskGroup);
+    }
+
+    ~PerThreadTaskGroup() { MOZ_COUNT_DTOR(PerThreadTaskGroup); }
+
+    nsRefPtr<AbstractThread> mThread;
+    nsTArray<nsCOMPtr<nsIRunnable>> mStateChangeTasks;
+    nsTArray<nsCOMPtr<nsIRunnable>> mRegularTasks;
+    bool mAssertDispatchSuccess;
+  };
+
+  class TaskGroupRunnable : public nsRunnable
+  {
+    public:
+      explicit TaskGroupRunnable(UniquePtr<PerThreadTaskGroup>&& aTasks) : mTasks(Move(aTasks)) {}
+
+      NS_IMETHODIMP Run()
+      {
+        for (size_t i = 0; i < mTasks->mStateChangeTasks.Length(); ++i) {
+          mTasks->mStateChangeTasks[i]->Run();
+        }
+
+        for (size_t i = 0; i < mTasks->mRegularTasks.Length(); ++i) {
+          mTasks->mRegularTasks[i]->Run();
+        }
+
+        return NS_OK;
+      }
+
+    private:
+      UniquePtr<PerThreadTaskGroup> mTasks;
+  };
+
+  PerThreadTaskGroup& EnsureTaskGroup(AbstractThread* aThread)
+  {
+    for (size_t i = 0; i < mTaskGroups.Length(); ++i) {
+      if (mTaskGroups[i]->mThread == aThread) {
+        return *mTaskGroups[i];
+      }
+    }
+
+    mTaskGroups.AppendElement(new PerThreadTaskGroup(aThread));
+    return *mTaskGroups.LastElement();
+  }
+
+  // Task groups, organized by thread.
+  nsTArray<UniquePtr<PerThreadTaskGroup>> mTaskGroups;
+};
+
+} // namespace mozilla
+
+#endif

--- a/dom/media/TaskDispatcher.h
+++ b/dom/media/TaskDispatcher.h
@@ -44,6 +44,12 @@ public:
   virtual void AddTask(AbstractThread* aThread,
                        already_AddRefed<nsIRunnable> aRunnable,
                        bool aAssertDispatchSuccess = true) = 0;
+
+#ifdef DEBUG
+  void AssertIsTailDispatcherIfRequired();
+#else
+  void AssertIsTailDispatcherIfRequired() {}
+#endif
 };
 
 /*
@@ -140,6 +146,18 @@ private:
 
   // Task groups, organized by thread.
   nsTArray<UniquePtr<PerThreadTaskGroup>> mTaskGroups;
+};
+
+// Little utility class to allow declaring AutoTaskDispatcher as a default
+// parameter for methods that take a TaskDispatcher&.
+template<typename T>
+class PassByRef
+{
+public:
+  PassByRef() {}
+  operator T&() { return mVal; }
+private:
+  T mVal;
 };
 
 } // namespace mozilla

--- a/dom/media/moz.build
+++ b/dom/media/moz.build
@@ -123,6 +123,7 @@ EXPORTS += [
     'SharedBuffer.h',
     'SharedThreadPool.h',
     'StreamBuffer.h',
+    'TaskDispatcher.h',
     'ThreadPoolCOMListener.h',
     'TimeUnits.h',
     'TimeVarying.h',

--- a/layout/build/nsLayoutStatics.cpp
+++ b/layout/build/nsLayoutStatics.cpp
@@ -130,6 +130,7 @@ using namespace mozilla::system;
 #include "nsDocument.h"
 #include "mozilla/dom/HTMLVideoElement.h"
 #include "CameraPreferences.h"
+#include "MediaDecoder.h"
 
 using namespace mozilla;
 using namespace mozilla::net;
@@ -298,6 +299,8 @@ nsLayoutStatics::Initialize()
 #ifdef MOZ_B2G
   RequestSyncWifiService::Init();
 #endif
+
+  MediaDecoder::InitStatics();
 
   return NS_OK;
 }


### PR DESCRIPTION
From the TaskDispatcher header file:

> TaskDispatcher is a general abstract class that accepts tasks and dispatches them at some later point. These groups of tasks are per-target-thread, and contain separate queues for two kinds of tasks - "state change tasks" (which run first, and are intended to be used to update the value held by mirrors), and regular tasks, which are other arbitrary operations that the are gated to run after all the state changes have completed.

This will work together with our new media AbstractThread (#930) and will help to improve the raciness in some of our current media code. It is also another step towards eliminating the decoder monitor that's caused some issues.

In addition to implementing the TaskDispatcher, this PR also makes some improvements to AbstractThread, improves atomicy (will be needed for future patches), and adds a few more assertions to the MDSM.

There will be future improvements made to and heavier use of the TaskDispatcher, but this basic implementation should be good enough for now to merge in based on my testing yesterday and today (although I am adding the "Verification Needed" label because it is still a fairly substantive change).