### PR TITLE
Customizable toolbars - backward compatible (but unidirectional)

### DIFF
--- a/toolkit/content/customizeToolbar.js
+++ b/toolkit/content/customizeToolbar.js
@@ -179,7 +179,7 @@ function persistCurrentSets()
         // Persist custom toolbar info on the <toolbarset/>
         // Attributes:
         // Names: "toolbarX" (X - the number of the toolbar)
-        // Values: "Name:HidingAttributeName-HidingAttributeValue:CurrentSet"
+        // Values: "Name|HidingAttributeName-HidingAttributeValue|CurrentSet"
         gToolbox.toolbarset.setAttribute("toolbar"+(++customCount),
                                          toolbar.toolbarName
                                          + gToolbarInfoSeparators[0]

--- a/toolkit/content/widgets/toolbar.xml
+++ b/toolkit/content/widgets/toolbar.xml
@@ -30,7 +30,7 @@
       </field>
 
       <field name="externalToolbars">
-       []
+        []
       </field>
 
       <!-- Set by customizeToolbar.js -->
@@ -50,6 +50,7 @@
       <constructor>
         <![CDATA[
           this.toolbarInfoSeparators = ["|", "-"];
+          this.toolbarInfoLegacySeparator = ":";
           // Look to see if there is a toolbarset.
           this.toolbarset = this.firstChild;
           while (this.toolbarset && this.toolbarset.localName != "toolbarset")
@@ -58,19 +59,45 @@
           if (this.toolbarset) {
             // Create each toolbar described by the toolbarset.
             var index = 0;
-            while (toolbarset.hasAttribute("toolbar"+(++index))) {
-              var toolbarInfo = toolbarset.getAttribute("toolbar"+index);
-              var infoSplit = toolbarInfo.split(this.toolbarInfoSeparators[0]);
-              var infoName = infoSplit[0];
-              var infoHidingAttribute = infoSplit[1].split(this.toolbarInfoSeparators[1]);
-              var infoCurrentSet = infoSplit[2];
-
-              this.appendCustomToolbar(infoName, infoCurrentSet, infoHidingAttribute);
+            while (toolbarset.hasAttribute("toolbar" + (++index))) {
+              let hiddingAttribute =
+                  toolbarset.getAttribute("type") == "menubar"
+                      ? "autohide" : "collapsed";
+              let toolbarInfo = toolbarset.getAttribute("toolbar" + index);
+              let infoSplit = toolbarInfo.split(this.toolbarInfoSeparators[0]);
+              if (infoSplit.length == 1) {
+                infoSplit = toolbarInfo.split(this.toolbarInfoLegacySeparator);
+              }
+              let infoName = infoSplit[0];
+              let infoHidingAttribute = [null, null];
+              let infoCurrentSet = "";
+              let infoSplitLen = infoSplit.length;
+              switch (infoSplitLen) {
+                case 3:
+                  // Pale Moon 27.2+
+                  infoHidingAttribute = infoSplit[1]
+                      .split(this.toolbarInfoSeparators[1]);
+                  infoCurrentSet = infoSplit[2];
+                  break;
+                case 2:
+                  // Legacy - toolbars from Pale Moon 27.0 - 27.1.x
+                  // The previous value (hiddingAttribute) isn't stored.
+                  infoHidingAttribute = [hiddingAttribute, "false"];
+                  infoCurrentSet = infoSplit[1];
+                  break;
+                default:
+                  Components.utils.reportError(
+                      "Customizable toolbars - an invalid value:" + "\n"
+                      + '"toolbar' + index + '" = "' + toolbarInfo + '"');
+                  break;
+              }
+              this.appendCustomToolbar(
+                  infoName, infoCurrentSet, infoHidingAttribute);
             }
           }
         ]]>
       </constructor>
-      
+
       <method name="appendCustomToolbar">
         <parameter name="aName"/>
         <parameter name="aCurrentSet"/>


### PR DESCRIPTION
Ad:
https://forum.palemoon.org/viewtopic.php?f=3&t=15212
("The 27.2.0 update deleted a custom toolbar")

It's my fault (#903), I'm sorry :unamused:

The structure is different:
`Name:CurrentSet` (27.1.2-)
vs.
`Name|HidingAttributeName-HidingAttributeValue|CurrentSet` (27.2.0+)

The structure should be (I don't know if forever - but maybe... it would bother later):
`Name:CurrentSet:HidingAttributeName-HidingAttributeValue` (e.g. - or JSON instead of strings?!)

AFAIK: But it's too late now... (IMHO: apparently three would be too much)

---

This (+ style clean up) is one way compatibility
(27.0/27.1 => 27.2.0+, but not vice versa - but in that case... use a script?!)

I haven't better idea...

---

I've created the new build (x32, Windows) and tested.
