### PR TITLE
Permissions: Cookies correspond to domain, difference between the "default value" and an "actual value" (improvements)

### DIFF
--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -21,9 +21,6 @@ let gPlacesDatabase = Cc["@mozilla.org/browser/nav-history-service;1"].
                       DBConnection.
                       clone(true);
 
-let gTLDService = Cc["@mozilla.org/network/effective-tld-service;1"].
-                  getService(Ci.nsIEffectiveTLDService);
-
 let gSitesStmt = gPlacesDatabase.createAsyncStatement(
                   "SELECT get_unreversed_host(rev_host) AS host " +
                   "FROM moz_places " +
@@ -1158,7 +1155,7 @@ let AboutPermissions = {
   domainFromHost: function(aHost) {
     let domain = aHost;
     try {
-      domain = gTLDService.getBaseDomainFromHost(aHost);
+      domain = Services.eTLD.getBaseDomainFromHost(aHost);
     } catch (e) {
       // getBaseDomainFromHost will fail if the host is an IP address or is empty
     }

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -1051,13 +1051,13 @@ let AboutPermissions = {
         _elementDefault.setAttribute("value", "*");
       }
     } else {
-      let _elementVisibility;
+      let _elementDefaultVisibility;
       if (!this._selectedSite || (permissionValue == permissionDefault)) {
-        _elementVisibility = false;
+        _elementDefaultVisibility = false;
       } else {
-        _elementVisibility = true;
+        _elementDefaultVisibility = true;
       }
-      pluginPermissionEntry.setVisibility(_elementVisibility);
+      pluginPermissionEntry.setDefaultVisibility(_elementDefaultVisibility);
     }
 
     permissionMenulist.selectedItem = document.getElementById(aType + "-" + permissionValue);

--- a/browser/components/preferences/aboutPermissions.xml
+++ b/browser/components/preferences/aboutPermissions.xml
@@ -25,6 +25,7 @@
       <xul:hbox flex="1" align="baseline">
         <xul:label xbl:inherits="value=label" class="plugins-label"/>
         <xul:label xbl:inherits="value=vulnerable" class="plugins-vulnerable"/>
+        <xul:label xbl:inherits="value=default" anonid="plugins-default" class="plugins-default"/>
         <xul:spacer flex="1"/>
         <xul:menulist anonid="plugins-menulist"
                       class="pref-menulist"
@@ -46,13 +47,28 @@
         menulist.setAttribute("mimeType", mimeType);
         menulist.setAttribute("type", permString);
         let askitem = document.getAnonymousElementByAttribute(this, "anonid", "ask");
-        askitem.setAttribute("id", permString + "-0")
+        askitem.setAttribute("id", permString + "-0");
         let allowitem = document.getAnonymousElementByAttribute(this, "anonid", "allow");
-        allowitem.setAttribute("id", permString + "-1")
+        allowitem.setAttribute("id", permString + "-1");
         let blockitem = document.getAnonymousElementByAttribute(this, "anonid", "block");
-        blockitem.setAttribute("id", permString + "-2")
-        ]]>
+        blockitem.setAttribute("id", permString + "-2");
+        let _default = document.getAnonymousElementByAttribute(this, "anonid", "plugins-default");
+        this.setVisibility(false);
+        _default.setAttribute("value", "*");
+      ]]>
       </constructor>
+      <method name="setVisibility">
+        <parameter name="visibility" />
+        <body><![CDATA[
+          let _default = document.getAnonymousElementByAttribute(this, "anonid", "plugins-default");
+          if (visibility) {
+            _default.style.visibility = "visible";
+          } else {
+            _default.style.visibility = "hidden";
+          }
+        ]]>
+        </body>
+      </method>
       <method name="isClickToPlay">
         <body><![CDATA[
           let pluginHost = Components.classes["@mozilla.org/plugin/host;1"]

--- a/browser/components/preferences/aboutPermissions.xml
+++ b/browser/components/preferences/aboutPermissions.xml
@@ -53,11 +53,11 @@
         let blockitem = document.getAnonymousElementByAttribute(this, "anonid", "block");
         blockitem.setAttribute("id", permString + "-2");
         let _default = document.getAnonymousElementByAttribute(this, "anonid", "plugins-default");
-        this.setVisibility(false);
+        this.setDefaultVisibility(false);
         _default.setAttribute("value", "*");
       ]]>
       </constructor>
-      <method name="setVisibility">
+      <method name="setDefaultVisibility">
         <parameter name="visibility" />
         <body><![CDATA[
           let _default = document.getAnonymousElementByAttribute(this, "anonid", "plugins-default");

--- a/browser/components/preferences/aboutPermissions.xul
+++ b/browser/components/preferences/aboutPermissions.xul
@@ -71,7 +71,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="password"/>
         <vbox>
-          <label class="pref-title" value="&password.label;"/>
+          <hbox>
+            <label class="pref-title" value="&password.label;"/>
+            <label id="password-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox align="center">
             <menulist id="password-menulist"
                       class="pref-menulist"
@@ -100,7 +103,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="image"/>
         <vbox>
-          <label class="pref-title" value="&image.label;"/>
+          <hbox>
+            <label class="pref-title" value="&image.label;"/>
+            <label id="image-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox>
             <menulist id="image-menulist"
                       class="pref-menulist"
@@ -121,7 +127,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="popup"/>
         <vbox>
-          <label class="pref-title" value="&popup.label;"/>
+          <hbox>
+            <label class="pref-title" value="&popup.label;"/>
+            <label id="popup-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox>
             <menulist id="popup-menulist"
                       class="pref-menulist"
@@ -141,7 +150,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="cookie"/>
         <vbox>
-          <label class="pref-title" value="&cookie.label;"/>
+          <hbox>
+            <label class="pref-title" value="&cookie.label;"/>
+            <label id="cookie-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox align="center">
             <menulist id="cookie-menulist"
                       class="pref-menulist"
@@ -178,7 +190,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="desktop-notification"/>
         <vbox>
-          <label class="pref-title" value="&desktop-notification.label;"/>
+          <hbox>
+            <label class="pref-title" value="&desktop-notification.label;"/>
+            <label id="desktop-notification-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox>
             <menulist id="desktop-notification-menulist"
                       class="pref-menulist"
@@ -199,7 +214,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="install"/>
         <vbox>
-          <label class="pref-title" value="&install.label;"/>
+          <hbox>
+            <label class="pref-title" value="&install.label;"/>
+            <label id="install-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox>
             <menulist id="install-menulist"
                       class="pref-menulist"
@@ -219,7 +237,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="geo"/>
         <vbox>
-          <label class="pref-title" value="&geo.label;"/>
+          <hbox>
+            <label class="pref-title" value="&geo.label;"/>
+            <label id="geo-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox>
             <menulist id="geo-menulist"
                       class="pref-menulist"
@@ -240,7 +261,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="indexedDB"/>
         <vbox>
-          <label class="pref-title" value="&indexedDB.label;"/>
+          <hbox>
+            <label class="pref-title" value="&indexedDB.label;"/>
+            <label id="indexedDB-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox>
             <menulist id="indexedDB-menulist"
                       class="pref-menulist"
@@ -271,7 +295,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="fullscreen"/>
         <vbox>
-          <label class="pref-title" value="&fullscreen.label;"/>
+          <hbox>
+            <label class="pref-title" value="&fullscreen.label;"/>
+            <label id="fullscreen-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox align="center">
             <menulist id="fullscreen-menulist"
                       class="pref-menulist"
@@ -292,7 +319,10 @@
             class="pref-item" align="top">
         <image class="pref-icon" type="pointerLock"/>
         <vbox>
-          <label class="pref-title" value="&pointerLock.label;"/>
+          <hbox>
+            <label class="pref-title" value="&pointerLock.label;"/>
+            <label id="pointerLock-default" class="pref-default" value="*"/>
+          </hbox>
           <hbox>
             <menulist id="pointerLock-menulist"
                       class="pref-menulist"

--- a/browser/themes/linux/preferences/aboutPermissions.css
+++ b/browser/themes/linux/preferences/aboutPermissions.css
@@ -115,6 +115,13 @@
   font-size: 125%;
   margin-bottom: 0;
   font-weight: bold;
+  margin-right: 0;
+  padding-right: 0;
+}
+
+.pref-default {
+  margin-left: 1ex;
+  padding-left: 0;
 }
 
 .pref-menulist {
@@ -130,4 +137,13 @@
 .plugins-vulnerable {
   margin-left: 0;
   padding-left: 0;
+  margin-right: 0;
+  padding-right: 0;
+}
+
+.plugins-default {
+  margin-left: 1ex;
+  padding-left: 0;
+  margin-right: 2ex;
+  padding-right: 0;
 }

--- a/browser/themes/linux/preferences/aboutPermissions.css
+++ b/browser/themes/linux/preferences/aboutPermissions.css
@@ -120,7 +120,7 @@
 }
 
 .pref-default {
-  margin-left: 1ex;
+  margin-left: 0.5em;
   padding-left: 0;
 }
 
@@ -142,8 +142,8 @@
 }
 
 .plugins-default {
-  margin-left: 1ex;
+  margin-left: 0.5em;
   padding-left: 0;
-  margin-right: 2ex;
+  margin-right: 1em;
   padding-right: 0;
 }

--- a/browser/themes/osx/preferences/aboutPermissions.css
+++ b/browser/themes/osx/preferences/aboutPermissions.css
@@ -123,7 +123,7 @@
 }
 
 .pref-default {
-  margin-left: 1ex;
+  margin-left: 0.5em;
   padding-left: 0;
 }
 
@@ -146,8 +146,8 @@
 }
 
 .plugins-default {
-  margin-left: 1ex;
+  margin-left: 0.5em;
   padding-left: 0;
-  margin-right: 2ex;
+  margin-right: 1em;
   padding-right: 0;
 }

--- a/browser/themes/osx/preferences/aboutPermissions.css
+++ b/browser/themes/osx/preferences/aboutPermissions.css
@@ -118,6 +118,13 @@
   font-size: 125%;
   margin-bottom: 0;
   font-weight: bold;
+  margin-right: 0;
+  padding-right: 0;
+}
+
+.pref-default {
+  margin-left: 1ex;
+  padding-left: 0;
 }
 
 .pref-menulist {
@@ -134,4 +141,13 @@
 .plugins-vulnerable {
   margin-left: 0;
   padding-left: 0;
+  margin-right: 0;
+  padding-right: 0;
+}
+
+.plugins-default {
+  margin-left: 1ex;
+  padding-left: 0;
+  margin-right: 2ex;
+  padding-right: 0;
 }

--- a/browser/themes/windows/preferences/aboutPermissions.css
+++ b/browser/themes/windows/preferences/aboutPermissions.css
@@ -123,7 +123,7 @@
 }
 
 .pref-default {
-  margin-left: 1ex;
+  margin-left: 0.5em;
   padding-left: 0;
 }
 
@@ -146,8 +146,8 @@
 }
 
 .plugins-default {
-  margin-left: 1ex;
+  margin-left: 0.5em;
   padding-left: 0;
-  margin-right: 2ex;
+  margin-right: 1em;
   padding-right: 0;
 }

--- a/browser/themes/windows/preferences/aboutPermissions.css
+++ b/browser/themes/windows/preferences/aboutPermissions.css
@@ -118,6 +118,13 @@
   font-size: 125%;
   margin-bottom: 0;
   font-weight: bold;
+  margin-right: 0;
+  padding-right: 0;
+}
+
+.pref-default {
+  margin-left: 1ex;
+  padding-left: 0;
 }
 
 .pref-menulist {
@@ -134,4 +141,13 @@
 .plugins-vulnerable {
   margin-left: 0;
   padding-left: 0;
+  margin-right: 0;
+  padding-right: 0;
+}
+
+.plugins-default {
+  margin-left: 1ex;
+  padding-left: 0;
+  margin-right: 2ex;
+  padding-right: 0;
 }


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/issues/823#issuecomment-294313936

> 1) Cookies correspond to strict urls, not to domains as on single page permissions
> 2) There are no easy way to find which permissions were changed on which pages

@JustOff
If that's how you meant (partially)...

While it is true that:
> There are no easy way to find which permissions were changed on which pages

...difference between the "default value" and an "actual value" - it may be displayed.

---

I've created the new build (x32, Windows) and tested.
