### PR TITLE
Resolve confusions between Flash and VLC plugins on permissions pages

### DIFF
--- a/browser/base/content/pageinfo/permissions.js
+++ b/browser/base/content/pageinfo/permissions.js
@@ -338,6 +338,9 @@ function initPluginsRow() {
       continue;
     }
     for (let mimeType of plugin.getMimeTypes()) {
+      if (mimeType == "application/x-shockwave-flash" && plugin.name != "Shockwave Flash") {
+        continue;
+      }
       let permString = pluginHost.getPermissionStringForType(mimeType);
       if (!permissionMap.has(permString)) {
         var name = makeNicePluginName(plugin.name) + " " + plugin.version;

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -531,6 +531,9 @@ let AboutPermissions = {
     let XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
     for (let plugin of tags) {
       for (let mimeType of plugin.getMimeTypes()) {
+        if (mimeType == "application/x-shockwave-flash" && plugin.name != "Shockwave Flash") {
+          continue;
+        }
         let permString = pluginHost.getPermissionStringForType(mimeType);
         if (!permissionMap.has(permString)) {
           let permissionEntry = document.createElementNS(XUL_NS, "box");
@@ -1061,6 +1064,9 @@ let AboutPermissions = {
         AddonManager.getAddonsByTypes(["plugin"], function(addons) {
           for (let addon of addons) {
             for (let type of addon.pluginMimeTypes) {
+              if (type.type == "application/x-shockwave-flash" && addon.name != "Shockwave Flash") {
+                continue;
+              }
               if (type.type.toLowerCase() == permissionMimeType.toLowerCase()) {
                 addon.userDisabled = addonValue;
                 return;

--- a/toolkit/mozapps/extensions/internal/PluginProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/PluginProvider.jsm
@@ -196,7 +196,8 @@ var PluginProvider = {
       if (!(tag.description in seenPlugins[tag.name])) {
         let plugin = {
           id: getIDHashForString(tag.name + tag.description),
-          name: tag.name,
+          // XXX Flash name substitution like in browser-plugins.js, aboutPermissions.js, permissions.js
+          name: tag.name == "Shockwave Flash" ? "Adobe Flash" : tag.name,
           description: tag.description,
           tags: [tag]
         };


### PR DESCRIPTION
Follow-up to #899, proper display and control Flash and VLC plugins on permissions pages. 

Also changes display name of Shockwave Flash to Adobe Flash in PluginProvider.jsm to unify the UI.


Before:
![palemoon_2017-04-15_22-21-27](https://cloud.githubusercontent.com/assets/340855/25066274/3bd18ccc-222a-11e7-8905-2f676c657589.png)
![palemoon_2017-04-15_22-21-56](https://cloud.githubusercontent.com/assets/340855/25066286/9a90bb7a-222a-11e7-8105-4417b65f8ee6.png)

After:
![palemoon_2017-04-15_22-22-45](https://cloud.githubusercontent.com/assets/340855/25066275/45f30104-222a-11e7-8919-8f515bee3347.png)
![palemoon_2017-04-15_22-23-27](https://cloud.githubusercontent.com/assets/340855/25066292/a81a1822-222a-11e7-8ad4-bb61150f106c.png)
