### PR TITLE
Cookies - sub1.example.com vs. sub2.sub1.example.com: Forget About site (+ improvements, follow up); Permissions (+ fix comments, follow up)

### DIFF
--- a/browser/components/places/content/controller.js
+++ b/browser/components/places/content/controller.js
@@ -228,7 +228,8 @@ PlacesController.prototype = {
       }
       else
         host = NetUtil.newURI(this._view.selectedNode.uri).host;
-      ForgetAboutSite.removeDataFromDomain(host);
+      ForgetAboutSite.removeDataFromDomain(host)
+                     .catch(Components.utils.reportError);
       break;
     case "cmd_selectAll":
       this.selectAll();

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -224,21 +224,19 @@ Site.prototype = {
   },
 
   /**
-   * Gets cookies stored for the site. This does not return cookies stored
-   * for the base domain, only the exact hostname stored for the site.
+   * Gets cookies stored for the site and base domain.
    *
-   * @return An array of the cookies set for the site.
+   * @return An array of the cookies set for the site and base domain.
    */
   get cookies() {
     let cookies = [];
-    let enumerator = Services.cookies.getCookiesFromHost(this.host);
+    let enumerator = Services.cookies.enumerator;
     while (enumerator.hasMoreElements()) {
       let cookie = enumerator.getNext().QueryInterface(Ci.nsICookie2);
-      // getCookiesFromHost returns cookies for base domain, but we only want
-      // the cookies for the exact domain.
-      // if (cookie.rawHost == this.host) {
+      if (cookie.host.hasRootDomain(
+          AboutPermissions.domainFromHost(this.host))) {
         cookies.push(cookie);
-      // }
+      }
     }
     return cookies;
   },
@@ -1269,7 +1267,7 @@ let AboutPermissions = {
   },
 
   /**
-   * Clears cookies for the selected site.
+   * Clears cookies for the selected site and base domain.
    */
   clearCookies: function() {
     if (!this._selectedSite) {

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -254,7 +254,8 @@ Site.prototype = {
    * Removes all data from the browser corresponding to the site.
    */
   forgetSite: function Site_forgetSite() {
-    ForgetAboutSite.removeDataFromDomain(this.host);
+    ForgetAboutSite.removeDataFromDomain(this.host)
+                   .catch(Cu.reportError);
   }
 }
 

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -818,36 +818,44 @@ let AboutPermissions = {
   getEnumerateServicesGenerator: function() {
     let itemCnt = 1;
 
-    let logins = Services.logins.getAllLogins();
-    logins.forEach(function(aLogin) {
-      if (itemCnt % this.LIST_BUILD_CHUNK == 0) {
-        yield true;
-      }
-      try {
-        // aLogin.hostname is a string in origin URL format
-        // (e.g. "http://foo.com").
-        let uri = NetUtil.newURI(aLogin.hostname);
-        this.addHost(uri.host);
-      } catch (e) {
-        // newURI will throw for add-ons logins stored in chrome:// URIs. 
-      }
-      itemCnt++;
-    }, this);
+    try {
+      let logins = Services.logins.getAllLogins();
+      logins.forEach(function(aLogin) {
+        if (itemCnt % this.LIST_BUILD_CHUNK == 0) {
+          yield true;
+        }
+        try {
+          // aLogin.hostname is a string in origin URL format
+          // (e.g. "http://foo.com").
+          let uri = NetUtil.newURI(aLogin.hostname);
+          this.addHost(uri.host);
+        } catch (e) {
+          // newURI will throw for add-ons logins stored in chrome:// URIs. 
+        }
+        itemCnt++;
+      }, this);
 
-    let disabledHosts = Services.logins.getAllDisabledHosts();
-    disabledHosts.forEach(function(aHostname) {
-      if (itemCnt % this.LIST_BUILD_CHUNK == 0) {
-        yield true;
+      let disabledHosts = Services.logins.getAllDisabledHosts();
+      disabledHosts.forEach(function(aHostname) {
+        if (itemCnt % this.LIST_BUILD_CHUNK == 0) {
+          yield true;
+        }
+        try {
+          // aHostname is a string in origin URL format (e.g. "http://foo.com").
+          let uri = NetUtil.newURI(aHostname);
+          this.addHost(uri.host);
+        } catch (e) {
+          // newURI will throw for add-ons logins stored in chrome:// URIs. 
+        }
+        itemCnt++;
+      }, this);
+    } catch (e) {
+      // XXX: is there a better way to do this rather than this
+      // hacky comparison?
+      if (e.message.indexOf("User canceled master password entry") == -1) {
+        Cu.reportError("AboutPermissions: " + e);
       }
-      try {
-        // aHostname is a string in origin URL format (e.g. "http://foo.com").
-        let uri = NetUtil.newURI(aHostname);
-        this.addHost(uri.host);
-      } catch (e) {
-        // newURI will throw for add-ons logins stored in chrome:// URIs. 
-      }
-      itemCnt++;
-    }, this);
+    }
 
     let enumerator = Services.perms.enumerator;
     while (enumerator.hasMoreElements()) {

--- a/browser/components/preferences/aboutPermissions.js
+++ b/browser/components/preferences/aboutPermissions.js
@@ -41,7 +41,9 @@ let gFlash = {
   type: "application/x-shockwave-flash",
 };
 
-// XXX: is there a better way to do this rather than this hacky comparison?
+// XXX:
+// Is there a better way to do this rather than this hacky comparison?
+// Copied this from toolkit/components/passwordmgr/crypto-SDR.js
 const MASTER_PASSWORD_MESSAGE = "User canceled master password entry";
 
 /**

--- a/dom/indexedDB/test/browser_forgetThisSite.js
+++ b/dom/indexedDB/test/browser_forgetThisSite.js
@@ -67,9 +67,10 @@ function test2()
 function test3()
 {
   // Remove database from domain 2
-  ForgetAboutSite.removeDataFromDomain(domains[1]);
-  setPermission(testPageURL4, "indexedDB");
-  executeSoon(test4);
+  ForgetAboutSite.removeDataFromDomain(domains[1]).then(() => {
+    setPermission(testPageURL4, "indexedDB");
+    executeSoon(test4);
+  });
 }
 
 function test4()

--- a/services/sync/tests/unit/test_service_login.js
+++ b/services/sync/tests/unit/test_service_login.js
@@ -206,7 +206,7 @@ add_test(function test_login_on_sync() {
     _("Old passphrase function is " + oldGetter);
     Service.identity.__defineGetter__("syncKey",
                            function() {
-                             throw "User canceled Master Password entry";
+                             throw "User canceled master password entry";
                            });
 
     let oldClearSyncTriggers = Service.scheduler.clearSyncTriggers;

--- a/services/sync/tests/unit/test_syncscheduler.js
+++ b/services/sync/tests/unit/test_syncscheduler.js
@@ -517,7 +517,7 @@ add_task(function test_autoconnect_mp_locked() {
   delete Service.identity.syncKey;
   Service.identity.__defineGetter__("syncKey", function() {
     _("Faking Master Password entry cancelation.");
-    throw "User canceled Master Password entry";
+    throw "User canceled master password entry";
   });
 
   let deferred = Promise.defer();

--- a/toolkit/forgetaboutsite/ForgetAboutSite.jsm
+++ b/toolkit/forgetaboutsite/ForgetAboutSite.jsm
@@ -200,8 +200,9 @@ this.ForgetAboutSite = {
         }
       }
     }).catch(ex => {
-      // XXXehsan: is there a better way to do this rather than this
-      // hacky comparison?
+      // XXX:
+      // Is there a better way to do this rather than this hacky comparison?
+      // Copied this from toolkit/components/passwordmgr/crypto-SDR.js
       if (!ex.message.includes("User canceled master password entry")) {
         throw new Error("Exception occured in clearing passwords: " + ex);
       }

--- a/toolkit/forgetaboutsite/ForgetAboutSite.jsm
+++ b/toolkit/forgetaboutsite/ForgetAboutSite.jsm
@@ -254,7 +254,7 @@ this.ForgetAboutSite = {
           // Notify other consumers, including extensions
           Services.obs.notifyObservers(null, "browser:purge-domain-data", aDomain);
           if (reason === cps2.COMPLETE_ERROR) {
-            throw new Error("Exception occured while clearing content preferences.");
+            throw new Error("Exception occured while clearing content preferences");
           }
         },
         handleError() {}

--- a/toolkit/forgetaboutsite/ForgetAboutSite.jsm
+++ b/toolkit/forgetaboutsite/ForgetAboutSite.jsm
@@ -21,16 +21,17 @@ this.EXPORTED_SYMBOLS = ["ForgetAboutSite"];
  * "mozilla.org", this will return true.  It would return false the other way
  * around.
  */
-function hasRootDomain(str, aDomain)
-{
+function hasRootDomain(str, aDomain) {
   let index = str.indexOf(aDomain);
   // If aDomain is not found, we know we do not have it as a root domain.
-  if (index == -1)
+  if (index == -1) {
     return false;
+  }
 
   // If the strings are the same, we obviously have a match.
-  if (str == aDomain)
+  if (str == aDomain) {
     return true;
+  }
 
   // Otherwise, we have aDomain as our root domain iff the index of aDomain is
   // aDomain.length subtracted from our length and (since we do not have an
@@ -45,198 +46,242 @@ const Ci = Components.interfaces;
 const Cu = Components.utils;
 
 this.ForgetAboutSite = {
-  removeDataFromDomain: function CRH_removeDataFromDomain(aDomain)
-  {
-    PlacesUtils.history.removePagesFromHost(aDomain, true);
+  removeDataFromDomain: Task.async(function* (aDomain) {
+    let promises = [];
+
+    // History
+    promises.push(Task.spawn(function*() {
+      PlacesUtils.history.removePagesFromHost(aDomain, true);
+    }).catch(ex => {
+      throw new Error("Exception thrown while clearing the history: " + ex);
+    }));
 
     // Cache
-    let cs = Cc["@mozilla.org/netwerk/cache-storage-service;1"].
-             getService(Ci.nsICacheStorageService);
-    // NOTE: there is no way to clear just that domain, so we clear out
-    //       everything)
-    try {
+    promises.push(Task.spawn(function*() {
+      let cs = Cc["@mozilla.org/netwerk/cache-storage-service;1"].
+               getService(Ci.nsICacheStorageService);
+      // NOTE: There is no way to clear just that domain, so we clear out
+      //       everything.
       cs.clear();
-    } catch (ex) {
-      Cu.reportError("Exception thrown while clearing the cache: " +
-        ex.toString());
-    }
+    }).catch(ex => {
+      throw new Error("Exception thrown while clearing the cache: " + ex);
+    }));
 
     // Image Cache
-    let imageCache = Cc["@mozilla.org/image/tools;1"].
-                     getService(Ci.imgITools).getImgCacheForDocument(null);
-    try {
+    promises.push(Task.spawn(function*() {
+      let imageCache = Cc["@mozilla.org/image/tools;1"].
+                       getService(Ci.imgITools).getImgCacheForDocument(null);
       imageCache.clearCache(false); // true=chrome, false=content
-    } catch (ex) {
-      Cu.reportError("Exception thrown while clearing the image cache: " +
-        ex.toString());
-    }
+    }).catch(ex => {
+      throw new Error("Exception thrown while clearing the image cache: " + ex);
+    }));
 
     // Cookies
-    let cm = Cc["@mozilla.org/cookiemanager;1"].
-             getService(Ci.nsICookieManager2);
-    let enumerator = cm.getCookiesFromHost(aDomain);
-    while (enumerator.hasMoreElements()) {
-      let cookie = enumerator.getNext().QueryInterface(Ci.nsICookie);
-      cm.remove(cookie.host, cookie.name, cookie.path, false);
-    }
+    // Need to maximize the number of cookies cleaned here
+    promises.push(Task.spawn(function*() {
+      let cm = Cc["@mozilla.org/cookiemanager;1"].
+               getService(Ci.nsICookieManager2);
+      let enumerator = cm.enumerator;
+      while (enumerator.hasMoreElements()) {
+        let cookie = enumerator.getNext().QueryInterface(Ci.nsICookie2);
+        if (hasRootDomain(cookie.host, aDomain)) {
+          cm.remove(cookie.host, cookie.name, cookie.path, false);
+        }
+      }
+    }).catch(ex => {
+      throw new Error("Exception thrown while clearing cookies: " + ex);
+    }));
 
     // EME
-    let mps = Cc["@mozilla.org/goanna-media-plugin-service;1"].
-               getService(Ci.mozIGoannaMediaPluginService);
-    mps.forgetThisSite(aDomain);
+    promises.push(Task.spawn(function*() {
+      let mps = Cc["@mozilla.org/goanna-media-plugin-service;1"].
+                getService(Ci.mozIGoannaMediaPluginService);
+      mps.forgetThisSite(aDomain);
+    }).catch(ex => {
+      throw new Error("Exception thrown while Encrypted Media Extensions: " + ex);
+    }));
 
     // Plugin data
     const phInterface = Ci.nsIPluginHost;
     const FLAG_CLEAR_ALL = phInterface.FLAG_CLEAR_ALL;
     let ph = Cc["@mozilla.org/plugin/host;1"].getService(phInterface);
     let tags = ph.getPluginTags();
-    let promises = [];
-    for (let i = 0; i < tags.length; i++) {
-      let promise = new Promise(resolve => {
-        let tag = tags[i];
+    for (let i = 0, iLen = tags.length; i < iLen; i++) {
+      promises.push(new Promise(resolve => {
         try {
-          ph.clearSiteData(tags[i], aDomain, FLAG_CLEAR_ALL, -1, function(rv) {
-            resolve();
-          });
-        } catch (e) {
-          // Ignore errors from the plugin, but resolve the promise
+          ph.clearSiteData(tags[i], aDomain, FLAG_CLEAR_ALL, -1, resolve);
+        } catch (ex) {
+          // Ignore exceptions from the plugin, but resolve the promise.
+          // We cannot check if something is a bailout or an exception.
           resolve();
         }
-      });
-      promises.push(promise);
+      }));
     }
 
     // Downloads
-    let useJSTransfer = false;
-    try {
-      // This method throws an exception if the old Download Manager is disabled.
-      Services.downloads.activeDownloadCount;
-    } catch (ex) {
-      useJSTransfer = true;
-    }
+    promises.push(Task.spawn(function*() {
+      let useJSTransfer = false;
+      try {
+        // This method throws an exception if the old Download Manager is disabled.
+        Services.downloads.activeDownloadCount;
+      } catch (ex) {
+        useJSTransfer = true;
+      }
 
-    if (useJSTransfer) {
-      Task.spawn(function*() {
+      if (useJSTransfer) {
         let list = yield Downloads.getList(Downloads.ALL);
         list.removeFinished(download => hasRootDomain(
              NetUtil.newURI(download.source.url).host, aDomain));
-      }).then(null, Cu.reportError);
-    }
-    else {
-      let dm = Cc["@mozilla.org/download-manager;1"].
-               getService(Ci.nsIDownloadManager);
-      // Active downloads
-      for (let enumerator of [dm.activeDownloads, dm.activePrivateDownloads]) {
-        while (enumerator.hasMoreElements()) {
-          let dl = enumerator.getNext().QueryInterface(Ci.nsIDownload);
-          if (hasRootDomain(dl.source.host, aDomain)) {
-            dl.cancel();
-            dl.remove();
+      } else {
+        let dm = Cc["@mozilla.org/download-manager;1"].
+                 getService(Ci.nsIDownloadManager);
+        // Active downloads
+        for (let enumerator of [dm.activeDownloads, dm.activePrivateDownloads]) {
+          while (enumerator.hasMoreElements()) {
+            let dl = enumerator.getNext().QueryInterface(Ci.nsIDownload);
+            if (hasRootDomain(dl.source.host, aDomain)) {
+              dl.cancel();
+              dl.remove();
+            }
           }
+
+          const deleteAllLike = function(db) {
+            // NOTE: This is lossy, but we feel that it is OK to be lossy here and not
+            //       invoke the cost of creating a URI for each download entry and
+            //       ensure that the hostname matches.
+            let stmt = db.createStatement(
+              "DELETE FROM moz_downloads " +
+              "WHERE source LIKE ?1 ESCAPE '/' " +
+              "AND state NOT IN (?2, ?3, ?4)"
+            );
+            let pattern = stmt.escapeStringForLIKE(aDomain, "/");
+            stmt.bindByIndex(0, "%" + pattern + "%");
+            stmt.bindByIndex(1, Ci.nsIDownloadManager.DOWNLOAD_DOWNLOADING);
+            stmt.bindByIndex(2, Ci.nsIDownloadManager.DOWNLOAD_PAUSED);
+            stmt.bindByIndex(3, Ci.nsIDownloadManager.DOWNLOAD_QUEUED);
+            try {
+              stmt.execute();
+            } finally {
+              stmt.finalize();
+            }
+          }
+
+          // Completed downloads
+          deleteAllLike(dm.DBConnection);
+          deleteAllLike(dm.privateDBConnection);
+
+          // We want to rebuild the list if the UI is showing, so dispatch the
+          // observer topic
+          let os = Cc["@mozilla.org/observer-service;1"].
+                   getService(Ci.nsIObserverService);
+          os.notifyObservers(null, "download-manager-remove-download", null);
         }
-
-        const deleteAllLike = function(db) {
-          // NOTE: This is lossy, but we feel that it is OK to be lossy here and not
-          //       invoke the cost of creating a URI for each download entry and
-          //       ensure that the hostname matches.
-          let stmt = db.createStatement(
-            "DELETE FROM moz_downloads " +
-            "WHERE source LIKE ?1 ESCAPE '/' " +
-            "AND state NOT IN (?2, ?3, ?4)"
-          );
-          let pattern = stmt.escapeStringForLIKE(aDomain, "/");
-          stmt.bindByIndex(0, "%" + pattern + "%");
-          stmt.bindByIndex(1, Ci.nsIDownloadManager.DOWNLOAD_DOWNLOADING);
-          stmt.bindByIndex(2, Ci.nsIDownloadManager.DOWNLOAD_PAUSED);
-          stmt.bindByIndex(3, Ci.nsIDownloadManager.DOWNLOAD_QUEUED);
-          try {
-            stmt.execute();
-          }
-          finally {
-            stmt.finalize();
-          }
-        }
-
-        // Completed downloads
-        deleteAllLike(dm.DBConnection);
-        deleteAllLike(dm.privateDBConnection);
-
-        // We want to rebuild the list if the UI is showing, so dispatch the
-        // observer topic
-        let os = Cc["@mozilla.org/observer-service;1"].
-                 getService(Ci.nsIObserverService);
-        os.notifyObservers(null, "download-manager-remove-download", null);
       }
-    }
+    }).catch(ex => {
+      throw new Error("Exception in clearing Downloads: " + ex);
+    }));
 
     // Passwords
-    let lm = Cc["@mozilla.org/login-manager;1"].
-             getService(Ci.nsILoginManager);
-    // Clear all passwords for domain
-    try {
+    promises.push(Task.spawn(function*() {
+      let lm = Cc["@mozilla.org/login-manager;1"].
+               getService(Ci.nsILoginManager);
+      // Clear all passwords for domain
       let logins = lm.getAllLogins();
-      for (let i = 0; i < logins.length; i++)
-        if (hasRootDomain(logins[i].hostname, aDomain))
+      for (let i = 0, iLen = logins.length; i < iLen; i++) {
+        if (hasRootDomain(logins[i].hostname, aDomain)) {
           lm.removeLogin(logins[i]);
-    }
-    // XXXehsan: is there a better way to do this rather than this
-    // hacky comparison?
-    catch (ex) {
-      if (ex.message.indexOf("User canceled Master Password entry") == -1) {
-        throw ex;
+        }
       }
-    }
-
-    // Clear any "do not save for this site" for this domain
-    let disabledHosts = lm.getAllDisabledHosts();
-    for (let i = 0; i < disabledHosts.length; i++)
-      if (hasRootDomain(disabledHosts[i], aDomain))
-        lm.setLoginSavingEnabled(disabledHosts, true);
+      // Clear any "do not save for this site" for this domain
+      let disabledHosts = lm.getAllDisabledHosts();
+      for (let i = 0, iLen = disabledHosts.length; i < iLen; i++) {
+        if (hasRootDomain(disabledHosts[i], aDomain)) {
+          lm.setLoginSavingEnabled(disabledHosts, true);
+        }
+      }
+    }).catch(ex => {
+      // XXXehsan: is there a better way to do this rather than this
+      // hacky comparison?
+      if (ex.message.indexOf("User canceled Master Password entry") == -1) {
+        throw new Error("Exception occured in clearing passwords: " + ex);
+      }
+    }));
 
     // Permissions
     let pm = Cc["@mozilla.org/permissionmanager;1"].
              getService(Ci.nsIPermissionManager);
     // Enumerate all of the permissions, and if one matches, remove it
-    enumerator = pm.enumerator;
+    let enumerator = pm.enumerator;
     while (enumerator.hasMoreElements()) {
       let perm = enumerator.getNext().QueryInterface(Ci.nsIPermission);
-      if (hasRootDomain(perm.host, aDomain))
-        pm.remove(perm.host, perm.type);
+      promises.push(new Promise((resolve, reject) => {
+        try {
+          if (hasRootDomain(perm.host, aDomain)) {
+            pm.remove(perm.host, perm.type);
+          }
+        } catch (ex) {
+          // Ignore entry
+        } finally {
+          resolve();
+        }
+      }));
     }
 
     // Offline Storages
-    let qm = Cc["@mozilla.org/dom/quota/manager;1"].
-             getService(Ci.nsIQuotaManager);
-    // delete data from both HTTP and HTTPS sites
-    let caUtils = {};
-    let scriptLoader = Cc["@mozilla.org/moz/jssubscript-loader;1"].
-                       getService(Ci.mozIJSSubScriptLoader);
-    scriptLoader.loadSubScript("chrome://global/content/contentAreaUtils.js",
-                               caUtils);
-    let httpURI = caUtils.makeURI("http://" + aDomain);
-    let httpsURI = caUtils.makeURI("https://" + aDomain);
-    qm.clearStoragesForURI(httpURI);
-    qm.clearStoragesForURI(httpsURI);
-
-    function onContentPrefsRemovalFinished() {
-      // Everybody else (including extensions)
-      Services.obs.notifyObservers(null, "browser:purge-domain-data", aDomain);
-    }
+    promises.push(Task.spawn(function*() {
+      let qm = Cc["@mozilla.org/dom/quota/manager;1"].
+               getService(Ci.nsIQuotaManager);
+      // delete data from both HTTP and HTTPS sites
+      let caUtils = {};
+      let scriptLoader = Cc["@mozilla.org/moz/jssubscript-loader;1"].
+                         getService(Ci.mozIJSSubScriptLoader);
+      scriptLoader.loadSubScript("chrome://global/content/contentAreaUtils.js",
+                                 caUtils);
+      let httpURI = caUtils.makeURI("http://" + aDomain);
+      let httpsURI = caUtils.makeURI("https://" + aDomain);
+      qm.clearStoragesForURI(httpURI);
+      qm.clearStoragesForURI(httpsURI);
+    }).catch(ex => {
+      throw new Error("Exception occured while clearing offline storages: " + ex);
+    }));
 
     // Content Preferences
-    let cps2 = Cc["@mozilla.org/content-pref/service;1"].
-               getService(Ci.nsIContentPrefService2);
-    cps2.removeBySubdomain(aDomain, null, {
-      handleCompletion: function() onContentPrefsRemovalFinished(),
-      handleError: function() {}
-    });
+    promises.push(Task.spawn(function*() {
+      let cps2 = Cc["@mozilla.org/content-pref/service;1"].
+                 getService(Ci.nsIContentPrefService2);
+      cps2.removeBySubdomain(aDomain, null, {
+        handleCompletion: (reason) => { 
+          // Notify other consumers, including extensions
+          Services.obs.notifyObservers(null, "browser:purge-domain-data", aDomain);
+          if (reason === cps2.COMPLETE_ERROR) {
+            throw new Error("Exception occured while clearing content preferences.");
+          }
+        },
+        handleError() {}
+      });
+    }));
 
     // Predictive network data - like cache, no way to clear this per
     // domain, so just trash it all
-    let np = Cc["@mozilla.org/network/predictor;1"].
-             getService(Ci.nsINetworkPredictor);
-    np.reset();
+    promises.push(Task.spawn(function*() {
+      let np = Cc["@mozilla.org/network/predictor;1"].
+               getService(Ci.nsINetworkPredictor);
+      np.reset();
+    }).catch(ex => {
+      throw new Error("Exception occured while clearing predictive network data: " + ex);
+    }));
 
-    return Promise.all(promises);
-  }
-};
+    let ErrorCount = 0;
+    for (let promise of promises) {
+      try {
+        yield promise;
+      } catch (ex) {
+        Cu.reportError(ex);
+        ErrorCount++;
+      }
+    }
+    if (ErrorCount !== 0) {
+      throw new Error(`There were a total of ${ErrorCount} errors during removal`);
+    }
+  })
+}

--- a/toolkit/forgetaboutsite/ForgetAboutSite.jsm
+++ b/toolkit/forgetaboutsite/ForgetAboutSite.jsm
@@ -202,7 +202,7 @@ this.ForgetAboutSite = {
     }).catch(ex => {
       // XXXehsan: is there a better way to do this rather than this
       // hacky comparison?
-      if (ex.message.indexOf("User canceled master password entry") == -1) {
+      if (!ex.message.includes("User canceled master password entry")) {
         throw new Error("Exception occured in clearing passwords: " + ex);
       }
     }));

--- a/toolkit/forgetaboutsite/ForgetAboutSite.jsm
+++ b/toolkit/forgetaboutsite/ForgetAboutSite.jsm
@@ -202,7 +202,7 @@ this.ForgetAboutSite = {
     }).catch(ex => {
       // XXXehsan: is there a better way to do this rather than this
       // hacky comparison?
-      if (ex.message.indexOf("User canceled Master Password entry") == -1) {
+      if (ex.message.indexOf("User canceled master password entry") == -1) {
         throw new Error("Exception occured in clearing passwords: " + ex);
       }
     }));

--- a/toolkit/forgetaboutsite/test/browser/browser_clearplugindata.js
+++ b/toolkit/forgetaboutsite/test/browser/browser_clearplugindata.js
@@ -37,73 +37,48 @@ function setTestPluginEnabledState(newEnabledState, plugin) {
   });
 }
 
-function test() {
-  waitForExplicitFinish();
-
+add_task(function* () {
   var tags = pluginHost.getPluginTags();
 
   // Find the test plugin
-  for (var i = 0; i < tags.length; i++)
-  {
-    if (tags[i].name == "Test Plug-in")
-    {
+  for (var i = 0; i < tags.length; i++) {
+    if (tags[i].name == "Test Plug-in") {
       pluginTag = tags[i];
     }
   }
   if (!pluginTag) {
     ok(false, "Test Plug-in not available, can't run test");
-    finish();
+    return;
   }
   setTestPluginEnabledState(Ci.nsIPluginTag.STATE_ENABLED, pluginTag);
+  yield BrowserTestUtils.openNewForegroundTab(gBrowser, testURL);
 
-  executeSoon(do_test);
-}
+  // Set data for the plugin after the page load.
+  yield ContentTask.spawn(gBrowser.selectedBrowser, null, function*() {
+    content.wrappedJSObject.testSteps();
+  });
 
-function setFinishedCallback(callback)
-{
-  let testPage = gBrowser.selectedBrowser.contentWindow.wrappedJSObject;
-  testPage.testFinishedCallback = function() {
-    setTimeout(function() {
-      info("got finished callback");
-      callback();
-    }, 0);
-  }
-}
+  ok(stored(["192.168.1.1", "foo.com", "nonexistent.foo.com", "bar.com", "localhost"]),
+    "Data stored for sites");
 
-function do_test()
-{
-  // Load page to set data for the plugin.
-  gBrowser.selectedTab = gBrowser.addTab();
-  gBrowser.selectedBrowser.addEventListener("load", function () {
-    gBrowser.selectedBrowser.removeEventListener("load", arguments.callee, true);
+  // Clear data for "foo.com" and its subdomains.
+  yield ForgetAboutSite.removeDataFromDomain("foo.com");
 
-    setFinishedCallback(function() {
-      ok(stored(["192.168.1.1","foo.com","nonexistent.foo.com","bar.com","localhost"]),
-        "Data stored for sites");
+  ok(stored(["bar.com", "192.168.1.1", "localhost"]), "Data stored for sites");
+  ok(!stored(["foo.com"]), "Data cleared for foo.com");
+  ok(!stored(["bar.foo.com"]), "Data cleared for subdomains of foo.com");
 
-      // Clear data for "foo.com" and its subdomains.
-      ForgetAboutSite.removeDataFromDomain("foo.com");
-      ok(stored(["bar.com","192.168.1.1","localhost"]), "Data stored for sites");
-      ok(!stored(["foo.com"]), "Data cleared for foo.com");
-      ok(!stored(["bar.foo.com"]), "Data cleared for subdomains of foo.com");
+    // Clear data for "bar.com" using a subdomain.
+  yield ForgetAboutSite.removeDataFromDomain("foo.bar.com");
+  ok(!stored(["bar.com"]), "Data cleared for bar.com");
 
-      // Clear data for "bar.com" using a subdomain.
-      ForgetAboutSite.removeDataFromDomain("foo.bar.com");
-      ok(!stored(["bar.com"]), "Data cleared for bar.com");
+  // Clear data for "192.168.1.1".
+  yield ForgetAboutSite.removeDataFromDomain("192.168.1.1");
+  ok(!stored(["192.168.1.1"]), "Data cleared for 192.168.1.1");
 
-      // Clear data for "192.168.1.1".
-      ForgetAboutSite.removeDataFromDomain("192.168.1.1");
-      ok(!stored(["192.168.1.1"]), "Data cleared for 192.168.1.1");
+  // Clear data for "localhost".
+  yield ForgetAboutSite.removeDataFromDomain("localhost");
+  ok(!stored(null), "All data cleared");
 
-      // Clear data for "localhost".
-      ForgetAboutSite.removeDataFromDomain("localhost");
-      ok(!stored(null), "All data cleared");
-
-      gBrowser.removeCurrentTab();
-
-      executeSoon(finish);
-    });
-  }, true);
-  content.location = testURL;
-}
-
+  gBrowser.removeCurrentTab();
+});

--- a/toolkit/forgetaboutsite/test/unit/test_removeDataFromDomain.js
+++ b/toolkit/forgetaboutsite/test/unit/test_removeDataFromDomain.js
@@ -322,33 +322,33 @@ function preference_exists(aURI)
 //// Test Functions
 
 // History
-function test_history_cleared_with_direct_match()
+function* test_history_cleared_with_direct_match()
 {
   const TEST_URI = uri("http://mozilla.org/foo");
   do_check_false(yield promiseIsURIVisited(TEST_URI));
   yield PlacesTestUtils.addVisits(TEST_URI);
   do_check_true(yield promiseIsURIVisited(TEST_URI));
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   do_check_false(yield promiseIsURIVisited(TEST_URI));
 }
 
-function test_history_cleared_with_subdomain()
+function* test_history_cleared_with_subdomain()
 {
   const TEST_URI = uri("http://www.mozilla.org/foo");
   do_check_false(yield promiseIsURIVisited(TEST_URI));
   yield PlacesTestUtils.addVisits(TEST_URI);
   do_check_true(yield promiseIsURIVisited(TEST_URI));
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   do_check_false(yield promiseIsURIVisited(TEST_URI));
 }
 
-function test_history_not_cleared_with_uri_contains_domain()
+function* test_history_not_cleared_with_uri_contains_domain()
 {
   const TEST_URI = uri("http://ilovemozilla.org/foo");
   do_check_false(yield promiseIsURIVisited(TEST_URI));
   yield PlacesTestUtils.addVisits(TEST_URI);
   do_check_true(yield promiseIsURIVisited(TEST_URI));
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   do_check_true(yield promiseIsURIVisited(TEST_URI));
 
   // Clear history since we left something there from this test.
@@ -356,32 +356,32 @@ function test_history_not_cleared_with_uri_contains_domain()
 }
 
 // Cookie Service
-function test_cookie_cleared_with_direct_match()
+function* test_cookie_cleared_with_direct_match()
 {
   const TEST_DOMAIN = "mozilla.org";
   add_cookie(TEST_DOMAIN);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_cookie_exists(TEST_DOMAIN, false);
 }
 
-function test_cookie_cleared_with_subdomain()
+function* test_cookie_cleared_with_subdomain()
 {
   const TEST_DOMAIN = "www.mozilla.org";
   add_cookie(TEST_DOMAIN);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_cookie_exists(TEST_DOMAIN, false);
 }
 
-function test_cookie_not_cleared_with_uri_contains_domain()
+function* test_cookie_not_cleared_with_uri_contains_domain()
 {
   const TEST_DOMAIN = "ilovemozilla.org";
   add_cookie(TEST_DOMAIN);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_cookie_exists(TEST_DOMAIN, true);
 }
 
 // Download Manager
-function test_download_history_cleared_with_direct_match()
+function* test_download_history_cleared_with_direct_match()
 {
   if (oldDownloadManagerDisabled()) {
     return;
@@ -389,11 +389,11 @@ function test_download_history_cleared_with_direct_match()
 
   const TEST_URI = "http://mozilla.org/foo";
   add_download(TEST_URI, false);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_downloaded(TEST_URI, false);
 }
 
-function test_download_history_cleared_with_subdomain()
+function* test_download_history_cleared_with_subdomain()
 {
   if (oldDownloadManagerDisabled()) {
     return;
@@ -401,11 +401,11 @@ function test_download_history_cleared_with_subdomain()
 
   const TEST_URI = "http://www.mozilla.org/foo";
   add_download(TEST_URI, false);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_downloaded(TEST_URI, false);
 }
 
-function test_download_history_not_cleared_with_active_direct_match()
+function* test_download_history_not_cleared_with_active_direct_match()
 {
   if (oldDownloadManagerDisabled()) {
     return;
@@ -414,7 +414,7 @@ function test_download_history_not_cleared_with_active_direct_match()
   // Tests that downloads marked as active in the db are not deleted from the db
   const TEST_URI = "http://mozilla.org/foo";
   add_download(TEST_URI, true);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_downloaded(TEST_URI, true);
 
   // Reset state
@@ -426,27 +426,27 @@ function test_download_history_not_cleared_with_active_direct_match()
 }
 
 // Login Manager
-function test_login_manager_disabled_hosts_cleared_with_direct_match()
+function* test_login_manager_disabled_hosts_cleared_with_direct_match()
 {
   const TEST_HOST = "http://mozilla.org";
   add_disabled_host(TEST_HOST);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_disabled_host(TEST_HOST, false);
 }
 
-function test_login_manager_disabled_hosts_cleared_with_subdomain()
+function* test_login_manager_disabled_hosts_cleared_with_subdomain()
 {
   const TEST_HOST = "http://www.mozilla.org";
   add_disabled_host(TEST_HOST);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_disabled_host(TEST_HOST, false);
 }
 
-function test_login_manager_disabled_hosts_not_cleared_with_uri_contains_domain()
+function* test_login_manager_disabled_hosts_not_cleared_with_uri_contains_domain()
 {
   const TEST_HOST = "http://ilovemozilla.org";
   add_disabled_host(TEST_HOST);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_disabled_host(TEST_HOST, true);
 
   // Reset state
@@ -456,19 +456,19 @@ function test_login_manager_disabled_hosts_not_cleared_with_uri_contains_domain(
   check_disabled_host(TEST_HOST, false);
 }
 
-function test_login_manager_logins_cleared_with_direct_match()
+function* test_login_manager_logins_cleared_with_direct_match()
 {
   const TEST_HOST = "http://mozilla.org";
   add_login(TEST_HOST);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_login_exists(TEST_HOST, false);
 }
 
-function test_login_manager_logins_cleared_with_subdomain()
+function* test_login_manager_logins_cleared_with_subdomain()
 {
   const TEST_HOST = "http://www.mozilla.org";
   add_login(TEST_HOST);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_login_exists(TEST_HOST, false);
 }
 
@@ -476,7 +476,7 @@ function tets_login_manager_logins_not_cleared_with_uri_contains_domain()
 {
   const TEST_HOST = "http://ilovemozilla.org";
   add_login(TEST_HOST);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_login_exists(TEST_HOST, true);
 
   let lm = Cc["@mozilla.org/login-manager;1"].
@@ -486,27 +486,27 @@ function tets_login_manager_logins_not_cleared_with_uri_contains_domain()
 }
 
 // Permission Manager
-function test_permission_manager_cleared_with_direct_match()
+function* test_permission_manager_cleared_with_direct_match()
 {
   const TEST_URI = uri("http://mozilla.org");
   add_permission(TEST_URI);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_permission_exists(TEST_URI, false);
 }
 
-function test_permission_manager_cleared_with_subdomain()
+function* test_permission_manager_cleared_with_subdomain()
 {
   const TEST_URI = uri("http://www.mozilla.org");
   add_permission(TEST_URI);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_permission_exists(TEST_URI, false);
 }
 
-function test_permission_manager_not_cleared_with_uri_contains_domain()
+function* test_permission_manager_not_cleared_with_uri_contains_domain()
 {
   const TEST_URI = uri("http://ilovemozilla.org");
   add_permission(TEST_URI);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   check_permission_exists(TEST_URI, true);
 
   // Reset state
@@ -537,46 +537,46 @@ function waitForPurgeNotification() {
 }
 
 // Content Preferences
-function test_content_preferences_cleared_with_direct_match()
+function* test_content_preferences_cleared_with_direct_match()
 {
   const TEST_URI = uri("http://mozilla.org");
   do_check_false(yield preference_exists(TEST_URI));
   yield add_preference(TEST_URI);
   do_check_true(yield preference_exists(TEST_URI));
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   yield waitForPurgeNotification();
   do_check_false(yield preference_exists(TEST_URI));
 }
 
-function test_content_preferences_cleared_with_subdomain()
+function* test_content_preferences_cleared_with_subdomain()
 {
   const TEST_URI = uri("http://www.mozilla.org");
   do_check_false(yield preference_exists(TEST_URI));
   yield add_preference(TEST_URI);
   do_check_true(yield preference_exists(TEST_URI));
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   yield waitForPurgeNotification();
   do_check_false(yield preference_exists(TEST_URI));
 }
 
-function test_content_preferences_not_cleared_with_uri_contains_domain()
+function* test_content_preferences_not_cleared_with_uri_contains_domain()
 {
   const TEST_URI = uri("http://ilovemozilla.org");
   do_check_false(yield preference_exists(TEST_URI));
   yield add_preference(TEST_URI);
   do_check_true(yield preference_exists(TEST_URI));
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   yield waitForPurgeNotification();
   do_check_true(yield preference_exists(TEST_URI));
 
   // Reset state
-  ForgetAboutSite.removeDataFromDomain("ilovemozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("ilovemozilla.org");
   yield waitForPurgeNotification();
   do_check_false(yield preference_exists(TEST_URI));
 }
 
 // Cache
-function test_cache_cleared()
+function* test_cache_cleared()
 {
   // Because this test is asynchronous, it should be the last test
   do_check_true(tests[tests.length - 1] == arguments.callee);
@@ -598,11 +598,11 @@ function test_cache_cleared()
     }
   };
   os.addObserver(observer, "cacheservice:empty-cache", false);
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   do_test_pending();
 }
 
-function test_storage_cleared()
+function* test_storage_cleared()
 {
   function getStorageForURI(aURI)
   {
@@ -628,7 +628,7 @@ function test_storage_cleared()
     do_check_eq(storage.getItem("test"), "value" + i);
   }
 
-  ForgetAboutSite.removeDataFromDomain("mozilla.org");
+  yield ForgetAboutSite.removeDataFromDomain("mozilla.org");
   yield waitForPurgeNotification();
 
   do_check_eq(s[0].getItem("test"), null);


### PR DESCRIPTION
## 1)

Ad https://forum.palemoon.org/viewtopic.php?f=50&p=112386#p112386

> The `getCookiesFromHost` method will only match `sub1.example.com` and `example.com` if aDomain = 
`sub1.example.com`. It will not match `sub2.sub1.example.com`.

## 2)
Ad https://github.com/MoonchildProductions/Pale-Moon/issues/579#issuecomment-257860811

> When I want to perform that command on a site that has a large number of entries (as shown on the screenshot; I chose CNN.com for this example) in the History menu, two things happen:
> - It only deletes one or a couple of entries instead of all of them.
> - The Forget About This Site and Delete This Page commands become unresponsive. When I try to apply them to any site in the History menu, they simply won't work.
>> I don't think it works as it should with 27b3. I just tried it on my desktop and on a portable x86 on my laptop and the issue is still there.

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1247201

---

## 3)

__3a)__
Fix Permissions - if the master password is set.

__3b)__
Follow up:
The indexOf() method is case sensitive!
`User canceled Master Password entry` !== `User canceled master password entry`

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1358772

---

I've created the new build (x32, Windows) and tested.
