### PR TITLE
Align the check of [[avilableLocales]] with ucol_getAvailable() from ICU55+

### DIFF
--- a/js/src/builtin/Intl.js
+++ b/js/src/builtin/Intl.js
@@ -437,15 +437,99 @@ function CanonicalizeLanguageTag(locale) {
 }
 
 
-// mappings from some commonly used old-style language tags to current flavors
-// with script codes
+function localeContainsNoUnicodeExtensions(locale) {
+    // No "-u-", no possible Unicode extension.
+    if (callFunction(std_String_indexOf, locale, "-u-") === -1)
+        return true;
+
+    // "-u-" within privateuse also isn't one.
+    if (callFunction(std_String_indexOf, locale, "-u-") > callFunction(std_String_indexOf, locale, "-x-"))
+        return true;
+
+    // An entirely-privateuse tag doesn't contain extensions.
+    if (callFunction(std_String_startsWith, locale, "x-"))
+        return true;
+
+    // Otherwise, we have a Unicode extension sequence.
+    return false;
+}
+
+
+// The last-ditch locale is used if none of the available locales satisfies a
+// request. "en-GB" is used based on the assumptions that English is the most
+// common second language, that both en-GB and en-US are normally available in
+// an implementation, and that en-GB is more representative of the English used
+// in other locales.
+function lastDitchLocale() {
+    // Per bug 1177929, strings don't clone out of self-hosted code as atoms,
+    // breaking IonBuilder::constant.  Put this in a function for now.
+    return "en-GB";
+}
+
+
+// Certain old, commonly-used language tags that lack a script, are expected to
+// nonetheless imply one.  This object maps these old-style tags to modern
+// equivalents.
 var oldStyleLanguageTagMappings = {
     "pa-PK": "pa-Arab-PK",
     "zh-CN": "zh-Hans-CN",
     "zh-HK": "zh-Hant-HK",
     "zh-SG": "zh-Hans-SG",
-    "zh-TW": "zh-Hant-TW"
+    "zh-TW": "zh-Hant-TW",
 };
+
+
+var localeCandidateCache = {
+    runtimeDefaultLocale: undefined,
+    candidateDefaultLocale: undefined,
+};
+
+
+var localeCache = {
+    runtimeDefaultLocale: undefined,
+    defaultLocale: undefined,
+};
+
+
+/**
+ * Compute the candidate default locale: the locale *requested* to be used as
+ * the default locale.  We'll use it if and only if ICU provides support (maybe
+ * fallback support, e.g. supporting "de-ZA" through "de" support implied by a
+ * "de-DE" locale).
+ */
+function DefaultLocaleIgnoringAvailableLocales() {
+    const runtimeDefaultLocale = RuntimeDefaultLocale();
+    if (runtimeDefaultLocale === localeCandidateCache.runtimeDefaultLocale)
+        return localeCandidateCache.candidateDefaultLocale;
+
+    // If we didn't get a cache hit, compute the candidate default locale and
+    // cache it.  Fall back on the last-ditch locale when necessary.
+    var candidate;
+    if (!IsStructurallyValidLanguageTag(runtimeDefaultLocale)) {
+        candidate = lastDitchLocale();
+    } else {
+        candidate = CanonicalizeLanguageTag(runtimeDefaultLocale);
+
+        // The default locale must be in [[availableLocales]], and that list
+        // must not contain any locales with Unicode extension sequences, so
+        // remove any present in the candidate.
+        candidate = removeUnicodeExtensions(candidate);
+
+        if (callFunction(std_Object_hasOwnProperty, oldStyleLanguageTagMappings, candidate))
+            candidate = oldStyleLanguageTagMappings[candidate];
+    }
+
+    // Cache the candidate locale until the runtime default locale changes.
+    localeCandidateCache.candidateDefaultLocale = candidate;
+    localeCandidateCache.runtimeDefaultLocale = runtimeDefaultLocale;
+
+    assert(IsStructurallyValidLanguageTag(candidate),
+           "the candidate must be structurally valid");
+    assert(localeContainsNoUnicodeExtensions(candidate),
+           "the candidate must not contain a Unicode extension sequence");
+
+    return candidate;
+}
 
 
 /**
@@ -454,27 +538,37 @@ var oldStyleLanguageTagMappings = {
  * Spec: ECMAScript Internationalization API Specification, 6.2.4.
  */
 function DefaultLocale() {
-    // The locale of last resort is used if none of the available locales
-    // satisfies a request. "en-GB" is used based on the assumptions that
-    // English is the most common second language, that both en-GB and en-US
-    // are normally available in an implementation, and that en-GB is more
-    // representative of the English used in other locales.
-    var localeOfLastResort = "en-GB";
+    const runtimeDefaultLocale = RuntimeDefaultLocale();
+    if (runtimeDefaultLocale === localeCache.runtimeDefaultLocale)
+        return localeCache.defaultLocale;
 
-    var locale = RuntimeDefaultLocale();
-    if (!IsStructurallyValidLanguageTag(locale))
-        return localeOfLastResort;
-
-    locale = CanonicalizeLanguageTag(locale);
-    if (callFunction(std_Object_hasOwnProperty, oldStyleLanguageTagMappings, locale))
-        locale = oldStyleLanguageTagMappings[locale];
-
-    if (!(collatorInternalProperties.availableLocales()[locale] &&
-          numberFormatInternalProperties.availableLocales()[locale] &&
-          dateTimeFormatInternalProperties.availableLocales()[locale]))
+    // If we didn't have a cache hit, compute the candidate default locale.
+    // Then use it as the actual default locale if ICU supports that locale
+    // (perhaps via fallback).  Otherwise use the last-ditch locale.
+    var candidate = DefaultLocaleIgnoringAvailableLocales();
+    var locale;
+    if (BestAvailableLocaleIgnoringDefault(collatorInternalProperties.availableLocales(),
+                                           candidate) &&
+        BestAvailableLocaleIgnoringDefault(numberFormatInternalProperties.availableLocales(),
+                                           candidate) &&
+        BestAvailableLocaleIgnoringDefault(dateTimeFormatInternalProperties.availableLocales(),
+                                           candidate))
     {
-        locale = localeOfLastResort;
+        locale = candidate;
+    } else {
+        locale = lastDitchLocale();
     }
+
+    assert(IsStructurallyValidLanguageTag(locale),
+           "the computed default locale must be structurally valid");
+    assert(locale === CanonicalizeLanguageTag(locale),
+           "the computed default locale must be canonical");
+    assert(localeContainsNoUnicodeExtensions(locale),
+           "the computed default locale must not contain a Unicode extension sequence");
+
+    localeCache.defaultLocale = locale;
+    localeCache.runtimeDefaultLocale = runtimeDefaultLocale;
+
     return locale;
 }
 
@@ -500,22 +594,28 @@ function IsWellFormedCurrencyCode(currency) {
 
 /********** Locale and Parameter Negotiation **********/
 
-
 /**
  * Add old-style language tags without script code for locales that in current
- * usage would include a script subtag. Returns the availableLocales argument
- * provided.
- *
- * Spec: ECMAScript Internationalization API Specification, 9.1.
+ * usage would include a script subtag.  Also add an entry for the last-ditch
+ * locale, in case ICU doesn't directly support it (but does support it through
+ * fallback, e.g. supporting "en-GB" indirectly using "en" support).
  */
-function addOldStyleLanguageTags(availableLocales) {
+function addSpecialMissingLanguageTags(availableLocales) {
+    // Certain old-style language tags lack a script code, but in current usage
+    // they *would* include a script code.  Map these over to modern forms.
     var oldStyleLocales = std_Object_getOwnPropertyNames(oldStyleLanguageTagMappings);
     for (var i = 0; i < oldStyleLocales.length; i++) {
         var oldStyleLocale = oldStyleLocales[i];
         if (availableLocales[oldStyleLanguageTagMappings[oldStyleLocale]])
             availableLocales[oldStyleLocale] = true;
     }
-    return availableLocales;
+
+    // Also forcibly provide the last-ditch locale.
+    var lastDitch = lastDitchLocale();
+    assert(lastDitch === "en-GB" && availableLocales["en"],
+           "shouldn't be a need to add every locale implied by the last-" +
+           "ditch locale, merely just the last-ditch locale");
+    availableLocales[lastDitch] = true;
 }
 
 
@@ -553,6 +653,50 @@ function CanonicalizeLocaleList(locales) {
 }
 
 
+function BestAvailableLocaleHelper(availableLocales, locale, considerDefaultLocale) {
+    assert(IsStructurallyValidLanguageTag(locale), "invalid BestAvailableLocale locale structure");
+    assert(locale === CanonicalizeLanguageTag(locale), "non-canonical BestAvailableLocale locale");
+    assert(localeContainsNoUnicodeExtensions(locale), "locale must contain no Unicode extensions");
+
+    // In the spec, [[availableLocales]] is formally a list of all available
+    // locales.  But in our implementation, it's an *incomplete* list, not
+    // necessarily including the default locale (and all locales implied by it,
+    // e.g. "de" implied by "de-CH"), if that locale isn't in every
+    // [[availableLocales]] list (because that locale is supported through
+    // fallback, e.g. "de-CH" supported through "de").
+    //
+    // If we're considering the default locale, augment the spec loop with
+    // additional checks to also test whether the current prefix is a prefix of
+    // the default locale.
+
+    var defaultLocale;
+    if (considerDefaultLocale)
+        defaultLocale = DefaultLocale();
+
+    var candidate = locale;
+    while (true) {
+        if (availableLocales[candidate])
+            return candidate;
+
+        if (considerDefaultLocale && candidate.length <= defaultLocale.length) {
+            if (candidate === defaultLocale)
+                return candidate;
+            if (callFunction(std_String_startsWith, defaultLocale, candidate + "-"))
+                return candidate;
+        }
+
+        var pos = callFunction(std_String_lastIndexOf, candidate, "-");
+        if (pos === -1)
+            return undefined;
+
+        if (pos >= 2 && candidate[pos - 2] === "-")
+            pos -= 2;
+
+        candidate = callFunction(std_String_substring, candidate, 0, pos);
+    }
+}
+
+
 /**
  * Compares a BCP 47 language tag against the locales in availableLocales
  * and returns the best available match. Uses the fallback
@@ -562,21 +706,16 @@ function CanonicalizeLocaleList(locales) {
  * Spec: RFC 4647, section 3.4.
  */
 function BestAvailableLocale(availableLocales, locale) {
-    assert(IsStructurallyValidLanguageTag(locale), "invalid BestAvailableLocale locale structure");
-    assert(locale === CanonicalizeLanguageTag(locale), "non-canonical BestAvailableLocale locale");
-    assert(callFunction(std_String_indexOf, locale, "-u-") === -1, "locale shouldn't contain -u-");
+    return BestAvailableLocaleHelper(availableLocales, locale, true);
+}
 
-    var candidate = locale;
-    while (true) {
-        if (availableLocales[candidate])
-            return candidate;
-        var pos = callFunction(std_String_lastIndexOf, candidate, "-");
-        if (pos === -1)
-            return undefined;
-        if (pos >= 2 && candidate[pos - 2] === "-")
-            pos -= 2;
-        candidate = callFunction(std_String_substring, candidate, 0, pos);
-    }
+
+/**
+ * Identical to BestAvailableLocale, but does not consider the default locale
+ * during computation.
+ */
+function BestAvailableLocaleIgnoringDefault(availableLocales, locale) {
+    return BestAvailableLocaleHelper(availableLocales, locale, false);
 }
 
 
@@ -1366,8 +1505,10 @@ var collatorInternalProperties = {
         var locales = this._availableLocales;
         if (locales)
             return locales;
-        return (this._availableLocales =
-          addOldStyleLanguageTags(intl_Collator_availableLocales()));
+
+        locales = intl_Collator_availableLocales();
+        addSpecialMissingLanguageTags(locales);
+        return (this._availableLocales = locales);
     },
     relevantExtensionKeys: ["co", "kn"]
 };
@@ -1480,8 +1621,10 @@ var numberFormatInternalProperties = {
         var locales = this._availableLocales;
         if (locales)
             return locales;
-        return (this._availableLocales =
-          addOldStyleLanguageTags(intl_NumberFormat_availableLocales()));
+
+        locales = intl_NumberFormat_availableLocales();
+        addSpecialMissingLanguageTags(locales);
+        return (this._availableLocales = locales);
     },
     relevantExtensionKeys: ["nu"]
 };
@@ -2513,8 +2656,10 @@ var dateTimeFormatInternalProperties = {
         var locales = this._availableLocales;
         if (locales)
             return locales;
-        return (this._availableLocales =
-          addOldStyleLanguageTags(intl_DateTimeFormat_availableLocales()));
+
+        locales = intl_DateTimeFormat_availableLocales();
+        addSpecialMissingLanguageTags(locales);
+        return (this._availableLocales = locales);
     },
     relevantExtensionKeys: ["ca", "nu"]
 };


### PR DESCRIPTION
Consider all locales implied from the default locale and the last-ditch locale (currently en-GB) to be always present in [[availableLocale]].

Based on [1175347](https://bugzilla.mozilla.org/show_bug.cgi?id=1175347) and [1272523](https://bugzilla.mozilla.org/show_bug.cgi?id=1272523).

Resolves #976.