### PR TITLE
fmp4 decoder: add missing #include for mac

### DIFF
--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -23,7 +23,9 @@
 #include "nsIGfxInfo.h"
 #include "AndroidBridge.h"
 #endif
-
+#ifdef MOZ_APPLEMEDIA
+#include "AppleDecoderModule.h"
+#endif
 #ifdef MOZ_FFMPEG
 #include "FFmpegRuntimeLinker.h"
 #endif


### PR DESCRIPTION
You might want to consider this a WIP -- while it helps the build get further
along, I still don't have a successful build.

manual cherry-pick of ab938f4e956e4f53c9cec092892e9f308fcafaf9 by @trav90