### PR TITLE
[suggestion] CORS - Wildcard allowing origin vs. use credentials

### DIFF
--- a/dom/locales/en-US/chrome/security/security.properties
+++ b/dom/locales/en-US/chrome/security/security.properties
@@ -10,6 +10,7 @@ CORSRequestFailed=Cross-Origin Request Blocked: The Same Origin Policy disallows
 CORSRequestNotHttp=Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at %1$S. (Reason: CORS request not http).
 CORSMissingAllowOrigin=Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at %1$S. (Reason: CORS header 'Access-Control-Allow-Origin' missing).
 CORSAllowOriginNotMatchingOrigin=Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at %1$S. (Reason: CORS header 'Access-Control-Allow-Origin' does not match '%2$S').
+CORSNotSupportingCredentials=Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at '%1$S'. (Reason: Credential is not supported if the CORS header 'Access-Control-Allow-Origin' is '*').
 CORSMethodNotFound=Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at %1$S. (Reason: Did not find method in CORS header 'Access-Control-Allow-Methods').
 CORSMissingAllowCredentials=Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at %1$S. (Reason: expected 'true' in CORS header 'Access-Control-Allow-Credentials').
 CORSPreflightDidNotSucceed=Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at %1$S. (Reason: CORS preflight channel did not succeed).

--- a/dom/security/nsCORSListenerProxy.cpp
+++ b/dom/security/nsCORSListenerProxy.cpp
@@ -556,6 +556,19 @@ nsCORSListenerProxy::CheckRequestApproved(nsIRequest* aRequest)
     return rv;
   }
 
+  // Bug 1210985 - Explicitly point out the error that the credential is
+  // not supported if the allowing origin is '*'. Note that this check
+  // has to be done before the condition
+  //
+  // >> if (mWithCredentials || !allowedOriginHeader.EqualsLiteral("*"))
+  //
+  // below since "if (A && B)" is included in "if (A || !B)".
+  //
+  if (mWithCredentials && allowedOriginHeader.EqualsLiteral("*")) {
+    LogBlockedRequest(aRequest, "CORSNotSupportingCredentials", nullptr);
+    return NS_ERROR_DOM_BAD_URI;
+  }
+
   if (mWithCredentials || !allowedOriginHeader.EqualsLiteral("*")) {
     nsAutoCString origin;
     nsContentUtils::GetASCIIOrigin(mOriginHeaderPrincipal, origin);


### PR DESCRIPTION
Ad https://forum.palemoon.org/viewtopic.php?f=57&t=15382

__Steps to reproduce__

1) Go to: https://www.amazon.com/

2) Throws an errors in Browser Console:
```
Cross-Origin Request Blocked: The Same Origin Policy
disallows reading the remote resource at
https://fls-na.amazon.com/1/action-impressions/1/OP/csm/action/
csm-features:impression-tracking?requestId=&marketplaceId=&session=&csm=1.
(Reason: CORS header 'Access-Control-Allow-Origin' does not match '*').
<unknown>

Cross-Origin Request Blocked: The Same Origin Policy
disallows reading the remote resource at https://fls-na.amazon.com/1/batch/1/OE/.
(Reason: CORS header 'Access-Control-Allow-Origin' does not match '*').
<unknown>
```

---

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1210985

---

I've created the new build (x32, Windows) and tested.
