### PR TITLE
[Minor fix] XMLHttpRequest - GetAllResponseHeaders() should return an empty string (instead null)

### DIFF
--- a/dom/base/nsXMLHttpRequest.cpp
+++ b/dom/base/nsXMLHttpRequest.cpp
@@ -1337,6 +1337,10 @@ nsXMLHttpRequest::GetAllResponseHeaders(nsCString& aResponseHeaders)
     return;
   }
 
+  if (mErrorLoad) {
+    return;
+  }
+
   if (nsCOMPtr<nsIHttpChannel> httpChannel = GetCurrentHttpChannel()) {
     nsRefPtr<nsHeaderVisitor> visitor = new nsHeaderVisitor(this, httpChannel);
     if (NS_SUCCEEDED(httpChannel->VisitResponseHeaders(visitor))) {

--- a/testing/web-platform/meta/XMLHttpRequest/xmlhttprequest-network-error.htm.ini
+++ b/testing/web-platform/meta/XMLHttpRequest/xmlhttprequest-network-error.htm.ini
@@ -1,5 +1,0 @@
-[xmlhttprequest-network-error.htm]
-  type: testharness
-  [XMLHttpRequest: members during network errors]
-    expected: FAIL
-


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1286744

An example: http://w3c-test.org/XMLHttpRequest/xmlhttprequest-network-error.htm

---

I've created the new build (x32, Windows) and tested.
