### PR TITLE
Make tail dispatching automatic and happen on the main thread

### DIFF
--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -27,9 +27,10 @@ public:
   {}
 
   virtual void Dispatch(already_AddRefed<nsIRunnable> aRunnable,
-                        DispatchFailureHandling aFailureHandling = AssertDispatchSuccess) override
+                        DispatchFailureHandling aFailureHandling = AssertDispatchSuccess,
+                        DispatchReason aReason = NormalDispatch) override
   {
-    AssertInTailDispatchIfNeeded();
+    MOZ_ASSERT_IF(aReason != TailDispatch, !CurrentThreadRequiresTailDispatch());
     nsCOMPtr<nsIRunnable> r = aRunnable;
     nsresult rv = mTarget->Dispatch(r, NS_DISPATCH_NORMAL);
     MOZ_DIAGNOSTIC_ASSERT(aFailureHandling == DontAssertDispatchSuccess || NS_SUCCEEDED(rv));
@@ -44,7 +45,6 @@ public:
   }
 
   virtual TaskDispatcher& TailDispatcher() override { MOZ_CRASH("Not implemented!"); }
-
   virtual bool InTailDispatch() override { MOZ_CRASH("Not implemented!"); }
 
 private:

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -50,7 +50,6 @@ public:
   }
 
   virtual TaskDispatcher& TailDispatcher() override { MOZ_CRASH("Not implemented!"); }
-  virtual bool InTailDispatch() override { MOZ_CRASH("Not implemented!"); }
 
 private:
   nsRefPtr<nsIThread> mTarget;

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -45,7 +45,7 @@ public:
   virtual bool IsCurrentThreadIn() override
   {
     bool in = NS_GetCurrentThread() == mTarget;
-    MOZ_ASSERT_IF(in, GetCurrent() == this);
+    MOZ_ASSERT(in == (GetCurrent() == this));
     return in;
   }
 

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -80,14 +80,4 @@ AbstractThread::InitStatics()
   sCurrentThreadTLS.set(sMainThread);
 }
 
-#ifdef DEBUG
-void
-TaskDispatcher::AssertIsTailDispatcherIfRequired()
-{
-  AbstractThread* current = AbstractThread::GetCurrent();
-  MOZ_ASSERT_IF(current && current->RequiresTailDispatch(),
-                this == &current->TailDispatcher());
-}
-#endif
-
 } // namespace mozilla

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -8,8 +8,14 @@
 
 #include "MediaTaskQueue.h"
 #include "nsThreadUtils.h"
+#include "TaskDispatcher.h"
+
+#include "nsIAppShell.h"
+#include "nsWidgetsCID.h"
+#include "nsServiceManagerUtils.h"
 
 #include "mozilla/ClearOnShutdown.h"
+#include "mozilla/Maybe.h"
 #include "mozilla/StaticPtr.h"
 #include "mozilla/unused.h"
 
@@ -18,13 +24,26 @@ namespace mozilla {
 StaticRefPtr<AbstractThread> sMainThread;
 ThreadLocal<AbstractThread*> AbstractThread::sCurrentThreadTLS;
 
+static NS_DEFINE_CID(kAppShellCID, NS_APPSHELL_CID);
+
 class XPCOMThreadWrapper : public AbstractThread
 {
 public:
-  explicit XPCOMThreadWrapper(nsIThread* aTarget)
-    : AbstractThread(/* aRequireTailDispatch = */ false)
+  explicit XPCOMThreadWrapper(nsIThread* aTarget, bool aRequireTailDispatch)
+    : AbstractThread(aRequireTailDispatch)
     , mTarget(aTarget)
-  {}
+  {
+    // Our current mechanism of implementing tail dispatch is appshell-specific.
+    // This is because a very similar mechanism already exists on the main
+    // thread, and we want to avoid making event dispatch on the main thread
+    // more complicated than it already is.
+    //
+    // If you need to use tail dispatch on other XPCOM threads, you'll need to
+    // implement an nsIThreadObserver to fire the tail dispatcher at the
+    // appropriate times.
+    MOZ_ASSERT_IF(aRequireTailDispatch,
+                  NS_IsMainThread() && NS_GetCurrentThread() == aTarget);
+  }
 
   virtual void Dispatch(already_AddRefed<nsIRunnable> aRunnable,
                         DispatchFailureHandling aFailureHandling = AssertDispatchSuccess,
@@ -49,10 +68,26 @@ public:
     return in;
   }
 
-  virtual TaskDispatcher& TailDispatcher() override { MOZ_CRASH("Not implemented!"); }
+  void FireTailDispatcher() { MOZ_ASSERT(mTailDispatcher.isSome()); mTailDispatcher.reset(); }
+
+  virtual TaskDispatcher& TailDispatcher() override
+  {
+    MOZ_ASSERT(this == sMainThread); // See the comment in the constructor.
+    MOZ_ASSERT(IsCurrentThreadIn());
+    if (!mTailDispatcher.isSome()) {
+      mTailDispatcher.emplace(/* aIsTailDispatcher = */ true);
+
+      nsCOMPtr<nsIRunnable> event = NS_NewRunnableMethod(this, &XPCOMThreadWrapper::FireTailDispatcher);
+      nsCOMPtr<nsIAppShell> appShell = do_GetService(kAppShellCID);
+      appShell->RunInStableState(event);
+    }
+
+    return mTailDispatcher.ref();
+  }
 
 private:
   nsRefPtr<nsIThread> mTarget;
+  Maybe<AutoTaskDispatcher> mTailDispatcher;
 };
 
 AbstractThread*
@@ -70,7 +105,7 @@ AbstractThread::InitStatics()
   nsCOMPtr<nsIThread> mainThread;
   NS_GetMainThread(getter_AddRefs(mainThread));
   MOZ_DIAGNOSTIC_ASSERT(mainThread);
-  sMainThread = new XPCOMThreadWrapper(mainThread.get());
+  sMainThread = new XPCOMThreadWrapper(mainThread.get(), /* aRequireTailDispatch = */ true);
   ClearOnShutdown(&sMainThread);
 
   if (!sCurrentThreadTLS.init()) {

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -56,18 +56,6 @@ private:
   nsRefPtr<nsIThread> mTarget;
 };
 
-void
-AbstractThread::MaybeTailDispatch(already_AddRefed<nsIRunnable> aRunnable,
-                                  DispatchFailureHandling aFailureHandling)
-{
-  AbstractThread* current = GetCurrent();
-  if (current && current->RequiresTailDispatch()) {
-    current->TailDispatcher().AddTask(this, Move(aRunnable), aFailureHandling);
-  } else {
-    Dispatch(Move(aRunnable), aFailureHandling);
-  }
-}
-
 AbstractThread*
 AbstractThread::MainThread()
 {

--- a/dom/media/AbstractThread.cpp
+++ b/dom/media/AbstractThread.cpp
@@ -16,16 +16,20 @@
 namespace mozilla {
 
 StaticRefPtr<AbstractThread> sMainThread;
+ThreadLocal<AbstractThread*> AbstractThread::sCurrentThreadTLS;
 
 class XPCOMThreadWrapper : public AbstractThread
 {
 public:
-  explicit XPCOMThreadWrapper(nsIThread* aTarget) : mTarget(aTarget) {}
+  explicit XPCOMThreadWrapper(nsIThread* aTarget)
+    : AbstractThread(/* aRequireTailDispatch = */ false)
+    , mTarget(aTarget)
+  {}
 
   virtual void Dispatch(already_AddRefed<nsIRunnable> aRunnable,
                         DispatchFailureHandling aFailureHandling = AssertDispatchSuccess) override
   {
-    MediaTaskQueue::AssertInTailDispatchIfNeeded();
+    AssertInTailDispatchIfNeeded();
     nsCOMPtr<nsIRunnable> r = aRunnable;
     nsresult rv = mTarget->Dispatch(r, NS_DISPATCH_NORMAL);
     MOZ_DIAGNOSTIC_ASSERT(aFailureHandling == DontAssertDispatchSuccess || NS_SUCCEEDED(rv));
@@ -35,9 +39,13 @@ public:
   virtual bool IsCurrentThreadIn() override
   {
     bool in = NS_GetCurrentThread() == mTarget;
-    MOZ_ASSERT_IF(in, MediaTaskQueue::GetCurrentQueue() == nullptr);
+    MOZ_ASSERT_IF(in, GetCurrent() == this);
     return in;
   }
+
+  virtual TaskDispatcher& TailDispatcher() override { MOZ_CRASH("Not implemented!"); }
+
+  virtual bool InTailDispatch() override { MOZ_CRASH("Not implemented!"); }
 
 private:
   nsRefPtr<nsIThread> mTarget;
@@ -47,9 +55,9 @@ void
 AbstractThread::MaybeTailDispatch(already_AddRefed<nsIRunnable> aRunnable,
                                   DispatchFailureHandling aFailureHandling)
 {
-  MediaTaskQueue* currentQueue = MediaTaskQueue::GetCurrentQueue();
-  if (currentQueue && currentQueue->RequiresTailDispatch()) {
-    currentQueue->TailDispatcher().AddTask(this, Move(aRunnable), aFailureHandling);
+  AbstractThread* current = GetCurrent();
+  if (current && current->RequiresTailDispatch()) {
+    current->TailDispatcher().AddTask(this, Move(aRunnable), aFailureHandling);
   } else {
     Dispatch(Move(aRunnable), aFailureHandling);
   }
@@ -72,6 +80,21 @@ AbstractThread::InitStatics()
   MOZ_DIAGNOSTIC_ASSERT(mainThread);
   sMainThread = new XPCOMThreadWrapper(mainThread.get());
   ClearOnShutdown(&sMainThread);
+
+  if (!sCurrentThreadTLS.init()) {
+    MOZ_CRASH();
+  }
+  sCurrentThreadTLS.set(sMainThread);
 }
+
+#ifdef DEBUG
+void
+TaskDispatcher::AssertIsTailDispatcherIfRequired()
+{
+  AbstractThread* current = AbstractThread::GetCurrent();
+  MOZ_ASSERT_IF(current && current->RequiresTailDispatch(),
+                this == &current->TailDispatcher());
+}
+#endif
 
 } // namespace mozilla

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -62,9 +62,6 @@ public:
   // threads which support it.
   virtual TaskDispatcher& TailDispatcher() = 0;
 
-  // Returns whether we're currently performing tail dispatch.
-  virtual bool InTailDispatch() = 0;
-
   // Returns true if this task queue requires all dispatches performed by its
   // tasks to go through the tail dispatcher.
   bool RequiresTailDispatch() const { return mRequireTailDispatch; }

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -80,14 +80,6 @@ public:
   // Must be called exactly once during startup.
   static void InitStatics();
 
-  // Returns true if the currently-running thread is an AbstractThread that
-  // requires tail dispatch.
-  static bool CurrentThreadRequiresTailDispatch()
-  {
-    AbstractThread* current = GetCurrent();
-    return current && current->RequiresTailDispatch();
-  }
-
 protected:
   virtual ~AbstractThread() {}
   static ThreadLocal<AbstractThread*> sCurrentThreadTLS;

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -13,7 +13,11 @@
 #include "nsIThread.h"
 #include "nsRefPtr.h"
 
+#include "mozilla/ThreadLocal.h"
+
 namespace mozilla {
+
+class TaskDispatcher;
 
 /*
  * We often want to run tasks on a target that guarantees that events will never
@@ -31,6 +35,12 @@ namespace mozilla {
 class AbstractThread
 {
 public:
+  // Returns the AbstractThread that the caller is currently running in, or null
+  // if the caller is not running in an AbstractThread.
+  static AbstractThread* GetCurrent() { return sCurrentThreadTLS.get(); }
+
+  AbstractThread(bool aRequireTailDispatch) : mRequireTailDispatch(aRequireTailDispatch) {}
+
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(AbstractThread);
 
   enum DispatchFailureHandling { AssertDispatchSuccess, DontAssertDispatchSuccess };
@@ -47,14 +57,51 @@ public:
   // against FlushableMediaTaskQueues, which eventually needs to go away.
   virtual bool IsDispatchReliable() { return true; }
 
+  // Returns a TaskDispatcher that will dispatch its tasks when the currently-
+  // running tasks pops off the stack.
+  //
+  // May only be called when running within the it is invoked up, and only on
+  // threads which support it.
+  virtual TaskDispatcher& TailDispatcher() = 0;
+
+  // Returns whether we're currently performing tail dispatch.
+  virtual bool InTailDispatch() = 0;
+
+  // Returns true if this task queue requires all dispatches performed by its
+  // tasks to go through the tail dispatcher.
+  bool RequiresTailDispatch() const { return mRequireTailDispatch; }
+
   // Convenience method for getting an AbstractThread for the main thread.
   static AbstractThread* MainThread();
 
   // Must be called exactly once during startup.
   static void InitStatics();
 
+#ifdef DEBUG
+  static void AssertInTailDispatchIfNeeded()
+  {
+    // See if we're currently running in a thread that requires tail
+    // dispatch.
+    AbstractThread* currentThread = GetCurrent();
+    if (!currentThread || !currentThread->RequiresTailDispatch()) {
+      return;
+    }
+
+    MOZ_ASSERT(currentThread->InTailDispatch(),
+               "Not allowed to dispatch tasks directly from this task queue - use TailDispatcher()");
+  }
+#else
+  static void AssertInTailDispatchIfNeeded() {}
+#endif
+
+
 protected:
   virtual ~AbstractThread() {}
+  static ThreadLocal<AbstractThread*> sCurrentThreadTLS;
+
+  // True if we want to require that every task dispatched from tasks running in
+  // this queue go through our queue's tail dispatcher.
+  const bool mRequireTailDispatch;
 };
 
 } // namespace mozilla

--- a/dom/media/AbstractThread.h
+++ b/dom/media/AbstractThread.h
@@ -51,11 +51,6 @@ public:
 
   virtual bool IsCurrentThreadIn() = 0;
 
-  // Convenience method for dispatching a runnable when we may be running on
-  // a thread that requires runnables to be dispatched with tail dispatch.
-  void MaybeTailDispatch(already_AddRefed<nsIRunnable> aRunnable,
-                         DispatchFailureHandling aFailureHandling = AssertDispatchSuccess);
-
   // Returns true if dispatch is generally reliable. This is used to guard
   // against FlushableMediaTaskQueues, which eventually needs to go away.
   virtual bool IsDispatchReliable() { return true; }

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -120,8 +120,6 @@ void
 MediaDecoder::InitStatics()
 {
   AbstractThread::InitStatics();
-
-  MediaTaskQueue::InitStatics();
 }
 
 NS_IMPL_ISUPPORTS(MediaMemoryTracker, nsIMemoryReporter)

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -1411,7 +1411,7 @@ void MediaDecoderStateMachine::SetDuration(int64_t aDuration)
       // Queue seek to new end position.
       nsCOMPtr<nsIRunnable> task =
         new SeekRunnable(mDecoder, double(mEndTime) / USECS_PER_S);
-      AbstractThread::MainThread()->MaybeTailDispatch(task.forget());
+      AbstractThread::MainThread()->Dispatch(task.forget());
     }
   }
 }
@@ -1425,7 +1425,7 @@ void MediaDecoderStateMachine::UpdateEstimatedDuration(int64_t aDuration)
     SetDuration(aDuration);
     nsCOMPtr<nsIRunnable> event =
       NS_NewRunnableMethod(mDecoder, &MediaDecoder::DurationChanged);
-    AbstractThread::MainThread()->MaybeTailDispatch(event.forget());
+    AbstractThread::MainThread()->Dispatch(event.forget());
   }
 }
 
@@ -3207,7 +3207,7 @@ void MediaDecoderStateMachine::UpdateReadyState() {
    */
   nsCOMPtr<nsIRunnable> event;
   event = NS_NewRunnableMethod(mDecoder, &MediaDecoder::UpdateReadyStateForData);
-  AbstractThread::MainThread()->MaybeTailDispatch(event.forget());
+  AbstractThread::MainThread()->Dispatch(event.forget());
 }
 
 bool MediaDecoderStateMachine::JustExitedQuickBuffering()
@@ -3300,7 +3300,7 @@ MediaDecoderStateMachine::ScheduleStateMachine() {
 
   nsCOMPtr<nsIRunnable> task =
     NS_NewRunnableMethod(this, &MediaDecoderStateMachine::RunStateMachine);
-  TaskQueue()->MaybeTailDispatch(task.forget());
+  TaskQueue()->Dispatch(task.forget());
 }
 
 void

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -1902,12 +1902,10 @@ MediaDecoderStateMachine::EnsureAudioDecodeTaskQueued()
              AudioQueue().GetSize(), mReader->SizeOfAudioQueueInFrames());
 
   mAudioDataRequest.Begin(ProxyMediaCall(DecodeTaskQueue(), mReader.get(),
-                                         __func__, &MediaDecoderReader::RequestAudioData,
-                                         TailDispatcher())
+                                         __func__, &MediaDecoderReader::RequestAudioData)
     ->RefableThen(TaskQueue(), __func__, this,
                   &MediaDecoderStateMachine::OnAudioDecoded,
-                  &MediaDecoderStateMachine::OnAudioNotDecoded,
-                  TailDispatcher()));
+                  &MediaDecoderStateMachine::OnAudioNotDecoded));
 
   return NS_OK;
 }

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -328,22 +328,6 @@ public:
 
   void NotifyDataArrived(const char* aBuffer, uint32_t aLength, int64_t aOffset);
 
-  // Returns the tail dispatcher associated with TaskQueue(), which will fire
-  // its tasks when the current task completes. May only be called when running
-  // in TaskQueue().
-  TaskDispatcher& TailDispatcher()
-  {
-    MOZ_ASSERT(OnTaskQueue());
-    return TaskQueue()->TailDispatcher();
-  }
-
-  // Convenience method to perform a tail dispatch.
-  void TailDispatch(AbstractThread* aThread,
-                    already_AddRefed<nsIRunnable> aTask)
-  {
-    TailDispatcher().AddTask(aThread, Move(aTask));
-  }
-
   // Returns the state machine task queue.
   MediaTaskQueue* TaskQueue() const { return mTaskQueue; }
 
@@ -805,7 +789,7 @@ protected:
         mRequest.Begin(mMediaTimer->WaitUntil(mTarget, __func__)->RefableThen(
           mSelf->TaskQueue(), __func__, mSelf,
           &MediaDecoderStateMachine::OnDelayedSchedule,
-          &MediaDecoderStateMachine::NotReached, mSelf->TailDispatcher()));
+          &MediaDecoderStateMachine::NotReached));
       }
 
       void CompleteRequest()
@@ -895,17 +879,17 @@ protected:
     return mTarget.IsValid();
   }
 
-  void Resolve(bool aAtEnd, const char* aCallSite, TaskDispatcher& aDispatcher)
+  void Resolve(bool aAtEnd, const char* aCallSite)
   {
     mTarget.Reset();
     MediaDecoder::SeekResolveValue val(aAtEnd, mTarget.mEventVisibility);
-    mPromise.Resolve(val, aCallSite, aDispatcher);
+    mPromise.Resolve(val, aCallSite);
   }
 
-  void RejectIfExists(const char* aCallSite, TaskDispatcher& aDispatcher)
+  void RejectIfExists(const char* aCallSite)
   {
     mTarget.Reset();
-    mPromise.RejectIfExists(true, aCallSite, aDispatcher);
+    mPromise.RejectIfExists(true, aCallSite);
   }
 
   ~SeekJob()

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -10,7 +10,6 @@
 #include "prlog.h"
 
 #include "AbstractThread.h"
-#include "TaskDispatcher.h"
 
 #include "nsTArray.h"
 #include "nsThreadUtils.h"
@@ -75,20 +74,18 @@ public:
   class Private;
 
   static nsRefPtr<MediaPromise>
-  CreateAndResolve(ResolveValueType aResolveValue, const char* aResolveSite,
-                   TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+  CreateAndResolve(ResolveValueType aResolveValue, const char* aResolveSite)
   {
     nsRefPtr<typename MediaPromise::Private> p = new MediaPromise::Private(aResolveSite);
-    p->Resolve(aResolveValue, aResolveSite, aDispatcher);
+    p->Resolve(aResolveValue, aResolveSite);
     return Move(p);
   }
 
   static nsRefPtr<MediaPromise>
-  CreateAndReject(RejectValueType aRejectValue, const char* aRejectSite,
-                  TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+  CreateAndReject(RejectValueType aRejectValue, const char* aRejectSite)
   {
     nsRefPtr<typename MediaPromise::Private> p = new MediaPromise::Private(aRejectSite);
-    p->Reject(aRejectValue, aRejectSite, aDispatcher);
+    p->Reject(aRejectValue, aRejectSite);
     return Move(p);
   }
 
@@ -174,8 +171,7 @@ protected:
 
     explicit ThenValueBase(const char* aCallSite) : mCallSite(aCallSite) {}
 
-    virtual void Dispatch(MediaPromise *aPromise,
-                          TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>()) = 0;
+    virtual void Dispatch(MediaPromise *aPromise) = 0;
 
   protected:
     virtual void DoResolve(ResolveValueType aResolveValue) = 0;
@@ -223,7 +219,7 @@ protected:
       , mResolveMethod(aResolveMethod)
       , mRejectMethod(aRejectMethod) {}
 
-    void Dispatch(MediaPromise *aPromise, TaskDispatcher& aDispatcher) override
+    void Dispatch(MediaPromise *aPromise) override
     {
       aPromise->mMutex.AssertCurrentThreadOwns();
       MOZ_ASSERT(!aPromise->IsPending());
@@ -239,7 +235,7 @@ protected:
       // then shut down the thread or task queue that the promise result would
       // be dispatched on. So we unfortunately can't assert that promise
       // dispatch succeeds. :-(
-      aDispatcher.AddTask(mResponseTarget, runnable.forget(), AbstractThread::DontAssertDispatchSuccess);
+      mResponseTarget->Dispatch(runnable.forget(), AbstractThread::DontAssertDispatchSuccess);
     }
 
 #ifdef DEBUG
@@ -308,18 +304,8 @@ public:
 
   template<typename ThisType, typename ResolveMethodType, typename RejectMethodType>
   already_AddRefed<Consumer> RefableThen(AbstractThread* aResponseThread, const char* aCallSite, ThisType* aThisVal,
-                                         ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod,
-                                         TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+                                         ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod)
   {
-    // {Refable,}Then() rarely dispatch directly - they do so only in the case
-    // where the promise has already been resolved by the time {Refable,}Then()
-    // is invoked. This case is rare, but it _can_ happen, which makes it a ripe
-    // target for race bugs. So we do an extra assertion here to make sure our
-    // caller is using tail dispatch correctly no matter what, rather than
-    // relying on the assertion in Dispatch(), which may be called extremely
-    // infrequently.
-    aDispatcher.AssertIsTailDispatcherIfRequired();
-
     MutexAutoLock lock(mMutex);
     MOZ_ASSERT(aResponseThread->IsDispatchReliable());
     MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveConsumer);
@@ -329,7 +315,7 @@ public:
     PROMISE_LOG("%s invoking Then() [this=%p, thenValue=%p, aThisVal=%p, isPending=%d]",
                 aCallSite, this, thenValue.get(), aThisVal, (int) IsPending());
     if (!IsPending()) {
-      thenValue->Dispatch(this, aDispatcher);
+      thenValue->Dispatch(this);
     } else {
       mThenValues.AppendElement(thenValue);
     }
@@ -339,16 +325,14 @@ public:
 
   template<typename ThisType, typename ResolveMethodType, typename RejectMethodType>
   void Then(AbstractThread* aResponseThread, const char* aCallSite, ThisType* aThisVal,
-            ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod,
-            TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+            ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod)
   {
     nsRefPtr<Consumer> c =
-      RefableThen(aResponseThread, aCallSite, aThisVal, aResolveMethod, aRejectMethod, aDispatcher);
+      RefableThen(aResponseThread, aCallSite, aThisVal, aResolveMethod, aRejectMethod);
     return;
   }
 
-  void ChainTo(already_AddRefed<Private> aChainedPromise, const char* aCallSite,
-               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+  void ChainTo(already_AddRefed<Private> aChainedPromise, const char* aCallSite)
   {
     MutexAutoLock lock(mMutex);
     MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveConsumer);
@@ -357,7 +341,7 @@ public:
     PROMISE_LOG("%s invoking Chain() [this=%p, chainedPromise=%p, isPending=%d]",
                 aCallSite, this, chainedPromise.get(), (int) IsPending());
     if (!IsPending()) {
-      ForwardTo(chainedPromise, aDispatcher);
+      ForwardTo(chainedPromise);
     } else {
       mChainedPromises.AppendElement(chainedPromise);
     }
@@ -365,27 +349,27 @@ public:
 
 protected:
   bool IsPending() { return mResolveValue.isNothing() && mRejectValue.isNothing(); }
-  void DispatchAll(TaskDispatcher& aDispatcher)
+  void DispatchAll()
   {
     mMutex.AssertCurrentThreadOwns();
     for (size_t i = 0; i < mThenValues.Length(); ++i) {
-      mThenValues[i]->Dispatch(this, aDispatcher);
+      mThenValues[i]->Dispatch(this);
     }
     mThenValues.Clear();
 
     for (size_t i = 0; i < mChainedPromises.Length(); ++i) {
-      ForwardTo(mChainedPromises[i], aDispatcher);
+      ForwardTo(mChainedPromises[i]);
     }
     mChainedPromises.Clear();
   }
 
-  void ForwardTo(Private* aOther, TaskDispatcher& aDispatcher)
+  void ForwardTo(Private* aOther)
   {
     MOZ_ASSERT(!IsPending());
     if (mResolveValue.isSome()) {
-      aOther->Resolve(mResolveValue.ref(), "<chained promise>", aDispatcher);
+      aOther->Resolve(mResolveValue.ref(), "<chained promise>");
     } else {
-      aOther->Reject(mRejectValue.ref(), "<chained promise>", aDispatcher);
+      aOther->Reject(mRejectValue.ref(), "<chained promise>");
     }
   }
 
@@ -413,24 +397,22 @@ class MediaPromise<ResolveValueT, RejectValueT, IsExclusive>::Private
 public:
   explicit Private(const char* aCreationSite) : MediaPromise(aCreationSite) {}
 
-  void Resolve(ResolveValueT aResolveValue, const char* aResolveSite,
-               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+  void Resolve(ResolveValueT aResolveValue, const char* aResolveSite)
   {
     MutexAutoLock lock(mMutex);
     MOZ_ASSERT(IsPending());
     PROMISE_LOG("%s resolving MediaPromise (%p created at %s)", aResolveSite, this, mCreationSite);
     mResolveValue.emplace(aResolveValue);
-    DispatchAll(aDispatcher);
+    DispatchAll();
   }
 
-  void Reject(RejectValueT aRejectValue, const char* aRejectSite,
-              TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+  void Reject(RejectValueT aRejectValue, const char* aRejectSite)
   {
     MutexAutoLock lock(mMutex);
     MOZ_ASSERT(IsPending());
     PROMISE_LOG("%s rejecting MediaPromise (%p created at %s)", aRejectSite, this, mCreationSite);
     mRejectValue.emplace(aRejectValue);
-    DispatchAll(aDispatcher);
+    DispatchAll();
   }
 };
 
@@ -491,44 +473,40 @@ public:
   }
 
   void Resolve(typename PromiseType::ResolveValueType aResolveValue,
-               const char* aMethodName,
-               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+               const char* aMethodName)
   {
     if (mMonitor) {
       mMonitor->AssertCurrentThreadOwns();
     }
     MOZ_ASSERT(mPromise);
-    mPromise->Resolve(aResolveValue, aMethodName, aDispatcher);
+    mPromise->Resolve(aResolveValue, aMethodName);
     mPromise = nullptr;
   }
 
   void ResolveIfExists(typename PromiseType::ResolveValueType aResolveValue,
-                       const char* aMethodName,
-                       TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+                       const char* aMethodName)
   {
     if (!IsEmpty()) {
-      Resolve(aResolveValue, aMethodName, aDispatcher);
+      Resolve(aResolveValue, aMethodName);
     }
   }
 
   void Reject(typename PromiseType::RejectValueType aRejectValue,
-              const char* aMethodName,
-              TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+              const char* aMethodName)
   {
     if (mMonitor) {
       mMonitor->AssertCurrentThreadOwns();
     }
     MOZ_ASSERT(mPromise);
-    mPromise->Reject(aRejectValue, aMethodName, aDispatcher);
+    mPromise->Reject(aRejectValue, aMethodName);
     mPromise = nullptr;
   }
 
   void RejectIfExists(typename PromiseType::RejectValueType aRejectValue,
-                      const char* aMethodName,
-                      TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+                      const char* aMethodName)
   {
     if (!IsEmpty()) {
-      Reject(aRejectValue, aMethodName, aDispatcher);
+      Reject(aRejectValue, aMethodName);
     }
   }
 
@@ -664,13 +642,12 @@ private:
 
 template<typename PromiseType>
 static nsRefPtr<PromiseType>
-ProxyInternal(AbstractThread* aTarget, MethodCallBase<PromiseType>* aMethodCall, const char* aCallerName,
-              TaskDispatcher& aDispatcher)
+ProxyInternal(AbstractThread* aTarget, MethodCallBase<PromiseType>* aMethodCall, const char* aCallerName)
 {
   nsRefPtr<typename PromiseType::Private> p = new (typename PromiseType::Private)(aCallerName);
   nsRefPtr<ProxyRunnable<PromiseType>> r = new ProxyRunnable<PromiseType>(p, aMethodCall);
   MOZ_ASSERT(aTarget->IsDispatchReliable());
-  aDispatcher.AddTask(aTarget, r.forget());
+  aTarget->Dispatch(r.forget());
   return Move(p);
 }
 
@@ -679,34 +656,31 @@ ProxyInternal(AbstractThread* aTarget, MethodCallBase<PromiseType>* aMethodCall,
 template<typename PromiseType, typename ThisType>
 static nsRefPtr<PromiseType>
 ProxyMediaCall(AbstractThread* aTarget, ThisType* aThisVal, const char* aCallerName,
-               nsRefPtr<PromiseType>(ThisType::*aMethod)(),
-               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+               nsRefPtr<PromiseType>(ThisType::*aMethod)())
 {
   typedef detail::MethodCallWithNoArgs<PromiseType, ThisType> MethodCallType;
   MethodCallType* methodCall = new MethodCallType(aThisVal, aMethod);
-  return detail::ProxyInternal(aTarget, methodCall, aCallerName, aDispatcher);
+  return detail::ProxyInternal(aTarget, methodCall, aCallerName);
 }
 
 template<typename PromiseType, typename ThisType, typename Arg1Type>
 static nsRefPtr<PromiseType>
 ProxyMediaCall(AbstractThread* aTarget, ThisType* aThisVal, const char* aCallerName,
-               nsRefPtr<PromiseType>(ThisType::*aMethod)(Arg1Type), Arg1Type aArg1,
-               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+               nsRefPtr<PromiseType>(ThisType::*aMethod)(Arg1Type), Arg1Type aArg1)
 {
   typedef detail::MethodCallWithOneArg<PromiseType, ThisType, Arg1Type> MethodCallType;
   MethodCallType* methodCall = new MethodCallType(aThisVal, aMethod, aArg1);
-  return detail::ProxyInternal(aTarget, methodCall, aCallerName, aDispatcher);
+  return detail::ProxyInternal(aTarget, methodCall, aCallerName);
 }
 
 template<typename PromiseType, typename ThisType, typename Arg1Type, typename Arg2Type>
 static nsRefPtr<PromiseType>
 ProxyMediaCall(AbstractThread* aTarget, ThisType* aThisVal, const char* aCallerName,
-               nsRefPtr<PromiseType>(ThisType::*aMethod)(Arg1Type, Arg2Type), Arg1Type aArg1, Arg2Type aArg2,
-               TaskDispatcher& aDispatcher = PassByRef<AutoTaskDispatcher>())
+               nsRefPtr<PromiseType>(ThisType::*aMethod)(Arg1Type, Arg2Type), Arg1Type aArg1, Arg2Type aArg2)
 {
   typedef detail::MethodCallWithTwoArgs<PromiseType, ThisType, Arg1Type, Arg2Type> MethodCallType;
   MethodCallType* methodCall = new MethodCallType(aThisVal, aMethod, aArg1, aArg2);
-  return detail::ProxyInternal(aTarget, methodCall, aCallerName, aDispatcher);
+  return detail::ProxyInternal(aTarget, methodCall, aCallerName);
 }
 
 #undef PROMISE_LOG

--- a/dom/media/MediaQueue.h
+++ b/dom/media/MediaQueue.h
@@ -186,7 +186,7 @@ private:
     for (uint32_t i = 0; i < mPopListeners.Length(); i++) {
       Listener& l = mPopListeners[i];
       nsCOMPtr<nsIRunnable> r = l.mRunnable;
-      l.mTarget->MaybeTailDispatch(r.forget());
+      l.mTarget->Dispatch(r.forget());
     }
   }
 

--- a/dom/media/MediaStreamGraph.cpp
+++ b/dom/media/MediaStreamGraph.cpp
@@ -279,7 +279,7 @@ MediaStreamGraphImpl::UpdateBufferSufficiencyState(SourceMediaStream* aStream)
 
   for (uint32_t i = 0; i < runnables.Length(); ++i) {
     nsCOMPtr<nsIRunnable> r = runnables[i].mRunnable;
-    runnables[i].mTarget->MaybeTailDispatch(r.forget(), AbstractThread::DontAssertDispatchSuccess);
+    runnables[i].mTarget->Dispatch(r.forget(), AbstractThread::DontAssertDispatchSuccess);
   }
 }
 
@@ -2500,7 +2500,7 @@ SourceMediaStream::DispatchWhenNotEnoughBuffered(TrackID aID,
   TrackData* data = FindDataForTrack(aID);
   if (!data) {
     nsCOMPtr<nsIRunnable> r = aSignalRunnable;
-    aSignalQueue->MaybeTailDispatch(r.forget());
+    aSignalQueue->Dispatch(r.forget());
     return;
   }
 
@@ -2510,7 +2510,7 @@ SourceMediaStream::DispatchWhenNotEnoughBuffered(TrackID aID,
     }
   } else {
     nsCOMPtr<nsIRunnable> r = aSignalRunnable;
-    aSignalQueue->MaybeTailDispatch(r.forget());
+    aSignalQueue->Dispatch(r.forget());
   }
 }
 

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -39,8 +39,10 @@ MediaTaskQueue::TailDispatcher()
 }
 
 nsresult
-MediaTaskQueue::DispatchLocked(already_AddRefed<nsIRunnable> aRunnable, DispatchMode aMode)
+MediaTaskQueue::DispatchLocked(already_AddRefed<nsIRunnable> aRunnable,
+                               DispatchMode aMode, DispatchReason aReason)
 {
+  MOZ_ASSERT_IF(aReason != TailDispatch, !CurrentThreadRequiresTailDispatch());
   mQueueMonitor.AssertCurrentThreadOwns();
   nsCOMPtr<nsIRunnable> r = aRunnable;
   if (mIsFlushing && aMode == AbortIfFlushing) {
@@ -155,7 +157,6 @@ FlushableMediaTaskQueue::Flush()
 nsresult
 FlushableMediaTaskQueue::FlushAndDispatch(TemporaryRef<nsIRunnable> aRunnable)
 {
-  AssertInTailDispatchIfNeeded(); // Do this before acquiring the monitor.
   MonitorAutoLock mon(mQueueMonitor);
   AutoSetFlushing autoFlush(this);
   FlushLocked();

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -10,25 +10,15 @@
 
 namespace mozilla {
 
-ThreadLocal<MediaTaskQueue*> MediaTaskQueue::sCurrentQueueTLS;
-
-/* static */ void
-MediaTaskQueue::InitStatics()
-{
-  if (!sCurrentQueueTLS.init()) {
-    MOZ_CRASH();
-  }
-}
-
 MediaTaskQueue::MediaTaskQueue(TemporaryRef<SharedThreadPool> aPool,
                                bool aRequireTailDispatch)
-  : mPool(aPool)
+  : AbstractThread(aRequireTailDispatch)
+  , mPool(aPool)
   , mQueueMonitor("MediaTaskQueue::Queue")
   , mTailDispatcher(nullptr)
   , mIsRunning(false)
   , mIsShutdown(false)
   , mIsFlushing(false)
-  , mRequireTailDispatch(aRequireTailDispatch)
 {
   MOZ_COUNT_CTOR(MediaTaskQueue);
 }
@@ -199,7 +189,7 @@ bool
 MediaTaskQueue::IsCurrentThreadIn()
 {
   bool in = NS_GetCurrentThread() == mRunningThread;
-  MOZ_ASSERT_IF(in, GetCurrentQueue() == this);
+  MOZ_ASSERT_IF(in, GetCurrent() == this);
   return in;
 }
 
@@ -265,15 +255,5 @@ MediaTaskQueue::Runner::Run()
 
   return NS_OK;
 }
-
-#ifdef DEBUG
-void
-TaskDispatcher::AssertIsTailDispatcherIfRequired()
-{
-  MediaTaskQueue* currentQueue = MediaTaskQueue::GetCurrentQueue();
-  MOZ_ASSERT_IF(currentQueue && currentQueue->RequiresTailDispatch(),
-                this == &currentQueue->TailDispatcher());
-}
-#endif
 
 } // namespace mozilla

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -219,7 +219,7 @@ bool
 MediaTaskQueue::IsCurrentThreadIn()
 {
   bool in = NS_GetCurrentThread() == mRunningThread;
-  MOZ_ASSERT_IF(in, GetCurrent() == this);
+  MOZ_ASSERT(in == (GetCurrent() == this));
   return in;
 }
 

--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -106,8 +106,16 @@ private:
 void
 MediaTaskQueue::SyncDispatch(TemporaryRef<nsIRunnable> aRunnable) {
   NS_WARNING("MediaTaskQueue::SyncDispatch is deprecated and potentially dangerous. Don't use!");
-  RefPtr<MediaTaskQueueSyncRunnable> task(new MediaTaskQueueSyncRunnable(aRunnable));
-  Dispatch(task);
+  nsRefPtr<MediaTaskQueueSyncRunnable> task(new MediaTaskQueueSyncRunnable(aRunnable));
+
+  // Tail dispatchers don't interact nicely with sync dispatch. We require that
+  // nothing is already in the tail dispatcher, and then sidestep it for this
+  // task.
+  MOZ_ASSERT_IF(AbstractThread::GetCurrent(),
+                !AbstractThread::GetCurrent()->TailDispatcher().HasTasksFor(this));
+  nsRefPtr<MediaTaskQueueSyncRunnable> taskRef = task;
+  Dispatch(taskRef.forget(), AssertDispatchSuccess, TailDispatch);
+
   task->WaitUntilDone();
 }
 
@@ -121,6 +129,11 @@ MediaTaskQueue::AwaitIdle()
 void
 MediaTaskQueue::AwaitIdleLocked()
 {
+  // Make sure there are no tasks for this queue waiting in the caller's tail
+  // dispatcher.
+  MOZ_ASSERT_IF(AbstractThread::GetCurrent(),
+                !AbstractThread::GetCurrent()->TailDispatcher().HasTasksFor(this));
+
   mQueueMonitor.AssertCurrentThreadOwns();
   MOZ_ASSERT(mIsRunning || mTasks.empty());
   while (mIsRunning) {
@@ -131,6 +144,11 @@ MediaTaskQueue::AwaitIdleLocked()
 void
 MediaTaskQueue::AwaitShutdownAndIdle()
 {
+  // Make sure there are no tasks for this queue waiting in the caller's tail
+  // dispatcher.
+  MOZ_ASSERT_IF(AbstractThread::GetCurrent(),
+                !AbstractThread::GetCurrent()->TailDispatcher().HasTasksFor(this));
+
   MonitorAutoLock mon(mQueueMonitor);
   while (!mIsShutdown) {
     mQueueMonitor.Wait();
@@ -176,6 +194,11 @@ FlushableMediaTaskQueue::FlushAndDispatch(TemporaryRef<nsIRunnable> aRunnable)
 void
 FlushableMediaTaskQueue::FlushLocked()
 {
+  // Make sure there are no tasks for this queue waiting in the caller's tail
+  // dispatcher.
+  MOZ_ASSERT_IF(AbstractThread::GetCurrent(),
+                !AbstractThread::GetCurrent()->TailDispatcher().HasTasksFor(this));
+
   mQueueMonitor.AssertCurrentThreadOwns();
   MOZ_ASSERT(mIsFlushing);
 

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -47,7 +47,7 @@ public:
                 DispatchReason aReason = NormalDispatch) override
   {
     MonitorAutoLock mon(mQueueMonitor);
-    nsresult rv = DispatchLocked(Move(aRunnable), AbortIfFlushing, aReason);
+    nsresult rv = DispatchLocked(Move(aRunnable), AbortIfFlushing, aFailureHandling, aReason);
     MOZ_DIAGNOSTIC_ASSERT(aFailureHandling == DontAssertDispatchSuccess || NS_SUCCEEDED(rv));
     unused << rv;
   }
@@ -100,6 +100,7 @@ protected:
   enum DispatchMode { AbortIfFlushing, IgnoreFlushing };
 
   nsresult DispatchLocked(already_AddRefed<nsIRunnable> aRunnable, DispatchMode aMode,
+                          DispatchFailureHandling aFailureHandling,
                           DispatchReason aReason = NormalDispatch);
 
   RefPtr<SharedThreadPool> mPool;

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -77,17 +77,6 @@ public:
   // the task queue.
   bool IsCurrentThreadIn() override;
 
-  bool InTailDispatch() override
-  {
-    MOZ_ASSERT(IsCurrentThreadIn());
-
-    // This is a bit tricky. The only moment when we're running in a task queue
-    // but don't have mTailDispatcher set is precisely the moment that we're
-    // doing tail dispatch (i.e. when AutoTaskGuard's destructor has already
-    // run and AutoTaskDispatcher's destructor is currently running).
-    return !mTailDispatcher;
-  }
-
 protected:
   virtual ~MediaTaskQueue();
 

--- a/dom/media/MediaTaskQueue.h
+++ b/dom/media/MediaTaskQueue.h
@@ -10,7 +10,6 @@
 #include <queue>
 #include "mozilla/RefPtr.h"
 #include "mozilla/Monitor.h"
-#include "mozilla/ThreadLocal.h"
 #include "mozilla/unused.h"
 #include "SharedThreadPool.h"
 #include "nsThreadUtils.h"
@@ -31,14 +30,7 @@ typedef MediaPromise<bool, bool, false> ShutdownPromise;
 // They may be executed on different threads, and a memory barrier is used
 // to make this threadsafe for objects that aren't already threadsafe.
 class MediaTaskQueue : public AbstractThread {
-  static ThreadLocal<MediaTaskQueue*> sCurrentQueueTLS;
 public:
-  static void InitStatics();
-
-  // Returns the task queue that the caller is currently running in, or null
-  // if the caller is not running in a MediaTaskQueue.
-  static MediaTaskQueue* GetCurrentQueue() { return sCurrentQueueTLS.get(); }
-
   explicit MediaTaskQueue(TemporaryRef<SharedThreadPool> aPool, bool aRequireTailDispatch = false);
 
   void Dispatch(TemporaryRef<nsIRunnable> aRunnable,
@@ -48,36 +40,7 @@ public:
     return Dispatch(r.forget(), aFailureHandling);
   }
 
-  // Returns a TaskDispatcher that will dispatch its tasks when the currently-
-  // running tasks pops off the stack.
-  //
-  // May only be called when running within the task queue it is invoked up.
-  TaskDispatcher& TailDispatcher();
-
-  // Returns true if this task queue requires all dispatches performed by its
-  // tasks to go through the tail dispatcher.
-  bool RequiresTailDispatch() { return mRequireTailDispatch; }
-
-#ifdef DEBUG
-  static void AssertInTailDispatchIfNeeded()
-  {
-    // See if we're currently running in a task queue that asserts tail
-    // dispatch.
-    MediaTaskQueue* currentQueue = MediaTaskQueue::GetCurrentQueue();
-    if (!currentQueue || !currentQueue->RequiresTailDispatch()) {
-      return;
-    }
-
-    // This is a bit tricky. The only moment when we're running in a task queue
-    // but don't have mTailDispatcher set is precisely the moment that we're
-    // doing tail dispatch (i.e. when AutoTaskGuard's destructor has already
-    // run and AutoTaskDispatcher's destructor is currently running).
-    MOZ_ASSERT(!currentQueue->mTailDispatcher,
-               "Not allowed to dispatch tasks directly from this task queue - use TailDispatcher()");
-  }
-#else
-  static void AssertInTailDispatchIfNeeded() {}
-#endif
+  TaskDispatcher& TailDispatcher() override;
 
   // For AbstractThread.
   void Dispatch(already_AddRefed<nsIRunnable> aRunnable,
@@ -113,6 +76,17 @@ public:
   // Returns true if the current thread is currently running a Runnable in
   // the task queue.
   bool IsCurrentThreadIn() override;
+
+  bool InTailDispatch() override
+  {
+    MOZ_ASSERT(IsCurrentThreadIn());
+
+    // This is a bit tricky. The only moment when we're running in a task queue
+    // but don't have mTailDispatcher set is precisely the moment that we're
+    // doing tail dispatch (i.e. when AutoTaskGuard's destructor has already
+    // run and AutoTaskDispatcher's destructor is currently running).
+    return !mTailDispatcher;
+  }
 
 protected:
   virtual ~MediaTaskQueue();
@@ -156,8 +130,8 @@ protected:
       MOZ_ASSERT(!mQueue->mTailDispatcher);
       mQueue->mTailDispatcher = this;
 
-      MOZ_ASSERT(sCurrentQueueTLS.get() == nullptr);
-      sCurrentQueueTLS.set(aQueue);
+      MOZ_ASSERT(sCurrentThreadTLS.get() == nullptr);
+      sCurrentThreadTLS.set(aQueue);
 
       MOZ_ASSERT(mQueue->mRunningThread == nullptr);
       mQueue->mRunningThread = NS_GetCurrentThread();
@@ -168,7 +142,7 @@ protected:
       MOZ_ASSERT(mQueue->mRunningThread == NS_GetCurrentThread());
       mQueue->mRunningThread = nullptr;
 
-      sCurrentQueueTLS.set(nullptr);
+      sCurrentThreadTLS.set(nullptr);
       mQueue->mTailDispatcher = nullptr;
     }
   private:
@@ -187,10 +161,6 @@ protected:
 
   // True if we're flushing; we reject new tasks if we're flushing.
   bool mIsFlushing;
-
-  // True if we want to require that every task dispatched from tasks running in
-  // this queue go through our queue's tail dispatcher.
-  bool mRequireTailDispatch;
 
   class Runner : public nsRunnable {
   public:

--- a/dom/media/TaskDispatcher.h
+++ b/dom/media/TaskDispatcher.h
@@ -44,12 +44,6 @@ public:
   virtual void AddTask(AbstractThread* aThread,
                        already_AddRefed<nsIRunnable> aRunnable,
                        AbstractThread::DispatchFailureHandling aFailureHandling = AbstractThread::AssertDispatchSuccess) = 0;
-
-#ifdef DEBUG
-  void AssertIsTailDispatcherIfRequired();
-#else
-  void AssertIsTailDispatcherIfRequired() {}
-#endif
 };
 
 /*

--- a/dom/media/TaskDispatcher.h
+++ b/dom/media/TaskDispatcher.h
@@ -44,6 +44,8 @@ public:
   virtual void AddTask(AbstractThread* aThread,
                        already_AddRefed<nsIRunnable> aRunnable,
                        AbstractThread::DispatchFailureHandling aFailureHandling = AbstractThread::AssertDispatchSuccess) = 0;
+
+  virtual bool HasTasksFor(AbstractThread* aThread) = 0;
 };
 
 /*
@@ -88,6 +90,8 @@ public:
     }
   }
 
+  bool HasTasksFor(AbstractThread* aThread) override { return !!GetTaskGroup(aThread); }
+
 private:
 
   struct PerThreadTaskGroup
@@ -131,14 +135,25 @@ private:
 
   PerThreadTaskGroup& EnsureTaskGroup(AbstractThread* aThread)
   {
-    for (size_t i = 0; i < mTaskGroups.Length(); ++i) {
-      if (mTaskGroups[i]->mThread == aThread) {
-        return *mTaskGroups[i];
-      }
+    PerThreadTaskGroup* existing = GetTaskGroup(aThread);
+    if (existing) {
+      return *existing;
     }
 
     mTaskGroups.AppendElement(new PerThreadTaskGroup(aThread));
     return *mTaskGroups.LastElement();
+  }
+
+  PerThreadTaskGroup* GetTaskGroup(AbstractThread* aThread)
+  {
+    for (size_t i = 0; i < mTaskGroups.Length(); ++i) {
+      if (mTaskGroups[i]->mThread == aThread) {
+        return mTaskGroups[i].get();
+      }
+    }
+
+    // Not found.
+    return nullptr;
   }
 
   // Task groups, organized by thread.

--- a/dom/media/TaskDispatcher.h
+++ b/dom/media/TaskDispatcher.h
@@ -52,7 +52,7 @@ public:
  * AutoTaskDispatcher is a stack-scoped TaskDispatcher implementation that fires
  * its queued tasks when it is popped off the stack.
  */
-class MOZ_STACK_CLASS AutoTaskDispatcher : public TaskDispatcher
+class AutoTaskDispatcher : public TaskDispatcher
 {
 public:
   explicit AutoTaskDispatcher(bool aIsTailDispatcher = false) : mIsTailDispatcher(aIsTailDispatcher) {}

--- a/dom/media/TaskDispatcher.h
+++ b/dom/media/TaskDispatcher.h
@@ -59,7 +59,7 @@ public:
 class MOZ_STACK_CLASS AutoTaskDispatcher : public TaskDispatcher
 {
 public:
-  AutoTaskDispatcher() {}
+  explicit AutoTaskDispatcher(bool aIsTailDispatcher = false) : mIsTailDispatcher(aIsTailDispatcher) {}
   ~AutoTaskDispatcher()
   {
     for (size_t i = 0; i < mTaskGroups.Length(); ++i) {
@@ -67,8 +67,10 @@ public:
       nsRefPtr<AbstractThread> thread = group->mThread;
 
       AbstractThread::DispatchFailureHandling failureHandling = group->mFailureHandling;
+      AbstractThread::DispatchReason reason = mIsTailDispatcher ? AbstractThread::TailDispatch
+                                                                : AbstractThread::NormalDispatch;
       nsCOMPtr<nsIRunnable> r = new TaskGroupRunnable(Move(group));
-      thread->Dispatch(r.forget(), failureHandling);
+      thread->Dispatch(r.forget(), failureHandling, reason);
     }
   }
 
@@ -146,7 +148,11 @@ private:
   }
 
   // Task groups, organized by thread.
-  nsTArray<UniquePtr<PerThreadTaskGroup>> mTaskGroups;
+  nsTArray<UniquePtr<PerThreadTaskGroup>> mTaskGroups;\
+
+  // True if this TaskDispatcher represents the tail dispatcher for the thread
+  // upon which it runs.
+  const bool mIsTailDispatcher;
 };
 
 // Little utility class to allow declaring AutoTaskDispatcher as a default

--- a/dom/media/test/test_error_in_video_document.html
+++ b/dom/media/test/test_error_in_video_document.html
@@ -21,9 +21,13 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=604067
 
 /** Test for Bug 604067 **/
 
+function documentVideo() {
+  return document.body.getElementsByTagName("iframe")[0]
+                 .contentDocument.body.getElementsByTagName("video")[0];
+}
+
 function check() {
-  var v = document.body.getElementsByTagName("iframe")[0]
-                  .contentDocument.body.getElementsByTagName("video")[0];
+  var v = documentVideo();
 
   // Debug info for Bug 608634
   ok(true, "iframe src=" + document.body.getElementsByTagName("iframe")[0].src);
@@ -47,7 +51,15 @@ if (!t) {
 
   var f = document.createElement("iframe");
   f.src = t.name;
-  f.addEventListener("load", function() { SimpleTest.executeSoon(check); }, false);
+  f.addEventListener("load", function() {
+    if (documentVideo().error) {
+      info("Error occured by the time we got |load| - checking directly.");
+      check();
+    } else {
+      todo(false, "Error hasn't occurred yet - adding |error| event listener. This shouldn't happen, see bug 608634.");
+      documentVideo().addEventListener("error", check);
+    }
+  }, false);
   document.body.appendChild(f);
 }
 


### PR DESCRIPTION
Just what it says in the tin. Only other changes are adjusting a few assertions and updating a couple tests. This should be the final big update to AbstractThread and TaskDispatcher, so this is one big hurdle behind us on the road to stabilizing our media code.

Tested on YouTube HD & Twitch and seems to be working as intended. Still adding the verification needed label since this is a substantive change (needs testing on Windows, obviously).