### PR TITLE
Places: Bookmarks properties window getting longer (sometimes), dialog window doesn't resize properly

### DIFF
--- a/browser/components/places/PlacesUIUtils.jsm
+++ b/browser/components/places/PlacesUIUtils.jsm
@@ -380,21 +380,17 @@ this.PlacesUIUtils = {
   showBookmarkDialog:
   function PUIU_showBookmarkDialog(aInfo, aParentWindow) {
     // Preserve size attributes differently based on the fact the dialog has
-    // a folder picker or not.  If the picker is visible, the dialog should
-    // be resizable since it may not show enough content for the folders
-    // hierarchy.
+    // a folder picker or not, since it needs more horizontal space than the
+    // other controls.
     let hasFolderPicker = !("hiddenRows" in aInfo) ||
                           aInfo.hiddenRows.indexOf("folderPicker") == -1;
-    // Use a different chrome url, since this allows to persist different sizes,
-    // based on resizability of the dialog.
+    // Use a different chrome url to persist different sizes.
     let dialogURL = hasFolderPicker ?
                     "chrome://browser/content/places/bookmarkProperties2.xul" :
                     "chrome://browser/content/places/bookmarkProperties.xul";
 
-    let features =
-      "centerscreen,chrome,modal,resizable=" + (hasFolderPicker ? "yes" : "no");
-
-    aParentWindow.openDialog(dialogURL, "",  features, aInfo);
+    let features = "centerscreen,chrome,modal,resizable=yes";
+    aParentWindow.openDialog(dialogURL, "", features, aInfo);
     return ("performed" in aInfo && aInfo.performed);
   },
 

--- a/browser/components/places/content/editBookmarkOverlay.xul
+++ b/browser/components/places/content/editBookmarkOverlay.xul
@@ -13,7 +13,7 @@
 <overlay id="editBookmarkOverlay"
          xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
-  <vbox id="editBookmarkPanelContent">
+  <vbox id="editBookmarkPanelContent" flex="1">
     <broadcaster id="paneElementsBroadcaster"/>
 
     <hbox id="editBMPanel_selectionCount" hidden="true" pack="center">
@@ -26,7 +26,9 @@
         <column flex="1" id="editBMPanel_editColumn" />
       </columns>
       <rows id="editBMPanel_rows">
-        <row align="center" id="editBMPanel_nameRow">
+        <row id="editBMPanel_nameRow"
+             align="center"
+             collapsed="true">
           <label value="&editBookmarkOverlay.name.label;"
                  class="editBMPanel_rowLabel"
                  accesskey="&editBookmarkOverlay.name.accesskey;"
@@ -36,7 +38,9 @@
                    observes="paneElementsBroadcaster"/>
         </row>
 
-        <row align="center" id="editBMPanel_locationRow">
+        <row id="editBMPanel_locationRow"
+             align="center"
+             collapsed="true">
           <label value="&editBookmarkOverlay.location.label;"
                  class="editBMPanel_rowLabel"
                  accesskey="&editBookmarkOverlay.location.accesskey;"
@@ -47,7 +51,9 @@
                    observes="paneElementsBroadcaster"/>
         </row>
 
-        <row align="center" id="editBMPanel_feedLocationRow">
+        <row id="editBMPanel_feedLocationRow"
+             align="center"
+             collapsed="true">
           <label value="&editBookmarkOverlay.feedLocation.label;"
                  class="editBMPanel_rowLabel"
                  accesskey="&editBookmarkOverlay.feedLocation.accesskey;"
@@ -58,7 +64,9 @@
                    observes="paneElementsBroadcaster"/>
         </row>
 
-        <row align="center" id="editBMPanel_siteLocationRow">
+        <row id="editBMPanel_siteLocationRow"
+             align="center"
+             collapsed="true">
           <label value="&editBookmarkOverlay.siteLocation.label;"
                  class="editBMPanel_rowLabel"
                  accesskey="&editBookmarkOverlay.siteLocation.accesskey;"
@@ -69,7 +77,9 @@
                    observes="paneElementsBroadcaster"/>
         </row>
 
-        <row align="center" id="editBMPanel_folderRow">
+        <row id="editBMPanel_folderRow"
+             align="center"
+             collapsed="true">
           <label value="&editBookmarkOverlay.folder.label;"
                  class="editBMPanel_rowLabel"
                  control="editBMPanel_folderMenuList"
@@ -105,13 +115,17 @@
           </hbox>
         </row>
 
-        <row align="center" id="editBMPanel_folderTreeRow" collapsed="true">
+        <row id="editBMPanel_folderTreeRow"
+             collapsed="true"
+             flex="1">
           <spacer/>
           <vbox flex="1">
             <tree id="editBMPanel_folderTree"
+                  flex="1"
                   class="placesTree"
                   type="places"
                   height="150"
+                  minheight="150"
                   editable="true"
                   onselect="gEditItemOverlay.onFolderTreeSelect();"
                   hidecolumnpicker="true"
@@ -131,7 +145,9 @@
           </vbox>
         </row>
 
-        <row align="center" id="editBMPanel_tagsRow">
+        <row id="editBMPanel_tagsRow"
+             align="center"
+             collapsed="true">
           <label value="&editBookmarkOverlay.tags.label;"
                  class="editBMPanel_rowLabel"
                  accesskey="&editBookmarkOverlay.tags.accesskey;"
@@ -167,7 +183,9 @@
                    observes="paneElementsBroadcaster"/>
         </row>
 
-        <row align="center" id="editBMPanel_keywordRow">
+        <row id="editBMPanel_keywordRow"
+             align="center"
+             collapsed="true">
           <observes element="additionalInfoBroadcaster" attribute="hidden"/>
           <label value="&editBookmarkOverlay.keyword.label;"
                  class="editBMPanel_rowLabel"
@@ -178,7 +196,8 @@
                    observes="paneElementsBroadcaster"/>
         </row>
 
-        <row id="editBMPanel_descriptionRow">
+        <row id="editBMPanel_descriptionRow"
+             collapsed="true">
           <observes element="additionalInfoBroadcaster" attribute="hidden"/>
           <label value="&editBookmarkOverlay.description.label;"
                  class="editBMPanel_rowLabel"
@@ -193,6 +212,7 @@
     </grid>
 
     <checkbox id="editBMPanel_loadInSidebarCheckbox"
+              collapsed="true"
               label="&editBookmarkOverlay.loadInSidebar.label;"
               accesskey="&editBookmarkOverlay.loadInSidebar.accesskey;"
               oncommand="gEditItemOverlay.onLoadInSidebarCheckboxCommand();"


### PR DESCRIPTION
## 1)
Ad https://forum.palemoon.org/viewtopic.php?f=3&p=109349

Steps to reproduce... I don't know the steps to reproduce the bug (IMHO: import from an old profile?).

But also:
Menu: "Bookmarks" - [a bookmark] - click right mouse button a click on "Properties",
throws a warning in Browser Console:
```
Use of Mutation Events is deprecated. Use MutationObserver instead.
bookmarkProperties.js:337:0
```

## 2)
"Bookmark All Tabs" dialog window doesn't resize properly.

__Steps to reproduce:__
- Right click on any Tab in the tab bar
- Choose "Bookmark All Tabs"
- Resize (enlarge) the window vertically

Actual results:
The window resized but the elements within did not.

Expected results:
The elements within (bookmarks folder tree) should have been resized to fill the available space inside the enlarged window.

---

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1199496
https://bugzilla.mozilla.org/show_bug.cgi?id=725252

---

I've created the new build (x32, Windows) and tested.
