### PR TITLE
XMLHttpRequest: Expose mozAnon constructor js binding to system scopes

### DIFF
--- a/browser/base/content/nsContextMenu.js
+++ b/browser/base/content/nsContextMenu.js
@@ -4,8 +4,6 @@
 
 Components.utils.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
 
-Components.utils.importGlobalProperties(["URL"]);
-
 function nsContextMenu(aXulMenu, aIsShift) {
   this.shouldDisplay = true;
   this.initMenu(aXulMenu, aIsShift);

--- a/dom/base/nsGlobalWindow.cpp
+++ b/dom/base/nsGlobalWindow.cpp
@@ -1148,7 +1148,6 @@ nsGlobalWindow::nsGlobalWindow(nsGlobalWindow *aOuterWindow)
 
     mObserver = new nsGlobalWindowObserver(this);
     if (mObserver) {
-      NS_ADDREF(mObserver);
       nsCOMPtr<nsIObserverService> os = mozilla::services::GetObserverService();
       if (os) {
         // Watch for online/offline status changes so we can fire events. Use
@@ -1168,8 +1167,6 @@ nsGlobalWindow::nsGlobalWindow(nsGlobalWindow *aOuterWindow)
     // remain frozen until they get an inner window, so freeze this
     // outer window here.
     Freeze();
-
-    mObserver = nullptr;
   }
 
   // We could have failed the first time through trying
@@ -1467,7 +1464,6 @@ nsGlobalWindow::CleanUp()
     // Drop its reference to this dying window, in case for some bogus reason
     // the object stays around.
     mObserver->Forget();
-    NS_RELEASE(mObserver);
   }
 
   if (mNavigator) {

--- a/dom/base/nsGlobalWindow.h
+++ b/dom/base/nsGlobalWindow.h
@@ -402,13 +402,22 @@ public:
                                 bool aUseCapture,
                                 const mozilla::dom::Nullable<bool>& aWantsUntrusted,
                                 mozilla::ErrorResult& aRv) override;
-  virtual nsIDOMWindow* GetOwnerGlobal() override
+  virtual nsIDOMWindow* GetOwnerGlobalForBindings() override
   {
     if (IsOuterWindow()) {
       return this;
     }
 
     return GetOuterFromCurrentInner(this);
+  }
+
+  virtual nsIGlobalObject* GetOwnerGlobal() const override
+  {
+    if (IsOuterWindow()) {
+      return GetCurrentInnerWindowInternal();
+    }
+
+    return const_cast<nsGlobalWindow*>(this);
   }
 
   // nsPIDOMWindow
@@ -1550,7 +1559,7 @@ protected:
   nsRefPtr<nsDOMWindowUtils>    mWindowUtils;
   nsString                      mStatus;
   nsString                      mDefaultStatus;
-  nsGlobalWindowObserver*       mObserver; // Inner windows only.
+  nsRefPtr<nsGlobalWindowObserver> mObserver; // Inner windows only.
   nsRefPtr<mozilla::dom::Crypto>  mCrypto;
   nsRefPtr<mozilla::dom::Console> mConsole;
   // We need to store an nsISupports pointer to this object because the

--- a/dom/base/nsINode.cpp
+++ b/dom/base/nsINode.cpp
@@ -1300,11 +1300,18 @@ nsINode::GetContextForEventHandlers(nsresult* aRv)
 }
 
 nsIDOMWindow*
-nsINode::GetOwnerGlobal()
+nsINode::GetOwnerGlobalForBindings()
 {
   bool dummy;
   return nsPIDOMWindow::GetOuterFromCurrentInner(
     static_cast<nsGlobalWindow*>(OwnerDoc()->GetScriptHandlingObject(dummy)));
+}
+
+nsIGlobalObject*
+nsINode::GetOwnerGlobal() const
+{
+  bool dummy;
+  return OwnerDoc()->GetScriptHandlingObject(dummy);
 }
 
 bool

--- a/dom/base/nsINode.h
+++ b/dom/base/nsINode.h
@@ -855,7 +855,8 @@ public:
                                 const mozilla::dom::Nullable<bool>& aWantsUntrusted,
                                 mozilla::ErrorResult& aRv) override;
   using nsIDOMEventTarget::AddSystemEventListener;
-  virtual nsIDOMWindow* GetOwnerGlobal() override;
+  virtual nsIDOMWindow* GetOwnerGlobalForBindings() override;
+  virtual nsIGlobalObject* GetOwnerGlobal() const override;
 
   /**
    * Adds a mutation observer to be notified when this node, or any of its

--- a/dom/base/nsPIWindowRoot.h
+++ b/dom/base/nsPIWindowRoot.h
@@ -38,7 +38,6 @@ public:
 
   virtual void SetParentTarget(mozilla::dom::EventTarget* aTarget) = 0;
   virtual mozilla::dom::EventTarget* GetParentTarget() = 0;
-  virtual nsIDOMWindow* GetOwnerGlobal() override = 0;
 };
 
 NS_DEFINE_STATIC_IID_ACCESSOR(nsPIWindowRoot, NS_IWINDOWROOT_IID)

--- a/dom/base/nsWindowRoot.cpp
+++ b/dom/base/nsWindowRoot.cpp
@@ -187,9 +187,18 @@ nsWindowRoot::PostHandleEvent(EventChainPostVisitor& aVisitor)
 }
 
 nsIDOMWindow*
-nsWindowRoot::GetOwnerGlobal()
+nsWindowRoot::GetOwnerGlobalForBindings()
 {
   return GetWindow();
+}
+
+nsIGlobalObject*
+nsWindowRoot::GetOwnerGlobal() const
+{
+  nsCOMPtr<nsIGlobalObject> global =
+    do_QueryInterface(mWindow->GetCurrentInnerWindow());
+  // We're still holding a ref to it, so returning the raw pointer is ok...
+  return global;
 }
 
 nsPIDOMWindow*

--- a/dom/base/nsWindowRoot.h
+++ b/dom/base/nsWindowRoot.h
@@ -65,7 +65,8 @@ public:
     mParent = aTarget;
   }
   virtual mozilla::dom::EventTarget* GetParentTarget() override { return mParent; }
-  virtual nsIDOMWindow* GetOwnerGlobal() override;
+  virtual nsIDOMWindow* GetOwnerGlobalForBindings() override;
+  virtual nsIGlobalObject* GetOwnerGlobal() const override;
 
   nsIGlobalObject* GetParentObject();
 

--- a/dom/base/nsXMLHttpRequest.cpp
+++ b/dom/base/nsXMLHttpRequest.cpp
@@ -392,29 +392,33 @@ nsXMLHttpRequest::InitParameters(bool aAnon, bool aSystem)
   }
 
   // Check for permissions.
-  nsCOMPtr<nsPIDOMWindow> window = do_QueryInterface(GetOwner());
-  if (!window || !window->GetDocShell()) {
-    return;
-  }
-
   // Chrome is always allowed access, so do the permission check only
   // for non-chrome pages.
   if (!IsSystemXHR() && aSystem) {
-    nsCOMPtr<nsIDocument> doc = window->GetExtantDoc();
-    if (!doc) {
+    nsIGlobalObject* global = GetOwnerGlobal();
+    if (NS_WARN_IF(!global)) {
+      SetParameters(aAnon, false);
       return;
     }
 
-    nsCOMPtr<nsIPrincipal> principal = doc->NodePrincipal();
+    nsIPrincipal* principal = global->PrincipalOrNull();
+    if (NS_WARN_IF(!principal)) {
+      SetParameters(aAnon, false);
+      return;
+    }
+
     nsCOMPtr<nsIPermissionManager> permMgr =
       services::GetPermissionManager();
-    if (!permMgr)
+    if (NS_WARN_IF(!permMgr)) {
+      SetParameters(aAnon, false);
       return;
+    }
 
     uint32_t permission;
     nsresult rv =
       permMgr->TestPermissionFromPrincipal(principal, "systemXHR", &permission);
     if (NS_FAILED(rv) || permission != nsIPermissionManager::ALLOW_ACTION) {
+      SetParameters(aAnon, false);
       return;
     }
   }

--- a/dom/base/test/test_bug927196.html
+++ b/dom/base/test/test_bug927196.html
@@ -21,18 +21,18 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=426308
 
 function startTest() {
   req = new XMLHttpRequest({mozSystem: true});
-  is(req.mozAnon, true, "XMLHttpRequest should be mozAnon");
+  is(req.mozAnon, true, "XMLHttpRequest should be mozAnon (3)");
 
   req = new XMLHttpRequest({mozAnon: true});
-  is(req.mozAnon, true, "XMLHttpRequest should be mozAnon");
-  is(req.mozSystem, false, "XMLHttpRequest should not be mozSystem");
+  is(req.mozAnon, true, "XMLHttpRequest should be mozAnon (4)");
+  is(req.mozSystem, false, "XMLHttpRequest should not be mozSystem (4)");
 
   req = new XMLHttpRequest({mozAnon: true, mozSystem: true});
-  is(req.mozAnon, true, "XMLHttpRequest should be mozAnon");
-  is(req.mozSystem, true, "XMLHttpRequest should be mozSystem");
+  is(req.mozAnon, true, "XMLHttpRequest should be mozAnon (5)");
+  is(req.mozSystem, true, "XMLHttpRequest should be mozSystem (5)");
 
   req = new XMLHttpRequest({mozAnon: false, mozSystem: true});
-  is(req.mozAnon, true, "XMLHttpRequest should be mozAnon");
+  is(req.mozAnon, true, "XMLHttpRequest should be mozAnon (6)");
 
   SimpleTest.finish();
 }
@@ -44,8 +44,8 @@ is(req.mozAnon, true, "XMLHttpRequest should be mozAnon");
 is(req.mozSystem, false, "XMLHttpRequest should not be mozSystem");
 
 req = new XMLHttpRequest({mozAnon: true, mozSystem: true});
-is(req.mozAnon, false, "XMLHttpRequest should be mozAnon");
-is(req.mozSystem, false, "XMLHttpRequest should not be mozSystem");
+is(req.mozAnon, true, "XMLHttpRequest should be mozAnon (2)");
+is(req.mozSystem, false, "XMLHttpRequest should not be mozSystem (2)");
 
 addLoadEvent(function() {
    SpecialPowers.pushPermissions([{'type': 'systemXHR', 'allow': true, 'context': document}], startTest);

--- a/dom/contacts/tests/test_contacts_cache.xul
+++ b/dom/contacts/tests/test_contacts_cache.xul
@@ -17,7 +17,6 @@
 
   const { 'utils': Cu } = Components;
   Cu.import("resource://gre/modules/ContactDB.jsm", window);
-  Cu.importGlobalProperties(["indexedDB"]);
 
   let contactsDB = new ContactDB();
   contactsDB.init();

--- a/dom/contacts/tests/test_contacts_upgrade.xul
+++ b/dom/contacts/tests/test_contacts_upgrade.xul
@@ -142,7 +142,6 @@
 
   const { 'utils': Cu } = Components;
   Cu.import("resource://gre/modules/ContactDB.jsm", window);
-  Cu.importGlobalProperties(["indexedDB"]);
 
   let cdb = new ContactDB();
   cdb.init();

--- a/dom/events/DOMEventTargetHelper.h
+++ b/dom/events/DOMEventTargetHelper.h
@@ -120,7 +120,7 @@ public:
                        JSContext* aCx,
                        JS::Value* aValue);
   using dom::EventTarget::GetEventHandler;
-  virtual nsIDOMWindow* GetOwnerGlobal() override
+  virtual nsIDOMWindow* GetOwnerGlobalForBindings() override
   {
     return nsPIDOMWindow::GetOuterFromCurrentInner(GetOwner());
   }
@@ -139,7 +139,12 @@ public:
   void BindToOwner(nsPIDOMWindow* aOwner);
   void BindToOwner(DOMEventTargetHelper* aOther);
   virtual void DisconnectFromOwner();                   
-  nsIGlobalObject* GetParentObject() const {
+  nsIGlobalObject* GetParentObject() const
+  {
+    return GetOwnerGlobal();
+  }
+  virtual nsIGlobalObject* GetOwnerGlobal() const override
+  {
     nsCOMPtr<nsIGlobalObject> parentObject = do_QueryReferent(mParentObject);
     return parentObject;
   }

--- a/dom/events/EventTarget.h
+++ b/dom/events/EventTarget.h
@@ -11,6 +11,7 @@
 #include "nsIAtom.h"
 
 class nsIDOMWindow;
+class nsIGlobalObject;
 class nsIDOMEventListener;
 
 namespace mozilla {
@@ -27,8 +28,8 @@ template <class T> struct Nullable;
 
 // IID for the dom::EventTarget interface
 #define NS_EVENTTARGET_IID \
-{ 0xce3817d0, 0x177b, 0x402f, \
- { 0xae, 0x75, 0xf8, 0x4e, 0xbe, 0x5a, 0x07, 0xc3 } }
+{ 0x605158a9, 0xe229, 0x45b1, \
+ { 0xbc, 0x12, 0x02, 0x9f, 0xa3, 0xa9, 0x3f, 0xcb } }
 
 class EventTarget : public nsIDOMEventTarget,
                     public nsWrapperCache
@@ -69,7 +70,12 @@ public:
   // Returns an outer window that corresponds to the inner window this event
   // target is associated with.  Will return null if the inner window is not the
   // current inner or if there is no window around at all.
-  virtual nsIDOMWindow* GetOwnerGlobal() = 0;
+  virtual nsIDOMWindow* GetOwnerGlobalForBindings() = 0;
+
+  // The global object this event target is associated with, if any.
+  // This may be an inner window or some other global object.  This
+  // will never be an outer window.
+  virtual nsIGlobalObject* GetOwnerGlobal() const = 0;
 
   /**
    * Get the event listener manager, creating it if it does not already exist.

--- a/dom/events/Touch.cpp
+++ b/dom/events/Touch.cpp
@@ -135,21 +135,16 @@ Touch::WrapObject(JSContext* aCx)
   return TouchBinding::Wrap(aCx, this);
 }
 
-// Parent ourselves to the window of the target. This achieves the desirable
+// Parent ourselves to the global of the target. This achieves the desirable
 // effects of parenting to the target, but avoids making the touch inaccessible
 // when the target happens to be NAC and therefore reflected into the XBL scope.
-EventTarget*
+nsIGlobalObject*
 Touch::GetParentObject()
 {
   if (!mTarget) {
     return nullptr;
   }
-  nsCOMPtr<nsPIDOMWindow> outer = do_QueryInterface(mTarget->GetOwnerGlobal());
-  if (!outer) {
-    return nullptr;
-  }
-  MOZ_ASSERT(outer->IsOuterWindow());
-  return static_cast<nsGlobalWindow*>(outer->GetCurrentInnerWindow());
+  return mTarget->GetOwnerGlobal();
 }
 
 } // namespace dom

--- a/dom/events/Touch.h
+++ b/dom/events/Touch.h
@@ -56,7 +56,7 @@ public:
 
   virtual JSObject* WrapObject(JSContext* aCx) override;
 
-  EventTarget* GetParentObject();
+  nsIGlobalObject* GetParentObject();
 
   // WebIDL
   int32_t Identifier() const { return mIdentifier; }

--- a/dom/indexedDB/IndexedDatabaseManager.cpp
+++ b/dom/indexedDB/IndexedDatabaseManager.cpp
@@ -415,7 +415,8 @@ IndexedDatabaseManager::CommonPostHandleEvent(EventChainPostVisitor& aVisitor,
   nsEventStatus status = nsEventStatus_eIgnore;
 
   if (NS_IsMainThread()) {
-    if (nsIDOMWindow* window = eventTarget->GetOwnerGlobal()) {
+    nsCOMPtr<nsIDOMWindow> window = do_QueryInterface(eventTarget->GetOwnerGlobal());
+    if (window) {
       nsCOMPtr<nsIScriptGlobalObject> sgo = do_QueryInterface(window);
       MOZ_ASSERT(sgo);
 

--- a/dom/indexedDB/test/chromeHelpers.js
+++ b/dom/indexedDB/test/chromeHelpers.js
@@ -10,8 +10,6 @@ let testGenerator = testSteps();
 if (!window.runTest) {
   window.runTest = function()
   {
-    Cu.importGlobalProperties(["indexedDB"]);
-
     SimpleTest.waitForExplicitFinish();
 
     testGenerator.next();

--- a/dom/tests/unit/test_xhr_init.js
+++ b/dom/tests/unit/test_xhr_init.js
@@ -1,0 +1,16 @@
+function run_test()
+{
+    Components.utils.importGlobalProperties(["XMLHttpRequest"]);
+
+    var x = new XMLHttpRequest({mozAnon: true, mozSystem: false});
+    do_check_true(x.mozAnon);
+    do_check_true(x.mozSystem); // Because we're system principal
+
+    x = new XMLHttpRequest({mozAnon: true});
+    do_check_true(x.mozAnon);
+    do_check_true(x.mozSystem);
+
+    x = new XMLHttpRequest();
+    do_check_false(x.mozAnon);
+    do_check_true(x.mozSystem);
+}

--- a/dom/tests/unit/xpcshell.ini
+++ b/dom/tests/unit/xpcshell.ini
@@ -23,3 +23,4 @@ skip-if = os == "android"
 [test_geolocation_position_unavailable_wrap.js]
 skip-if = os == "mac" || os == "android"
 [test_PromiseDebugging.js]
+[test_xhr_init.js]

--- a/dom/webidl/EventTarget.webidl
+++ b/dom/webidl/EventTarget.webidl
@@ -43,6 +43,6 @@ partial interface EventTarget {
 // chrome easier.  This returns the window which can be used to create
 // events to fire at this EventTarget, or null if there isn't one.
 partial interface EventTarget {
-  [ChromeOnly]
+  [ChromeOnly, BinaryName="ownerGlobalForBindings"]
   readonly attribute WindowProxy? ownerGlobal;
 };

--- a/js/xpconnect/src/Sandbox.cpp
+++ b/js/xpconnect/src/Sandbox.cpp
@@ -195,31 +195,6 @@ SandboxImport(JSContext* cx, unsigned argc, Value* vp)
 }
 
 static bool
-SandboxCreateXMLHttpRequest(JSContext* cx, unsigned argc, jsval* vp)
-{
-    CallArgs args = CallArgsFromVp(argc, vp);
-
-    RootedObject global(cx, JS::CurrentGlobalOrNull(cx));
-    MOZ_ASSERT(global);
-
-    nsIScriptObjectPrincipal* sop =
-        static_cast<nsIScriptObjectPrincipal*>(xpc_GetJSPrivate(global));
-    nsCOMPtr<nsIGlobalObject> iglobal = do_QueryInterface(sop);
-
-    nsCOMPtr<nsIXMLHttpRequest> xhr = new nsXMLHttpRequest();
-    nsresult rv = xhr->Init(nsContentUtils::SubjectPrincipal(), nullptr,
-                            iglobal, nullptr, nullptr);
-    if (NS_FAILED(rv))
-        return false;
-
-    rv = nsContentUtils::WrapNative(cx, xhr, args.rval());
-    if (NS_FAILED(rv))
-        return false;
-
-    return true;
-}
-
-static bool
 SandboxCreateCrypto(JSContext* cx, JS::HandleObject obj)
 {
     MOZ_ASSERT(JS_IsGlobalObject(obj));
@@ -837,7 +812,7 @@ xpc::GlobalProperties::Define(JSContext* cx, JS::HandleObject obj)
         return false;
 
     if (XMLHttpRequest &&
-        !JS_DefineFunction(cx, obj, "XMLHttpRequest", SandboxCreateXMLHttpRequest, 0, JSFUN_CONSTRUCTOR))
+        !dom::XMLHttpRequestBinding::GetConstructorObject(cx, obj))
         return false;
 
     if (TextEncoder &&

--- a/js/xpconnect/src/XPCComponents.cpp
+++ b/js/xpconnect/src/XPCComponents.cpp
@@ -15,6 +15,7 @@
 #include "nsContentUtils.h"
 #include "jsfriendapi.h"
 #include "js/StructuredClone.h"
+#include "mozilla/dom/WindowBinding.h"
 #include "mozilla/Attributes.h"
 #include "mozilla/jsipc/CrossProcessObjectWrappers.h"
 #include "mozilla/Preferences.h"
@@ -2719,6 +2720,13 @@ nsXPCComponents_Utils::ImportGlobalProperties(HandleValue aPropertyList,
 {
     RootedObject global(cx, CurrentGlobalOrNull(cx));
     MOZ_ASSERT(global);
+
+    // Don't allow doing this if the global is a Window
+    nsGlobalWindow* win;
+    if (NS_SUCCEEDED(UNWRAP_OBJECT(Window, global, win))) {
+        return NS_ERROR_NOT_AVAILABLE;
+    }
+
     GlobalProperties options;
     NS_ENSURE_TRUE(aPropertyList.isObject(), NS_ERROR_INVALID_ARG);
     RootedObject propertyList(cx, &aPropertyList.toObject());

--- a/testing/specialpowers/content/specialpowersAPI.js
+++ b/testing/specialpowers/content/specialpowersAPI.js
@@ -19,7 +19,14 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
-Cu.importGlobalProperties(["File"]);
+// We're loaded with "this" not set to the global in some cases, so we
+// have to play some games to get at the global object here.  Normally
+// we'd try "this" from a function called with undefined this value,
+// but this whole file is in strict mode.  So instead fall back on
+// returning "this" from indirect eval, which returns the global.
+if (!(function() { var e = eval; return e("this"); })().File) {
+  Cu.importGlobalProperties(["File"]);
+}
 
 // Allow stuff from this scope to be accessed from non-privileged scopes. This
 // would crash if used outside of automation.

--- a/toolkit/devtools/server/tests/mochitest/test_css-logic.html
+++ b/toolkit/devtools/server/tests/mochitest/test_css-logic.html
@@ -15,7 +15,6 @@ Cu.import("resource://gre/modules/devtools/Loader.jsm");
 const {Promise: promise} = Cu.import("resource://gre/modules/Promise.jsm", {});
 
 const {CssLogic} = devtools.require("devtools/styleinspector/css-logic");
-Cu.importGlobalProperties(['CSS']);
 
 window.onload = function() {
   SimpleTest.waitForExplicitFinish();


### PR DESCRIPTION
## 1) __Depends on: 2)__

XMLHttpRequest.mozAnon is a boolean. If true, the request will be sent without cookie and authentication headers.

An example:
```
Components.utils.importGlobalProperties(["XMLHttpRequest"]);

var x = new XMLHttpRequest({mozAnon: true});
```
The problem is that this object property (x.mozAnon) has still the same value = false.

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1156101
https://bugzilla.mozilla.org/show_bug.cgi?id=1163898

## 2)

__!! This example crashes browser (Pale Moon 27.2.0) !!:__

__Steps to reproduce__

1) Open Scratchpad

2) Menu: "Environment-Browser"

3) Insert the code:
```
Components.utils.importGlobalProperties(["XMLHttpRequest"]);

var x = new XMLHttpRequest({mozAnon: true});
```
4) Run
5) Result: ...crashes browser.

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1137591
https://bugzilla.mozilla.org/show_bug.cgi?id=1141510

---

Regression (`Components.utils.importGlobalProperties(["URL"])`):
https://github.com/MoonchildProductions/Pale-Moon/pull/933/files#diff-78edc04f5fd7f14f6c33615a003f60f8R7
(but it is no longer needed - see (follow up): https://github.com/MoonchildProductions/Pale-Moon/pull/948)

See also (e.g.):
https://github.com/greasemonkey/greasemonkey/commit/535d996c3266b99158fa0cd2729027551d8b4ebf

---

__Please would you all try.__

---

You add the label `Extensions`, please.

---

I've created the new build (x32, Windows) and tested.
