### PR TITLE
PageMenu.jsm (follow up) - removal of redundant code, style clean up

### DIFF
--- a/browser/modules/PageMenu.jsm
+++ b/browser/modules/PageMenu.jsm
@@ -12,8 +12,6 @@ PageMenu.prototype = {
   GENERATEDITEMID_ATTR: "generateditemid",
 
   _popup: null,
-
-  // Only one of builder will end up getting set.
   _builder: null,
 
   // Given a target node, get the context menu for it or its ancestor.

--- a/browser/modules/PageMenu.jsm
+++ b/browser/modules/PageMenu.jsm
@@ -13,13 +13,11 @@ PageMenu.prototype = {
 
   _popup: null,
 
-  // Only one of builder or browser will end up getting set.
+  // Only one of builder will end up getting set.
   _builder: null,
-  _browser: null,
 
   // Given a target node, get the context menu for it or its ancestor.
   getContextMenu: function(aTarget) {
-    let pageMenu = null;
     let target = aTarget;
     while (target) {
       let contextMenu = target.contextMenu;
@@ -85,7 +83,6 @@ PageMenu.prototype = {
       insertionPoint.appendChild(fragment);
     }
 
-    this._browser = aBrowser;
     this._popup = aPopup;
 
     this._popup.addEventListener("command", this);
@@ -161,10 +158,6 @@ PageMenu.prototype = {
       if (this._builder) {
         this._builder.click(target.getAttribute(this.GENERATEDITEMID_ATTR));
       }
-      else if (this._browser) {
-        this._browser.messageManager.sendAsyncMessage("ContextMenu:DoCustomCommand",
-          target.getAttribute(this.GENERATEDITEMID_ATTR));
-      }
     } else if (type == "popuphidden" && this._popup == target) {
       this.removeGeneratedContent(this._popup);
 
@@ -173,7 +166,6 @@ PageMenu.prototype = {
 
       this._popup = null;
       this._builder = null;
-      this._browser = null;
     }
   },
 


### PR DESCRIPTION
Removal of redundant code (e10s).

Style clean up:
https://hg.mozilla.org/mozilla-central/diff/239dd56733c4/toolkit/modules/PageMenu.jsm

---

I've created the new build (x32, Windows) and tested
(only: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu).
