### PR TITLE
Media crash & compatibility fixes

### DIFF
--- a/dom/media/mediasource/ContainerParser.cpp
+++ b/dom/media/mediasource/ContainerParser.cpp
@@ -297,7 +297,9 @@ public:
     return ((*aData)[4] == 'm' && (*aData)[5] == 'o' && (*aData)[6] == 'o' &&
             (*aData)[7] == 'f') ||
            ((*aData)[4] == 's' && (*aData)[5] == 't' && (*aData)[6] == 'y' &&
-            (*aData)[7] == 'p');
+            (*aData)[7] == 'p') ||
+           ((*aData)[4] == 's' && (*aData)[5] == 'i' && (*aData)[6] == 'd' &&
+            (*aData)[7] == 'x');
   }
 
   bool ParseStartAndEndTimestamps(MediaLargeByteBuffer* aData,

--- a/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
@@ -40,8 +40,6 @@
 #include <utils/String8.h>
 #include "nsTArray.h"
 
-#include <limits>
-
 static const uint32_t kMAX_ALLOCATION =
     (SIZE_MAX < INT32_MAX ? SIZE_MAX : INT32_MAX) - 128;
 
@@ -726,30 +724,6 @@ static bool underMetaDataPath(const Vector<uint32_t> &path) {
         && path[1] == FOURCC('u', 'd', 't', 'a')
         && path[2] == FOURCC('m', 'e', 't', 'a')
         && path[3] == FOURCC('i', 'l', 's', 't');
-}
-
-// Given a time in seconds since Jan 1 1904, produce a human-readable string.
-static bool convertTimeToDate(int64_t time_1904, String8 *s) {
-    int64_t time_1970 = time_1904 - (((66 * 365 + 17) * 24) * 3600);
-    if (time_1970 < 0) {
-        return false;
-    }
-    if (time_1970 >= std::numeric_limits<time_t>::max()) {
-        return false;
-    }
-    time_t time_checked = time_1970;
-
-    struct tm* time_gm = gmtime(&time_checked);
-    if (!time_gm) {
-        return false;
-    }
-    char tmp[32];
-    if (!strftime(tmp, sizeof(tmp), "%Y%m%dT%H%M%S.000Z", time_gm)) {
-        return false;
-    }
-
-    s->setTo(tmp);
-    return true;
 }
 
 static bool ValidInputSize(int32_t size) {
@@ -1820,11 +1794,6 @@ status_t MPEG4Extractor::parseChunk(off64_t *offset, int depth) {
             } else {
                 creationTime = U32_AT(&header[4]);
                 mHeaderTimescale = U32_AT(&header[12]);
-            }
-
-            String8 s;
-            if (convertTimeToDate(creationTime, &s)) {
-                mFileMetaData->setCString(kKeyDate, s.string());
             }
 
             *offset += chunk_size;

--- a/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
@@ -1276,9 +1276,8 @@ status_t MPEG4Extractor::parseChunk(off64_t *offset, int depth) {
                 }
             }
 
-            if (*offset != stop_offset) {
-                return ERROR_MALFORMED;
-            }
+            // Some muxers add some padding after the stsd content. Skip it.
+            *offset = stop_offset;
             break;
         }
 

--- a/media/libstagefright/frameworks/av/media/libstagefright/SampleTable.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/SampleTable.cpp
@@ -395,7 +395,7 @@ status_t SampleTable::setCompositionTimeToSampleParams(
 
     uint32_t numEntries = U32_AT(&header[4]);
 
-    if (data_size != ((uint64_t)numEntries + 1) * 8) {
+    if (data_size < ((uint64_t)numEntries + 1) * 8) {
         return ERROR_MALFORMED;
     }
 


### PR DESCRIPTION
This PR makes the following changes:

- Don't reject boxes that contains padding but can be easily skipped - increases compatibility with some MP4's encoded with VBR.

- Don't parse the creation date of MP4 files -  not really needed for web browsing/streaming and is a potential crash point.

- Check for sidx box media segments (MSE). Our MSE code supports and can play sidx boxes, but currently we do not check for it.

Tested on Linux and appears to be working as intended.