### PR TITLE
Apply prefs-related prefs before applying other synced prefs

### DIFF
--- a/services/sync/modules/engines/prefs.js
+++ b/services/sync/modules/engines/prefs.js
@@ -8,7 +8,7 @@ const Cc = Components.classes;
 const Ci = Components.interfaces;
 const Cu = Components.utils;
 
-const WEAVE_SYNC_PREFS = "services.sync.prefs.sync.";
+const PREF_SYNC_PREFS_PREFIX = "services.sync.prefs.sync.";
 
 Cu.import("resource://services-sync/engines.js");
 Cu.import("resource://services-sync/record.js");
@@ -43,7 +43,7 @@ PrefsEngine.prototype = {
 
   syncPriority: 1,
 
-  getChangedIDs: function getChangedIDs() {
+  getChangedIDs: function () {
     // No need for a proper timestamp (no conflict resolution needed).
     let changedIDs = {};
     if (this._tracker.modified)
@@ -51,12 +51,12 @@ PrefsEngine.prototype = {
     return changedIDs;
   },
 
-  _wipeClient: function _wipeClient() {
+  _wipeClient: function () {
     SyncEngine.prototype._wipeClient.call(this);
     this.justWiped = true;
   },
 
-  _reconcile: function _reconcile(item) {
+  _reconcile: function (item) {
     // Apply the incoming item if we don't care about the local data
     if (this.justWiped) {
       this.justWiped = false;
@@ -78,24 +78,25 @@ PrefStore.prototype = {
 
  __prefs: null,
   get _prefs() {
-    if (!this.__prefs)
+    if (!this.__prefs) {
       this.__prefs = new Preferences();
+    }
     return this.__prefs;
   },
 
-  _getSyncPrefs: function _getSyncPrefs() {
+  _getSyncPrefs: function () {
     let syncPrefs = Cc["@mozilla.org/preferences-service;1"]
                       .getService(Ci.nsIPrefService)
-                      .getBranch(WEAVE_SYNC_PREFS)
+                      .getBranch(PREF_SYNC_PREFS_PREFIX)
                       .getChildList("", {});
     // Also sync preferences that determine which prefs get synced.
-    return syncPrefs.concat(
-      syncPrefs.map(function (pref) { return WEAVE_SYNC_PREFS + pref; }));
+    let controlPrefs = syncPrefs.map(pref => PREF_SYNC_PREFS_PREFIX + pref);
+    return controlPrefs.concat(syncPrefs);
   },
 
-  _isSynced: function _isSyncedPref(pref) {
-    return (pref.indexOf(WEAVE_SYNC_PREFS) == 0)
-            || this._prefs.get(WEAVE_SYNC_PREFS + pref, false);
+  _isSynced: function (pref) {
+    return pref.startsWith(PREF_SYNC_PREFS_PREFIX) ||
+            this._prefs.get(PREF_SYNC_PREFS_PREFIX + pref, false);
   },
 
   _getAllPrefs: function () {
@@ -109,16 +110,22 @@ PrefStore.prototype = {
     return values;
   },
 
-  _setAllPrefs: function PrefStore__setAllPrefs(values) {
+  _setAllPrefs: function (values) {
     let enabledPref = "lightweightThemes.isThemeSelected";
     let enabledBefore = this._prefs.get(enabledPref, false);
     let prevTheme = LightweightThemeManager.currentTheme;
 
-    for (let [pref, value] in Iterator(values)) {
-      if (!this._isSynced(pref))
+    // Update 'services.sync.prefs.sync.foo.pref' before 'foo.pref', otherwise
+    // _isSynced returns false when 'foo.pref' doesn't exist (e.g., on a new device).
+    let prefs = Object.keys(values).sort(a => -a.indexOf(PREF_SYNC_PREFS_PREFIX));
+    for (let pref of prefs) {
+      if (!this._isSynced(pref)) {
         continue;
+      }
 
-      // Pref has gone missing, best we can do is reset it.
+      let value = values[pref];
+
+      // Pref has gone missing. The best we can do is reset it.
       if (value == null) {
         this._prefs.reset(pref);
         continue;
@@ -141,22 +148,22 @@ PrefStore.prototype = {
     }
   },
 
-  getAllIDs: function PrefStore_getAllIDs() {
+  getAllIDs: function () {
     /* We store all prefs in just one WBO, with just one GUID */
     let allprefs = {};
     allprefs[PREFS_GUID] = true;
     return allprefs;
   },
 
-  changeItemID: function PrefStore_changeItemID(oldID, newID) {
+  changeItemID: function (oldID, newID) {
     this._log.trace("PrefStore GUID is constant!");
   },
 
-  itemExists: function FormStore_itemExists(id) {
+  itemExists: function (id) {
     return (id === PREFS_GUID);
   },
 
-  createRecord: function createRecord(id, collection) {
+  createRecord: function (id, collection) {
     let record = new PrefRec(collection, id);
 
     if (id == PREFS_GUID) {
@@ -168,15 +175,15 @@ PrefStore.prototype = {
     return record;
   },
 
-  create: function PrefStore_create(record) {
+  create: function (record) {
     this._log.trace("Ignoring create request");
   },
 
-  remove: function PrefStore_remove(record) {
+  remove: function (record) {
     this._log.trace("Ignoring remove request");
   },
 
-  update: function PrefStore_update(record) {
+  update: function (record) {
     // Silently ignore pref updates that are for other apps.
     if (record.id != PREFS_GUID)
       return;
@@ -185,7 +192,7 @@ PrefStore.prototype = {
     this._setAllPrefs(record.value);
   },
 
-  wipe: function PrefStore_wipe() {
+  wipe: function () {
     this._log.trace("Ignoring wipe request");
   }
 };
@@ -241,8 +248,8 @@ PrefTracker.prototype = {
       case "nsPref:changed":
         // Trigger a sync for MULTI-DEVICE for a change that determines
         // which prefs are synced or a regular pref change.
-        if (data.indexOf(WEAVE_SYNC_PREFS) == 0 ||
-            this._prefs.get(WEAVE_SYNC_PREFS + data, false)) {
+        if (data.indexOf(PREF_SYNC_PREFS_PREFIX) == 0 ||
+            this._prefs.get(PREF_SYNC_PREFS_PREFIX + data, false)) {
           this.score += SCORE_INCREMENT_XLARGE;
           this.modified = true;
           this._log.trace("Preference " + data + " changed");

--- a/services/sync/modules/engines/prefs.js
+++ b/services/sync/modules/engines/prefs.js
@@ -8,7 +8,7 @@ const Cc = Components.classes;
 const Ci = Components.interfaces;
 const Cu = Components.utils;
 
-const PREF_SYNC_PREFS_PREFIX = "services.sync.prefs.sync.";
+const SYNC_PREFS_PREFIX = "services.sync.prefs.sync.";
 
 Cu.import("resource://services-sync/engines.js");
 Cu.import("resource://services-sync/record.js");
@@ -87,16 +87,16 @@ PrefStore.prototype = {
   _getSyncPrefs: function () {
     let syncPrefs = Cc["@mozilla.org/preferences-service;1"]
                       .getService(Ci.nsIPrefService)
-                      .getBranch(PREF_SYNC_PREFS_PREFIX)
+                      .getBranch(SYNC_PREFS_PREFIX)
                       .getChildList("", {});
     // Also sync preferences that determine which prefs get synced.
-    let controlPrefs = syncPrefs.map(pref => PREF_SYNC_PREFS_PREFIX + pref);
+    let controlPrefs = syncPrefs.map(pref => SYNC_PREFS_PREFIX + pref);
     return controlPrefs.concat(syncPrefs);
   },
 
   _isSynced: function (pref) {
-    return pref.startsWith(PREF_SYNC_PREFS_PREFIX) ||
-            this._prefs.get(PREF_SYNC_PREFS_PREFIX + pref, false);
+    return pref.startsWith(SYNC_PREFS_PREFIX) ||
+            this._prefs.get(SYNC_PREFS_PREFIX + pref, false);
   },
 
   _getAllPrefs: function () {
@@ -117,7 +117,7 @@ PrefStore.prototype = {
 
     // Update 'services.sync.prefs.sync.foo.pref' before 'foo.pref', otherwise
     // _isSynced returns false when 'foo.pref' doesn't exist (e.g., on a new device).
-    let prefs = Object.keys(values).sort(a => -a.indexOf(PREF_SYNC_PREFS_PREFIX));
+    let prefs = Object.keys(values).sort(a => -a.indexOf(SYNC_PREFS_PREFIX));
     for (let pref of prefs) {
       if (!this._isSynced(pref)) {
         continue;
@@ -248,8 +248,8 @@ PrefTracker.prototype = {
       case "nsPref:changed":
         // Trigger a sync for MULTI-DEVICE for a change that determines
         // which prefs are synced or a regular pref change.
-        if (data.indexOf(PREF_SYNC_PREFS_PREFIX) == 0 ||
-            this._prefs.get(PREF_SYNC_PREFS_PREFIX + data, false)) {
+        if (data.indexOf(SYNC_PREFS_PREFIX) == 0 ||
+            this._prefs.get(SYNC_PREFS_PREFIX + data, false)) {
           this.score += SCORE_INCREMENT_XLARGE;
           this.modified = true;
           this._log.trace("Preference " + data + " changed");

--- a/services/sync/tests/unit/test_prefs_store.js
+++ b/services/sync/tests/unit/test_prefs_store.js
@@ -81,6 +81,7 @@ function run_test() {
       "testing.string": "im in ur prefs",
       "testing.bool": false,
       "testing.deleteme": null,
+      "testing.somepref": "im a new pref from other device",
       "services.sync.prefs.sync.testing.somepref": true
     };
     store.update(record);
@@ -89,6 +90,7 @@ function run_test() {
     do_check_eq(prefs.get("testing.bool"), false);
     do_check_eq(prefs.get("testing.deleteme"), undefined);
     do_check_eq(prefs.get("testing.dont.change"), "Please don't change me.");
+    do_check_eq(prefs.get("testing.somepref"), "im a new pref from other device");
     do_check_eq(Svc.Prefs.get("prefs.sync.testing.somepref"), true);
 
     _("Enable persona");


### PR DESCRIPTION
Based on https://bugzilla.mozilla.org/show_bug.cgi?id=753289.

This fixes [the following wrong behavior](https://discourse.mozilla-community.org/t/how-to-sync-preferences-of-a-bootstrapped-extension-via-sync/3024/6): if user create new profile and enable sync in the new profile before adding all extensions then the preferences from extensions that are not installed yet will be remove from the sync server, thus will set to default in all other profiles (devices).

Reported at https://forum.palemoon.org/viewtopic.php?t=15213&p=109958.

Need verification.