### PR TITLE
Improve seeking behavior when audio and video buffered ranges differ

### DIFF
--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -1156,7 +1156,6 @@ MediaFormatReader::OnVideoSeekCompleted(media::TimeUnit aTime)
 
   if (HasAudio()) {
     MOZ_ASSERT(mPendingSeekTime.isSome());
-    mPendingSeekTime.ref() = aTime;
     DoAudioSeek();
   } else {
     mPendingSeekTime.reset();

--- a/dom/media/mediasource/MediaSourceReader.cpp
+++ b/dom/media/mediasource/MediaSourceReader.cpp
@@ -46,6 +46,7 @@ MediaSourceReader::MediaSourceReader(MediaSourceDecoder* aDecoder)
   : MediaDecoderReader(aDecoder)
   , mLastAudioTime(0)
   , mLastVideoTime(0)
+  , mOriginalSeekTime(-1)
   , mPendingSeekTime(-1)
   , mWaitingForSeekData(false)
   , mSeekToEnd(false)
@@ -807,6 +808,7 @@ MediaSourceReader::Seek(int64_t aTime, int64_t aIgnored /* Used only for ogg whi
 
   // Store pending seek target in case the track buffers don't contain
   // the desired time and we delay doing the seek.
+  mOriginalSeekTime = aTime;
   mPendingSeekTime = aTime;
 
   {
@@ -890,7 +892,8 @@ MediaSourceReader::DoAudioSeek()
   if (mSeekToEnd) {
     seekTime = LastSampleTime(MediaData::AUDIO_DATA);
   }
-  if (SwitchAudioSource(&seekTime) == SOURCE_NONE) {
+  if (SwitchAudioSource(&seekTime) == SOURCE_NONE &&
+      SwitchAudioSource(&mOriginalSeekTime) == SOURCE_NONE) {
     // Data we need got evicted since the last time we checked for data
     // availability. Abort current seek attempt.
     mWaitingForSeekData = true;

--- a/dom/media/mediasource/MediaSourceReader.h
+++ b/dom/media/mediasource/MediaSourceReader.h
@@ -253,6 +253,7 @@ private:
 
   // Temporary seek information while we wait for the data
   // to be added to the track buffer.
+  int64_t mOriginalSeekTime;
   int64_t mPendingSeekTime;
   bool mWaitingForSeekData;
   bool mSeekToEnd;

--- a/dom/media/mediasource/TrackBuffer.cpp
+++ b/dom/media/mediasource/TrackBuffer.cpp
@@ -624,6 +624,7 @@ TrackBuffer::InitializeDecoder(SourceBufferDecoder* aDecoder)
 
   if (mCurrentDecoder != aDecoder) {
     MSE_DEBUG("append was cancelled. Aborting initialization.");
+    RemoveDecoder(aDecoder);
     // If we reached this point, the SourceBuffer would have disconnected
     // the promise. So no need to reject it.
     return;
@@ -669,6 +670,7 @@ TrackBuffer::InitializeDecoder(SourceBufferDecoder* aDecoder)
   }
   if (mCurrentDecoder != aDecoder) {
     MSE_DEBUG("append was cancelled. Aborting initialization.");
+    RemoveDecoder(aDecoder);
     return;
   }
 
@@ -767,6 +769,7 @@ TrackBuffer::CompleteInitializeDecoder(SourceBufferDecoder* aDecoder)
     MSE_DEBUG("append was cancelled. Aborting initialization.");
     // If we reached this point, the SourceBuffer would have disconnected
     // the promise. So no need to reject it.
+    RemoveDecoder(aDecoder);
     return;
   }
 


### PR DESCRIPTION
Currently, when seeking to video we may seek to a different time in the audio stream in order to get good A/V sync. But in some cases this causes our media code to get stuck in waiting mode resulting in the player never actually starting playback. Some examples of this:

https://www.youtube.com/watch?t=61&v=ktbGjjzSKao
https://www.youtube.com/watch?t=61&v=5m5harNeUd8

This PR adjusts seeking in MSE and lets the MDSM handle dropping video frames if needed so we can keep good A/V sync.
Additionally, a few calls to RemoveDecoder have been added for if TrackBuffer initialization is aborted (prevents hangs in some cases).

Tested and now plays the links above, as well as other YouTube, Vimeo, and Twitch videos. While this PR doesn't seem to fully fix the A/V desync issue on Twitch, it does appear to improve some live streams there.