### PR TITLE
Add documents to embed element capabilities

### DIFF
--- a/dom/html/HTMLSharedObjectElement.cpp
+++ b/dom/html/HTMLSharedObjectElement.cpp
@@ -343,7 +343,7 @@ HTMLSharedObjectElement::GetCapabilities() const
 {
   uint32_t capabilities = eSupportPlugins | eAllowPluginSkipChannel;
   if (mNodeInfo->Equals(nsGkAtoms::embed)) {
-    capabilities |= eSupportSVG | eSupportImages;
+    capabilities |= eSupportSVG | eSupportImages | eSupportDocuments;
   }
 
   return capabilities;


### PR DESCRIPTION
Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1237963.

Resolves problem with embedded YouTube videos, also [allows to play internally supported media types using embed tag without external plugins](https://forum.palemoon.org/viewtopic.php?t=15165&p=109995).