### PR TITLE
Re-land "Dispatch AudioSink notifications asynchronously" + fixes

### DIFF
--- a/dom/media/AudioSink.cpp
+++ b/dom/media/AudioSink.cpp
@@ -257,7 +257,10 @@ AudioSink::Cleanup()
   AssertCurrentThreadInMonitor();
   nsRefPtr<AudioStream> audioStream;
   audioStream.swap(mAudioStream);
-  mStateMachine->DispatchOnAudioSinkComplete();
+  // Suppress the callback when the stop is requested by MediaDecoderStateMachine.
+  if (!mStopAudioThread) {
+    mStateMachine->DispatchOnAudioSinkComplete();
+  }
 
   ReentrantMonitorAutoExit exit(GetReentrantMonitor());
   audioStream->Shutdown();

--- a/dom/media/AudioSink.cpp
+++ b/dom/media/AudioSink.cpp
@@ -25,6 +25,38 @@ extern PRLogModuleInfo* gMediaDecoderLog;
 #define SINK_LOG_V(msg, ...)
 #endif
 
+AudioSink::OnAudioEndTimeUpdateTask::OnAudioEndTimeUpdateTask(
+                                     MediaDecoderStateMachine* aStateMachine)
+  : mMutex("OnAudioEndTimeUpdateTask")
+  , mEndTime(0)
+  , mStateMachine(aStateMachine)
+{
+}
+
+NS_IMETHODIMP
+AudioSink::OnAudioEndTimeUpdateTask::Run() {
+  MutexAutoLock lock(mMutex);
+  if (mStateMachine) {
+    mStateMachine->OnAudioEndTimeUpdate(mEndTime);
+  }
+  return NS_OK;
+}
+
+void
+AudioSink::OnAudioEndTimeUpdateTask::Dispatch(int64_t aEndTime) {
+  MutexAutoLock lock(mMutex);
+  if (mStateMachine) {
+    mEndTime = aEndTime;
+    mStateMachine->TaskQueue()->Dispatch(this);
+  }
+}
+
+void
+AudioSink::OnAudioEndTimeUpdateTask::Cancel() {
+  MutexAutoLock lock(mMutex);
+  mStateMachine = nullptr;
+}
+
 // The amount of audio frames that is used to fuzz rounding errors.
 static const int64_t AUDIO_FUZZ_FRAMES = 1;
 
@@ -46,6 +78,7 @@ AudioSink::AudioSink(MediaDecoderStateMachine* aStateMachine,
   , mPlaying(true)
 {
   NS_ASSERTION(mStartTime != -1, "Should have audio start time by now");
+  mOnAudioEndTimeUpdateTask = new OnAudioEndTimeUpdateTask(aStateMachine);
 }
 
 nsresult
@@ -108,6 +141,7 @@ AudioSink::PrepareToShutdown()
 void
 AudioSink::Shutdown()
 {
+  mOnAudioEndTimeUpdateTask->Cancel();
   mThread->Shutdown();
   mThread = nullptr;
   MOZ_ASSERT(!mAudioStream);
@@ -203,7 +237,7 @@ AudioSink::AudioLoop()
     }
     int64_t endTime = GetEndTime();
     if (endTime != -1) {
-      mStateMachine->DispatchOnAudioEndTimeUpdate(endTime);
+      mOnAudioEndTimeUpdateTask->Dispatch(endTime);
     }
   }
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());

--- a/dom/media/AudioSink.cpp
+++ b/dom/media/AudioSink.cpp
@@ -182,7 +182,8 @@ AudioSink::AudioLoop()
     CheckedInt64 sampleTime = UsecsToFrames(AudioQueue().PeekFront()->mTime, mInfo.mRate);
 
     // Calculate the number of frames that have been pushed onto the audio hardware.
-    CheckedInt64 playedFrames = UsecsToFrames(mStartTime, mInfo.mRate) + mWritten;
+    CheckedInt64 playedFrames = UsecsToFrames(mStartTime, mInfo.mRate) +
+                                static_cast<int64_t>(mWritten);
 
     CheckedInt64 missingFrames = sampleTime - playedFrames;
     if (!missingFrames.isValid() || !sampleTime.isValid()) {

--- a/dom/media/AudioSink.cpp
+++ b/dom/media/AudioSink.cpp
@@ -202,7 +202,7 @@ AudioSink::AudioLoop()
     }
     int64_t endTime = GetEndTime();
     if (endTime != -1) {
-      mStateMachine->OnAudioEndTimeUpdate(endTime);
+      mStateMachine->DispatchOnAudioEndTimeUpdate(endTime);
     }
   }
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
@@ -256,7 +256,7 @@ AudioSink::Cleanup()
   AssertCurrentThreadInMonitor();
   nsRefPtr<AudioStream> audioStream;
   audioStream.swap(mAudioStream);
-  mStateMachine->OnAudioSinkComplete();
+  mStateMachine->DispatchOnAudioSinkComplete();
 
   ReentrantMonitorAutoExit exit(GetReentrantMonitor());
   audioStream->Shutdown();
@@ -340,7 +340,7 @@ AudioSink::PlayFromAudioQueue()
   StartAudioStreamPlaybackIfNeeded();
 
   if (audio->mOffset != -1) {
-    mStateMachine->OnPlaybackOffsetUpdate(audio->mOffset);
+    mStateMachine->DispatchOnPlaybackOffsetUpdate(audio->mOffset);
   }
   return audio->mFrames;
 }

--- a/dom/media/AudioSink.h
+++ b/dom/media/AudioSink.h
@@ -9,6 +9,7 @@
 #include "nsISupportsImpl.h"
 #include "MediaDecoderReader.h"
 #include "mozilla/dom/AudioChannelBinding.h"
+#include "mozilla/Atomics.h"
 
 namespace mozilla {
 
@@ -118,7 +119,7 @@ private:
   int64_t mStartTime;
 
   // PCM frames written to the stream so far.
-  int64_t mWritten;
+  Atomic<int64_t> mWritten;
 
   // Keep the last good position returned from the audio stream. Used to ensure
   // position returned by GetPosition() is mono-increasing in spite of audio

--- a/dom/media/AudioSink.h
+++ b/dom/media/AudioSink.h
@@ -141,6 +141,23 @@ private:
   bool mSetPreservesPitch;
 
   bool mPlaying;
+
+  class OnAudioEndTimeUpdateTask : public nsRunnable {
+  public:
+    explicit OnAudioEndTimeUpdateTask(MediaDecoderStateMachine* aStateMachine);
+
+    NS_IMETHOD Run() override;
+
+    void Dispatch(int64_t aEndTime);
+    void Cancel();
+
+  private:
+    Mutex mMutex;
+    int64_t mEndTime;
+    nsRefPtr<MediaDecoderStateMachine> mStateMachine;
+  };
+
+  nsRefPtr<OnAudioEndTimeUpdateTask> mOnAudioEndTimeUpdateTask;
 };
 
 } // namespace mozilla

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -1538,7 +1538,7 @@ void MediaDecoder::SetLoadInBackground(bool aLoadInBackground)
 
 void MediaDecoder::UpdatePlaybackOffset(int64_t aOffset)
 {
-  ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
+  GetReentrantMonitor().AssertCurrentThreadIn();
   mPlaybackPosition = aOffset;
 }
 

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -3409,6 +3409,7 @@ void MediaDecoderStateMachine::QueueMetadata(int64_t aPublishTime,
 
 void MediaDecoderStateMachine::OnAudioEndTimeUpdate(int64_t aAudioEndTime)
 {
+  MOZ_ASSERT(OnTaskQueue());
   ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   MOZ_ASSERT(aAudioEndTime >= mAudioEndTime);
   mAudioEndTime = aAudioEndTime;
@@ -3416,11 +3417,15 @@ void MediaDecoderStateMachine::OnAudioEndTimeUpdate(int64_t aAudioEndTime)
 
 void MediaDecoderStateMachine::OnPlaybackOffsetUpdate(int64_t aPlaybackOffset)
 {
+  MOZ_ASSERT(OnTaskQueue());
+  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   mDecoder->UpdatePlaybackOffset(aPlaybackOffset);
 }
 
 void MediaDecoderStateMachine::OnAudioSinkComplete()
 {
+  MOZ_ASSERT(OnTaskQueue());
+  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   if (mAudioCaptured) {
     return;
   }

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -718,16 +718,9 @@ protected:
   // Can only be called on the state machine thread.
   void SetPlayStartTime(const TimeStamp& aTimeStamp);
 
-private:
+public:
   // Update mAudioEndTime.
   void OnAudioEndTimeUpdate(int64_t aAudioEndTime);
-public:
-  void DispatchOnAudioEndTimeUpdate(int64_t aAudioEndTime)
-  {
-    RefPtr<nsRunnable> r =
-      NS_NewRunnableMethodWithArg<int64_t>(this, &MediaDecoderStateMachine::OnAudioEndTimeUpdate, aAudioEndTime);
-    TaskQueue()->Dispatch(r.forget());
-  }
 
 private:
   // Update mDecoder's playback offset.

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -718,15 +718,37 @@ protected:
   // Can only be called on the state machine thread.
   void SetPlayStartTime(const TimeStamp& aTimeStamp);
 
+private:
   // Update mAudioEndTime.
   void OnAudioEndTimeUpdate(int64_t aAudioEndTime);
+public:
+  void DispatchOnAudioEndTimeUpdate(int64_t aAudioEndTime)
+  {
+    RefPtr<nsRunnable> r =
+      NS_NewRunnableMethodWithArg<int64_t>(this, &MediaDecoderStateMachine::OnAudioEndTimeUpdate, aAudioEndTime);
+    TaskQueue()->Dispatch(r.forget());
+  }
 
+private:
   // Update mDecoder's playback offset.
   void OnPlaybackOffsetUpdate(int64_t aPlaybackOffset);
+public:
+  void DispatchOnPlaybackOffsetUpdate(int64_t aPlaybackOffset)
+  {
+    RefPtr<nsRunnable> r =
+      NS_NewRunnableMethodWithArg<int64_t>(this, &MediaDecoderStateMachine::OnPlaybackOffsetUpdate, aPlaybackOffset);
+    TaskQueue()->Dispatch(r.forget());
+  }
 
+private:
   // Called by the AudioSink to signal that all outstanding work is complete
   // and the sink is shutting down.
   void OnAudioSinkComplete();
+public:
+  void DispatchOnAudioSinkComplete()
+  {
+    TaskQueue()->Dispatch(NS_NewRunnableMethod(this, &MediaDecoderStateMachine::OnAudioSinkComplete));
+  }
 
   // Called by the AudioSink to signal errors.
   void OnAudioSinkError();

--- a/dom/media/omx/AudioOffloadPlayer.cpp
+++ b/dom/media/omx/AudioOffloadPlayer.cpp
@@ -51,7 +51,7 @@ PRLogModuleInfo* gAudioOffloadPlayerLog;
 #endif
 
 // maximum time in paused state when offloading audio decompression.
-// When elapsed, the AudioSink is destroyed to allow the audio DSP to power down.
+// When elapsed, the GonkAudioSink is destroyed to allow the audio DSP to power down.
 static const uint64_t OFFLOAD_PAUSE_MAX_MSECS = 60000ll;
 
 AudioOffloadPlayer::AudioOffloadPlayer(MediaOmxCommonDecoder* aObserver) :
@@ -473,28 +473,28 @@ void AudioOffloadPlayer::NotifyAudioTearDown()
 }
 
 // static
-size_t AudioOffloadPlayer::AudioSinkCallback(AudioSink* aAudioSink,
+size_t AudioOffloadPlayer::AudioSinkCallback(GonkAudioSink* aAudioSink,
                                              void* aBuffer,
                                              size_t aSize,
                                              void* aCookie,
-                                             AudioSink::cb_event_t aEvent)
+                                             GonkAudioSink::cb_event_t aEvent)
 {
   AudioOffloadPlayer* me = (AudioOffloadPlayer*) aCookie;
 
   switch (aEvent) {
 
-    case AudioSink::CB_EVENT_FILL_BUFFER:
+    case GonkAudioSink::CB_EVENT_FILL_BUFFER:
       AUDIO_OFFLOAD_LOG(PR_LOG_DEBUG, ("Notify Audio position changed"));
       me->NotifyPositionChanged();
       return me->FillBuffer(aBuffer, aSize);
 
-    case AudioSink::CB_EVENT_STREAM_END:
+    case GonkAudioSink::CB_EVENT_STREAM_END:
       AUDIO_OFFLOAD_LOG(PR_LOG_DEBUG, ("Notify Audio EOS"));
       me->mReachedEOS = true;
       me->NotifyAudioEOS();
       break;
 
-    case AudioSink::CB_EVENT_TEAR_DOWN:
+    case GonkAudioSink::CB_EVENT_TEAR_DOWN:
       AUDIO_OFFLOAD_LOG(PR_LOG_DEBUG, ("Notify Tear down event"));
       me->NotifyAudioTearDown();
       break;
@@ -699,7 +699,7 @@ MediaDecoderOwner::NextFrameStatus AudioOffloadPlayer::GetNextFrameStatus()
   }
 }
 
-void AudioOffloadPlayer::SendMetaDataToHal(sp<AudioSink>& aSink,
+void AudioOffloadPlayer::SendMetaDataToHal(sp<GonkAudioSink>& aSink,
                                            const sp<MetaData>& aMeta)
 {
   int32_t sampleRate = 0;

--- a/dom/media/omx/AudioOffloadPlayer.h
+++ b/dom/media/omx/AudioOffloadPlayer.h
@@ -50,11 +50,11 @@ class WakeLock;
  * it to the sink
  *
  * Also this class passes state changes (play/pause/seek) from
- * MediaOmxCommonDecoder to AudioSink as well as provide AudioSink status
+ * MediaOmxCommonDecoder to GonkAudioSink as well as provide GonkAudioSink status
  * (position changed, playback ended, seek complete, audio tear down) back to
  * MediaOmxCommonDecoder
  *
- * It acts as a bridge between MediaOmxCommonDecoder and AudioSink during
+ * It acts as a bridge between MediaOmxCommonDecoder and GonkAudioSink during
  * offload playback
  */
 
@@ -80,7 +80,7 @@ public:
   // Caller retains ownership of "aSource".
   virtual void SetSource(const android::sp<MediaSource> &aSource) override;
 
-  // Start the source if it's not already started and open the AudioSink to
+  // Start the source if it's not already started and open the GonkAudioSink to
   // create an offloaded audio track
   virtual status_t Start(bool aSourceAlreadyStarted = false) override;
 
@@ -106,7 +106,7 @@ public:
   void Reset();
 
 private:
-  // Set when audio source is started and audioSink is initialized
+  // Set when audio source is started and GonkAudioSink is initialized
   // Used only in main thread
   bool mStarted;
 
@@ -170,7 +170,7 @@ private:
   // Audio sink wrapper to access offloaded audio tracks
   // Used in main thread and offload callback thread
   // Race conditions are protected in underlying Android::AudioTrack class
-  android::sp<AudioSink> mAudioSink;
+  android::sp<GonkAudioSink> mAudioSink;
 
   // Buffer used to get date from audio source. Used in offload callback thread
   MediaBuffer* mInputBuffer;
@@ -183,7 +183,7 @@ private:
   // Timer to trigger position changed events
   nsCOMPtr<nsITimer> mTimeUpdateTimer;
 
-  // Timer to reset AudioSink when audio is paused for OFFLOAD_PAUSE_MAX_USECS.
+  // Timer to reset GonkAudioSink when audio is paused for OFFLOAD_PAUSE_MAX_USECS.
   // It is triggered in Pause() and canceled when there is a Play() within
   // OFFLOAD_PAUSE_MAX_USECS. Used only from main thread so no lock is needed.
   nsCOMPtr<nsITimer> mResetTimer;
@@ -203,12 +203,12 @@ private:
   // case of error
   size_t FillBuffer(void *aData, size_t aSize);
 
-  // Called by AudioSink when it needs data, to notify EOS or tear down event
-  static size_t AudioSinkCallback(AudioSink *aAudioSink,
+  // Called by GonkAudioSink when it needs data, to notify EOS or tear down event
+  static size_t AudioSinkCallback(GonkAudioSink *aAudioSink,
                                   void *aData,
                                   size_t aSize,
                                   void *aMe,
-                                  AudioSink::cb_event_t aEvent);
+                                  GonkAudioSink::cb_event_t aEvent);
 
   bool IsSeeking();
 
@@ -254,8 +254,8 @@ private:
   // MediaDecoder to re-evaluate offloading options
   void NotifyAudioTearDown();
 
-  // Send information from MetaData to the HAL via AudioSink
-  void SendMetaDataToHal(android::sp<AudioSink>& aSink,
+  // Send information from MetaData to the HAL via GonkAudioSink
+  void SendMetaDataToHal(android::sp<GonkAudioSink>& aSink,
                          const android::sp<MetaData>& aMeta);
 
   AudioOffloadPlayer(const AudioOffloadPlayer &);

--- a/dom/media/omx/AudioOutput.h
+++ b/dom/media/omx/AudioOutput.h
@@ -24,7 +24,7 @@
 #include <utils/Mutex.h>
 #include <AudioTrack.h>
 
-#include "AudioSink.h"
+#include "GonkAudioSink.h"
 
 namespace mozilla {
 
@@ -34,7 +34,7 @@ namespace mozilla {
  * Android::AudioTrack
  * Similarly to ease handling offloaded tracks, part of AudioOutput is used here
  */
-class AudioOutput : public AudioSink
+class AudioOutput : public GonkAudioSink
 {
   typedef android::Mutex Mutex;
   typedef android::String8 String8;

--- a/dom/media/omx/GonkAudioSink.h
+++ b/dom/media/omx/GonkAudioSink.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef AUDIO_SINK_H_
-#define AUDIO_SINK_H_
+#ifndef GONK_AUDIO_SINK_H_
+#define GONK_AUDIO_SINK_H_
 
 #include <utils/Errors.h>
 #include <utils/String8.h>
@@ -39,7 +39,7 @@ namespace mozilla {
  * Stripped version of Android KK MediaPlayerBase::AudioSink class
  */
 
-class AudioSink : public android::RefBase
+class GonkAudioSink : public android::RefBase
 {
   typedef android::String8 String8;
   typedef android::status_t status_t;
@@ -54,12 +54,12 @@ public:
   };
 
   // Callback returns the number of bytes actually written to the buffer.
-  typedef size_t (*AudioCallback)(AudioSink* aAudioSink,
+  typedef size_t (*AudioCallback)(GonkAudioSink* aAudioSink,
                                   void* aBuffer,
                                   size_t aSize,
                                   void* aCookie,
                                   cb_event_t aEvent);
-  virtual ~AudioSink() {}
+  virtual ~GonkAudioSink() {}
   virtual ssize_t FrameSize() const = 0;
   virtual status_t GetPosition(uint32_t* aPosition) const = 0;
   virtual status_t SetVolume(float aVolume) const = 0;
@@ -86,4 +86,4 @@ public:
 
 } // namespace mozilla
 
-#endif // AUDIO_SINK_H_
+#endif // GONK_AUDIO_SINK_H_

--- a/dom/media/omx/moz.build
+++ b/dom/media/omx/moz.build
@@ -26,7 +26,7 @@ if CONFIG['MOZ_AUDIO_OFFLOAD']:
     EXPORTS += [
         'AudioOffloadPlayer.h',
         'AudioOutput.h',
-        'AudioSink.h',
+        'GonkAudioSink.h',
     ]
     SOURCES += [
         'AudioOffloadPlayer.cpp',


### PR DESCRIPTION
I have been putting a lot of work recently into implementing some so-called "state machinery", which will be a major step towards stabilizing and reducing the raciness of our media code as a whole, as well as being a prerequisite to updating our MSE code. However, without AudioSink notifications being dispatched async, the state machinery does not work as-intended and instead segfaults reliably.

Dispatching AudioSink notifications async previously landed in commit a0125e4, but was backed out for causing a regression as noted in #841. This PR re-lands it, with these additional fixes:

- Make AudioSink:mWritten an Atomic (fixes a potential crash point).
- Suppress call to DispatchOnAudioSinkComplete (fixes an issue that could cause the decode to enter COMPLETED state before reaching the end of the stream).
- Add a cancelable runnable to fix a problem with slow (and in some cases incorrect) seeking.
- Rename OMX AudioSink to GonkAudioSink to prevent conflicts with the new, above mentioned runnable.

Built on Linux and tested playing/seeking the various audio formats here: http://hpr.dogphilosophy.net/test/. Appears to work as intended without introducing any regressions.
