### PR TITLE
Extend the "highlight all" option behavior in findbar

### DIFF
--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -3824,9 +3824,6 @@ var XULBrowserWindow = {
           // Close the Find toolbar if we're in old-style TAF mode
           gFindBar.close();
         }
-
-        // fix bug 253793 - turn off highlight when page changes
-        gFindBar.getElement("highlight").checked = false;
       }
     }
     UpdateBackForwardCommands(gBrowser.webNavigation);

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -3824,6 +3824,9 @@ var XULBrowserWindow = {
           // Close the Find toolbar if we're in old-style TAF mode
           gFindBar.close();
         }
+
+        // fix bug 253793 - turn off highlight when page changes
+        gFindBar.getElement("highlight").checked = false;
       }
     }
     UpdateBackForwardCommands(gBrowser.webNavigation);

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -3825,8 +3825,7 @@ var XULBrowserWindow = {
           gFindBar.close();
         }
         
-        if (!(gPrefService.getBoolPref("accessibility.typeaheadfind.highlightallremember") ||
-              gPrefService.getBoolPref("accessibility.typeaheadfind.highlightallbydefault"))) {
+        if (gPrefService.getIntPref("accessibility.typeaheadfind.highlightAllBehavior") == 0) {
             // fix bug 253793 - turn off highlight when page changes
             gFindBar.getElement("highlight").checked = false;
         }

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -3824,9 +3824,12 @@ var XULBrowserWindow = {
           // Close the Find toolbar if we're in old-style TAF mode
           gFindBar.close();
         }
-
-        // fix bug 253793 - turn off highlight when page changes
-        gFindBar.getElement("highlight").checked = false;
+        
+        if (!(gPrefService.getBoolPref("accessibility.typeaheadfind.highlightallremember") ||
+              gPrefService.getBoolPref("accessibility.typeaheadfind.highlightallbydefault"))) {
+            // fix bug 253793 - turn off highlight when page changes
+            gFindBar.getElement("highlight").checked = false;
+        }
       }
     }
     UpdateBackForwardCommands(gBrowser.webNavigation);

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -754,8 +754,7 @@ pref("accessibility.typeaheadfind.autostart", true);
 //     1 - "always" (case-sensitive)
 // other - "auto"   (case-sensitive for mixed-case input, insensitive otherwise)
 pref("accessibility.typeaheadfind.casesensitive", 0);
-pref("accessibility.typeaheadfind.highlightallbydefault", false);
-pref("accessibility.typeaheadfind.highlightallremember", false);
+pref("accessibility.typeaheadfind.highlightAllBehavior", 0);
 pref("accessibility.typeaheadfind.linksonly", true);
 pref("accessibility.typeaheadfind.startlinksonly", false);
 pref("accessibility.typeaheadfind.timeout", 4000);

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -754,6 +754,8 @@ pref("accessibility.typeaheadfind.autostart", true);
 //     1 - "always" (case-sensitive)
 // other - "auto"   (case-sensitive for mixed-case input, insensitive otherwise)
 pref("accessibility.typeaheadfind.casesensitive", 0);
+pref("accessibility.typeaheadfind.highlightallbydefault", false);
+pref("accessibility.typeaheadfind.highlightallremember", false);
 pref("accessibility.typeaheadfind.linksonly", true);
 pref("accessibility.typeaheadfind.startlinksonly", false);
 pref("accessibility.typeaheadfind.timeout", 4000);

--- a/toolkit/content/widgets/findbar.xml
+++ b/toolkit/content/widgets/findbar.xml
@@ -323,7 +323,7 @@
               this._self._setCaseSensitivity(prefsvc.getIntPref(aPrefName));
               break;
             case "accessibility.typeaheadfind.highlightallbydefault":
-                this._self._typeAheadHighlightAllByDefault = prefsvc.getBoolPref(aPrefName);
+              this._self._typeAheadHighlightAllByDefault = prefsvc.getBoolPref(aPrefName);
               break;
             case "accessibility.typeaheadfind.highlightallremember":
               this._self._typeAheadHighlightAllRemember = prefsvc.getBoolPref(aPrefName);

--- a/toolkit/content/widgets/findbar.xml
+++ b/toolkit/content/widgets/findbar.xml
@@ -322,6 +322,12 @@
             case "accessibility.typeaheadfind.casesensitive":
               this._self._setCaseSensitivity(prefsvc.getIntPref(aPrefName));
               break;
+            case "accessibility.typeaheadfind.highlightallbydefault":
+                this._self._typeAheadHighlightAllByDefault = prefsvc.getBoolPref(aPrefName);
+              break;
+            case "accessibility.typeaheadfind.highlightallremember":
+              this._self._typeAheadHighlightAllRemember = prefsvc.getBoolPref(aPrefName);
+              break;
           }
         }
       })]]></field>
@@ -356,6 +362,10 @@
                             this._observer, false);
         prefsvc.addObserver("accessibility.typeaheadfind.casesensitive",
                             this._observer, false);
+        prefsvc.addObserver("accessibility.typeaheadfind.highlightallbydefault",
+                            this._observer, false);
+        prefsvc.addObserver("accessibility.typeaheadfind.highlightallremember",
+                            this._observer, false);
 
         this._useTypeAheadFind =
           prefsvc.getBoolPref("accessibility.typeaheadfind");
@@ -363,6 +373,10 @@
           prefsvc.getBoolPref("accessibility.typeaheadfind.linksonly");
         this._typeAheadCaseSensitive =
           prefsvc.getIntPref("accessibility.typeaheadfind.casesensitive");
+        this._typeAheadHighlightAllByDefault =
+          prefsvc.getBoolPref("accessibility.typeaheadfind.highlightallbydefault");
+        this._typeAheadHighlightAllRemember =
+          prefsvc.getBoolPref("accessibility.typeaheadfind.highlightallremember");
 
         // Convenience
         this.nsITypeAheadFind = Components.interfaces.nsITypeAheadFind;
@@ -400,6 +414,10 @@
           prefsvc.removeObserver("accessibility.typeaheadfind.linksonly",
                                  this._observer);
           prefsvc.removeObserver("accessibility.typeaheadfind.casesensitive",
+                                 this._observer);
+          prefsvc.removeObserver("accessibility.typeaheadfind.highlightallbydefault",
+                                 this._observer);
+          prefsvc.removeObserver("accessibility.typeaheadfind.highlightallremember",
                                  this._observer);
 
           // Clear all timers that might still be running.
@@ -641,7 +659,17 @@
 
           this._cancelTimers();
           this.toggleHighlight(false);
-          this.getElement("highlight").checked = false;
+          
+          // If the "highlight all" option state should be remembered,
+          // then the preference to highlight all by default gets
+          // overwritten with the current state, just before closing
+          if (this._typeAheadHighlightAllRemember) {
+            let prefsvc = Components.classes["@mozilla.org/preferences-service;1"]
+                         .getService(Components.interfaces.nsIPrefBranch);
+            let pref = "accessibility.typeaheadfind.highlightallbydefault";
+            let state = this.getElement("highlight").checked;
+            prefsvc.setBoolPref(pref, state);
+          }
 
           this._findFailedString = null;
         ]]></body>
@@ -898,6 +926,10 @@
           this.getElement("find-next").hidden =
             this.getElement("find-previous").hidden = showMinimalUI;
           this._updateCaseSensitivity();
+          
+          this.getElement("highlight").checked = this._typeAheadHighlightAllByDefault;
+          if (this._typeAheadHighlightAllByDefault)
+            this.toggleHighlight(true);
 
           if (showMinimalUI)
             this._findField.classList.add("minimal");
@@ -1141,7 +1173,11 @@
             this._find(this._findField.value);
           else
             this._findAgain(aFindPrevious);
-
+            
+          // Fix ignoring the "highlight all" option when page changes
+          // and the "find again" command gets executed afterwards
+          if (this.getElement("highlight").checked)
+            this.toggleHighlight(true);
         ]]></body>
       </method>
 

--- a/toolkit/content/widgets/findbar.xml
+++ b/toolkit/content/widgets/findbar.xml
@@ -422,6 +422,16 @@
 
           // Clear all timers that might still be running.
           this._cancelTimers();
+          
+          // If the "highlight all" option state should be remembered,
+          // then the preference to highlight all by default gets
+          // overwritten with the current state, just before destroying
+          // which usually happens while closing a browser window
+          if (this._typeAheadHighlightAllRemember) {
+            let pref = "accessibility.typeaheadfind.highlightallbydefault";
+            let state = this.getElement("highlight").checked;
+            prefsvc.setBoolPref(pref, state);
+          }
         ]]></body>
       </method>
 

--- a/toolkit/content/widgets/findbar.xml
+++ b/toolkit/content/widgets/findbar.xml
@@ -322,11 +322,8 @@
             case "accessibility.typeaheadfind.casesensitive":
               this._self._setCaseSensitivity(prefsvc.getIntPref(aPrefName));
               break;
-            case "accessibility.typeaheadfind.highlightallbydefault":
-              this._self._typeAheadHighlightAllByDefault = prefsvc.getBoolPref(aPrefName);
-              break;
-            case "accessibility.typeaheadfind.highlightallremember":
-              this._self._typeAheadHighlightAllRemember = prefsvc.getBoolPref(aPrefName);
+            case "accessibility.typeaheadfind.highlightAllBehavior":
+              this._self._typeAheadHighlightAllBehavior = prefsvc.getIntPref(aPrefName);
               break;
           }
         }
@@ -362,9 +359,7 @@
                             this._observer, false);
         prefsvc.addObserver("accessibility.typeaheadfind.casesensitive",
                             this._observer, false);
-        prefsvc.addObserver("accessibility.typeaheadfind.highlightallbydefault",
-                            this._observer, false);
-        prefsvc.addObserver("accessibility.typeaheadfind.highlightallremember",
+        prefsvc.addObserver("accessibility.typeaheadfind.highlightAllBehavior",
                             this._observer, false);
 
         this._useTypeAheadFind =
@@ -373,10 +368,8 @@
           prefsvc.getBoolPref("accessibility.typeaheadfind.linksonly");
         this._typeAheadCaseSensitive =
           prefsvc.getIntPref("accessibility.typeaheadfind.casesensitive");
-        this._typeAheadHighlightAllByDefault =
-          prefsvc.getBoolPref("accessibility.typeaheadfind.highlightallbydefault");
-        this._typeAheadHighlightAllRemember =
-          prefsvc.getBoolPref("accessibility.typeaheadfind.highlightallremember");
+        this._typeAheadHighlightAllBehavior =
+          prefsvc.getIntPref("accessibility.typeaheadfind.highlightAllBehavior");
 
         // Convenience
         this.nsITypeAheadFind = Components.interfaces.nsITypeAheadFind;
@@ -415,22 +408,20 @@
                                  this._observer);
           prefsvc.removeObserver("accessibility.typeaheadfind.casesensitive",
                                  this._observer);
-          prefsvc.removeObserver("accessibility.typeaheadfind.highlightallbydefault",
-                                 this._observer);
-          prefsvc.removeObserver("accessibility.typeaheadfind.highlightallremember",
+          prefsvc.removeObserver("accessibility.typeaheadfind.highlightAllBehavior",
                                  this._observer);
 
           // Clear all timers that might still be running.
           this._cancelTimers();
           
           // If the "highlight all" option state should be remembered,
-          // then the preference to highlight all by default gets
-          // overwritten with the current state, just before destroying
-          // which usually happens while closing a browser window
-          if (this._typeAheadHighlightAllRemember) {
-            let pref = "accessibility.typeaheadfind.highlightallbydefault";
-            let state = this.getElement("highlight").checked;
-            prefsvc.setBoolPref(pref, state);
+          // then the preference gets overwritten with the current
+          // state (on = 2, off = 3), just before destroying which
+          // usually happens while closing a browser window
+          if (this._typeAheadHighlightAllBehavior > 1) {
+            let pref = "accessibility.typeaheadfind.highlightAllBehavior";
+            let state = this.getElement("highlight").checked ? 2 : 3;
+            prefsvc.setIntPref(pref, state);
           }
         ]]></body>
       </method>
@@ -671,14 +662,14 @@
           this.toggleHighlight(false);
           
           // If the "highlight all" option state should be remembered,
-          // then the preference to highlight all by default gets
-          // overwritten with the current state, just before closing
-          if (this._typeAheadHighlightAllRemember) {
+          // then the preference gets overwritten with the current
+          // state (on = 2, off = 3), just before closing
+          if (this._typeAheadHighlightAllBehavior > 1) {
             let prefsvc = Components.classes["@mozilla.org/preferences-service;1"]
                          .getService(Components.interfaces.nsIPrefBranch);
-            let pref = "accessibility.typeaheadfind.highlightallbydefault";
-            let state = this.getElement("highlight").checked;
-            prefsvc.setBoolPref(pref, state);
+            let pref = "accessibility.typeaheadfind.highlightAllBehavior";
+            let state = this.getElement("highlight").checked ? 2 : 3;
+            prefsvc.setIntPref(pref, state);
           }
 
           this._findFailedString = null;
@@ -937,9 +928,13 @@
             this.getElement("find-previous").hidden = showMinimalUI;
           this._updateCaseSensitivity();
           
-          this.getElement("highlight").checked = this._typeAheadHighlightAllByDefault;
-          if (this._typeAheadHighlightAllByDefault)
+          if (this._typeAheadHighlightAllBehavior == 1 ||
+              this._typeAheadHighlightAllBehavior == 2) {
+            this.getElement("highlight").checked = true;
             this.toggleHighlight(true);
+          } else {
+            this.getElement("highlight").checked = false;
+          }
 
           if (showMinimalUI)
             this._findField.classList.add("minimal");


### PR DESCRIPTION
These changes are targeted at #364. 

Preference `accessibility.typeaheadfind.highlightallbydefault` indicates the default state of "highlight all" option after opening a findbar, i.e. `true` - enabled, `false` - disabled.

Preference `accessibility.typeaheadfind.highlightallremember` indicates whether the "highlight all" option state should be remembered after closing a findbar or not. If it's set to `true`, then the previous preference gets overwritten with the "highlight all" option state from recently closed findbar.

If both preferences are set to `false`, then original behavior is preserved.

Tested on Linux and observed no negative side-effects.