### PR TITLE
Proper import Bookmarks from HTML containing <HR> separators

### DIFF
--- a/toolkit/components/places/BookmarkHTMLUtils.jsm
+++ b/toolkit/components/places/BookmarkHTMLUtils.jsm
@@ -736,6 +736,7 @@ BookmarkImporter.prototype = {
         this._curFrame.inDescription = true;
         break;
       case "hr":
+        this._closeContainer(aElt);
         this._handleSeparator(aElt);
         break;
     }


### PR DESCRIPTION
Don't loose description and modification time when import Bookmarks from HTML containing separators.

Resolves #996, alternative to #997.

See also bug [482911](https://bugzilla.mozilla.org/show_bug.cgi?id=482911) and bug [753205](https://bugzilla.mozilla.org/show_bug.cgi?id=753205).