### PR TITLE
[minor fix] The urlbar - entering 127.0.0.1/1 and the like performs a search instead of loading the site

### DIFF
--- a/docshell/base/nsDefaultURIFixup.cpp
+++ b/docshell/base/nsDefaultURIFixup.cpp
@@ -981,6 +981,23 @@ nsDefaultURIFixup::KeywordURIFixup(const nsACString& aURIString,
         looksLikeIpv6 = false;
       }
     }
+
+    // If we're at the end of the string or this is the first slash,
+    // check if the thing before the slash looks like ipv4:
+    if ((iter.size_forward() == 1 || (lastSlashLoc == uint32_t(kNotFound) && *iter == '/')) &&
+        // Need 2 or 3 dots + only digits
+        (foundDots == 2 || foundDots == 3) &&
+        // and they should be all that came before now:
+        (foundDots + foundDigits == pos ||
+         // or maybe there was also exactly 1 colon that came after the last dot,
+         // and the digits, dots and colon were all that came before now:
+         (foundColons == 1 && firstColonLoc > lastDotLoc &&
+          foundDots + foundDigits + foundColons == pos))) {
+      // Hurray, we got ourselves some ipv4!
+      // At this point, there's no way we will do a keyword lookup, so just bail immediately:
+      return NS_OK;
+    }
+
     if (*iter == '.') {
       ++foundDots;
       lastDotLoc = pos;
@@ -1019,6 +1036,12 @@ nsDefaultURIFixup::KeywordURIFixup(const nsACString& aURIString,
     looksLikeIpv6 = false;
   }
 
+  // If there are only colons and only hexadecimal characters ([a-z][0-9])
+  // enclosed in [], then don't do a keyword lookup
+  if (looksLikeIpv6) {
+    return NS_OK;
+  }
+
   nsAutoCString asciiHost;
   nsAutoCString host;
 
@@ -1031,34 +1054,6 @@ nsDefaultURIFixup::KeywordURIFixup(const nsACString& aURIString,
     aFixupInfo->mFixedURI &&
     NS_SUCCEEDED(aFixupInfo->mFixedURI->GetHost(host)) &&
     !host.IsEmpty();
-
-  // If there are 2 dots and only numbers between them, an optional port number
-  // and a trailing slash, then don't do a keyword lookup
-  if (foundDots == 2 && lastSlashLoc == pos - 1 &&
-      ((foundDots + foundDigits == pos - 1) ||
-       (foundColons == 1 && firstColonLoc > lastDotLoc &&
-        foundDots + foundDigits + foundColons == pos - 1))) {
-    return NS_OK;
-  }
-
-  uint32_t posWithNoTrailingSlash = pos;
-  if (lastSlashLoc == pos - 1) {
-    posWithNoTrailingSlash -= 1;
-  }
-  // If there are 3 dots and only numbers between them, an optional port number
-  // and an optional trailling slash, then don't do a keyword lookup (ipv4)
-  if (foundDots == 3 &&
-      ((foundDots + foundDigits == posWithNoTrailingSlash) ||
-       (foundColons == 1 && firstColonLoc > lastDotLoc &&
-        foundDots + foundDigits + foundColons == posWithNoTrailingSlash))) {
-    return NS_OK;
-  }
-
-  // If there are only colons and only hexadecimal characters ([a-z][0-9])
-  // enclosed in [], then don't do a keyword lookup
-  if (looksLikeIpv6) {
-    return NS_OK;
-  }
 
   nsresult rv = NS_OK;
   // We do keyword lookups if a space or quote preceded the dot, colon

--- a/docshell/test/unit/test_nsDefaultURIFixup_info.js
+++ b/docshell/test/unit/test_nsDefaultURIFixup_info.js
@@ -115,11 +115,25 @@ let testcases = [ {
     fixedURI: "http://192.168.10.110/",
     protocolChange: true,
   }, {
+    input: "192.168.10.110/123",
+    fixedURI: "http://192.168.10.110/123",
+    protocolChange: true,
+  }, {
+    input: "192.168.10.110/123foo",
+    fixedURI: "http://192.168.10.110/123foo",
+    protocolChange: true,
+  }, {
+    input: "192.168.10.110:1234/123",
+    fixedURI: "http://192.168.10.110:1234/123",
+    protocolChange: true,
+  }, {
+    input: "192.168.10.110:1234/123foo",
+    fixedURI: "http://192.168.10.110:1234/123foo",
+    protocolChange: true,
+  }, {
     input: "1.2.3",
     fixedURI: "http://1.2.3/",
-    keywordLookup: true,
     protocolChange: true,
-    affectedByDNSForSingleHosts: true,
   }, {
     input: "1.2.3/",
     fixedURI: "http://1.2.3/",
@@ -129,11 +143,13 @@ let testcases = [ {
     fixedURI: "http://1.2.3/foo",
     protocolChange: true,
   }, {
+    input: "1.2.3/123",
+    fixedURI: "http://1.2.3/123",
+    protocolChange: true,
+  }, {
     input: "1.2.3:8000",
     fixedURI: "http://1.2.3:8000/",
-    keywordLookup: true,
     protocolChange: true,
-    affectedByDNSForSingleHosts: true,
   }, {
     input: "1.2.3:8000/",
     fixedURI: "http://1.2.3:8000/",
@@ -141,6 +157,10 @@ let testcases = [ {
   }, {
     input: "1.2.3:8000/foo",
     fixedURI: "http://1.2.3:8000/foo",
+    protocolChange: true,
+  }, {
+    input: "1.2.3:8000/123",
+    fixedURI: "http://1.2.3:8000/123",
     protocolChange: true,
   }, {
     input: "http://1.2.3",


### PR DESCRIPTION
__Steps to reproduce__

Go to: 127.0.0.1/1

A search instead of loading the site

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1154245

---

I've created the new build (x32, Windows) and tested:

http://192.168.10.110/123
192.168.10.110/123foo
192.168.10.110:1234/123
192.168.10.110:1234/123foo
1.2.3
1.2.3/
1.2.3/foo
1.2.3/123
1.2.3:8000
1.2.3:8000/
1.2.3:8000/foo
1.2.3:8000/123
