### PR TITLE
Permissions: Reload list of sites, use default, confirm before any action, permissions.places-sites-limit (improvements), style clean up

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1049,6 +1049,11 @@ pref("full-screen-api.enabled", true);
 // approval.
 pref("full-screen-api.approval-required", true);
 
+// about:permissions
+// Maximum number of sites to return from the places database.
+// 0-100 (currently)
+pref("permissions.places-sites-limit", 50);
+
 // Startup Crash Tracking
 // number of startup crashes that can occur before starting into safe mode automatically
 // (this pref has no effect if more than 6 hours have passed since the last crash)

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var Cc = Components.classes;
-var Ci = Components.interfaces;
-var Cu = Components.utils;
+let Cc = Components.classes;
+let Ci = Components.interfaces;
+let Cu = Components.utils;
 
 Cu.import("resource://gre/modules/Services.jsm");
 
@@ -14,15 +14,15 @@ Cu.import("resource://gre/modules/ForgetAboutSite.jsm");
 Cu.import("resource://gre/modules/NetUtil.jsm");
 Cu.import("resource://gre/modules/PluralForm.jsm");
 
-var gFaviconService = Cc["@mozilla.org/browser/favicon-service;1"].
+let gFaviconService = Cc["@mozilla.org/browser/favicon-service;1"].
                       getService(Ci.nsIFaviconService);
 
-var gPlacesDatabase = Cc["@mozilla.org/browser/nav-history-service;1"].
+let gPlacesDatabase = Cc["@mozilla.org/browser/nav-history-service;1"].
                       getService(Ci.nsPIPlacesDatabase).
                       DBConnection.
                       clone(true);
 
-var gSitesStmt = gPlacesDatabase.createAsyncStatement(
+let gSitesStmt = gPlacesDatabase.createAsyncStatement(
                  "SELECT get_unreversed_host(rev_host) AS host " +
                  "FROM moz_places " +
                  "WHERE rev_host > '.' " +
@@ -31,12 +31,12 @@ var gSitesStmt = gPlacesDatabase.createAsyncStatement(
                  "ORDER BY MAX(frecency) DESC " +
                  "LIMIT :limit");
 
-var gVisitStmt = gPlacesDatabase.createAsyncStatement(
+let gVisitStmt = gPlacesDatabase.createAsyncStatement(
                  "SELECT SUM(visit_count) AS count " +
                  "FROM moz_places " +
                  "WHERE rev_host = :rev_host");
 
-var gFlash = {
+let gFlash = {
   name: "Shockwave Flash",
   betterName: "Adobe Flash",
   type: "application/x-shockwave-flash",
@@ -47,7 +47,7 @@ var gFlash = {
  * to testPermission. This is based on what consumers use to test these
  * permissions.
  */
-var TEST_EXACT_PERM_TYPES = ["desktop-notification", "geo", "pointerLock"];
+const TEST_EXACT_PERM_TYPES = ["desktop-notification", "geo", "pointerLock"];
 
 /**
  * Site object represents a single site, uniquely identified by a host.
@@ -80,11 +80,11 @@ Site.prototype = {
     }
 
     // Try to find favicon for both URIs, but always prefer the https favicon.
-    gFaviconService.getFaviconURLForPage(this.httpsURI, function (aURI) {
+    gFaviconService.getFaviconURLForPage(this.httpsURI, function(aURI) {
       if (aURI) {
         invokeCallback(aURI);
       } else {
-        gFaviconService.getFaviconURLForPage(this.httpURI, function (aURI) {
+        gFaviconService.getFaviconURLForPage(this.httpURI, function(aURI) {
           if (aURI) {
             invokeCallback(aURI);
           }
@@ -103,7 +103,7 @@ Site.prototype = {
     let rev_host = this.host.split("").reverse().join("") + ".";
     gVisitStmt.params.rev_host = rev_host;
     gVisitStmt.executeAsync({
-      handleResult: function (aResults) {
+      handleResult: function(aResults) {
         let row = aResults.getNextRow();
         let count = row.getResultByName("count") || 0;
         try {
@@ -112,10 +112,10 @@ Site.prototype = {
           Cu.reportError("AboutPermissions: " + e);
         }
       },
-      handleError: function (aError) {
+      handleError: function(aError) {
         Cu.reportError("AboutPermissions: " + aError);
       },
-      handleCompletion: function (aReason) {
+      handleCompletion: function(aReason) {
       }
     });
   },
@@ -125,7 +125,7 @@ Site.prototype = {
    *
    * @param aType
    *        The permission type string stored in permission manager.
-   *        e.g. "image", "popup", "cookie", "geo", "indexedDB"
+   *        e.g. "cookie", "geo", "indexedDB", "popup", "image"
    * @param aResultObj
    *        An object that stores the permission value set for aType.
    *
@@ -164,7 +164,7 @@ Site.prototype = {
    *
    * @param aType
    *        The permission type string stored in permission manager.
-   *        e.g. "image", "popup", "cookie", "geo", "indexedDB"
+   *        e.g. "cookie", "geo", "indexedDB", "popup", "image"
    * @param aPerm
    *        The permission value to set for the permission type. This should
    *        be one of the constants defined in nsIPermissionManager.
@@ -193,7 +193,7 @@ Site.prototype = {
    *
    * @param aType
    *        The permission type string stored in permission manager.
-   *        e.g. "image", "popup", "cookie", "geo", "indexedDB"
+   *        e.g. "cookie", "geo", "indexedDB", "popup", "image"
    */
   clearPermission: function Site_clearPermission(aType) {
     Services.perms.remove(this.host, aType);
@@ -248,7 +248,7 @@ Site.prototype = {
    * Removes a set of specific cookies from the browser.
    */
   clearCookies: function Site_clearCookies() {
-    this.cookies.forEach(function (aCookie) {
+    this.cookies.forEach(function(aCookie) {
       Services.cookies.remove(aCookie.host, aCookie.name, aCookie.path, false);
     });
   },
@@ -267,7 +267,7 @@ Site.prototype = {
  *
  * Inspired by pageinfo/permissions.js
  */
-var PermissionDefaults = {
+let PermissionDefaults = {
   UNKNOWN: Ci.nsIPermissionManager.UNKNOWN_ACTION,   // 0
   ALLOW: Ci.nsIPermissionManager.ALLOW_ACTION,       // 1
   DENY: Ci.nsIPermissionManager.DENY_ACTION,         // 2
@@ -426,7 +426,7 @@ var PermissionDefaults = {
 /**
  * AboutPermissions manages the about:permissions page.
  */
-var AboutPermissions = {
+let AboutPermissions = {
  /**
   * Maximum number of sites to return from the places database.
   */  
@@ -480,7 +480,7 @@ var AboutPermissions = {
   _stringBundleAboutPermissions: Services.strings.createBundle(
       "chrome://browser/locale/preferences/aboutPermissions.properties"),
 
-  _initPart1: function () {
+  _initPart1: function() {
     this.initPluginList();
     this.cleanupPluginList();
 
@@ -490,8 +490,8 @@ var AboutPermissions = {
     setTimeout(this.enumerateServicesDriver.bind(this), this.LIST_BUILD_DELAY);
   },
 
-  _initPart2: function () {
-    this._supportedPermissions.forEach(function (aType) {
+  _initPart2: function() {
+    this._supportedPermissions.forEach(function(aType) {
       this.updatePermission(aType);
     }, this);
   },
@@ -499,7 +499,7 @@ var AboutPermissions = {
   /**
    * Called on page load.
    */
-  init: function () {
+  init: function() {
     this.sitesList = document.getElementById("sites-list");
 
     this._initPart1();
@@ -532,8 +532,8 @@ var AboutPermissions = {
     this._initPart2();
   },
 
-  sitesReload: function () {
-    Object.getOwnPropertyNames(this._sites).forEach(function (prop) {
+  sitesReload: function() {
+    Object.getOwnPropertyNames(this._sites).forEach(function(prop) {
       AboutPermissions.deleteFromSitesList(prop);
     });
     this._initPart1();
@@ -542,7 +542,7 @@ var AboutPermissions = {
 
   // XXX copied this from browser-plugins.js - is there a way to share?
   // Map the plugin's name to a filtered version more suitable for user UI.
-  makeNicePluginName: function (aName) {
+  makeNicePluginName: function(aName) {
     if (aName == gFlash.name) {
       return gFlash.betterName;
     }
@@ -557,7 +557,7 @@ var AboutPermissions = {
     return newName;
   },
 
-  initPluginList: function () {
+  initPluginList: function() {
     let pluginHost = Cc["@mozilla.org/plugin/host;1"]
                      .getService(Ci.nsIPluginHost);
     let tags = pluginHost.getPluginTags();
@@ -601,12 +601,12 @@ var AboutPermissions = {
           this._supportedPermissions.push(permString);
           this._noGlobalDeny.push(permString);
           Object.defineProperty(PermissionDefaults, permString, {
-            get: function () {
+            get: function() {
                    return this.isClickToPlay()
                           ? PermissionDefaults.UNKNOWN
                           : PermissionDefaults.ALLOW;
                  }.bind(permissionEntry),
-            set: function (aValue) {
+            set: function(aValue) {
                    this.clicktoplay = (aValue == PermissionDefaults.UNKNOWN);
                  }.bind(plugin),
             configurable: true
@@ -617,7 +617,7 @@ var AboutPermissions = {
     }
 
     if (permissionEntries.length > 0) {
-      permissionEntries.sort(function (entryA, entryB) {
+      permissionEntries.sort(function(entryA, entryB) {
         let labelA = entryA.getAttribute("label");
         let labelB = entryB.getAttribute("label");
         return ((labelA < labelB) ? -1 : (labelA == labelB ? 0 : 1));
@@ -633,7 +633,7 @@ var AboutPermissions = {
     }
   },
 
-  cleanupPluginList: function () {
+  cleanupPluginList: function() {
     let pluginsPrefItem = document.getElementById("plugins-pref-item");
     let pluginsBox = document.getElementById("plugins-box");
     let pluginsBoxEmpty = true;
@@ -655,7 +655,7 @@ var AboutPermissions = {
   /**
    * Called on page unload.
    */
-  cleanUp: function () {
+  cleanUp: function() {
     if (this._observersInitialized) {
       Services.prefs.removeObserver("signon.rememberSignons", this, false);
       Services.prefs.removeObserver("permissions.default.image", this, false);
@@ -684,8 +684,8 @@ var AboutPermissions = {
     gPlacesDatabase.asyncClose(null);
   },
 
-  observe: function (aSubject, aTopic, aData) {
-    switch (aTopic) {
+  observe: function(aSubject, aTopic, aData) {
+    switch(aTopic) {
       case "perm-changed":
         // Permissions changes only affect individual sites.
         if (!this._selectedSite) {
@@ -693,7 +693,7 @@ var AboutPermissions = {
         }
         // aSubject is null when nsIPermisionManager::removeAll() is called.
         if (!aSubject) {
-          this._supportedPermissions.forEach(function (aType) {
+          this._supportedPermissions.forEach(function(aType) {
             this.updatePermission(aType);
           }, this);
           break;
@@ -718,7 +718,7 @@ var AboutPermissions = {
         if (plugin) {
           this.initPluginList();
         }
-        this._supportedPermissions.forEach(function (aType) {
+        this._supportedPermissions.forEach(function(aType) {
           if (!plugin || (plugin && aType.startsWith("plugin"))) {
             this.updatePermission(aType);
           }
@@ -745,7 +745,7 @@ var AboutPermissions = {
       case "plugin-list-updated":
       case "blocklist-updated":
         this.initPluginList();
-        this._supportedPermissions.forEach(function (aType) {
+        this._supportedPermissions.forEach(function(aType) {
           if (aType.startsWith("plugin")) {
             this.updatePermission(aType);
           }
@@ -760,7 +760,7 @@ var AboutPermissions = {
    * and stores them in _sites.
    * The number of sites created is controlled by _placesSitesLimit.
    */
-  getSitesFromPlaces: function () {
+  getSitesFromPlaces: function() {
     let _placesSitesLimit = Services.prefs.getIntPref(
         "permissions.places-sites-limit");
     if (_placesSitesLimit <= 0) {
@@ -772,7 +772,7 @@ var AboutPermissions = {
 
     gSitesStmt.params.limit = _placesSitesLimit;
     gSitesStmt.executeAsync({
-      handleResult: function (aResults) {
+      handleResult: function(aResults) {
         AboutPermissions.startSitesListBatch();
         let row;
         while (row = aResults.getNextRow()) {
@@ -781,10 +781,10 @@ var AboutPermissions = {
         }
         AboutPermissions.endSitesListBatch();
       },
-      handleError: function (aError) {
+      handleError: function(aError) {
         Cu.reportError("AboutPermissions: " + aError);
       },
-      handleCompletion: function (aReason) {
+      handleCompletion: function(aReason) {
         // Notify oberservers for testing purposes.
         AboutPermissions._initPlacesDone = true;
         if (AboutPermissions._initServicesDone) {
@@ -798,7 +798,7 @@ var AboutPermissions = {
   /**
    * Drives getEnumerateServicesGenerator to work in intervals.
    */
-  enumerateServicesDriver: function () {
+  enumerateServicesDriver: function() {
     if (this.enumerateServicesGenerator.next()) {
       // Build top sitesList items faster so that the list never seems sparse
       let delay = Math.min(this.sitesList.itemCount * 5, this.LIST_BUILD_DELAY);
@@ -817,11 +817,11 @@ var AboutPermissions = {
    * Finds sites that have non-default permissions and creates Site objects
    * for them if they are not already stored in _sites.
    */
-  getEnumerateServicesGenerator: function () {
+  getEnumerateServicesGenerator: function() {
     let itemCnt = 1;
 
     let logins = Services.logins.getAllLogins();
-    logins.forEach(function (aLogin) {
+    logins.forEach(function(aLogin) {
       if (itemCnt % this.LIST_BUILD_CHUNK == 0) {
         yield true;
       }
@@ -837,7 +837,7 @@ var AboutPermissions = {
     }, this);
 
     let disabledHosts = Services.logins.getAllDisabledHosts();
-    disabledHosts.forEach(function (aHostname) {
+    disabledHosts.forEach(function(aHostname) {
       if (itemCnt % this.LIST_BUILD_CHUNK == 0) {
         yield true;
       }
@@ -873,7 +873,7 @@ var AboutPermissions = {
    * @param aHost
    *        A host string.
    */
-  addHost: function (aHost) {
+  addHost: function(aHost) {
     if (aHost in this._sites) {
       return;
     }
@@ -888,12 +888,12 @@ var AboutPermissions = {
    * @param aSite
    *        A Site object.
    */
-  addToSitesList: function (aSite) {
+  addToSitesList: function(aSite) {
     let item = document.createElement("richlistitem");
     item.setAttribute("class", "site");
     item.setAttribute("value", aSite.host);
 
-    aSite.getFavicon(function (aURL) {
+    aSite.getFavicon(function(aURL) {
       item.setAttribute("favicon", aURL);
     });
     aSite.listitem = item;
@@ -906,12 +906,12 @@ var AboutPermissions = {
     (this._listFragment || this.sitesList).appendChild(item);
   },
 
-  startSitesListBatch: function () {
+  startSitesListBatch: function() {
     if (!this._listFragment)
       this._listFragment = document.createDocumentFragment();
   },
 
-  endSitesListBatch: function () {
+  endSitesListBatch: function() {
     if (this._listFragment) {
       this.sitesList.appendChild(this._listFragment);
       this._listFragment = null;
@@ -921,7 +921,7 @@ var AboutPermissions = {
   /**
    * Hides sites in richlistbox based on search text in sites-filter textbox.
    */
-  filterSitesList: function () {
+  filterSitesList: function() {
     let siteItems = this.sitesList.children;
     let filterValue =
         document.getElementById("sites-filter").value.toLowerCase();
@@ -943,7 +943,7 @@ var AboutPermissions = {
    * Removes all evidence of the selected site. The "forget this site" observer
    * will call deleteFromSitesList to update the UI.
    */
-  forgetSite: function () {
+  forgetSite: function() {
     this._selectedSite.forgetSite();
   },
 
@@ -954,7 +954,7 @@ var AboutPermissions = {
    * @param aHost
    *        The host string corresponding to the site to delete.
    */
-  deleteFromSitesList: function (aHost) {
+  deleteFromSitesList: function(aHost) {
     for (let host in this._sites) {
       let site = this._sites[host];
       if (site.host.hasRootDomain(aHost)) {
@@ -973,7 +973,7 @@ var AboutPermissions = {
   /**
    * Shows interface for managing site-specific permissions.
    */
-  onSitesListSelect: function (event) {
+  onSitesListSelect: function(event) {
     if (event.target.selectedItem.id == "all-sites-item") {
       // Clear the header label value from the previously selected site.
       document.getElementById("site-label").value = "";
@@ -995,7 +995,7 @@ var AboutPermissions = {
    * Shows interface for managing default permissions. This corresponds to
    * the "All Sites" list item.
    */
-  manageDefaultPermissions: function () {
+  manageDefaultPermissions: function() {
     this._selectedSite = null;
 
     document.getElementById("header-deck").selectedPanel =
@@ -1007,8 +1007,8 @@ var AboutPermissions = {
   /**
    * Updates permissions interface based on selected site.
    */
-  updatePermissionsBox: function () {
-    this._supportedPermissions.forEach(function (aType) {
+  updatePermissionsBox: function() {
+    this._supportedPermissions.forEach(function(aType) {
       this.updatePermission(aType);
     }, this);
 
@@ -1024,7 +1024,7 @@ var AboutPermissions = {
    *        The permission type string stored in permission manager.
    *        e.g. "cookie", "geo", "indexedDB", "popup", "image"
    */
-  updatePermission: function (aType) {
+  updatePermission: function(aType) {
     let allowItem = document.getElementById(
         aType + "-" + PermissionDefaults.ALLOW);
     allowItem.hidden = !this._selectedSite &&
@@ -1138,7 +1138,7 @@ var AboutPermissions = {
         aType + "-" + permissionValue);
   },
 
-  onPermissionCommand: function (event, _default) {
+  onPermissionCommand: function(event, _default) {
     let pluginHost = Cc["@mozilla.org/plugin/host;1"] 
                      .getService(Ci.nsIPluginHost);
     let permissionMimeType = event.currentTarget.getAttribute("mimeType");
@@ -1148,7 +1148,7 @@ var AboutPermissions = {
     if (!this._selectedSite) {
       if (permissionType.startsWith("plugin")) {
         let addonValue = AddonManager.STATE_ASK_TO_ACTIVATE;
-        switch (permissionValue) {
+        switch(permissionValue) {
           case "1":
             addonValue = false;
             break;
@@ -1157,7 +1157,7 @@ var AboutPermissions = {
             break;
         }
 
-        AddonManager.getAddonsByTypes(["plugin"], function (addons) {
+        AddonManager.getAddonsByTypes(["plugin"], function(addons) {
           for (let addon of addons) {
             for (let type of addon.pluginMimeTypes) {
               if ((type.type == gFlash.type) && (addon.name != gFlash.name)) {
@@ -1183,8 +1183,8 @@ var AboutPermissions = {
     }
   },
 
-  updateVisitCount: function () {
-    this._selectedSite.getVisitCount(function (aCount) {
+  updateVisitCount: function() {
+    this._selectedSite.getVisitCount(function(aCount) {
       let visitForm = AboutPermissions._stringBundleAboutPermissions
                       .GetStringFromName("visitCount");
       let visitLabel = PluralForm.get(aCount, visitForm)
@@ -1193,7 +1193,7 @@ var AboutPermissions = {
     });  
   },
 
-  updatePasswordsCount: function () {
+  updatePasswordsCount: function() {
     if (!this._selectedSite) {
       document.getElementById("passwords-count").hidden = true;
       document.getElementById("passwords-manage-all-button").hidden = false;
@@ -1216,7 +1216,7 @@ var AboutPermissions = {
   /**
    * Opens password manager dialog.
    */
-  managePasswords: function () {
+  managePasswords: function() {
     let selectedHost = "";
     if (this._selectedSite) {
       selectedHost = this._selectedSite.host;
@@ -1233,7 +1233,7 @@ var AboutPermissions = {
     }
   },
 
-  domainFromHost: function (aHost) {
+  domainFromHost: function(aHost) {
     let domain = aHost;
     try {
       domain = Services.eTLD.getBaseDomainFromHost(aHost);
@@ -1245,7 +1245,7 @@ var AboutPermissions = {
     return domain;
   },
 
-  updateCookiesCount: function () {
+  updateCookiesCount: function() {
     if (!this._selectedSite) {
       document.getElementById("cookies-count").hidden = true;
       document.getElementById("cookies-clear-all-button").hidden = false;
@@ -1272,7 +1272,7 @@ var AboutPermissions = {
   /**
    * Clears cookies for the selected site.
    */
-  clearCookies: function () {
+  clearCookies: function() {
     if (!this._selectedSite) {
       return;
     }
@@ -1284,7 +1284,7 @@ var AboutPermissions = {
   /**
    * Opens cookie manager dialog.
    */
-  manageCookies: function () {
+  manageCookies: function() {
     let selectedHost = "";
     let selectedDomain = "";
     if (this._selectedSite) {

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -1176,9 +1176,10 @@ var AboutPermissions = {
       }
     } else {
       if (_default) {
-        permissionValue = PermissionDefaults[permissionType];
+        this._selectedSite.clearPermission(permissionType);
+      } else {
+        this._selectedSite.setPermission(permissionType, permissionValue);
       }
-      this._selectedSite.setPermission(permissionType, permissionValue);
     }
   },
 

--- a/browser/components/preferences/aboutPermissions.xml
+++ b/browser/components/preferences/aboutPermissions.xml
@@ -29,13 +29,18 @@
         <xul:spacer flex="1"/>
         <xul:menulist anonid="plugins-menulist"
                       class="pref-menulist"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
           <xul:menupopup>
             <xul:menuitem anonid="ask" value="0" label="&permission.alwaysAsk;"/>
             <xul:menuitem anonid="allow" value="1" label="&permission.allow;"/>
             <xul:menuitem anonid="block" value="2" label="&permission.block;"/>
           </xul:menupopup>
         </xul:menulist>
+        <xul:button xbl:inherits="value=set-default"
+                    anonid="plugins-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
       </xul:hbox>
     </content>
     <implementation>
@@ -55,6 +60,10 @@
         let _default = document.getAnonymousElementByAttribute(this, "anonid", "plugins-default");
         this.setDefaultVisibility(false);
         _default.setAttribute("value", "*");
+        let _setDefault = document.getAnonymousElementByAttribute(this, "anonid", "plugins-set-default");
+        _setDefault.setAttribute("id", permString + "-set-default");
+        _setDefault.setAttribute("class", "pref-set-default");
+        _setDefault.setAttribute("type", permString);
       ]]>
       </constructor>
       <method name="setDefaultVisibility">

--- a/browser/components/preferences/aboutPermissions.xul
+++ b/browser/components/preferences/aboutPermissions.xul
@@ -61,6 +61,7 @@
                   label="&permissions.forgetSite;"
                   oncommand="if (Services.prompt.confirm(null,
                       this.getAttribute('label'),
+                      this.getAttribute('label') + '\n\n' +
                       AboutPermissions._stringBundleAboutPermissions
                       .GetStringFromName('permissionsConfirm')))
                       { AboutPermissions.forgetSite(); }"/>
@@ -197,6 +198,7 @@
                     label="&cookie.removeAll;"
                     oncommand="if (Services.prompt.confirm(null,
                         this.getAttribute('label'),
+                        this.getAttribute('label') + '\n\n' +
                         AboutPermissions._stringBundleAboutPermissions
                         .GetStringFromName('permissionsConfirm')))
                         { Services.cookies.removeAll(); }"/>
@@ -209,7 +211,8 @@
             <button id="cookies-clear-button"
                     label="&cookie.remove;"
                     oncommand="if (Services.prompt.confirm(null,
-                        event.target.getAttribute('label'),
+                        this.getAttribute('label'),
+                        this.getAttribute('label') + '\n\n' +
                         AboutPermissions._stringBundleAboutPermissions
                         .GetStringFromName('permissionsConfirm')))
                         { AboutPermissions.clearCookies(); }"/>

--- a/browser/components/preferences/aboutPermissions.xul
+++ b/browser/components/preferences/aboutPermissions.xul
@@ -31,6 +31,9 @@
   <hbox flex="1" id="permissions-content" class="main-content">
 
     <vbox id="sites-box">
+      <button id="sites-reload"
+              label="&permissions.sitesReload;"
+              oncommand="AboutPermissions.sitesReload();"/>
       <textbox id="sites-filter"
                emptytext="&sites.search;"
                oncommand="AboutPermissions.filterSitesList();"
@@ -56,7 +59,11 @@
           <spacer flex="1"/>
           <button id="forget-site-button"
                   label="&permissions.forgetSite;"
-                  oncommand="AboutPermissions.forgetSite();"/>
+                  oncommand="if (Services.prompt.confirm(null,
+                      this.getAttribute('label'),
+                      AboutPermissions._stringBundleAboutPermissions
+                      .GetStringFromName('permissionsConfirm')))
+                      { AboutPermissions.forgetSite(); }"/>
         </hbox>
 
         <hbox id="defaults-header" class="pref-item" align="center">
@@ -79,12 +86,17 @@
             <menulist id="password-menulist"
                       class="pref-menulist"
                       type="password"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="password-1" value="1" label="&permission.allow;"/>
                 <menuitem id="password-2" value="2" label="&permission.block;"/>
               </menupopup>
             </menulist>
+            <button id="password-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="password"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
             <button id="passwords-manage-all-button"
                     label="&password.manage;"
                     oncommand="AboutPermissions.managePasswords();"/>
@@ -111,13 +123,18 @@
             <menulist id="image-menulist"
                       class="pref-menulist"
                       type="image"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="image-1" value="1" label="&permission.allow;"/>
                 <menuitem id="image-2" value="2" label="&permission.block;"/>
                 <menuitem id="image-3" value="3" label="&permission.allowFirstPartyOnly;"/>
               </menupopup>
             </menulist>
+            <button id="image-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="image"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
           </hbox>
         </vbox>
       </hbox>
@@ -135,12 +152,17 @@
             <menulist id="popup-menulist"
                       class="pref-menulist"
                       type="popup"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="popup-1" value="1" label="&permission.allow;"/>
                 <menuitem id="popup-2" value="2" label="&permission.block;"/>
               </menupopup>
             </menulist>
+            <button id="popup-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="popup"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
           </hbox>
         </vbox>
       </hbox>
@@ -158,7 +180,7 @@
             <menulist id="cookie-menulist"
                       class="pref-menulist"
                       type="cookie"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="cookie-1" value="1" label="&permission.allow;"/>
                 <menuitem id="cookie-8" value="8" label="&permission.allowForSession;"/>
@@ -166,9 +188,18 @@
                 <menuitem id="cookie-2" value="2" label="&permission.block;"/>
               </menupopup>
             </menulist>
+            <button id="cookie-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="cookie"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
             <button id="cookies-clear-all-button"
                     label="&cookie.removeAll;"
-                    oncommand="Services.cookies.removeAll();"/>
+                    oncommand="if (Services.prompt.confirm(null,
+                        this.getAttribute('label'),
+                        AboutPermissions._stringBundleAboutPermissions
+                        .GetStringFromName('permissionsConfirm')))
+                        { Services.cookies.removeAll(); }"/>
             <button id="cookies-manage-all-button"
                     label="&cookie.manage;"
                     oncommand="AboutPermissions.manageCookies();"/>
@@ -177,7 +208,11 @@
             <label id="cookies-label"/>
             <button id="cookies-clear-button"
                     label="&cookie.remove;"
-                    oncommand="AboutPermissions.clearCookies();"/>
+                    oncommand="if (Services.prompt.confirm(null,
+                        event.target.getAttribute('label'),
+                        AboutPermissions._stringBundleAboutPermissions
+                        .GetStringFromName('permissionsConfirm')))
+                        { AboutPermissions.clearCookies(); }"/>
             <button id="cookies-manage-button"
                     label="&cookie.manage;"
                     oncommand="AboutPermissions.manageCookies();"/>
@@ -198,13 +233,18 @@
             <menulist id="desktop-notification-menulist"
                       class="pref-menulist"
                       type="desktop-notification"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="desktop-notification-0" value="0" label="&permission.alwaysAsk;"/>
                 <menuitem id="desktop-notification-1" value="1" label="&permission.allow;"/>
                 <menuitem id="desktop-notification-2" value="2" label="&permission.block;"/>
               </menupopup>
             </menulist>
+            <button id="desktop-notification-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="desktop-notification"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
           </hbox>
         </vbox>
       </hbox>
@@ -222,12 +262,17 @@
             <menulist id="install-menulist"
                       class="pref-menulist"
                       type="install"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="install-1" value="1" label="&permission.allow;"/>
                 <menuitem id="install-2" value="2" label="&permission.block;"/>
               </menupopup>
             </menulist>
+            <button id="install-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="install"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
           </hbox>
         </vbox>
       </hbox>
@@ -245,13 +290,18 @@
             <menulist id="geo-menulist"
                       class="pref-menulist"
                       type="geo"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="geo-0" value="0" label="&permission.alwaysAsk;"/>
                 <menuitem id="geo-1" value="1" label="&permission.allow;"/>
                 <menuitem id="geo-2" value="2" label="&permission.block;"/>
               </menupopup>
             </menulist>
+            <button id="geo-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="geo"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
           </hbox>
         </vbox>
       </hbox>
@@ -269,13 +319,18 @@
             <menulist id="indexedDB-menulist"
                       class="pref-menulist"
                       type="indexedDB"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="indexedDB-0" value="0" label="&permission.alwaysAsk;"/>
                 <menuitem id="indexedDB-1" value="1" label="&permission.allow;"/>
                 <menuitem id="indexedDB-2" value="2" label="&permission.block;"/>
               </menupopup>
             </menulist>
+            <button id="indexedDB-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="indexedDB"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
           </hbox>
         </vbox>
       </hbox>
@@ -303,13 +358,18 @@
             <menulist id="fullscreen-menulist"
                       class="pref-menulist"
                       type="fullscreen"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="fullscreen-0" value="0" label="&permission.alwaysAsk;"/>
                 <menuitem id="fullscreen-1" value="1" label="&permission.allow;"/>
                 <menuitem id="fullscreen-2" value="2" label="&permission.block;"/>
               </menupopup>
             </menulist>
+            <button id="fullscreen-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="fullscreen"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
           </hbox>
         </vbox>
       </hbox>      
@@ -327,13 +387,18 @@
             <menulist id="pointerLock-menulist"
                       class="pref-menulist"
                       type="pointerLock"
-                      oncommand="AboutPermissions.onPermissionCommand(event);">
+                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
               <menupopup>
                 <menuitem id="pointerLock-0" value="0" label="&permission.alwaysAsk;"/>
                 <menuitem id="pointerLock-1" value="1" label="&permission.allow;"/>
                 <menuitem id="pointerLock-2" value="2" label="&permission.block;"/>
               </menupopup>
             </menulist>
+            <button id="pointerLock-set-default"
+                    class="pref-set-default"
+                    label="&permission.default;"
+                    type="pointerLock"
+                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
           </hbox>
         </vbox>
       </hbox>

--- a/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
+++ b/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
@@ -19,7 +19,7 @@
 
 <!ENTITY permissions.forgetSite          "Forget About This Site">
 
-<!ENTITY permission.default              "Set a default value">
+<!ENTITY permission.default              "Use Default">
 
 <!ENTITY permission.alwaysAsk            "Always Ask">
 <!ENTITY permission.allow                "Allow">

--- a/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
+++ b/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
@@ -15,7 +15,11 @@
 
 <!ENTITY header.defaults                 "Default Permissions for All Sites">
 
+<!ENTITY permissions.sitesReload         "Reload list of sites">
+
 <!ENTITY permissions.forgetSite          "Forget About This Site">
+
+<!ENTITY permission.default              "Set a default value">
 
 <!ENTITY permission.alwaysAsk            "Always Ask">
 <!ENTITY permission.allow                "Allow">

--- a/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.properties
+++ b/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.properties
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # LOCALIZATION NOTE (permissionsConfirm): Confirm before any action.
-# See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
 permissionsConfirm=Are you sure you want to continue?
 
 # LOCALIZATION NOTE (visitCount): Semicolon-separated list of plural forms.

--- a/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.properties
+++ b/browser/locales/en-US/chrome/browser/preferences/aboutPermissions.properties
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# LOCALIZATION NOTE (permissionsConfirm): Confirm before any action.
+# See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
+permissionsConfirm=Are you sure you want to continue?
+
 # LOCALIZATION NOTE (visitCount): Semicolon-separated list of plural forms.
 # See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
 # #1 is the number of history visits for a site

--- a/browser/themes/linux/preferences/aboutPermissions.css
+++ b/browser/themes/linux/preferences/aboutPermissions.css
@@ -124,6 +124,11 @@
   padding-left: 0;
 }
 
+.pref-set-default {
+  font-size: 90%;
+  visibility: collapse;
+}
+
 .pref-menulist {
   margin-left: 6px;
   margin-right: 6px;

--- a/browser/themes/osx/preferences/aboutPermissions.css
+++ b/browser/themes/osx/preferences/aboutPermissions.css
@@ -127,6 +127,11 @@
   padding-left: 0;
 }
 
+.pref-set-default {
+  font-size: 90%;
+  visibility: collapse;
+}
+
 .pref-menulist {
   margin-left: 6px;
   margin-right: 6px;

--- a/browser/themes/windows/preferences/aboutPermissions.css
+++ b/browser/themes/windows/preferences/aboutPermissions.css
@@ -127,6 +127,11 @@
   padding-left: 0;
 }
 
+.pref-set-default {
+  font-size: 90%;
+  visibility: collapse;
+}
+
 .pref-menulist {
   margin-left: 6px;
   margin-right: 6px;

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1962,6 +1962,7 @@ pref("network.automatic-ntlm-auth.allow-non-fqdn", false);
 pref("network.automatic-ntlm-auth.trusted-uris", "");
 
 pref("permissions.default.image",           1); // 1-Accept, 2-Deny, 3-dontAcceptForeign
+pref("permissions.places-sites-limit",      50); // 0 - max. 100 - currently
 
 pref("network.proxy.type",                  5);
 pref("network.proxy.ftp",                   "");

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1962,7 +1962,6 @@ pref("network.automatic-ntlm-auth.allow-non-fqdn", false);
 pref("network.automatic-ntlm-auth.trusted-uris", "");
 
 pref("permissions.default.image",           1); // 1-Accept, 2-Deny, 3-dontAcceptForeign
-pref("permissions.places-sites-limit",      50); // 0 - max. 100 - currently
 
 pref("network.proxy.type",                  5);
 pref("network.proxy.ftp",                   "");


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/issues/823#issuecomment-294831241

> `about:permissions` does not allow to set the permission for site into "use default" state

Added a button.

> Once set using `about:permissions` the plugin state can't be cleared from the database the same way.

By "cleared" do you mean disabled? For global: I don't know how to do it better. See:
http://xref.palemoon.org/palemoon-trunk/search?string=.userDisabled&find=AddonManager.jsm

> `Forget About This Site` and `Remove [All] Cookies` buttons immediately remove the corresponding data without any warnings or confirmation dialogs.

It was added.

> `about:permissions` does not provide the filter to display only sites with modified permissions that could help to easily find the culprit in case of any problems.

Added configurable parameter (`about:config`): `permissions.places-sites-limit`.

> `about:permissions` does not allow to set the permission for site if target value equals current default.

> `pageinfo>permissions` has several mistakes in control logic which prevent to set specific permissions in case when global permissions for all sites differ from default values

__I don't have time to look at it just now...__

---

I've created the new build (x32, Windows) and tested.
