### PR TITLE
Clean up and improve AbstractThread dispatch semantics

### DIFF
--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -48,8 +48,8 @@ AbstractThread::MaybeTailDispatch(already_AddRefed<nsIRunnable> aRunnable,
                                   DispatchFailureHandling aFailureHandling)
 {
   MediaTaskQueue* currentQueue = MediaTaskQueue::GetCurrentQueue();
-  currentQueue->TailDispatcher().AddTask(this, Move(aRunnable), aFailureHandling);
-    currentQueue->TailDispatcher().AddTask(this, Move(aRunnable), aAssertDispatchSuccess);
+  if (currentQueue && currentQueue->RequiresTailDispatch()) {
+    currentQueue->TailDispatcher().AddTask(this, Move(aRunnable), aFailureHandling);
   } else {
     Dispatch(Move(aRunnable), aFailureHandling);
   }

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -32,13 +32,16 @@ class AbstractThread
 {
 public:
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(AbstractThread);
-  virtual nsresult Dispatch(already_AddRefed<nsIRunnable> aRunnable) = 0;
+
+  enum DispatchFailureHandling { AssertDispatchSuccess, DontAssertDispatchSuccess };
+  virtual void Dispatch(already_AddRefed<nsIRunnable> aRunnable,
+                        DispatchFailureHandling aHandling = AssertDispatchSuccess) = 0;
   virtual bool IsCurrentThreadIn() = 0;
 
   // Convenience method for dispatching a runnable when we may be running on
   // a thread that requires runnables to be dispatched with tail dispatch.
   void MaybeTailDispatch(already_AddRefed<nsIRunnable> aRunnable,
-                         bool aAssertDispatchSuccess = true);
+                         DispatchFailureHandling aFailureHandling = AssertDispatchSuccess);
 
   // Convenience method for getting an AbstractThread for the main thread.
   static AbstractThread* MainThread();

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -50,17 +50,6 @@ protected:
   virtual ~AbstractThread() {}
 };
 
-template<typename TargetType>
-class AbstractThreadImpl : public AbstractThread
-{
-public:
-  explicit AbstractThreadImpl(TargetType* aTarget) : mTarget(aTarget) {}
-  virtual nsresult Dispatch(already_AddRefed<nsIRunnable> aRunnable);
-  virtual bool IsCurrentThreadIn();
-private:
-  nsRefPtr<TargetType> mTarget;
-};
-
 } // namespace mozilla
 
 #endif

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -43,6 +43,10 @@ public:
   void MaybeTailDispatch(already_AddRefed<nsIRunnable> aRunnable,
                          DispatchFailureHandling aFailureHandling = AssertDispatchSuccess);
 
+  // Returns true if dispatch is generally reliable. This is used to guard
+  // against FlushableMediaTaskQueues, which eventually needs to go away.
+  virtual bool IsDispatchReliable() { return true; }
+
   // Convenience method for getting an AbstractThread for the main thread.
   static AbstractThread* MainThread();
 

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -239,7 +239,7 @@ protected:
       // then shut down the thread or task queue that the promise result would
       // be dispatched on. So we unfortunately can't assert that promise
       // dispatch succeeds. :-(
-      aDispatcher.AddTask(mResponseTarget, runnable.forget(), /* aAssertDispatchSuccess = */ false);
+      aDispatcher.AddTask(mResponseTarget, runnable.forget(), AbstractThread::DontAssertDispatchSuccess);
     }
 
 #ifdef DEBUG

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -321,6 +321,7 @@ public:
     aDispatcher.AssertIsTailDispatcherIfRequired();
 
     MutexAutoLock lock(mMutex);
+    MOZ_ASSERT(aResponseThread->IsDispatchReliable());
     MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveConsumer);
     mHaveConsumer = true;
     nsRefPtr<ThenValueBase> thenValue = new ThenValue<ThisType, ResolveMethodType, RejectMethodType>(
@@ -668,6 +669,7 @@ ProxyInternal(AbstractThread* aTarget, MethodCallBase<PromiseType>* aMethodCall,
 {
   nsRefPtr<typename PromiseType::Private> p = new (typename PromiseType::Private)(aCallerName);
   nsRefPtr<ProxyRunnable<PromiseType>> r = new ProxyRunnable<PromiseType>(p, aMethodCall);
+  MOZ_ASSERT(aTarget->IsDispatchReliable());
   aDispatcher.AddTask(aTarget, r.forget());
   return Move(p);
 }

--- a/dom/media/MediaStreamGraph.cpp
+++ b/dom/media/MediaStreamGraph.cpp
@@ -279,7 +279,7 @@ MediaStreamGraphImpl::UpdateBufferSufficiencyState(SourceMediaStream* aStream)
 
   for (uint32_t i = 0; i < runnables.Length(); ++i) {
     nsCOMPtr<nsIRunnable> r = runnables[i].mRunnable;
-    runnables[i].mTarget->MaybeTailDispatch(r.forget(), /* aAssertDispatchSuccess = */ false);
+    runnables[i].mTarget->MaybeTailDispatch(r.forget(), AbstractThread::DontAssertDispatchSuccess);
   }
 }
 

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -107,6 +107,7 @@ private:
 
 void
 MediaTaskQueue::SyncDispatch(TemporaryRef<nsIRunnable> aRunnable) {
+  NS_WARNING("MediaTaskQueue::SyncDispatch is deprecated and potentially dangerous. Don't use!");
   RefPtr<MediaTaskQueueSyncRunnable> task(new MediaTaskQueueSyncRunnable(aRunnable));
   Dispatch(task);
   task->WaitUntilDone();

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -93,12 +93,11 @@ public:
     return rv;
   }
 
-  nsresult WaitUntilDone() {
+  void WaitUntilDone() {
     MonitorAutoLock mon(mMonitor);
     while (!mDone) {
       mon.Wait();
     }
-    return NS_OK;
   }
 private:
   RefPtr<nsIRunnable> mRunnable;
@@ -106,12 +105,11 @@ private:
   bool mDone;
 };
 
-nsresult
+void
 MediaTaskQueue::SyncDispatch(TemporaryRef<nsIRunnable> aRunnable) {
   RefPtr<MediaTaskQueueSyncRunnable> task(new MediaTaskQueueSyncRunnable(aRunnable));
-  nsresult rv = Dispatch(task);
-  NS_ENSURE_SUCCESS(rv, rv);
-  return task->WaitUntilDone();
+  Dispatch(task);
+  task->WaitUntilDone();
 }
 
 void

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -57,14 +57,6 @@ MediaTaskQueue::TailDispatcher()
 }
 
 nsresult
-MediaTaskQueue::ForceDispatch(TemporaryRef<nsIRunnable> aRunnable)
-{
-  AssertInTailDispatchIfNeeded(); // Do this before acquiring the monitor.
-  MonitorAutoLock mon(mQueueMonitor);
-  return DispatchLocked(aRunnable, Forced);
-}
-
-nsresult
 MediaTaskQueue::DispatchLocked(TemporaryRef<nsIRunnable> aRunnable,
                                DispatchMode aMode)
 {
@@ -75,7 +67,7 @@ MediaTaskQueue::DispatchLocked(TemporaryRef<nsIRunnable> aRunnable,
   if (mIsShutdown) {
     return NS_ERROR_FAILURE;
   }
-  mTasks.push(TaskQueueEntry(aRunnable, aMode == Forced));
+  mTasks.push(aRunnable);
   if (mIsRunning) {
     return NS_OK;
   }
@@ -198,13 +190,8 @@ FlushableMediaTaskQueue::FlushLocked()
   mQueueMonitor.AssertCurrentThreadOwns();
   MOZ_ASSERT(mIsFlushing);
 
-  // Clear the tasks, but preserve those with mForceDispatch by re-appending
-  // them to the queue.
-  size_t numTasks = mTasks.size();
-  for (size_t i = 0; i < numTasks; ++i) {
-    if (mTasks.front().mForceDispatch) {
-      mTasks.push(mTasks.front());
-    }
+  // Clear the tasks.
+  while (!mTasks.empty()) {
     mTasks.pop();
   }
 }
@@ -237,7 +224,7 @@ MediaTaskQueue::Runner::Run()
       mon.NotifyAll();
       return NS_OK;
     }
-    event = mQueue->mTasks.front().mRunnable;
+    event = mQueue->mTasks.front();
     mQueue->mTasks.pop();
   }
   MOZ_ASSERT(event);

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -40,14 +40,6 @@ MediaTaskQueue::~MediaTaskQueue()
   MOZ_COUNT_DTOR(MediaTaskQueue);
 }
 
-nsresult
-MediaTaskQueue::Dispatch(TemporaryRef<nsIRunnable> aRunnable)
-{
-  AssertInTailDispatchIfNeeded(); // Do this before acquiring the monitor.
-  MonitorAutoLock mon(mQueueMonitor);
-  return DispatchLocked(aRunnable, AbortIfFlushing);
-}
-
 TaskDispatcher&
 MediaTaskQueue::TailDispatcher()
 {
@@ -57,17 +49,17 @@ MediaTaskQueue::TailDispatcher()
 }
 
 nsresult
-MediaTaskQueue::DispatchLocked(TemporaryRef<nsIRunnable> aRunnable,
-                               DispatchMode aMode)
+MediaTaskQueue::DispatchLocked(already_AddRefed<nsIRunnable> aRunnable, DispatchMode aMode)
 {
   mQueueMonitor.AssertCurrentThreadOwns();
+  nsCOMPtr<nsIRunnable> r = aRunnable;
   if (mIsFlushing && aMode == AbortIfFlushing) {
     return NS_ERROR_ABORT;
   }
   if (mIsShutdown) {
     return NS_ERROR_FAILURE;
   }
-  mTasks.push(aRunnable);
+  mTasks.push(r.forget());
   if (mIsRunning) {
     return NS_OK;
   }
@@ -178,7 +170,8 @@ FlushableMediaTaskQueue::FlushAndDispatch(TemporaryRef<nsIRunnable> aRunnable)
   MonitorAutoLock mon(mQueueMonitor);
   AutoSetFlushing autoFlush(this);
   FlushLocked();
-  nsresult rv = DispatchLocked(aRunnable, IgnoreFlushing);
+  nsCOMPtr<nsIRunnable> r = dont_AddRef(aRunnable.take());
+  nsresult rv = DispatchLocked(r.forget(), IgnoreFlushing);
   NS_ENSURE_SUCCESS(rv, rv);
   AwaitIdleLocked();
   return NS_OK;

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -41,7 +41,12 @@ public:
 
   explicit MediaTaskQueue(TemporaryRef<SharedThreadPool> aPool, bool aRequireTailDispatch = false);
 
-  nsresult Dispatch(TemporaryRef<nsIRunnable> aRunnable);
+  nsresult Dispatch(TemporaryRef<nsIRunnable> aRunnable)
+  {
+    MonitorAutoLock mon(mQueueMonitor);
+    nsCOMPtr<nsIRunnable> r = dont_AddRef(aRunnable.take());
+    return DispatchLocked(r.forget(), AbortIfFlushing);
+  }
 
   // Returns a TaskDispatcher that will dispatch its tasks when the currently-
   // running tasks pops off the stack.
@@ -78,9 +83,8 @@ public:
   void Dispatch(already_AddRefed<nsIRunnable> aRunnable,
                 DispatchFailureHandling aFailureHandling = AssertDispatchSuccess) override
   {
-    RefPtr<nsIRunnable> r(aRunnable);
     MonitorAutoLock mon(mQueueMonitor);
-    nsresult rv = DispatchLocked(r, AbortIfFlushing);
+    nsresult rv = DispatchLocked(Move(aRunnable), AbortIfFlushing);
     MOZ_DIAGNOSTIC_ASSERT(aFailureHandling == DontAssertDispatchSuccess || NS_SUCCEEDED(rv));
     unused << rv;
   }
@@ -119,8 +123,7 @@ protected:
 
   enum DispatchMode { AbortIfFlushing, IgnoreFlushing };
 
-  nsresult DispatchLocked(TemporaryRef<nsIRunnable> aRunnable,
-                          DispatchMode aMode);
+  nsresult DispatchLocked(already_AddRefed<nsIRunnable> aRunnable, DispatchMode aMode);
 
   RefPtr<SharedThreadPool> mPool;
 
@@ -128,7 +131,7 @@ protected:
   Monitor mQueueMonitor;
 
   // Queue of tasks to run.
-  std::queue<RefPtr<nsIRunnable>> mTasks;
+  std::queue<nsCOMPtr<nsIRunnable>> mTasks;
 
   // The thread currently running the task queue. We store a reference
   // to this so that IsCurrentThreadIn() can tell if the current thread

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -41,11 +41,11 @@ public:
 
   explicit MediaTaskQueue(TemporaryRef<SharedThreadPool> aPool, bool aRequireTailDispatch = false);
 
-  nsresult Dispatch(TemporaryRef<nsIRunnable> aRunnable)
+  void Dispatch(TemporaryRef<nsIRunnable> aRunnable,
+                DispatchFailureHandling aFailureHandling = AssertDispatchSuccess)
   {
-    MonitorAutoLock mon(mQueueMonitor);
     nsCOMPtr<nsIRunnable> r = dont_AddRef(aRunnable.take());
-    return DispatchLocked(r.forget(), AbortIfFlushing);
+    return Dispatch(r.forget(), aFailureHandling);
   }
 
   // Returns a TaskDispatcher that will dispatch its tasks when the currently-
@@ -89,7 +89,7 @@ public:
     unused << rv;
   }
 
-  nsresult SyncDispatch(TemporaryRef<nsIRunnable> aRunnable);
+  void SyncDispatch(TemporaryRef<nsIRunnable> aRunnable);
 
   // Puts the queue in a shutdown state and returns immediately. The queue will
   // remain alive at least until all the events are drained, because the Runners

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -89,6 +89,8 @@ public:
     unused << rv;
   }
 
+  // DEPRECATED; do not use! If a flush happens at the same time, this function
+  // can hang and block forever! This needs to be removed in the future.
   void SyncDispatch(TemporaryRef<nsIRunnable> aRunnable);
 
   // Puts the queue in a shutdown state and returns immediately. The queue will

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -80,14 +80,10 @@ public:
   {
     RefPtr<nsIRunnable> r(aRunnable);
     MonitorAutoLock mon(mQueueMonitor);
-    nsresult rv = DispatchLocked(r, Forced);
+    nsresult rv = DispatchLocked(r, AbortIfFlushing);
     MOZ_DIAGNOSTIC_ASSERT(aFailureHandling == DontAssertDispatchSuccess || NS_SUCCEEDED(rv));
     unused << rv;
   }
-
-  // This should only be used for things that absolutely can't afford to be
-  // flushed. Normal operations should use Dispatch.
-  nsresult ForceDispatch(TemporaryRef<nsIRunnable> aRunnable);
 
   nsresult SyncDispatch(TemporaryRef<nsIRunnable> aRunnable);
 
@@ -121,7 +117,7 @@ protected:
   // mQueueMonitor must be held.
   void AwaitIdleLocked();
 
-  enum DispatchMode { AbortIfFlushing, IgnoreFlushing, Forced };
+  enum DispatchMode { AbortIfFlushing, IgnoreFlushing };
 
   nsresult DispatchLocked(TemporaryRef<nsIRunnable> aRunnable,
                           DispatchMode aMode);
@@ -131,17 +127,8 @@ protected:
   // Monitor that protects the queue and mIsRunning;
   Monitor mQueueMonitor;
 
-  struct TaskQueueEntry {
-    RefPtr<nsIRunnable> mRunnable;
-    bool mForceDispatch;
-
-    explicit TaskQueueEntry(TemporaryRef<nsIRunnable> aRunnable,
-                            bool aForceDispatch = false)
-      : mRunnable(aRunnable), mForceDispatch(aForceDispatch) {}
-  };
-
   // Queue of tasks to run.
-  std::queue<TaskQueueEntry> mTasks;
+  std::queue<RefPtr<nsIRunnable>> mTasks;
 
   // The thread currently running the task queue. We store a reference
   // to this so that IsCurrentThreadIn() can tell if the current thread
@@ -218,6 +205,8 @@ public:
   explicit FlushableMediaTaskQueue(TemporaryRef<SharedThreadPool> aPool) : MediaTaskQueue(aPool) {}
   nsresult FlushAndDispatch(TemporaryRef<nsIRunnable> aRunnable);
   void Flush();
+
+  bool IsDispatchReliable() override { return false; }
 
 private:
 

--- a/dom/media/omx/MediaOmxCommonDecoder.cpp
+++ b/dom/media/omx/MediaOmxCommonDecoder.cpp
@@ -61,6 +61,11 @@ MediaOmxCommonDecoder::FirstFrameLoaded(nsAutoPtr<MediaInfo> aInfo,
                                         MediaDecoderEventVisibility aEventVisibility)
 {
   MOZ_ASSERT(NS_IsMainThread());
+
+  if (mShuttingDown) {
+    return;
+  }
+
   MediaDecoder::FirstFrameLoaded(aInfo, aEventVisibility);
 
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
@@ -98,6 +103,11 @@ MediaOmxCommonDecoder::PauseStateMachine()
   MOZ_ASSERT(NS_IsMainThread());
   GetReentrantMonitor().AssertCurrentThreadIn();
   DECODER_LOG(PR_LOG_DEBUG, ("%s", __PRETTY_FUNCTION__));
+
+  if (mShuttingDown) {
+    return;
+  }
+
   if (!mDecoderStateMachine) {
     return;
   }
@@ -111,6 +121,10 @@ MediaOmxCommonDecoder::ResumeStateMachine()
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
   DECODER_LOG(PR_LOG_DEBUG, ("%s current time %f", __PRETTY_FUNCTION__,
       mCurrentTime));
+
+  if (mShuttingDown) {
+    return;
+  }
 
   if (!mDecoderStateMachine) {
     return;


### PR DESCRIPTION
The main accomplishments of this PR is that the assertion of dispatch success is now automated and the API entry points on MediaTaskQueue have been streamlined. Additionally, some unused code has been removed and a few shutdown checks have been added to help prevent crashes.

Been testing on YouTube HD, Twitch, and a couple Vimeo vids and appears to be working as intended.