### PR TITLE
[Minor fix] Importing from HTML - A bookmark loses it's description text if a separator is in place next to it

### DIFF
--- a/toolkit/components/places/BookmarkHTMLUtils.jsm
+++ b/toolkit/components/places/BookmarkHTMLUtils.jsm
@@ -1173,6 +1173,6 @@ BookmarkExporter.prototype = {
     let descriptionAnno = aItem.annos &&
                           aItem.annos.find(anno => anno.name == DESCRIPTION_ANNO);
     if (descriptionAnno)
-      this._writeLine(aIndent + "<DD>" + escapeHtmlEntities(descriptionAnno.value));
+      this._writeLine(aIndent + "<DD>" + escapeHtmlEntities(descriptionAnno.value) + "</DD>");
   }
 };


### PR DESCRIPTION
Ad #996 

---

I've created the new build (x32, Windows) and tested.
