### PR TITLE
More improvements for the state machinery + use it in even more places

### DIFF
--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -2023,7 +2023,7 @@ HTMLMediaElement::LookupMediaElementURITable(nsIURI* aURI)
 
 HTMLMediaElement::HTMLMediaElement(already_AddRefed<mozilla::dom::NodeInfo>& aNodeInfo)
   : nsGenericHTMLElement(aNodeInfo),
-    mWatchManager(this),
+    mWatchManager(this, AbstractThread::MainThread()),
     mCurrentLoadID(0),
     mNetworkState(nsIDOMHTMLMediaElement::NETWORK_EMPTY),
     mReadyState(nsIDOMHTMLMediaElement::HAVE_NOTHING, "HTMLMediaElement::mReadyState"),

--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -2081,7 +2081,6 @@ HTMLMediaElement::HTMLMediaElement(already_AddRefed<mozilla::dom::NodeInfo>& aNo
   if (!gMediaElementEventsLog) {
     gMediaElementEventsLog = PR_NewLogModule("nsMediaElementEvents");
   }
-  EnsureStateWatchingLog();
 #endif
   ErrorResult rv;
 

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -596,7 +596,7 @@ MediaDecoder::MediaDecoder() :
   mCurrentTime(0.0),
   mVolume(AbstractThread::MainThread(), 0.0, "MediaDecoder::mVolume (Canonical)"),
   mPlaybackRate(AbstractThread::MainThread(), 1.0, "MediaDecoder::mPlaybackRate (Canonical)"),
-  mInitialPreservesPitch(true),
+  mPreservesPitch(AbstractThread::MainThread(), true, "MediaDecoder::mPreservesPitch (Canonical)"),
   mDuration(-1),
   mMediaSeekable(true),
   mSameOriginMedia(false),
@@ -745,7 +745,6 @@ void MediaDecoder::SetStateMachineParameters()
   if (GetDecodedStream()) {
     mDecoderStateMachine->SetAudioCaptured();
   }
-  mDecoderStateMachine->SetPreservesPitch(mInitialPreservesPitch);
   if (mMinimizePreroll) {
     mDecoderStateMachine->SetMinimizePrerollUntilPlaybackStarts();
   }
@@ -1556,11 +1555,7 @@ void MediaDecoder::SetPlaybackRate(double aPlaybackRate)
 
 void MediaDecoder::SetPreservesPitch(bool aPreservesPitch)
 {
-  if (mDecoderStateMachine) {
-    mDecoderStateMachine->SetPreservesPitch(aPreservesPitch);
-  } else {
-    mInitialPreservesPitch = aPreservesPitch;
-  }
+  mPreservesPitch = aPreservesPitch;
 }
 
 bool MediaDecoder::OnDecodeTaskQueue() const {

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -116,10 +116,21 @@ public:
 
 StaticRefPtr<MediaMemoryTracker> MediaMemoryTracker::sUniqueInstance;
 
+PRLogModuleInfo* gStateWatchingLog;
+PRLogModuleInfo* gMediaPromiseLog;
+PRLogModuleInfo* gMediaTimerLog;
+
 void
 MediaDecoder::InitStatics()
 {
   AbstractThread::InitStatics();
+
+  // Log modules.
+#ifdef PR_LOGGING
+  gMediaDecoderLog = PR_NewLogModule("MediaDecoder");
+#endif
+  gMediaPromiseLog = PR_NewLogModule("MediaPromise");
+  gStateWatchingLog = PR_NewLogModule("StateWatching");
 }
 
 NS_IMPL_ISUPPORTS(MediaMemoryTracker, nsIMemoryReporter)
@@ -611,12 +622,6 @@ MediaDecoder::MediaDecoder() :
   MOZ_COUNT_CTOR(MediaDecoder);
   MOZ_ASSERT(NS_IsMainThread());
   MediaMemoryTracker::AddMediaDecoder(this);
-#ifdef PR_LOGGING
-  if (!gMediaDecoderLog) {
-    gMediaDecoderLog = PR_NewLogModule("MediaDecoder");
-  }
-  EnsureStateWatchingLog();
-#endif
 
   // Initialize canonicals.
   mPlayState.Init(AbstractThread::MainThread(), PLAY_STATE_LOADING, "MediaDecoder::mPlayState (Canonical)");

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -746,14 +746,19 @@ void MediaDecoder::SetStateMachineParameters()
     mDecoderStateMachine->DispatchAudioCaptured();
   }
   if (mMinimizePreroll) {
-    mDecoderStateMachine->SetMinimizePrerollUntilPlaybackStarts();
+    mDecoderStateMachine->DispatchMinimizePrerollUntilPlaybackStarts();
   }
 }
 
 void MediaDecoder::SetMinimizePrerollUntilPlaybackStarts()
 {
+  DECODER_LOG("SetMinimizePrerollUntilPlaybackStarts()");
   MOZ_ASSERT(NS_IsMainThread());
   mMinimizePreroll = true;
+
+  // This needs to be called before we init the state machine, otherwise it will
+  // have no effect.
+  MOZ_DIAGNOSTIC_ASSERT(!mDecoderStateMachine);
 }
 
 nsresult MediaDecoder::ScheduleStateMachineThread()

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -595,7 +595,7 @@ MediaDecoder::MediaDecoder() :
   mPlaybackPosition(0),
   mCurrentTime(0.0),
   mVolume(AbstractThread::MainThread(), 0.0, "MediaDecoder::mVolume (Canonical)"),
-  mInitialPlaybackRate(1.0),
+  mPlaybackRate(AbstractThread::MainThread(), 1.0, "MediaDecoder::mPlaybackRate (Canonical)"),
   mInitialPreservesPitch(true),
   mDuration(-1),
   mMediaSeekable(true),
@@ -745,7 +745,6 @@ void MediaDecoder::SetStateMachineParameters()
   if (GetDecodedStream()) {
     mDecoderStateMachine->SetAudioCaptured();
   }
-  SetPlaybackRate(mInitialPlaybackRate);
   mDecoderStateMachine->SetPreservesPitch(mInitialPreservesPitch);
   if (mMinimizePreroll) {
     mDecoderStateMachine->SetMinimizePrerollUntilPlaybackStarts();
@@ -1540,11 +1539,10 @@ bool MediaDecoder::OnStateMachineTaskQueue() const
 
 void MediaDecoder::SetPlaybackRate(double aPlaybackRate)
 {
-  if (aPlaybackRate == 0.0) {
+  mPlaybackRate = aPlaybackRate;
+  if (mPlaybackRate == 0.0) {
     mPausedForPlaybackRateNull = true;
-    mInitialPlaybackRate = aPlaybackRate;
     Pause();
-    return;
   } else if (mPausedForPlaybackRateNull) {
     // Play() uses mPausedForPlaybackRateNull value, so must reset it first
     mPausedForPlaybackRateNull = false;
@@ -1553,12 +1551,6 @@ void MediaDecoder::SetPlaybackRate(double aPlaybackRate)
     if (mOwner && !mOwner->GetPaused()) {
       Play();
     }
-  }
-
-  if (mDecoderStateMachine) {
-    mDecoderStateMachine->SetPlaybackRate(aPlaybackRate);
-  } else {
-    mInitialPlaybackRate = aPlaybackRate;
   }
 }
 

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -590,7 +590,7 @@ bool MediaDecoder::IsInfinite()
 }
 
 MediaDecoder::MediaDecoder() :
-  mWatchManager(this),
+  mWatchManager(this, AbstractThread::MainThread()),
   mNextFrameStatus(AbstractThread::MainThread(),
                    MediaDecoderOwner::NEXT_FRAME_UNINITIALIZED,
                    "MediaDecoder::mNextFrameStatus (Mirror)"),

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -530,7 +530,7 @@ void MediaDecoder::AddOutputStream(ProcessedMediaStream* aStream,
   {
     ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
     if (mDecoderStateMachine) {
-      mDecoderStateMachine->SetAudioCaptured();
+      mDecoderStateMachine->DispatchAudioCaptured();
     }
     if (!GetDecodedStream()) {
       int64_t t = mDecoderStateMachine ?
@@ -743,7 +743,7 @@ void MediaDecoder::SetStateMachineParameters()
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
   mDecoderStateMachine->SetDuration(mDuration);
   if (GetDecodedStream()) {
-    mDecoderStateMachine->SetAudioCaptured();
+    mDecoderStateMachine->DispatchAudioCaptured();
   }
   if (mMinimizePreroll) {
     mDecoderStateMachine->SetMinimizePrerollUntilPlaybackStarts();

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -290,10 +290,7 @@ void MediaDecoder::Pause()
 void MediaDecoder::SetVolume(double aVolume)
 {
   MOZ_ASSERT(NS_IsMainThread());
-  mInitialVolume = aVolume;
-  if (mDecoderStateMachine) {
-    mDecoderStateMachine->SetVolume(aVolume);
-  }
+  mVolume = aVolume;
 }
 
 void MediaDecoder::ConnectDecodedStreamToOutputStream(OutputStreamData* aStream)
@@ -597,7 +594,7 @@ MediaDecoder::MediaDecoder() :
   mDecoderPosition(0),
   mPlaybackPosition(0),
   mCurrentTime(0.0),
-  mInitialVolume(0.0),
+  mVolume(AbstractThread::MainThread(), 0.0, "MediaDecoder::mVolume (Canonical)"),
   mInitialPlaybackRate(1.0),
   mInitialPreservesPitch(true),
   mDuration(-1),
@@ -745,7 +742,6 @@ void MediaDecoder::SetStateMachineParameters()
 {
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
   mDecoderStateMachine->SetDuration(mDuration);
-  mDecoderStateMachine->SetVolume(mInitialVolume);
   if (GetDecodedStream()) {
     mDecoderStateMachine->SetAudioCaptured();
   }

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -591,6 +591,9 @@ bool MediaDecoder::IsInfinite()
 
 MediaDecoder::MediaDecoder() :
   mWatchManager(this),
+  mNextFrameStatus(AbstractThread::MainThread(),
+                   MediaDecoderOwner::NEXT_FRAME_UNINITIALIZED,
+                   "MediaDecoder::mNextFrameStatus (Mirror)"),
   mDecoderPosition(0),
   mPlaybackPosition(0),
   mCurrentTime(0.0),
@@ -601,6 +604,10 @@ MediaDecoder::MediaDecoder() :
   mMediaSeekable(true),
   mSameOriginMedia(false),
   mReentrantMonitor("media.decoder"),
+  mPlayState(AbstractThread::MainThread(), PLAY_STATE_LOADING,
+             "MediaDecoder::mPlayState (Canonical)"),
+  mNextState(AbstractThread::MainThread(), PLAY_STATE_PAUSED,
+             "MediaDecoder::mNextState (Canonical)"),
   mIgnoreProgressData(false),
   mInfiniteStream(false),
   mOwner(nullptr),
@@ -622,14 +629,6 @@ MediaDecoder::MediaDecoder() :
   MOZ_COUNT_CTOR(MediaDecoder);
   MOZ_ASSERT(NS_IsMainThread());
   MediaMemoryTracker::AddMediaDecoder(this);
-
-  // Initialize canonicals.
-  mPlayState.Init(AbstractThread::MainThread(), PLAY_STATE_LOADING, "MediaDecoder::mPlayState (Canonical)");
-  mNextState.Init(AbstractThread::MainThread(), PLAY_STATE_PAUSED, "MediaDecoder::mNextState (Canonical)");
-
-  // Initialize mirrors.
-  mNextFrameStatus.Init(AbstractThread::MainThread(), MediaDecoderOwner::NEXT_FRAME_UNINITIALIZED,
-                        "MediaDecoder::mNextFrameStatus (Mirror)");
 
   mAudioChannel = AudioChannelService::GetDefaultAudioChannel();
 

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -1035,7 +1035,7 @@ protected:
   WatchManager<MediaDecoder> mWatchManager;
 
   // NextFrameStatus, mirrored from the state machine.
-  Mirror<MediaDecoderOwner::NextFrameStatus>::Holder mNextFrameStatus;
+  Mirror<MediaDecoderOwner::NextFrameStatus> mNextFrameStatus;
 
   /******
    * The following members should be accessed with the decoder lock held.

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -1065,8 +1065,11 @@ public:
 protected:
 
   // PlaybackRate and pitch preservation status we should start at.
-  // Readable/Writeable from the main thread.
-  double mInitialPlaybackRate;
+  Canonical<double> mPlaybackRate;
+public:
+  AbstractCanonical<double>* CanonicalPlaybackRate() { return &mPlaybackRate; }
+protected:
+
   bool mInitialPreservesPitch;
 
   // Duration of the media resource. Set to -1 if unknown.

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -1058,9 +1058,11 @@ protected:
   // It is read and written from the main thread only.
   double mCurrentTime;
 
-  // Volume that playback should start at.  0.0 = muted. 1.0 = full
-  // volume.  Readable/Writeable from the main thread.
-  double mInitialVolume;
+  // Volume of playback.  0.0 = muted. 1.0 = full volume.
+  Canonical<double> mVolume;
+public:
+  AbstractCanonical<double>* CanonicalVolume() { return &mVolume; }
+protected:
 
   // PlaybackRate and pitch preservation status we should start at.
   // Readable/Writeable from the main thread.

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -1070,7 +1070,10 @@ public:
   AbstractCanonical<double>* CanonicalPlaybackRate() { return &mPlaybackRate; }
 protected:
 
-  bool mInitialPreservesPitch;
+  Canonical<bool> mPreservesPitch;
+public:
+  AbstractCanonical<bool>* CanonicalPreservesPitch() { return &mPreservesPitch; }
+protected:
 
   // Duration of the media resource. Set to -1 if unknown.
   // Set when the metadata is loaded. Accessed on the main thread

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -1117,14 +1117,14 @@ protected:
   // OR on the main thread.
   // Any change to the state on the main thread must call NotifyAll on the
   // monitor so the decode thread can wake up.
-  Canonical<PlayState>::Holder mPlayState;
+  Canonical<PlayState> mPlayState;
 
   // This can only be changed on the main thread while holding the decoder
   // monitor. Thus, it can be safely read while holding the decoder monitor
   // OR on the main thread.
   // Any change to the state must call NotifyAll on the monitor.
   // This can only be PLAY_STATE_PAUSED or PLAY_STATE_PLAYING.
-  Canonical<PlayState>::Holder mNextState;
+  Canonical<PlayState> mNextState;
 public:
   AbstractCanonical<PlayState>* CanonicalPlayState() { return &mPlayState; }
   AbstractCanonical<PlayState>* CanonicalNextPlayState() { return &mNextState; }

--- a/dom/media/MediaDecoderReader.cpp
+++ b/dom/media/MediaDecoderReader.cpp
@@ -33,25 +33,6 @@ extern PRLogModuleInfo* gMediaDecoderLog;
 #define DECODER_WARN(x, ...) \
   DECODER_WARN_HELPER(0, (nsPrintfCString("Decoder=%p " x, mDecoder, ##__VA_ARGS__).get()))
 
-PRLogModuleInfo* gMediaPromiseLog;
-PRLogModuleInfo* gStateWatchingLog;
-
-void
-EnsureMediaPromiseLog()
-{
-  if (!gMediaPromiseLog) {
-    gMediaPromiseLog = PR_NewLogModule("MediaPromise");
-  }
-}
-
-void
-EnsureStateWatchingLog()
-{
-  if (!gStateWatchingLog) {
-    gStateWatchingLog = PR_NewLogModule("StateWatching");
-  }
-}
-
 class VideoQueueMemoryFunctor : public nsDequeFunctor {
 public:
   VideoQueueMemoryFunctor() : mSize(0) {}
@@ -95,8 +76,6 @@ MediaDecoderReader::MediaDecoderReader(AbstractMediaDecoder* aDecoder)
   , mVideoDiscontinuity(false)
 {
   MOZ_COUNT_CTOR(MediaDecoderReader);
-  EnsureMediaPromiseLog();
-  EnsureStateWatchingLog();
 }
 
 MediaDecoderReader::~MediaDecoderReader()

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -3417,14 +3417,6 @@ void MediaDecoderStateMachine::PreservesPitchChanged()
   }
 }
 
-void
-MediaDecoderStateMachine::SetMinimizePrerollUntilPlaybackStarts()
-{
-  AssertCurrentThreadInMonitor();
-  DECODER_LOG("SetMinimizePrerollUntilPlaybackStarts()");
-  mMinimizePreroll = true;
-}
-
 bool MediaDecoderStateMachine::IsShutdown()
 {
   AssertCurrentThreadInMonitor();

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -213,6 +213,14 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
   mStartTime(-1),
   mEndTime(-1),
   mDurationSet(false),
+  mPlayState(mTaskQueue, MediaDecoder::PLAY_STATE_LOADING,
+             "MediaDecoderStateMachine::mPlayState (Mirror)",
+             aDecoder->CanonicalPlayState()),
+  mNextPlayState(mTaskQueue, MediaDecoder::PLAY_STATE_PAUSED,
+                 "MediaDecoderStateMachine::mNextPlayState (Mirror)",
+                 aDecoder->CanonicalNextPlayState()),
+  mNextFrameStatus(mTaskQueue, MediaDecoderOwner::NEXT_FRAME_UNINITIALIZED,
+                   "MediaDecoderStateMachine::mNextFrameStatus (Canonical)"),
   mFragmentEndTime(-1),
   mReader(aReader),
   mCurrentFrameTime(0),
@@ -253,16 +261,7 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
   MOZ_COUNT_CTOR(MediaDecoderStateMachine);
   NS_ASSERTION(NS_IsMainThread(), "Should be on main thread.");
 
-  // Initialize canonicals.
-  mNextFrameStatus.Init(mTaskQueue, MediaDecoderOwner::NEXT_FRAME_UNINITIALIZED,
-                        "MediaDecoderStateMachine::mNextFrameStatus (Canonical)");
-
-  // Initialize mirrors.
-  mPlayState.Init(mTaskQueue, MediaDecoder::PLAY_STATE_LOADING, "MediaDecoderStateMachine::mPlayState (Mirror)",
-                  aDecoder->CanonicalPlayState());
-  mNextPlayState.Init(mTaskQueue, MediaDecoder::PLAY_STATE_PAUSED, "MediaDecoderStateMachine::mNextPlayState (Mirror)",
-                  aDecoder->CanonicalNextPlayState());
-
+  // Initialize watchers.
   mWatchManager.Watch(mState, &MediaDecoderStateMachine::UpdateNextFrameStatus);
   mWatchManager.Watch(mAudioCompleted, &MediaDecoderStateMachine::UpdateNextFrameStatus);
 

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -203,6 +203,7 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
                                                    MediaDecoderReader* aReader,
                                                    bool aRealTime) :
   mDecoder(aDecoder),
+  mTaskQueue(new MediaTaskQueue(GetMediaThreadPool(), /* aAssertTailDispatch = */ true)),
   mWatchManager(this),
   mRealTime(aRealTime),
   mDispatchedStateMachine(false),
@@ -251,11 +252,6 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
 {
   MOZ_COUNT_CTOR(MediaDecoderStateMachine);
   NS_ASSERTION(NS_IsMainThread(), "Should be on main thread.");
-
-  // Set up our task queue.
-  RefPtr<SharedThreadPool> pool(GetMediaThreadPool());
-  MOZ_DIAGNOSTIC_ASSERT(pool);
-  mTaskQueue = new MediaTaskQueue(pool.forget(), /* aAssertTailDispatch = */ true);
 
   // Initialize canonicals.
   mNextFrameStatus.Init(mTaskQueue, MediaDecoderOwner::NEXT_FRAME_UNINITIALIZED,

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -1371,17 +1371,6 @@ void MediaDecoderStateMachine::VolumeChanged()
   }
 }
 
-void MediaDecoderStateMachine::SetAudioCaptured()
-{
-  NS_ASSERTION(NS_IsMainThread(), "Should be on main thread.");
-  AssertCurrentThreadInMonitor();
-  if (!mAudioCaptured) {
-    mAudioCaptured = true;
-    // Schedule the state machine to send stream data as soon as possible.
-    ScheduleStateMachine();
-  }
-}
-
 double MediaDecoderStateMachine::GetCurrentTime() const
 {
   return static_cast<double>(mCurrentFrameTime) / static_cast<double>(USECS_PER_S);

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -229,6 +229,7 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
   mDecodedVideoEndTime(-1),
   mVolume(mTaskQueue, 1.0, "MediaDecoderStateMachine::mVolume (Mirror)"),
   mPlaybackRate(1.0),
+  mLogicalPlaybackRate(mTaskQueue, 1.0, "MediaDecoderStateMachine::mLogicalPlaybackRate (Mirror)"),
   mPreservesPitch(true),
   mAmpleVideoFrames(MIN_VIDEO_QUEUE_SIZE),
   mLowAudioThresholdUsecs(detail::LOW_AUDIO_USECS),
@@ -310,11 +311,13 @@ MediaDecoderStateMachine::InitializationTask()
   mPlayState.Connect(mDecoder->CanonicalPlayState());
   mNextPlayState.Connect(mDecoder->CanonicalNextPlayState());
   mVolume.Connect(mDecoder->CanonicalVolume());
+  mLogicalPlaybackRate.Connect(mDecoder->CanonicalPlaybackRate());
 
   // Initialize watchers.
   mWatchManager.Watch(mState, &MediaDecoderStateMachine::UpdateNextFrameStatus);
   mWatchManager.Watch(mAudioCompleted, &MediaDecoderStateMachine::UpdateNextFrameStatus);
   mWatchManager.Watch(mVolume, &MediaDecoderStateMachine::VolumeChanged);
+  mWatchManager.Watch(mLogicalPlaybackRate, &MediaDecoderStateMachine::LogicalPlaybackRateChanged);
 
 }
 
@@ -2548,6 +2551,7 @@ MediaDecoderStateMachine::FinishShutdown()
   mPlayState.DisconnectIfConnected();
   mNextPlayState.DisconnectIfConnected();
   mVolume.DisconnectIfConnected();
+  mLogicalPlaybackRate.DisconnectIfConnected();
   mNextFrameStatus.DisconnectAll();
 
   // Shut down the watch manager before shutting down our task queue.
@@ -3384,14 +3388,14 @@ bool MediaDecoderStateMachine::IsStateMachineScheduled() const
   return mDispatchedStateMachine || mDelayedScheduler.IsScheduled();
 }
 
-void MediaDecoderStateMachine::SetPlaybackRate(double aPlaybackRate)
+void
+MediaDecoderStateMachine::LogicalPlaybackRateChanged()
 {
-  NS_ASSERTION(NS_IsMainThread(), "Should be on main thread.");
-  NS_ASSERTION(aPlaybackRate != 0,
-      "PlaybackRate == 0 should be handled before this function.");
+  MOZ_ASSERT(OnTaskQueue());
   ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
 
-  if (mPlaybackRate == aPlaybackRate) {
+  if (mLogicalPlaybackRate == 0) {
+    // This case is handled in MediaDecoder by pausing playback.
     return;
   }
 
@@ -3405,7 +3409,7 @@ void MediaDecoderStateMachine::SetPlaybackRate(double aPlaybackRate)
     SetPlayStartTime(TimeStamp::Now());
   }
 
-  mPlaybackRate = aPlaybackRate;
+  mPlaybackRate = mLogicalPlaybackRate;
   if (mAudioSink) {
     mAudioSink->SetPlaybackRate(mPlaybackRate);
   }

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -204,7 +204,7 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
                                                    bool aRealTime) :
   mDecoder(aDecoder),
   mTaskQueue(new MediaTaskQueue(GetMediaThreadPool(), /* aAssertTailDispatch = */ true)),
-  mWatchManager(this),
+  mWatchManager(this, mTaskQueue),
   mRealTime(aRealTime),
   mDispatchedStateMachine(false),
   mDelayedScheduler(this),
@@ -2528,6 +2528,9 @@ MediaDecoderStateMachine::FinishShutdown()
   mPlayState.DisconnectIfConnected();
   mNextPlayState.DisconnectIfConnected();
   mNextFrameStatus.DisconnectAll();
+
+  // Shut down the watch manager before shutting down our task queue.
+  mWatchManager.Shutdown();
 
   MOZ_ASSERT(mState == DECODER_STATE_SHUTDOWN,
              "How did we escape from the shutdown state?");

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -227,7 +227,7 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
   mDecodedAudioEndTime(-1),
   mVideoFrameEndTime(-1),
   mDecodedVideoEndTime(-1),
-  mVolume(1.0),
+  mVolume(mTaskQueue, 1.0, "MediaDecoderStateMachine::mVolume (Mirror)"),
   mPlaybackRate(1.0),
   mPreservesPitch(true),
   mAmpleVideoFrames(MIN_VIDEO_QUEUE_SIZE),
@@ -309,10 +309,13 @@ MediaDecoderStateMachine::InitializationTask()
   // Connect mirrors.
   mPlayState.Connect(mDecoder->CanonicalPlayState());
   mNextPlayState.Connect(mDecoder->CanonicalNextPlayState());
+  mVolume.Connect(mDecoder->CanonicalVolume());
 
   // Initialize watchers.
   mWatchManager.Watch(mState, &MediaDecoderStateMachine::UpdateNextFrameStatus);
   mWatchManager.Watch(mAudioCompleted, &MediaDecoderStateMachine::UpdateNextFrameStatus);
+  mWatchManager.Watch(mVolume, &MediaDecoderStateMachine::VolumeChanged);
+
 }
 
 bool MediaDecoderStateMachine::HasFutureAudio() {
@@ -1354,11 +1357,10 @@ void MediaDecoderStateMachine::SetState(State aState)
   mSentPlaybackEndedEvent = false;
 }
 
-void MediaDecoderStateMachine::SetVolume(double volume)
+void MediaDecoderStateMachine::VolumeChanged()
 {
-  NS_ASSERTION(NS_IsMainThread(), "Should be on main thread.");
+  MOZ_ASSERT(OnTaskQueue());
   ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
-  mVolume = volume;
   if (mAudioSink) {
     mAudioSink->SetVolume(mVolume);
   }
@@ -2545,6 +2547,7 @@ MediaDecoderStateMachine::FinishShutdown()
   // Disconnect canonicals and mirrors before shutting down our task queue.
   mPlayState.DisconnectIfConnected();
   mNextPlayState.DisconnectIfConnected();
+  mVolume.DisconnectIfConnected();
   mNextFrameStatus.DisconnectAll();
 
   // Shut down the watch manager before shutting down our task queue.

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -316,6 +316,7 @@ MediaDecoderStateMachine::InitializationTask()
 }
 
 bool MediaDecoderStateMachine::HasFutureAudio() {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   NS_ASSERTION(HasAudio(), "Should only call HasFutureAudio() when we have audio");
   // We've got audio ready to play if:
@@ -330,6 +331,7 @@ bool MediaDecoderStateMachine::HasFutureAudio() {
 }
 
 bool MediaDecoderStateMachine::HaveNextFrameData() {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   return (!HasAudio() || HasFutureAudio()) &&
          (!HasVideo() || VideoQueue().GetSize() > 0);
@@ -569,6 +571,7 @@ void MediaDecoderStateMachine::SendStreamData()
 MediaDecoderStateMachine::WakeDecoderRunnable*
 MediaDecoderStateMachine::GetWakeDecoderRunnable()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
 
   if (!mPendingWakeDecoder.get()) {
@@ -579,6 +582,7 @@ MediaDecoderStateMachine::GetWakeDecoderRunnable()
 
 bool MediaDecoderStateMachine::HaveEnoughDecodedAudio(int64_t aAmpleAudioUSecs)
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
 
   if (AudioQueue().GetSize() == 0 ||
@@ -606,6 +610,7 @@ bool MediaDecoderStateMachine::HaveEnoughDecodedAudio(int64_t aAmpleAudioUSecs)
 
 bool MediaDecoderStateMachine::HaveEnoughDecodedVideo()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
 
   if (static_cast<uint32_t>(VideoQueue().GetSize()) < mAmpleVideoFrames * mPlaybackRate) {
@@ -630,6 +635,7 @@ bool MediaDecoderStateMachine::HaveEnoughDecodedVideo()
 bool
 MediaDecoderStateMachine::NeedToDecodeVideo()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   return IsVideoDecoding() &&
          ((mState == DECODER_STATE_SEEKING && mDecodeToSeekTarget) ||
@@ -641,6 +647,7 @@ MediaDecoderStateMachine::NeedToDecodeVideo()
 bool
 MediaDecoderStateMachine::NeedToSkipToNextKeyframe()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   if (mState == DECODER_STATE_DECODING_FIRSTFRAME) {
     return false;
@@ -689,6 +696,7 @@ MediaDecoderStateMachine::NeedToSkipToNextKeyframe()
 bool
 MediaDecoderStateMachine::NeedToDecodeAudio()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   SAMPLE_LOG("NeedToDecodeAudio() isDec=%d decToTar=%d minPrl=%d seek=%d enufAud=%d",
              IsAudioDecoding(), mDecodeToSeekTarget, mMinimizePreroll,
@@ -707,6 +715,7 @@ MediaDecoderStateMachine::NeedToDecodeAudio()
 bool
 MediaDecoderStateMachine::IsAudioSeekComplete()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   SAMPLE_LOG("IsAudioSeekComplete() curTarVal=%d mAudDis=%d aqFin=%d aqSz=%d",
     mCurrentSeek.Exists(), mDropAudioUntilNextDiscontinuity, AudioQueue().IsFinished(), AudioQueue().GetSize());
@@ -720,6 +729,7 @@ MediaDecoderStateMachine::IsAudioSeekComplete()
 bool
 MediaDecoderStateMachine::IsVideoSeekComplete()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   SAMPLE_LOG("IsVideoSeekComplete() curTarVal=%d mVidDis=%d vqFin=%d vqSz=%d",
     mCurrentSeek.Exists(), mDropVideoUntilNextDiscontinuity, VideoQueue().IsFinished(), VideoQueue().GetSize());
@@ -1142,6 +1152,7 @@ MediaDecoderStateMachine::CheckIfSeekComplete()
 bool
 MediaDecoderStateMachine::IsAudioDecoding()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   return HasAudio() && !AudioQueue().IsFinished();
 }
@@ -1149,6 +1160,7 @@ MediaDecoderStateMachine::IsAudioDecoding()
 bool
 MediaDecoderStateMachine::IsVideoDecoding()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   return HasVideo() && !VideoQueue().IsFinished();
 }
@@ -1746,6 +1758,7 @@ void MediaDecoderStateMachine::StopAudioThread()
 nsresult
 MediaDecoderStateMachine::EnqueueDecodeFirstFrameTask()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   MOZ_ASSERT(mState == DECODER_STATE_DECODING_FIRSTFRAME);
 
@@ -2032,6 +2045,7 @@ MediaDecoderStateMachine::StartAudioThread()
 
 int64_t MediaDecoderStateMachine::AudioDecodedUsecs()
 {
+  MOZ_ASSERT(OnTaskQueue());
   NS_ASSERTION(HasAudio(),
                "Should only call AudioDecodedUsecs() when we have audio");
   // The amount of audio we have decoded is the amount of audio data we've
@@ -2049,6 +2063,7 @@ int64_t MediaDecoderStateMachine::AudioDecodedUsecs()
 
 bool MediaDecoderStateMachine::HasLowDecodedData(int64_t aAudioUsecs)
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   MOZ_ASSERT(mReader->UseBufferingHeuristics());
   // We consider ourselves low on decoded data if we're low on audio,
@@ -2062,6 +2077,7 @@ bool MediaDecoderStateMachine::HasLowDecodedData(int64_t aAudioUsecs)
 
 bool MediaDecoderStateMachine::OutOfDecodedAudio()
 {
+    MOZ_ASSERT(OnTaskQueue());
     return IsAudioDecoding() && !AudioQueue().IsFinished() &&
            AudioQueue().GetSize() == 0 &&
            (!mAudioSink || !mAudioSink->HasUnplayedFrames());
@@ -2069,11 +2085,13 @@ bool MediaDecoderStateMachine::OutOfDecodedAudio()
 
 bool MediaDecoderStateMachine::HasLowUndecodedData()
 {
+  MOZ_ASSERT(OnTaskQueue());
   return HasLowUndecodedData(mLowDataThresholdUsecs);
 }
 
 bool MediaDecoderStateMachine::HasLowUndecodedData(int64_t aUsecs)
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   NS_ASSERTION(mState > DECODER_STATE_DECODING_FIRSTFRAME,
                "Must have loaded first frame for GetBuffered() to work");
@@ -2142,9 +2160,9 @@ MediaDecoderStateMachine::DecodeError()
 void
 MediaDecoderStateMachine::OnMetadataRead(MetadataHolder* aMetadata)
 {
-  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   MOZ_ASSERT(OnTaskQueue());
   MOZ_ASSERT(mState == DECODER_STATE_DECODING_METADATA);
+  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   mMetadataRequest.Complete();
 
   mDecoder->SetMediaSeekable(mReader->IsMediaSeekable());
@@ -2185,9 +2203,9 @@ MediaDecoderStateMachine::OnMetadataRead(MetadataHolder* aMetadata)
 void
 MediaDecoderStateMachine::OnMetadataNotRead(ReadMetadataFailureReason aReason)
 {
-  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   MOZ_ASSERT(OnTaskQueue());
   MOZ_ASSERT(mState == DECODER_STATE_DECODING_METADATA);
+  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   mMetadataRequest.Complete();
 
   if (aReason == ReadMetadataFailureReason::WAITING_FOR_RESOURCES) {
@@ -2298,8 +2316,8 @@ MediaDecoderStateMachine::DecodeFirstFrame()
 nsresult
 MediaDecoderStateMachine::FinishDecodeFirstFrame()
 {
-  AssertCurrentThreadInMonitor();
   MOZ_ASSERT(OnTaskQueue());
+  AssertCurrentThreadInMonitor();
   DECODER_LOG("FinishDecodeFirstFrame");
 
   if (IsShutdown()) {
@@ -2374,8 +2392,8 @@ MediaDecoderStateMachine::FinishDecodeFirstFrame()
 void
 MediaDecoderStateMachine::OnSeekCompleted(int64_t aTime)
 {
-  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   MOZ_ASSERT(OnTaskQueue());
+  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   mSeekRequest.Complete();
 
   // We must decode the first samples of active streams, so we can determine
@@ -2388,8 +2406,8 @@ MediaDecoderStateMachine::OnSeekCompleted(int64_t aTime)
 void
 MediaDecoderStateMachine::OnSeekFailed(nsresult aResult)
 {
-  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   MOZ_ASSERT(OnTaskQueue());
+  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   mSeekRequest.Complete();
   MOZ_ASSERT(NS_FAILED(aResult), "Cancels should also disconnect mSeekRequest");
   DecodeError();
@@ -2837,6 +2855,7 @@ void MediaDecoderStateMachine::RenderVideoFrame(VideoData* aData,
 
 void MediaDecoderStateMachine::ResyncAudioClock()
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
   if (IsPlaying()) {
     SetPlayStartTime(TimeStamp::Now());
@@ -2847,6 +2866,7 @@ void MediaDecoderStateMachine::ResyncAudioClock()
 int64_t
 MediaDecoderStateMachine::GetAudioClock() const
 {
+  MOZ_ASSERT(OnTaskQueue());
   // We must hold the decoder monitor while using the audio stream off the
   // audio sink to ensure that it doesn't get destroyed on the audio sink
   // while we're using it.
@@ -2873,6 +2893,7 @@ int64_t MediaDecoderStateMachine::GetVideoStreamPosition() const
 
 int64_t MediaDecoderStateMachine::GetClock() const
 {
+  MOZ_ASSERT(OnTaskQueue());
   AssertCurrentThreadInMonitor();
 
   // Determine the clock time. If we've got audio, and we've not reached
@@ -3050,6 +3071,7 @@ void MediaDecoderStateMachine::AdvanceFrame()
 nsresult
 MediaDecoderStateMachine::DropVideoUpToSeekTarget(VideoData* aSample)
 {
+  MOZ_ASSERT(OnTaskQueue());
   nsRefPtr<VideoData> video(aSample);
   MOZ_ASSERT(video);
   DECODER_LOG("DropVideoUpToSeekTarget() frame [%lld, %lld] dup=%d",
@@ -3101,6 +3123,7 @@ MediaDecoderStateMachine::DropVideoUpToSeekTarget(VideoData* aSample)
 nsresult
 MediaDecoderStateMachine::DropAudioUpToSeekTarget(AudioData* aSample)
 {
+  MOZ_ASSERT(OnTaskQueue());
   nsRefPtr<AudioData> audio(aSample);
   MOZ_ASSERT(audio &&
              mCurrentSeek.Exists() &&
@@ -3200,7 +3223,8 @@ void MediaDecoderStateMachine::SetStartTime(int64_t aStartTimeUsecs)
   DECODER_LOG("Set media start time to %lld", mStartTime);
 }
 
-void MediaDecoderStateMachine::UpdateNextFrameStatus() {
+void MediaDecoderStateMachine::UpdateNextFrameStatus()
+{
   MOZ_ASSERT(OnTaskQueue());
   ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
 
@@ -3229,6 +3253,7 @@ void MediaDecoderStateMachine::UpdateNextFrameStatus() {
 
 bool MediaDecoderStateMachine::JustExitedQuickBuffering()
 {
+  MOZ_ASSERT(OnTaskQueue());
   return !mDecodeStartTime.IsNull() &&
     mQuickBuffering &&
     (TimeStamp::Now() - mDecodeStartTime) < TimeDuration::FromMicroseconds(QUICK_BUFFER_THRESHOLD_USECS);
@@ -3286,7 +3311,9 @@ void MediaDecoderStateMachine::SetPlayStartTime(const TimeStamp& aTimeStamp)
   }
 }
 
-void MediaDecoderStateMachine::ScheduleStateMachineWithLockAndWakeDecoder() {
+void MediaDecoderStateMachine::ScheduleStateMachineWithLockAndWakeDecoder()
+{
+  MOZ_ASSERT(OnTaskQueue());
   ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
   DispatchAudioDecodeTaskIfNeeded();
   DispatchVideoDecodeTaskIfNeeded();

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -214,11 +214,9 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
   mEndTime(-1),
   mDurationSet(false),
   mPlayState(mTaskQueue, MediaDecoder::PLAY_STATE_LOADING,
-             "MediaDecoderStateMachine::mPlayState (Mirror)",
-             aDecoder->CanonicalPlayState()),
+             "MediaDecoderStateMachine::mPlayState (Mirror)"),
   mNextPlayState(mTaskQueue, MediaDecoder::PLAY_STATE_PAUSED,
-                 "MediaDecoderStateMachine::mNextPlayState (Mirror)",
-                 aDecoder->CanonicalNextPlayState()),
+                 "MediaDecoderStateMachine::mNextPlayState (Mirror)"),
   mNextFrameStatus(mTaskQueue, MediaDecoderOwner::NEXT_FRAME_UNINITIALIZED,
                    "MediaDecoderStateMachine::mNextFrameStatus (Canonical)"),
   mFragmentEndTime(-1),
@@ -261,9 +259,9 @@ MediaDecoderStateMachine::MediaDecoderStateMachine(MediaDecoder* aDecoder,
   MOZ_COUNT_CTOR(MediaDecoderStateMachine);
   NS_ASSERTION(NS_IsMainThread(), "Should be on main thread.");
 
-  // Initialize watchers.
-  mWatchManager.Watch(mState, &MediaDecoderStateMachine::UpdateNextFrameStatus);
-  mWatchManager.Watch(mAudioCompleted, &MediaDecoderStateMachine::UpdateNextFrameStatus);
+  // Dispatch initialization that needs to happen on that task queue.
+  nsCOMPtr<nsIRunnable> r = NS_NewRunnableMethod(this, &MediaDecoderStateMachine::InitializationTask);
+  mTaskQueue->Dispatch(r.forget());
 
   static bool sPrefCacheInit = false;
   if (!sPrefCacheInit) {
@@ -301,6 +299,20 @@ MediaDecoderStateMachine::~MediaDecoderStateMachine()
 #ifdef XP_WIN
   timeEndPeriod(1);
 #endif
+}
+
+void
+MediaDecoderStateMachine::InitializationTask()
+{
+  MOZ_ASSERT(OnTaskQueue());
+
+  // Connect mirrors.
+  mPlayState.Connect(mDecoder->CanonicalPlayState());
+  mNextPlayState.Connect(mDecoder->CanonicalNextPlayState());
+
+  // Initialize watchers.
+  mWatchManager.Watch(mState, &MediaDecoderStateMachine::UpdateNextFrameStatus);
+  mWatchManager.Watch(mAudioCompleted, &MediaDecoderStateMachine::UpdateNextFrameStatus);
 }
 
 bool MediaDecoderStateMachine::HasFutureAudio() {

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -310,7 +310,6 @@ public:
     return mReader->GetBuffered();
   }
 
-  void SetPlaybackRate(double aPlaybackRate);
   void SetPreservesPitch(bool aPreservesPitch);
 
   size_t SizeOfVideoQueue() {
@@ -449,6 +448,7 @@ protected:
   already_AddRefed<VideoData> PopVideo();
 
   void VolumeChanged();
+  void LogicalPlaybackRateChanged();
 
   class WakeDecoderRunnable : public nsRunnable {
   public:
@@ -1014,9 +1014,13 @@ protected:
   // Volume of playback. 0.0 = muted. 1.0 = full volume.
   Mirror<double> mVolume;
 
-  // Playback rate. 1.0 : normal speed, 0.5 : two times slower. Synchronized via
-  // decoder monitor.
+  // Playback rate. 1.0 : normal speed, 0.5 : two times slower.
+  //
+  // The separation between mPlaybackRate and mLogicalPlaybackRate is a mess
+  // to preserve existing fragile logic while converting this setup to state-
+  // mirroring. This should be cleaned up in the future.
   double mPlaybackRate;
+  Mirror<double> mLogicalPlaybackRate;
 
   // Pitch preservation for the playback rate. Synchronized via decoder monitor.
   bool mPreservesPitch;

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -910,7 +910,7 @@ public:
 
   // The status of our next frame. Mirrored on the main thread and used to
   // compute ready state.
-  Canonical<NextFrameStatus>::Holder mNextFrameStatus;
+  Canonical<NextFrameStatus> mNextFrameStatus;
 public:
   AbstractCanonical<NextFrameStatus>* CanonicalNextFrameStatus() { return &mNextFrameStatus; }
 protected:

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -403,7 +403,21 @@ public:
   // the state machine is free to return to prerolling normally. Note
   // "prerolling" in this context refers to when we decode and buffer decoded
   // samples in advance of when they're needed for playback.
-  void SetMinimizePrerollUntilPlaybackStarts();
+  void DispatchMinimizePrerollUntilPlaybackStarts()
+  {
+    nsRefPtr<MediaDecoderStateMachine> self = this;
+    nsCOMPtr<nsIRunnable> r = NS_NewRunnableFunction([self] () -> void
+    {
+      MOZ_ASSERT(self->OnTaskQueue());
+      ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
+      self->mMinimizePreroll = true;
+
+      // Make sure that this arrives before playback starts, otherwise this won't
+      // have the intended effect.
+      MOZ_DIAGNOSTIC_ASSERT(self->mPlayState == MediaDecoder::PLAY_STATE_LOADING);
+    });
+    TaskQueue()->Dispatch(r.forget());
+  };
 
   void OnAudioDecoded(AudioData* aSample);
   void OnVideoDecoded(VideoData* aSample);

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -310,8 +310,6 @@ public:
     return mReader->GetBuffered();
   }
 
-  void SetPreservesPitch(bool aPreservesPitch);
-
   size_t SizeOfVideoQueue() {
     if (mReader) {
       return mReader->SizeOfVideoQueueInBytes();
@@ -449,6 +447,7 @@ protected:
 
   void VolumeChanged();
   void LogicalPlaybackRateChanged();
+  void PreservesPitchChanged();
 
   class WakeDecoderRunnable : public nsRunnable {
   public:
@@ -1022,8 +1021,8 @@ protected:
   double mPlaybackRate;
   Mirror<double> mLogicalPlaybackRate;
 
-  // Pitch preservation for the playback rate. Synchronized via decoder monitor.
-  bool mPreservesPitch;
+  // Pitch preservation for the playback rate.
+  Mirror<bool> mPreservesPitch;
 
   // Time at which we started decoding. Synchronised via decoder monitor.
   TimeStamp mDecodeStartTime;

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -157,7 +157,20 @@ public:
     return mState;
   }
 
-  void SetAudioCaptured();
+  void DispatchAudioCaptured()
+  {
+    nsRefPtr<MediaDecoderStateMachine> self = this;
+    nsCOMPtr<nsIRunnable> r = NS_NewRunnableFunction([self] () -> void
+    {
+      MOZ_ASSERT(self->OnTaskQueue());
+      ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
+      if (!self->mAudioCaptured) {
+        self->mAudioCaptured = true;
+        self->ScheduleStateMachine();
+      }
+    });
+    TaskQueue()->Dispatch(r.forget());
+  }
 
   // Check if the decoder needs to become dormant state.
   bool IsDormantNeeded();

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -893,8 +893,8 @@ public:
   bool mDurationSet;
 
   // The current play state and next play state, mirrored from the main thread.
-  Mirror<MediaDecoder::PlayState>::Holder mPlayState;
-  Mirror<MediaDecoder::PlayState>::Holder mNextPlayState;
+  Mirror<MediaDecoder::PlayState> mPlayState;
+  Mirror<MediaDecoder::PlayState> mNextPlayState;
 
   // Returns true if we're logically playing, that is, if the Play() has
   // been called and Pause() has not or we have not yet reached the end

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -168,6 +168,10 @@ public:
   void SetDormant(bool aDormant);
 
 private:
+  // Initialization that needs to happen on the task queue. This is the first
+  // task that gets run on the task queue, and is dispatched from the MDSM
+  // constructor immediately after the task queue is created.
+  void InitializationTask();
   void Shutdown();
 public:
 

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -157,9 +157,6 @@ public:
     return mState;
   }
 
-  // Set the audio volume. The decoder monitor must be obtained before
-  // calling this.
-  void SetVolume(double aVolume);
   void SetAudioCaptured();
 
   // Check if the decoder needs to become dormant state.
@@ -450,6 +447,8 @@ protected:
   // remove the audio thread in bug 750596.
   already_AddRefed<AudioData> PopAudio();
   already_AddRefed<VideoData> PopVideo();
+
+  void VolumeChanged();
 
   class WakeDecoderRunnable : public nsRunnable {
   public:
@@ -1012,10 +1011,8 @@ protected:
   // on decoded video data.
   int64_t mDecodedVideoEndTime;
 
-  // Volume of playback. 0.0 = muted. 1.0 = full volume. Read/Written
-  // from the state machine and main threads. Synchronised via decoder
-  // monitor.
-  double mVolume;
+  // Volume of playback. 0.0 = muted. 1.0 = full volume.
+  Mirror<double> mVolume;
 
   // Playback rate. 1.0 : normal speed, 0.5 : two times slower. Synchronized via
   // decoder monitor.

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -1081,12 +1081,14 @@ protected:
 
   bool DonePrerollingAudio()
   {
+    MOZ_ASSERT(OnTaskQueue());
     AssertCurrentThreadInMonitor();
     return !IsAudioDecoding() || GetDecodedAudioDuration() >= AudioPrerollUsecs() * mPlaybackRate;
   }
 
   bool DonePrerollingVideo()
   {
+    MOZ_ASSERT(OnTaskQueue());
     AssertCurrentThreadInMonitor();
     return !IsVideoDecoding() ||
            static_cast<uint32_t>(VideoQueue().GetSize()) >= VideoPrerollFrames() * mPlaybackRate;

--- a/dom/media/StateMirroring.h
+++ b/dom/media/StateMirroring.h
@@ -269,10 +269,9 @@ template<typename T>
 class Mirror
 {
 public:
-  Mirror(AbstractThread* aThread, const T& aInitialValue, const char* aName,
-         AbstractCanonical<T>* aCanonical = nullptr)
+  Mirror(AbstractThread* aThread, const T& aInitialValue, const char* aName)
   {
-    mImpl = new Impl(aThread, aInitialValue, aName, aCanonical);
+    mImpl = new Impl(aThread, aInitialValue, aName);
   }
 
   ~Mirror()
@@ -293,15 +292,10 @@ private:
   public:
     using AbstractMirror<T>::OwnerThread;
 
-    Impl(AbstractThread* aThread, const T& aInitialValue, const char* aName,
-         AbstractCanonical<T>* aCanonical)
+    Impl(AbstractThread* aThread, const T& aInitialValue, const char* aName)
       : AbstractMirror<T>(aThread), WatchTarget(aName), mValue(aInitialValue)
     {
       MIRROR_LOG("%s [%p] initialized", mName, this);
-
-      if (aCanonical) {
-        ConnectInternal(aCanonical);
-      }
     }
 
     operator const T&()
@@ -330,16 +324,8 @@ private:
 
     void Connect(AbstractCanonical<T>* aCanonical)
     {
-      MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
-      ConnectInternal(aCanonical);
-    }
-
-  private:
-    // We separate the guts of Connect into a helper so that we can call it from
-    // initialization while not necessarily on the owner thread.
-    void ConnectInternal(AbstractCanonical<T>* aCanonical)
-    {
       MIRROR_LOG("%s [%p] Connecting to %p", mName, this, aCanonical);
+      MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
       MOZ_ASSERT(!IsConnected());
 
       nsCOMPtr<nsIRunnable> r = NS_NewRunnableMethodWithArg<StorensRefPtrPassByPtr<AbstractMirror<T>>>

--- a/dom/media/StateMirroring.h
+++ b/dom/media/StateMirroring.h
@@ -104,155 +104,157 @@ protected:
  * Canonical<T> is also a WatchTarget, and may be set up to trigger other routines
  * (on the same thread) when the canonical value changes.
  *
- * Do not instantiate a Canonical<T> directly as a member. Instead, instantiate a
- * Canonical<T>::Holder, which handles lifetime issues and may eventually be
- * extended to do other things as well.
+ * Canonical<T> is intended to be used as a member variable, so it doesn't actually
+ * inherit AbstractCanonical<T> (a refcounted type). Rather, it contains an inner
+ * class called |Impl| that implements most of the interesting logic.
  */
 template<typename T>
-class Canonical : public AbstractCanonical<T>, public WatchTarget
+class Canonical
 {
 public:
-  using AbstractCanonical<T>::OwnerThread;
+  Canonical() {}
+  ~Canonical() { MOZ_DIAGNOSTIC_ASSERT(mImpl, "Should have initialized me"); }
 
-  Canonical(AbstractThread* aThread, const T& aInitialValue, const char* aName)
-    : AbstractCanonical<T>(aThread), WatchTarget(aName), mValue(aInitialValue)
+private:
+  class Impl : public AbstractCanonical<T>, public WatchTarget
   {
-    MIRROR_LOG("%s [%p] initialized", mName, this);
-    MOZ_ASSERT(aThread->RequiresTailDispatch(), "Can't get coherency without tail dispatch");
-  }
+  public:
+    using AbstractCanonical<T>::OwnerThread;
 
-  void AddMirror(AbstractMirror<T>* aMirror) override
-  {
-    MIRROR_LOG("%s [%p] adding mirror %p", mName, this, aMirror);
-    MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
-    MOZ_ASSERT(!mMirrors.Contains(aMirror));
-    mMirrors.AppendElement(aMirror);
-    aMirror->OwnerThread()->Dispatch(MakeNotifier(aMirror), AbstractThread::DontAssertDispatchSuccess);
-  }
+    Impl(AbstractThread* aThread, const T& aInitialValue, const char* aName)
+      : AbstractCanonical<T>(aThread), WatchTarget(aName), mValue(aInitialValue)
+    {
+      MIRROR_LOG("%s [%p] initialized", mName, this);
+      MOZ_ASSERT(aThread->RequiresTailDispatch(), "Can't get coherency without tail dispatch");
+    }
 
-  void RemoveMirror(AbstractMirror<T>* aMirror) override
-  {
-    MIRROR_LOG("%s [%p] removing mirror %p", mName, this, aMirror);
-    MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
-    MOZ_ASSERT(mMirrors.Contains(aMirror));
-    mMirrors.RemoveElement(aMirror);
-  }
+    void AddMirror(AbstractMirror<T>* aMirror) override
+    {
+      MIRROR_LOG("%s [%p] adding mirror %p", mName, this, aMirror);
+      MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
+      MOZ_ASSERT(!mMirrors.Contains(aMirror));
+      mMirrors.AppendElement(aMirror);
+      aMirror->OwnerThread()->Dispatch(MakeNotifier(aMirror), AbstractThread::DontAssertDispatchSuccess);
+    }
 
-  void DisconnectAll()
-  {
-    MIRROR_LOG("%s [%p] Disconnecting all mirrors", mName, this);
-    for (size_t i = 0; i < mMirrors.Length(); ++i) {
+    void RemoveMirror(AbstractMirror<T>* aMirror) override
+    {
+      MIRROR_LOG("%s [%p] removing mirror %p", mName, this, aMirror);
+      MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
+      MOZ_ASSERT(mMirrors.Contains(aMirror));
+      mMirrors.RemoveElement(aMirror);
+    }
+
+    void DisconnectAll()
+    {
+      MIRROR_LOG("%s [%p] Disconnecting all mirrors", mName, this);
+      for (size_t i = 0; i < mMirrors.Length(); ++i) {
+        nsCOMPtr<nsIRunnable> r =
+          NS_NewRunnableMethod(mMirrors[i], &AbstractMirror<T>::NotifyDisconnected);
+        mMirrors[i]->OwnerThread()->Dispatch(r.forget(), AbstractThread::DontAssertDispatchSuccess);
+      }
+      mMirrors.Clear();
+    }
+
+    operator const T&()
+    {
+      MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
+      return mValue;
+    }
+
+    void Set(const T& aNewValue)
+    {
+      MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
+
+      if (aNewValue == mValue) {
+        return;
+      }
+
+      // Notify same-thread watchers. The state watching machinery will make sure
+      // that notifications run at the right time.
+      NotifyWatchers();
+
+      // Check if we've already got a pending update. If so we won't schedule another
+      // one.
+      bool alreadyNotifying = mInitialValue.isSome();
+
+      // Stash the initial value if needed, then update to the new value.
+      if (mInitialValue.isNothing()) {
+        mInitialValue.emplace(mValue);
+      }
+      mValue = aNewValue;
+
+      // We wait until things have stabilized before sending state updates so that
+      // we can avoid sending multiple updates, and possibly avoid sending any
+      // updates at all if the value ends up where it started.
+      if (!alreadyNotifying) {
+        nsCOMPtr<nsIRunnable> r = NS_NewRunnableMethod(this, &Impl::DoNotify);
+        AbstractThread::GetCurrent()->TailDispatcher().AddDirectTask(r.forget());
+      }
+    }
+
+    Impl& operator=(const T& aNewValue) { Set(aNewValue); return *this; }
+    Impl& operator=(const Impl& aOther) { Set(aOther); return *this; }
+    Impl(const Impl& aOther) = delete;
+
+  protected:
+    ~Impl() { MOZ_DIAGNOSTIC_ASSERT(mMirrors.IsEmpty()); }
+
+  private:
+    void DoNotify()
+    {
+      MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
+      MOZ_ASSERT(mInitialValue.isSome());
+      bool same = mInitialValue.ref() == mValue;
+      mInitialValue.reset();
+
+      if (same) {
+        MIRROR_LOG("%s [%p] unchanged - not sending update", mName, this);
+        return;
+      }
+
+      for (size_t i = 0; i < mMirrors.Length(); ++i) {
+        OwnerThread()->TailDispatcher().AddStateChangeTask(mMirrors[i]->OwnerThread(), MakeNotifier(mMirrors[i]));
+      }
+    }
+
+    already_AddRefed<nsIRunnable> MakeNotifier(AbstractMirror<T>* aMirror)
+    {
       nsCOMPtr<nsIRunnable> r =
-        NS_NewRunnableMethod(mMirrors[i], &AbstractMirror<T>::NotifyDisconnected);
-      mMirrors[i]->OwnerThread()->Dispatch(r.forget(), AbstractThread::DontAssertDispatchSuccess);
+        NS_NewRunnableMethodWithArg<T>(aMirror, &AbstractMirror<T>::UpdateValue, mValue);
+      return r.forget();
     }
-    mMirrors.Clear();
-  }
 
-  operator const T&()
+    T mValue;
+    Maybe<T> mInitialValue;
+    nsTArray<nsRefPtr<AbstractMirror<T>>> mMirrors;
+  };
+public:
+
+  // NB: Because mirror-initiated disconnection can race with canonical-
+  // initiated disconnection, a canonical should never be reinitialized.
+  void Init(AbstractThread* aThread, const T& aInitialValue, const char* aName)
   {
-    MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
-    return mValue;
+    mImpl = new Impl(aThread, aInitialValue, aName);
   }
 
-  void Set(const T& aNewValue)
-  {
-    MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
+  // Forward control operations to the Impl.
+  void DisconnectAll() { return mImpl->DisconnectAll(); }
 
-    if (aNewValue == mValue) {
-      return;
-    }
+  // Access to the Impl.
+  operator Impl&() { return *mImpl; }
+  Impl* operator&() { return mImpl; }
 
-    // Notify same-thread watchers. The state watching machinery will make sure
-    // that notifications run at the right time.
-    NotifyWatchers();
-
-    // Check if we've already got a pending update. If so we won't schedule another
-    // one.
-    bool alreadyNotifying = mInitialValue.isSome();
-
-    // Stash the initial value if needed, then update to the new value.
-    if (mInitialValue.isNothing()) {
-      mInitialValue.emplace(mValue);
-    }
-    mValue = aNewValue;
-
-    // We wait until things have stablized before sending state updates so that
-    // we can avoid sending multiple updates, and possibly avoid sending any
-    // updates at all if the value ends up where it started.
-    if (!alreadyNotifying) {
-      nsCOMPtr<nsIRunnable> r = NS_NewRunnableMethod(this, &Canonical::DoNotify);
-      AbstractThread::GetCurrent()->TailDispatcher().AddDirectTask(r.forget());
-    }
-  }
-
+  // Access to the T.
+  const T& Ref() const { return *mImpl; }
+  operator const T&() const { return Ref(); }
+  void Set(const T& aNewValue) { mImpl->Set(aNewValue); }
   Canonical& operator=(const T& aNewValue) { Set(aNewValue); return *this; }
   Canonical& operator=(const Canonical& aOther) { Set(aOther); return *this; }
   Canonical(const Canonical& aOther) = delete;
 
-  class Holder
-  {
-  public:
-    Holder() {}
-    ~Holder() { MOZ_DIAGNOSTIC_ASSERT(mCanonical, "Should have initialized me"); }
-
-    // NB: Because mirror-initiated disconnection can race with canonical-
-    // initiated disconnection, a canonical should never be reinitialized.
-    void Init(AbstractThread* aThread, const T& aInitialValue, const char* aName)
-    {
-      mCanonical = new Canonical<T>(aThread, aInitialValue, aName);
-    }
-
-    // Forward control operations to the Canonical<T>.
-    void DisconnectAll() { return mCanonical->DisconnectAll(); }
-
-    // Access to the Canonical<T>.
-    operator Canonical<T>&() { return *mCanonical; }
-    Canonical<T>* operator&() { return mCanonical; }
-
-    // Access to the T.
-    const T& Ref() const { return *mCanonical; }
-    operator const T&() const { return Ref(); }
-    void Set(const T& aNewValue) { mCanonical->Set(aNewValue); }
-    Holder& operator=(const T& aNewValue) { Set(aNewValue); return *this; }
-    Holder& operator=(const Holder& aOther) { Set(aOther); return *this; }
-    Holder(const Holder& aOther) = delete;
-
-  private:
-    nsRefPtr<Canonical<T>> mCanonical;
-  };
-
-protected:
-  ~Canonical() { MOZ_DIAGNOSTIC_ASSERT(mMirrors.IsEmpty()); }
-
 private:
-  void DoNotify()
-  {
-    MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
-    MOZ_ASSERT(mInitialValue.isSome());
-    bool same = mInitialValue.ref() == mValue;
-    mInitialValue.reset();
-
-    if (same) {
-      MIRROR_LOG("%s [%p] unchanged - not sending update", mName, this);
-      return;
-    }
-
-    for (size_t i = 0; i < mMirrors.Length(); ++i) {
-      OwnerThread()->TailDispatcher().AddStateChangeTask(mMirrors[i]->OwnerThread(), MakeNotifier(mMirrors[i]));
-    }
-  }
-
-  already_AddRefed<nsIRunnable> MakeNotifier(AbstractMirror<T>* aMirror)
-  {
-    nsCOMPtr<nsIRunnable> r =
-      NS_NewRunnableMethodWithArg<T>(aMirror, &AbstractMirror<T>::UpdateValue, mValue);
-    return r.forget();
-  }
-
-  T mValue;
-  Maybe<T> mInitialValue;
-  nsTArray<nsRefPtr<AbstractMirror<T>>> mMirrors;
+  nsRefPtr<Impl> mImpl;
 };
 
 /*

--- a/dom/media/StateMirroring.h
+++ b/dom/media/StateMirroring.h
@@ -112,8 +112,12 @@ template<typename T>
 class Canonical
 {
 public:
-  Canonical() {}
-  ~Canonical() { MOZ_DIAGNOSTIC_ASSERT(mImpl, "Should have initialized me"); }
+  Canonical(AbstractThread* aThread, const T& aInitialValue, const char* aName)
+  {
+    mImpl = new Impl(aThread, aInitialValue, aName);
+  }
+
+  ~Canonical() {}
 
 private:
   class Impl : public AbstractCanonical<T>, public WatchTarget
@@ -231,13 +235,6 @@ private:
   };
 public:
 
-  // NB: Because mirror-initiated disconnection can race with canonical-
-  // initiated disconnection, a canonical should never be reinitialized.
-  void Init(AbstractThread* aThread, const T& aInitialValue, const char* aName)
-  {
-    mImpl = new Impl(aThread, aInitialValue, aName);
-  }
-
   // Forward control operations to the Impl.
   void DisconnectAll() { return mImpl->DisconnectAll(); }
 
@@ -272,10 +269,14 @@ template<typename T>
 class Mirror
 {
 public:
-  Mirror() {}
+  Mirror(AbstractThread* aThread, const T& aInitialValue, const char* aName,
+         AbstractCanonical<T>* aCanonical = nullptr)
+  {
+    mImpl = new Impl(aThread, aInitialValue, aName, aCanonical);
+  }
+
   ~Mirror()
   {
-    MOZ_DIAGNOSTIC_ASSERT(mImpl, "Should have initialized me");
     if (mImpl->OwnerThread()->IsCurrentThreadIn()) {
       mImpl->DisconnectIfConnected();
     } else {
@@ -370,14 +371,6 @@ private:
     nsRefPtr<AbstractCanonical<T>> mCanonical;
   };
 public:
-
-  // NB: Because mirror-initiated disconnection can race with canonical-
-  // initiated disconnection, a mirror should never be reinitialized.
-  void Init(AbstractThread* aThread, const T& aInitialValue, const char* aName,
-            AbstractCanonical<T>* aCanonical = nullptr)
-  {
-    mImpl = new Impl(aThread, aInitialValue, aName, aCanonical);
-  }
 
   // Forward control operations to the Impl<T>.
   void Connect(AbstractCanonical<T>* aCanonical) { mImpl->Connect(aCanonical); }

--- a/dom/media/StateWatching.h
+++ b/dom/media/StateWatching.h
@@ -58,8 +58,6 @@ namespace mozilla {
 
 extern PRLogModuleInfo* gStateWatchingLog;
 
-void EnsureStateWatchingLog();
-
 #define WATCH_LOG(x, ...) \
   MOZ_ASSERT(gStateWatchingLog); \
   PR_LOG(gStateWatchingLog, PR_LOG_DEBUG, (x, ##__VA_ARGS__))

--- a/dom/media/omx/MediaOmxCommonDecoder.cpp
+++ b/dom/media/omx/MediaOmxCommonDecoder.cpp
@@ -52,8 +52,8 @@ MediaOmxCommonDecoder::SetPlatformCanOffloadAudio(bool aCanOffloadAudio)
 bool
 MediaOmxCommonDecoder::CheckDecoderCanOffloadAudio()
 {
-  return (mCanOffloadAudio && !mFallbackToStateMachine && !mOutputStreams.Length() &&
-      mInitialPlaybackRate == 1.0);
+  return (mCanOffloadAudio && !mFallbackToStateMachine &&
+          !mOutputStreams.Length() && mPlaybackRate == 1.0);
 }
 
 void


### PR DESCRIPTION
This PR eliminates the state machinery ::Holder setup and provides the WatchManager an owner thread, both of which improves the overall ergonomics of the state machinery. Additionally, this PR uses state mirroring for stuff in MediaDecoderStateMachine::SetStateMachineParameters, which  currently accounts for a good portion of the cross-thread calls in our media code.

Tested on Linux (YouTube, Vimeo, Twitch, etc.) and appears to be working as intended.