### PR TITLE
A channel suspend()-ed in http-on-modify-request shouldn't send out any traffic until resume()-d

### DIFF
--- a/netwerk/base/nsBaseChannel.cpp
+++ b/netwerk/base/nsBaseChannel.cpp
@@ -293,7 +293,7 @@ nsBaseChannel::ClassifyURI()
   if (mLoadFlags & LOAD_CLASSIFY_URI) {
     nsRefPtr<nsChannelClassifier> classifier = new nsChannelClassifier();
     if (classifier) {
-      classifier->Start(this, false);
+      classifier->Start(this);
     } else {
       Cancel(NS_ERROR_OUT_OF_MEMORY);
     }

--- a/netwerk/base/nsChannelClassifier.cpp
+++ b/netwerk/base/nsChannelClassifier.cpp
@@ -221,12 +221,9 @@ nsChannelClassifier::NotifyTrackingProtectionDisabled(nsIChannel *aChannel)
 }
 
 void
-nsChannelClassifier::Start(nsIChannel *aChannel, bool aContinueBeginConnect)
+nsChannelClassifier::Start(nsIChannel *aChannel)
 {
   mChannel = aChannel;
-  if (aContinueBeginConnect) {
-    mChannelInternal = do_QueryInterface(aChannel);
-  }
 
   nsresult rv = StartInternal();
   if (NS_FAILED(rv)) {
@@ -514,13 +511,7 @@ nsChannelClassifier::OnClassifyComplete(nsresult aErrorCode)
         mChannel->Resume();
     }
 
-    // Even if we have cancelled the channel, we may need to call
-    // ContinueBeginConnect so that we abort appropriately.
-    if (mChannelInternal) {
-        mChannelInternal->ContinueBeginConnect();
-    }
     mChannel = nullptr;
-    mChannelInternal = nullptr;
 
     return NS_OK;
 }

--- a/netwerk/base/nsChannelClassifier.h
+++ b/netwerk/base/nsChannelClassifier.h
@@ -21,10 +21,8 @@ public:
     NS_DECL_NSIURICLASSIFIERCALLBACK
 
     // Calls nsIURIClassifier.Classify with the principal of the given channel,
-    // and cancels the channel on a bad verdict.  If callContinueBeginConnect is true,
-    // and aChannel is an nsIHttpChannelInternal, nsChannelClassifier must call
-    // nsIHttpChannelInternal.ContinueBeginConnect once Start has returned.
-    void Start(nsIChannel *aChannel, bool aContinueBeginConnect);
+    // and cancels the channel on a bad verdict.
+    void Start(nsIChannel *aChannel);
     // Whether or not tracking protection should be enabled on this channel.
     nsresult ShouldEnableTrackingProtection(nsIChannel *aChannel, bool *result);
 
@@ -34,7 +32,6 @@ private:
     // True if the channel has been suspended.
     bool mSuspendedChannel;
     nsCOMPtr<nsIChannel> mChannel;
-    nsCOMPtr<nsIHttpChannelInternal> mChannelInternal;
 
     ~nsChannelClassifier() {}
     // Caches good classifications for the channel principal.

--- a/netwerk/protocol/http/HttpBaseChannel.cpp
+++ b/netwerk/protocol/http/HttpBaseChannel.cpp
@@ -1435,15 +1435,6 @@ HttpBaseChannel::RedirectTo(nsIURI *newURI)
 //-----------------------------------------------------------------------------
 
 NS_IMETHODIMP
-HttpBaseChannel::ContinueBeginConnect()
-{
-  MOZ_ASSERT(XRE_GetProcessType() != GoannaProcessType_Default,
-             "The parent overrides this");
-  MOZ_ASSERT(false, "This method must be overridden");
-  return NS_ERROR_NOT_IMPLEMENTED;
-}
-
-NS_IMETHODIMP
 HttpBaseChannel::GetTopWindowURI(nsIURI **aTopWindowURI)
 {
   nsresult rv = NS_OK;

--- a/netwerk/protocol/http/HttpBaseChannel.h
+++ b/netwerk/protocol/http/HttpBaseChannel.h
@@ -189,7 +189,6 @@ public:
   NS_IMETHOD GetLastModifiedTime(PRTime* lastModifiedTime) override;
   NS_IMETHOD ForceNoIntercept() override;
   NS_IMETHOD GetTopWindowURI(nsIURI **aTopWindowURI) override;
-  NS_IMETHOD ContinueBeginConnect() override;
   NS_IMETHOD GetProxyURI(nsIURI **proxyURI) override;
 
   inline void CleanRedirectCacheChainIfNecessary()

--- a/netwerk/protocol/http/nsHttpChannel.h
+++ b/netwerk/protocol/http/nsHttpChannel.h
@@ -119,7 +119,6 @@ public:
     NS_IMETHOD AsyncOpen(nsIStreamListener *listener, nsISupports *aContext) override;
     // nsIHttpChannelInternal
     NS_IMETHOD SetupFallbackChannel(const char *aFallbackKey) override;
-    NS_IMETHOD ContinueBeginConnect() override;
     // nsISupportsPriority
     NS_IMETHOD SetPriority(int32_t value) override;
     // nsIClassOfService
@@ -228,6 +227,8 @@ private:
 
     bool     RequestIsConditional();
     nsresult BeginConnect();
+    nsresult ContinueBeginConnectWithResult();
+    void     ContinueBeginConnect();
     nsresult Connect();
     void     SpeculativeConnect();
     nsresult SetupTransaction();

--- a/netwerk/protocol/http/nsIHttpChannelInternal.idl
+++ b/netwerk/protocol/http/nsIHttpChannelInternal.idl
@@ -25,7 +25,7 @@ interface nsIURI;
  * The callback interface for nsIHttpChannelInternal::HTTPUpgrade()
  */
 
-[scriptable, uuid(7b48d081-1dc1-4d08-b7a5-81491bf28c0e)]
+[scriptable, uuid(c025c35a-dda3-4a1d-9e6c-e02d7149ac79)]
 interface nsIHttpUpgradeListener : nsISupports
 {
     void onTransportAvailable(in nsISocketTransport   aTransport,
@@ -224,12 +224,6 @@ interface nsIHttpChannelInternal : nsISupports
      * The URI of the top-level window that's associated with this channel.
      */
     readonly attribute nsIURI topWindowURI;
-
-    /**
-     * Used only by nsChannelClassifier to resume connecting or abort the
-     * channel after a remote classification verdict.
-     */
-    void continueBeginConnect();
 
     /**
      * Read the proxy URI, which, if non-null, will be used to resolve

--- a/netwerk/test/unit/test_suspend_channel_before_connect.js
+++ b/netwerk/test/unit/test_suspend_channel_before_connect.js
@@ -1,0 +1,108 @@
+
+const CC = Components.Constructor;
+
+Cu.import("resource://gre/modules/Services.jsm");
+
+const ServerSocket = CC("@mozilla.org/network/server-socket;1",
+                        "nsIServerSocket",
+                        "init");
+
+var obs = Cc["@mozilla.org/observer-service;1"]
+            .getService(Ci.nsIObserverService);
+
+var ios = Cc["@mozilla.org/network/io-service;1"]
+            .getService(Components.interfaces.nsIIOService);
+
+// A server that waits for a connect. If a channel is suspended it should not
+// try to connect to the server until it is is resumed or not try at all if it
+// is cancelled as in this test.
+function TestServer() {
+  this.listener = ServerSocket(-1, true, -1);
+  this.port = this.listener.port;
+  this.listener.asyncListen(this);
+}
+
+TestServer.prototype = {
+  onSocketAccepted: function(socket, trans) {
+    do_check_true(false, "Socket should not have tried to connect!");
+  },
+
+  onStopListening: function(socket) {
+  },
+
+  stop: function() {
+    try { this.listener.close(); } catch(ignore) {}
+  }
+}
+
+var requestListenerObserver = {
+
+  QueryInterface: function queryinterface(iid) {
+    if (iid.equals(Ci.nsISupports) ||
+        iid.equals(Ci.nsIObserver))
+      return this;
+    throw Components.results.NS_ERROR_NO_INTERFACE;
+  },
+
+  observe: function(subject, topic, data) {
+    if (topic === "http-on-modify-request" &&
+        subject instanceof Ci.nsIHttpChannel) {
+
+      var chan = subject.QueryInterface(Ci.nsIHttpChannel);
+      chan.suspend();
+      var obs = Cc["@mozilla.org/observer-service;1"].getService();
+      obs = obs.QueryInterface(Ci.nsIObserverService);
+      obs.removeObserver(this, "http-on-modify-request");
+
+      // Timers are bad, but we need to wait to see that we are not trying to
+      // connect to the server. There are no other event since nothing should
+      // happen until we resume the channel.
+      let timer = Cc["@mozilla.org/timer;1"].createInstance(Ci.nsITimer);
+      timer.initWithCallback(() => {
+        chan.cancel(Cr.NS_BINDING_ABORTED);
+        chan.resume();
+      }, 1000, Ci.nsITimer.TYPE_ONE_SHOT);
+    }
+  }
+};
+
+var listener = {
+  onStartRequest: function test_onStartR(request, ctx) {
+  },
+
+  onDataAvailable: function test_ODA() {
+    do_throw("Should not get any data!");
+  },
+
+  onStopRequest: function test_onStopR(request, ctx, status) {
+    do_execute_soon(run_next_test);
+  }
+};
+
+// Add observer and start a channel. Observer is going to suspend the channel on
+// "http-on-modify-request" even. If a channel is suspended so early it should
+// not try to connect at all until it is resumed. In this case we are going to
+// wait for some time and cancel the channel before resuming it.
+add_test(function testNoConnectChannelCanceledEarly() {
+
+  serv = new TestServer();
+
+  obs.addObserver(requestListenerObserver, "http-on-modify-request", false);
+
+  var chan = ios.newChannel2("http://localhost:" + serv.port,
+                             "",
+                             null,
+                             null,      // aLoadingNode
+                             Services.scriptSecurityManager.getSystemPrincipal(),
+                             null,      // aTriggeringPrincipal
+                             Ci.nsILoadInfo.SEC_NORMAL,
+                             Ci.nsIContentPolicy.TYPE_OTHER);
+
+  chan.asyncOpen(listener, chan);
+
+  do_register_cleanup(function(){ serv.stop(); });
+});
+
+function run_test() {
+  run_next_test();
+}

--- a/netwerk/test/unit/xpcshell.ini
+++ b/netwerk/test/unit/xpcshell.ini
@@ -313,3 +313,4 @@ skip-if = os == "android"
 [test_1073747.js]
 [test_multipart_streamconv_application_package.js]
 [test_safeoutputstream_append.js]
+[test_suspend_channel_before_connect.js]


### PR DESCRIPTION
A channel suspend()-ed in http-on-modify-request shouldn't send out any traffic until resume()-d.

---

Browser Console:

```
GET [url] [HTTP/1.1 302 Found 67ms]
```

vs.

```
[nothing]
```

---

Here are even more reasons:
https://bugzilla.mozilla.org/show_bug.cgi?id=1170197#c0 ,
it's not just an extension.

An example:
https://bugzilla.mozilla.org/show_bug.cgi?id=1170197#c1

---

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1170197
(regression from: https://bugzilla.mozilla.org/show_bug.cgi?id=1166133)

See also:
https://forum.palemoon.org/viewtopic.php?f=56&t=12557&p=88895#p88898
https://github.com/OpenUserJs/OpenUserJS.org/issues/1066
(https://github.com/greasemonkey/greasemonkey/pull/2407)

---

IMHO:
It should also be properly tested... :-/
You add the label `Verification needed`, please.

---

I've created the new build (x32, Windows) and tested.
