### PR TITLE
Do not pre-multiply JXR planar alpha twice

### DIFF
--- a/image/decoders/nsJXRDecoder.h
+++ b/image/decoders/nsJXRDecoder.h
@@ -111,6 +111,7 @@ private:
     bool m_skippedTileRows;
 
     uint32_t m_alphaBitDepth;
+    bool m_planarAlphaIsPremultiplied;
 
 private:
 


### PR DESCRIPTION
If the image already had pre-multiplied alpha, the decoder would
pre-multiply those already pre-multiplied values again when decoding
the alpha plane separately from the main plane.