### PR TITLE
Add support for posting C++11 lambdas to messageloop/threads

### DIFF
--- a/build/clang-plugin/clang-plugin.cpp
+++ b/build/clang-plugin/clang-plugin.cpp
@@ -373,7 +373,8 @@ bool classHasAddRefRelease(const CXXRecordDecl *D) {
 
   bool seenAddRef = false;
   bool seenRelease = false;
-  for (const auto& method : D->methods()) {
+  for (CXXRecordDecl::method_iterator method = D->method_begin();
+    method != D->method_end(); ++method) {
     std::string name = method->getNameAsString();
     if (name == "AddRef") {
       seenAddRef = true;
@@ -397,8 +398,9 @@ bool isClassRefCounted(const CXXRecordDecl *D) {
     return true;
 
   // Look through all base cases to figure out if the parent is a refcounted class.
-  for (const auto& base : D->bases()) {
-    bool super = isClassRefCounted(base.getType());
+  for (CXXRecordDecl::base_class_const_iterator base = D->bases_begin();
+       base != D->bases_end(); ++base) {
+    bool super = isClassRefCounted(base->getType());
     if (super) {
       return true;
     }

--- a/build/clang-plugin/clang-plugin.cpp
+++ b/build/clang-plugin/clang-plugin.cpp
@@ -79,6 +79,11 @@ private:
     virtual void run(const MatchFinder::MatchResult &Result);
   };
 
+  class RefCountedInsideLambdaChecker : public MatchFinder::MatchCallback {
+    public:
+      virtual void run(const MatchFinder::MatchResult &Result);
+  }
+
   ScopeChecker stackClassChecker;
   ScopeChecker globalClassChecker;
   NonHeapClassChecker nonheapClassChecker;
@@ -86,6 +91,7 @@ private:
   TrivialCtorDtorChecker trivialCtorDtorChecker;
   NaNExprChecker nanExprChecker;
   NoAddRefReleaseOnReturnChecker noAddRefReleaseOnReturnChecker;
+  RefCountedInsideLambdaChecker refCountedInsideLambdaChecker;
   MatchFinder astMatcher;
 };
 
@@ -354,6 +360,60 @@ ClassAllocationNature getClassAttrs(QualType T) {
   return clazz ? getClassAttrs(clazz) : RegularClass;
 }
 
+/// A cached data of whether classes are refcounted or not.
+typedef DenseMap<const CXXRecordDecl *,
+  std::pair<const Decl *, bool> > RefCountedMap;
+RefCountedMap refCountedClasses;
+
+bool classHasAddRefRelease(const CXXRecordDecl *D) {
+  const RefCountedMap::iterator& it = refCountedClasses.find(D);
+  if (it != refCountedClasses.end()) {
+    return it->second.second;
+  }
+
+  bool seenAddRef = false;
+  bool seenRelease = false;
+  for (const auto& method : D->methods()) {
+    std::string name = method->getNameAsString();
+    if (name == "AddRef") {
+      seenAddRef = true;
+    } else if (name == "Release") {
+      seenRelease = true;
+    }
+  }
+  refCountedClasses[D] = std::make_pair(D, seenAddRef && seenRelease);
+  return seenAddRef && seenRelease;
+}
+
+bool isClassRefCounted(QualType T);
+
+bool isClassRefCounted(const CXXRecordDecl *D) {
+  // Normalize so that D points to the definition if it exists.
+  if (!D->hasDefinition())
+    return false;
+  D = D->getDefinition();
+  // Base class: anyone with AddRef/Release is obviously a refcounted class.
+  if (classHasAddRefRelease(D))
+    return true;
+
+  // Look through all base cases to figure out if the parent is a refcounted class.
+  for (const auto& base : D->bases()) {
+    bool super = isClassRefCounted(base.getType());
+    if (super) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool isClassRefCounted(QualType T) {
+  while (const ArrayType *arrTy = T->getAsArrayTypeUnsafe())
+    T = arrTy->getElementType();
+  CXXRecordDecl *clazz = T->getAsCXXRecordDecl();
+  return clazz ? isClassRefCounted(clazz) : RegularClass;
+}
+
 }
 
 namespace clang {
@@ -481,6 +541,11 @@ AST_MATCHER(MemberExpr, isAddRefOrRelease) {
   return false;
 }
 
+/// This matcher will select classes which are refcounted.
+AST_MATCHER(QualType, isRefCounted) {
+  return isClassRefCounted(Node);
+}
+
 }
 }
 
@@ -577,6 +642,11 @@ DiagnosticsMatcher::DiagnosticsMatcher()
                                                       hasParent(callExpr())).bind("member")
       )).bind("node"),
     &noAddRefReleaseOnReturnChecker);
+
+    astMatcher.addMatcher(lambdaExpr(
+            hasDescendant(declRefExpr(hasType(pointerType(pointee(isRefCounted())))).bind("node"))
+        ),
+    &refCountedInsideLambdaChecker);
 }
 
 void DiagnosticsMatcher::ScopeChecker::run(
@@ -773,6 +843,20 @@ void DiagnosticsMatcher::NoAddRefReleaseOnReturnChecker::run(
   const CXXMethodDecl *method = dyn_cast<CXXMethodDecl>(member->getMemberDecl());
 
   Diag.Report(node->getLocStart(), errorID) << func << method;
+}
+
+void DiagnosticsMatcher::RefCountedInsideLambdaChecker::run(
+    const MatchFinder::MatchResult &Result) {
+  DiagnosticsEngine &Diag = Result.Context->getDiagnostics();
+  unsigned errorID = Diag.getDiagnosticIDs()->getCustomDiagID(
+      DiagnosticIDs::Error, "Refcounted variable %0 of type %1 cannot be used inside a lambda");
+  unsigned noteID = Diag.getDiagnosticIDs()->getCustomDiagID(
+      DiagnosticIDs::Note, "Please consider using a smart pointer");
+  const DeclRefExpr *node = Result.Nodes.getNodeAs<DeclRefExpr>("node");
+
+  Diag.Report(node->getLocStart(), errorID) << node->getFoundDecl() <<
+    node->getType()->getPointeeType();
+  Diag.Report(node->getLocStart(), noteID);
 }
 
 class MozCheckAction : public PluginASTAction {

--- a/build/clang-plugin/tests/TestNoRefcountedInsideLambdas.cpp
+++ b/build/clang-plugin/tests/TestNoRefcountedInsideLambdas.cpp
@@ -1,0 +1,58 @@
+#define MOZ_STRONG_REF __attribute__((annotate("moz_strong_ref")))
+
+struct RefCountedBase {
+  void AddRef();
+  void Release();
+};
+
+template <class T>
+struct SmartPtr {
+  T* MOZ_STRONG_REF t;
+  T* operator->() const;
+};
+
+struct R : RefCountedBase {
+  void method();
+};
+
+void take(...);
+void foo() {
+  R* ptr;
+  SmartPtr<R> sp;
+  take([&]() {
+    ptr->method(); // expected-error{{Refcounted variable 'ptr' of type 'R' cannot be used inside a lambda}} expected-note{{Please consider using a smart pointer}}
+  });
+  take([&]() {
+    sp->method();
+  });
+  take([&]() {
+    take(ptr); // expected-error{{Refcounted variable 'ptr' of type 'R' cannot be used inside a lambda}} expected-note{{Please consider using a smart pointer}}
+  });
+  take([&]() {
+    take(sp);
+  });
+  take([=]() {
+    ptr->method(); // expected-error{{Refcounted variable 'ptr' of type 'R' cannot be used inside a lambda}} expected-note{{Please consider using a smart pointer}}
+  });
+  take([=]() {
+    sp->method();
+  });
+  take([=]() {
+    take(ptr); // expected-error{{Refcounted variable 'ptr' of type 'R' cannot be used inside a lambda}} expected-note{{Please consider using a smart pointer}}
+  });
+  take([=]() {
+    take(sp);
+  });
+  take([ptr]() {
+    ptr->method(); // expected-error{{Refcounted variable 'ptr' of type 'R' cannot be used inside a lambda}} expected-note{{Please consider using a smart pointer}}
+  });
+  take([sp]() {
+    sp->method();
+  });
+  take([ptr]() {
+    take(ptr); // expected-error{{Refcounted variable 'ptr' of type 'R' cannot be used inside a lambda}} expected-note{{Please consider using a smart pointer}}
+  });
+  take([sp]() {
+    take(sp);
+  });
+}

--- a/build/clang-plugin/tests/moz.build
+++ b/build/clang-plugin/tests/moz.build
@@ -14,6 +14,7 @@ SOURCES += [
     'TestNoAddRefReleaseOnReturn.cpp',
     'TestNoArithmeticExprInArgument.cpp',
     'TestNonHeapClass.cpp',
+    'TestNoRefcountedInsideLambdas.cpp',
     'TestStackClass.cpp',
     'TestTrivialCtorDtor.cpp',
 ]

--- a/dom/media/MediaManager.cpp
+++ b/dom/media/MediaManager.cpp
@@ -255,18 +255,6 @@ public:
     mOnFailure.swap(aOnFailure);
   }
 
-  ~DeviceSuccessCallbackRunnable()
-  {
-    if (!NS_IsMainThread()) {
-      // This can happen if the main thread processes the runnable before
-      // GetUserMediaDevicesTask::Run returns.
-      nsCOMPtr<nsIThread> mainThread = do_GetMainThread();
-
-      NS_ProxyRelease(mainThread, mOnSuccess);
-      NS_ProxyRelease(mainThread, mOnFailure);
-    }
-  }
-
   NS_IMETHOD
   Run()
   {
@@ -312,6 +300,18 @@ public:
   {
     mOnSuccess.swap(aOnSuccess);
     mOnFailure.swap(aOnFailure);
+  }
+
+  ~DeviceSuccessCallbackRunnable()
+  {
+    if (!NS_IsMainThread()) {
+      // This can happen if the main thread processes the runnable before
+      // GetUserMediaDevicesTask::Run returns.
+      nsCOMPtr<nsIThread> mainThread = do_GetMainThread();
+
+      NS_ProxyRelease(mainThread, mOnSuccess);
+      NS_ProxyRelease(mainThread, mOnFailure);
+    }
   }
 
   NS_IMETHOD

--- a/xpcom/glue/nsThreadUtils.h
+++ b/xpcom/glue/nsThreadUtils.h
@@ -18,6 +18,7 @@
 #include "nsCOMPtr.h"
 #include "nsAutoPtr.h"
 #include "mozilla/Likely.h"
+#include "mozilla/TypeTraits.h"
 
 //-----------------------------------------------------------------------------
 // These methods are alternatives to the methods on nsIThreadManager, provided
@@ -236,6 +237,33 @@ public:
 protected:
   virtual ~nsCancelableRunnable() {}
 };
+
+// An event that can be used to call a C++11 functions or function objects,
+// including lambdas. The function must have no required arguments, and must
+// return void.
+template<typename Function>
+class nsRunnableFunction : public nsRunnable
+{
+public:
+  explicit nsRunnableFunction(const Function& aFunction)
+    : mFunction(aFunction)
+  { }
+
+  NS_IMETHOD Run() {
+    static_assert(mozilla::IsVoid<decltype(mFunction())>::value,
+                  "The lambda must return void!");
+    mFunction();
+    return NS_OK;
+  }
+private:
+  Function mFunction;
+};
+
+template<typename Function>
+nsRunnableFunction<Function>* NS_NewRunnableFunction(const Function& aFunction)
+{
+  return new nsRunnableFunction<Function>(aFunction);
+}
 
 // An event that can be used to call a method on a class.  The class type must
 // support reference counting. This event supports Revoke for use


### PR DESCRIPTION
As part of the media threading/dispatch work Mozilla did, they also began using lambdas in parts of the media code. This PR adds a wrapper that will allow us to also use lambdas in our media code. This PR also makes necessary changes to Mozilla's clang-plugin to account for lambdas.

Compiled/tested on Linux and doesn't appear to break anything. Note that I have _not_ tested the changes to the clang-plugin, since (unless I'm mistaken) it is not used on any platform we currently support.