### PR TITLE
DevTools - the cmd line - support for "-browserconsole", "-jsdebugger", "-devtools" and "-start-debugger-server"

### DIFF
--- a/browser/components/nsBrowserContentHandler.js
+++ b/browser/components/nsBrowserContentHandler.js
@@ -518,16 +518,16 @@ nsBrowserContentHandler.prototype = {
 #endif
   },
 
-  helpInfo : "  -browser                  Open a browser window.\n" +
-             "  -new-window         <url> Open <url> in a new window.\n" +
-             "  -new-tab            <url> Open <url> in a new tab.\n" +
-             "  -private-window     <url> Open <url> in a new private window.\n" +
+  helpInfo : "  -browser                            Open a browser window.\n" +
+             "  -new-window <url>                   Open <url> in a new window.\n" +
+             "  -new-tab <url>                      Open <url> in a new tab.\n" +
+             "  -private-window <url>               Open <url> in a new private window.\n" +
 #ifdef XP_WIN
-             "  -preferences              Open Options dialog.\n" +
+             "  -preferences                        Open Options dialog.\n" +
 #else
-             "  -preferences              Open Preferences dialog.\n" +
+             "  -preferences                        Open Preferences dialog.\n" +
 #endif
-             "  -search            <term> Search <term> with your default search engine.\n",
+             "  -search <term>                      Search <term> with your default search engine.\n",
 
   /* nsIBrowserHandler */
 

--- a/browser/components/shell/nsSetDefaultBrowser.js
+++ b/browser/components/shell/nsSetDefaultBrowser.js
@@ -22,7 +22,7 @@ nsSetDefaultBrowser.prototype = {
     }
   },
 
-  helpInfo: "  -setDefaultBrowser        Set this app as the default browser.\n",
+  helpInfo: "  -setDefaultBrowser                  Set this app as the default browser.\n",
 
   classID: Components.ID("{F57899D0-4E2C-4ac6-9E29-50C736103B0C}"),
   QueryInterface: XPCOMUtils.generateQI([Ci.nsICommandLineHandler]),

--- a/browser/installer/package-manifest.in
+++ b/browser/installer/package-manifest.in
@@ -414,6 +414,10 @@
 @RESPATH@/components/crypto-SDR.js
 @RESPATH@/components/jsconsole-clhandler.manifest
 @RESPATH@/components/jsconsole-clhandler.js
+#ifdef MOZ_DEVTOOLS
+@RESPATH@/components/devtools-clhandler.manifest
+@RESPATH@/components/devtools-clhandler.js
+#endif
 @RESPATH@/components/webvtt.xpt
 @RESPATH@/components/WebVTT.manifest
 @RESPATH@/components/WebVTTParserWrapper.js

--- a/layout/tools/recording/recording-cmdline.js
+++ b/layout/tools/recording/recording-cmdline.js
@@ -67,8 +67,8 @@ RecordingCmdLineHandler.prototype =
         cmdLine.preventDefault = true;
     },
 
-    helpInfo : "  --recording        <file> Record drawing for a given URL.\n" +
-               "  --recording-output <file> Specify destination file for a drawing recording.\n"
+    helpInfo : "  --recording <file>                  Record drawing for a given URL.\n" +
+               "  --recording-output <file>           Specify destination file for a drawing recording.\n"
 };
 
 this.NSGetFactory = XPCOMUtils.generateNSGetFactory([RecordingCmdLineHandler]);

--- a/toolkit/components/console/jsconsole-clhandler.js
+++ b/toolkit/components/console/jsconsole-clhandler.js
@@ -31,7 +31,7 @@ jsConsoleHandler.prototype = {
       cmdLine.preventDefault = true;
   },
 
-  helpInfo : "  -jsconsole                Open the Error console.\n",
+  helpInfo : "  -jsconsole                          Open the Error console.\n",
 
   classID: Components.ID("{2cd0c310-e127-44d0-88fc-4435c9ab4d4b}"),
   QueryInterface: XPCOMUtils.generateQI([Ci.nsICommandLineHandler]),

--- a/toolkit/devtools/devtools-clhandler.manifest
+++ b/toolkit/devtools/devtools-clhandler.manifest
@@ -1,2 +1,3 @@
 component {9e9a9283-0ce9-4e4a-8f1c-ba129a032c32} devtools-clhandler.js
-contract @mozilla.org/toolkit/console-clh;1 {9e9a9283-0ce9-4e4a-8f1c-ba129a032c32}
+contract @mozilla.org/toolkit/devtools-clh;1 {9e9a9283-0ce9-4e4a-8f1c-ba129a032c32}
+category command-line-handler m-devtools @mozilla.org/toolkit/devtools-clh;1

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -1296,27 +1296,27 @@ DumpHelp()
 
 #ifdef MOZ_X11
   printf("X11 options\n"
-         "  --display=DISPLAY         X display to use\n"
-         "  --sync                    Make X calls synchronous\n");
+         "  --display=DISPLAY                   X display to use\n"
+         "  --sync                              Make X calls synchronous\n");
 #endif
 #ifdef XP_UNIX
-  printf("  --g-fatal-warnings        Make all warnings fatal\n"
+  printf("  --g-fatal-warnings                  Make all warnings fatal\n"
          "\n%s options\n", gAppData->name);
 #endif
 
-  printf("  -h or --help              Print this message.\n"
-         "  -v or --version           Print %s version.\n"
-         "  -P <profile>              Start with <profile>.\n"
-         "  --profile <path>          Start with profile at <path>.\n"
-         "  --migration               Start with migration wizard.\n"
-         "  --ProfileManager          Start with ProfileManager.\n"
-         "  --no-remote               Do not accept or send remote commands; implies --new-instance.\n"
-         "  --new-instance            Open new instance, not a new window in running instance.\n"
-         "  --UILocale <locale>       Start with <locale> resources as UI Locale.\n"
-         "  --safe-mode               Disables extensions and themes for this session.\n", gAppData->name);
+  printf("  -h or --help                        Print this message.\n"
+         "  -v or --version                     Print %s version.\n"
+         "  -P <profile>                        Start with <profile>.\n"
+         "  --profile <path>                    Start with profile at <path>.\n"
+         "  --migration                         Start with migration wizard.\n"
+         "  --ProfileManager                    Start with ProfileManager.\n"
+         "  --no-remote                         Do not accept or send remote commands; implies --new-instance.\n"
+         "  --new-instance                      Open new instance, not a new window in running instance.\n"
+         "  --UILocale <locale>                 Start with <locale> resources as UI Locale.\n"
+         "  --safe-mode                         Disables extensions and themes for this session.\n", gAppData->name);
 
 #if defined(XP_WIN)
-  printf("  --console                 Start %s with a debugging console.\n", gAppData->name);
+  printf("  --console                           Start %s with a debugging console.\n", gAppData->name);
 #endif
 
   // this works, but only after the components have registered.  so if you drop in a new command line handler, --help


### PR DESCRIPTION
See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1226744

`-help` - the columns alignment - see also:
https://github.com/MoonchildProductions/Pale-Moon/commit/c1fe90aaffc36485048f1c92170d01f9e094f870

\+ style clean up

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows) and tested.
