### PR TITLE
Fixes to nsWEBPDecoder

### DIFF
--- a/image/decoders/nsWEBPDecoder.cpp
+++ b/image/decoders/nsWEBPDecoder.cpp
@@ -36,24 +36,19 @@ nsWEBPDecoder::~nsWEBPDecoder()
          ("nsWEBPDecoder::~nsWEBPDecoder: Destroying WEBP decoder %p",
           this));
 
-  // Flush the Decoder and let it free the output image buffer.
+  // It is safe to pass nullptr to WebPIDelete().
   WebPIDelete(mDecoder);
-  WebPFreeDecBuffer(&mDecBuf);
 }
 
 
 void
 nsWEBPDecoder::InitInternal()
 {
-  if (!WebPInitDecBuffer(&mDecBuf)) {
-    PostDecoderError(NS_ERROR_FAILURE);
-    return;
-  }
+  mDecoder = WebPINewRGB(MODE_rgbA, nullptr, 0, 0);
 
-  mDecBuf.colorspace = MODE_rgbA;
-  mDecoder = WebPINewDecoder(&mDecBuf);
   if (!mDecoder) {
     PostDecoderError(NS_ERROR_FAILURE);
+    return;
   }
 }
 

--- a/image/decoders/nsWEBPDecoder.cpp
+++ b/image/decoders/nsWEBPDecoder.cpp
@@ -150,7 +150,10 @@ nsWEBPDecoder::WriteInternal(const char *aBuffer, uint32_t aCount)
     } 
 
     // Invalidate
-    nsIntRect r(0, mLastLine, width, lastLineRead);
+    nsIntRect r(0,
+                mPreviousLastLine,
+                width,
+                lastLineRead - mPreviousLastLine + 1);
     PostInvalidation(r);
   }
 

--- a/image/decoders/nsWEBPDecoder.cpp
+++ b/image/decoders/nsWEBPDecoder.cpp
@@ -106,14 +106,6 @@ nsWEBPDecoder::WriteInternal(const char *aBuffer, uint32_t aCount)
 
   mData = WebPIDecGetRGB(mDecoder, &lastLineRead, &width, &height, &stride);
 
-  // The only valid format for WebP decoding for both alpha and non-alpha
-  // images is BGRA, where Opaque images have an A of 255.
-  // Assume transparency for all images.
-  // XXX: This could be compositor-optimized by doing a one-time check for
-  // all-255 alpha pixels, but that might interfere with progressive
-  // decoding. Probably not worth it?
-  PostHasTransparency();
-  
   if (lastLineRead == -1 || !mData)
     return;
 
@@ -127,6 +119,14 @@ nsWEBPDecoder::WriteInternal(const char *aBuffer, uint32_t aCount)
 
   if (IsSizeDecode())
     return;
+
+  // The only valid format for WebP decoding for both alpha and non-alpha
+  // images is BGRA, where Opaque images have an A of 255.
+  // Assume transparency for all images.
+  // XXX: This could be compositor-optimized by doing a one-time check for
+  // all-255 alpha pixels, but that might interfere with progressive
+  // decoding. Probably not worth it?
+  PostHasTransparency();
 
   if (!mImageData) {
     PostDecoderError(NS_ERROR_FAILURE);

--- a/image/decoders/nsWEBPDecoder.h
+++ b/image/decoders/nsWEBPDecoder.h
@@ -29,7 +29,7 @@ public:
   virtual void InitInternal();
   virtual void WriteInternal(const char* aBuffer, uint32_t aCount);
   virtual void FinishInternal();
-public:
+private:
   WebPDecBuffer mDecBuf;   
   WebPIDecoder *mDecoder;  
   uint8_t *mData;          // Pointer to WebP-decoded data.

--- a/image/decoders/nsWEBPDecoder.h
+++ b/image/decoders/nsWEBPDecoder.h
@@ -28,7 +28,6 @@ public:
   void WriteInternal(const char* aBuffer, uint32_t aCount) override;
   void FinishInternal() override;
 private:
-  WebPDecBuffer mDecBuf;
   WebPIDecoder *mDecoder;
   uint8_t *mData;          // Pointer to WebP-decoded data.
   int mPreviousLastLine;   // Last image scan-line read so far.

--- a/image/decoders/nsWEBPDecoder.h
+++ b/image/decoders/nsWEBPDecoder.h
@@ -7,8 +7,6 @@
 
 #include "Decoder.h"
 
-#include "nsCOMPtr.h"
-
 extern "C" {
 #include "webp/decode.h"
 }
@@ -24,16 +22,16 @@ class nsWEBPDecoder : public Decoder
 {
 public:
   nsWEBPDecoder(RasterImage* aImage);
-  virtual ~nsWEBPDecoder();
+  ~nsWEBPDecoder() override;
 
-  virtual void InitInternal();
-  virtual void WriteInternal(const char* aBuffer, uint32_t aCount);
-  virtual void FinishInternal();
+  void InitInternal() override;
+  void WriteInternal(const char* aBuffer, uint32_t aCount) override;
+  void FinishInternal() override;
 private:
-  WebPDecBuffer mDecBuf;   
-  WebPIDecoder *mDecoder;  
+  WebPDecBuffer mDecBuf;
+  WebPIDecoder *mDecoder;
   uint8_t *mData;          // Pointer to WebP-decoded data.
-  int mLastLine;           // Last image scan-line read so far.
+  int mPreviousLastLine;   // Last image scan-line read so far.
 
 };
 
@@ -41,4 +39,3 @@ private:
 } // namespace mozilla
 
 #endif // nsWEBPDecoder_h__
-

--- a/layout/media/symbols.def.in
+++ b/layout/media/symbols.def.in
@@ -277,19 +277,10 @@ BGRA32_RGBA32
 SetCurrentTileRow
 #endif
 #ifndef MOZ_NATIVE_WEBP
-WebPInitDecBufferInternal
-WebPFreeDecBuffer
-WebPINewDecoder
+WebPINewRGB
 WebPIDelete
 WebPIAppend
 WebPIDecGetRGB
-WebPConfigInitInternal
-WebPMemoryWriterInit
-WebPMemoryWrite
-WebPPictureInitInternal
-WebPPictureAlloc
-WebPPictureFree
-WebPEncode
 #endif
 qcms_enable_iccv4
 qcms_data_from_unicode_path


### PR DESCRIPTION
Since I had spent some time learning the workings of ImageLib while adding JXR support, I was able to spot a few issues in the WebP decoder while experimenting with downscaling during decode. A cleanup commit, which you will hopefully consider an improvement, has been packaged with this also.

Everything should be pretty clear, the only doubts I have are about the "Simplify libwebp usage in nsWEBPDecoder" commit where I am not sure whether what I removed wasn't there as a test for ABI compatibility for cases when system/custom libwebp is loaded on unix-like systems. If that was so, let me know, and I will try to find a clearer way to do this, or I will at least add a comment to clarify this.