### PR TITLE
[suggestion] PageMenu.jsm - Ci.nsIXULContextMenuBuilder no longer exists (throws an error), allow separator lines

### DIFF
--- a/browser/modules/PageMenu.jsm
+++ b/browser/modules/PageMenu.jsm
@@ -11,80 +11,175 @@ PageMenu.prototype = {
   PAGEMENU_ATTR: "pagemenu",
   GENERATEDITEMID_ATTR: "generateditemid",
 
-  popup: null,
-  builder: null,
+  _popup: null,
 
-  maybeBuildAndAttachMenu: function(aTarget, aPopup) {
-    var pageMenu = null;
-    var target = aTarget;
+  // Only one of builder or browser will end up getting set.
+  _builder: null,
+  _browser: null,
+
+  // Given a target node, get the context menu for it or its ancestor.
+  getContextMenu: function(aTarget) {
+    let pageMenu = null;
+    let target = aTarget;
     while (target) {
-      var contextMenu = target.contextMenu;
+      let contextMenu = target.contextMenu;
       if (contextMenu) {
-        pageMenu = contextMenu;
-        break;
+        return contextMenu;
       }
       target = target.parentNode;
     }
 
-    if (!pageMenu) {
-      return false;
-    }
+    return null;
+  },
 
-    var insertionPoint = this.getInsertionPoint(aPopup);
-    if (!insertionPoint) {
-      return false;
+  // Given a target node, generate a JSON object for any context menu
+  // associated with it, or null if there is no context menu.
+  maybeBuild: function(aTarget) {
+    let pageMenu = this.getContextMenu(aTarget);
+    if (!pageMenu) {
+      return null;
     }
 
     pageMenu.QueryInterface(Components.interfaces.nsIHTMLMenu);
     pageMenu.sendShowEvent();
     // the show event is not cancelable, so no need to check a result here
 
-    var fragment = aPopup.ownerDocument.createDocumentFragment();
+    this._builder = pageMenu.createBuilder();
+    if (!this._builder) {
+      return null;
+    }
 
-    var builder = pageMenu.createBuilder();
-    if (!builder) {
+    pageMenu.build(this._builder);
+
+    // This serializes then parses again, however this could be avoided in
+    // the single-process case with further improvement.
+    let menuString = this._builder.toJSONString();
+    if (!menuString) {
+      return null;
+    }
+
+    return JSON.parse(menuString);
+  },
+
+  // Given a JSON menu object and popup, add the context menu to the popup.
+  buildAndAttachMenuWithObject: function(aMenu, aBrowser, aPopup) {
+    if (!aMenu) {
       return false;
     }
-    builder.QueryInterface(Components.interfaces.nsIXULContextMenuBuilder);
-    builder.init(fragment, this.GENERATEDITEMID_ATTR);
 
-    pageMenu.build(builder);
+    let insertionPoint = this.getInsertionPoint(aPopup);
+    if (!insertionPoint) {
+      return false;
+    }
 
-    var pos = insertionPoint.getAttribute(this.PAGEMENU_ATTR);
+    let fragment = aPopup.ownerDocument.createDocumentFragment();
+    this.buildXULMenu(aMenu, fragment);
+
+    let pos = insertionPoint.getAttribute(this.PAGEMENU_ATTR);
     if (pos == "start") {
       insertionPoint.insertBefore(fragment,
                                   insertionPoint.firstChild);
+    } else if (pos.startsWith("#")) {
+      insertionPoint.insertBefore(fragment, insertionPoint.querySelector(pos));
     } else {
       insertionPoint.appendChild(fragment);
     }
 
-    this.builder = builder;
-    this.popup = aPopup;
+    this._browser = aBrowser;
+    this._popup = aPopup;
 
-    this.popup.addEventListener("command", this);
-    this.popup.addEventListener("popuphidden", this);
+    this._popup.addEventListener("command", this);
+    this._popup.addEventListener("popuphidden", this);
 
     return true;
   },
 
-  handleEvent: function(event) {
-    var type = event.type;
-    var target = event.target;
-    if (type == "command" && target.hasAttribute(this.GENERATEDITEMID_ATTR)) {
-      this.builder.click(target.getAttribute(this.GENERATEDITEMID_ATTR));
-    } else if (type == "popuphidden" && this.popup == target) {
-      this.removeGeneratedContent(this.popup);
+  // Construct the XUL menu structure for a given JSON object.
+  buildXULMenu: function(aNode, aElementForAppending) {
+    let document = aElementForAppending.ownerDocument;
 
-      this.popup.removeEventListener("popuphidden", this);
-      this.popup.removeEventListener("command", this);
+    let children = aNode.children;
+    for (let child of children) {
+      let menuitem;
+      switch (child.type) {
+        case "menuitem":
+          if (!child.id) {
+            continue; // Ignore children without ids
+          }
 
-      this.popup = null;
-      this.builder = null;
+          menuitem = document.createElement("menuitem");
+          if (child.checkbox) {
+            menuitem.setAttribute("type", "checkbox");
+            if (child.checked) {
+              menuitem.setAttribute("checked", "true");
+            }
+          }
+
+          if (child.label) {
+            menuitem.setAttribute("label", child.label);
+          }
+          if (child.icon) {
+            menuitem.setAttribute("image", child.icon);
+            menuitem.className = "menuitem-iconic";
+          }
+          if (child.disabled) {
+            menuitem.setAttribute("disabled", true);
+          }
+
+          break;
+
+        case "separator":
+          menuitem = document.createElement("menuseparator");
+          break;
+
+        case "menu":
+          menuitem = document.createElement("menu");
+          if (child.label) {
+            menuitem.setAttribute("label", child.label);
+          }
+
+          let menupopup = document.createElement("menupopup");
+          menuitem.appendChild(menupopup);
+
+          this.buildXULMenu(child, menupopup);
+          break;
+      }
+
+      menuitem.setAttribute(this.GENERATEDITEMID_ATTR, child.id ? child.id : 0);
+      aElementForAppending.appendChild(menuitem);
     }
   },
 
+  // Called when the generated menuitem is executed.
+  handleEvent: function(event) {
+    let type = event.type;
+    let target = event.target;
+    if (type == "command" && target.hasAttribute(this.GENERATEDITEMID_ATTR)) {
+      // If a builder is assigned, call click on it directly. Otherwise, this is
+      // likely a menu with data from another process, so send a message to the
+      // browser to execute the menuitem.
+      if (this._builder) {
+        this._builder.click(target.getAttribute(this.GENERATEDITEMID_ATTR));
+      }
+      else if (this._browser) {
+        this._browser.messageManager.sendAsyncMessage("ContextMenu:DoCustomCommand",
+          target.getAttribute(this.GENERATEDITEMID_ATTR));
+      }
+    } else if (type == "popuphidden" && this._popup == target) {
+      this.removeGeneratedContent(this._popup);
+
+      this._popup.removeEventListener("popuphidden", this);
+      this._popup.removeEventListener("command", this);
+
+      this._popup = null;
+      this._builder = null;
+      this._browser = null;
+    }
+  },
+
+  // Get the first child of the given element with the given tag name.
   getImmediateChild: function(element, tag) {
-    var child = element.firstChild;
+    let child = element.firstChild;
     while (child) {
       if (child.localName == tag) {
         return child;
@@ -94,16 +189,19 @@ PageMenu.prototype = {
     return null;
   },
 
+  // Return the location where the generated items should be inserted into the
+  // given popup. They should be inserted as the next sibling of the returned
+  // element.
   getInsertionPoint: function(aPopup) {
     if (aPopup.hasAttribute(this.PAGEMENU_ATTR))
       return aPopup;
 
-    var element = aPopup.firstChild;
+    let element = aPopup.firstChild;
     while (element) {
       if (element.localName == "menu") {
-        var popup = this.getImmediateChild(element, "menupopup");
+        let popup = this.getImmediateChild(element, "menupopup");
         if (popup) {
-          var result = this.getInsertionPoint(popup);
+          let result = this.getInsertionPoint(popup);
           if (result) {
             return result;
           }
@@ -115,19 +213,30 @@ PageMenu.prototype = {
     return null;
   },
 
+  // Returns true if custom menu items were present.
+  maybeBuildAndAttachMenu: function(aTarget, aPopup) {
+    let menuObject = this.maybeBuild(aTarget);
+    if (!menuObject) {
+      return false;
+    }
+
+    return this.buildAndAttachMenuWithObject(menuObject, null, aPopup);
+  },
+
+  // Remove the generated content from the given popup.
   removeGeneratedContent: function(aPopup) {
-    var ungenerated = [];
+    let ungenerated = [];
     ungenerated.push(aPopup);
 
-    var count;
+    let count;
     while (0 != (count = ungenerated.length)) {
-      var last = count - 1;
-      var element = ungenerated[last];
+      let last = count - 1;
+      let element = ungenerated[last];
       ungenerated.splice(last, 1);
 
-      var i = element.childNodes.length;
+      let i = element.childNodes.length;
       while (i-- > 0) {
-        var child = element.childNodes[i];
+        let child = element.childNodes[i];
         if (!child.hasAttribute(this.GENERATEDITEMID_ATTR)) {
           ungenerated.push(child);
           continue;

--- a/dom/html/HTMLMenuElement.cpp
+++ b/dom/html/HTMLMenuElement.cpp
@@ -227,6 +227,8 @@ HTMLMenuElement::TraverseContent(nsIContent* aContent,
       aBuilder->AddItemFor(menuitem, CanLoadIcon(child, icon));
 
       aSeparator = ST_FALSE;
+    } else if (child->IsHTML(nsGkAtoms::hr)) {
+      aBuilder->AddSeparator();
     } else if (tag == nsGkAtoms::menu && !element->IsHidden()) {
       if (child->HasAttr(kNameSpaceID_None, nsGkAtoms::label)) {
         nsAutoString label;


### PR DESCRIPTION
Ad:
https://github.com/MoonchildProductions/Pale-Moon/issues/993

Ad also:
https://github.com/MoonchildProductions/Tycho/issues/31

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=870388

---

You add the label `Verification needed`, please.

---

I've created the new build (x32, Windows) and tested
(only: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu).
