### PR TITLE
[minor fix] If the master password is set, sometimes throws an error

### DIFF
--- a/toolkit/content/widgets/popup.xml
+++ b/toolkit/content/widgets/popup.xml
@@ -262,12 +262,13 @@
       <handler event="popupshowing"><![CDATA[
         // Capture the previous focus before has a chance to get set inside the panel
         try {
-          this._prevFocus = document.commandDispatcher.focusedElement;
-          if (this._prevFocus)
+          this._prevFocus = Components.utils
+                            .getWeakReference(document.commandDispatcher.focusedElement);
+          if (this._prevFocus.get())
             return;
         } catch (ex) { }
 
-        this._prevFocus = document.activeElement;
+        this._prevFocus = Components.utils.getWeakReference(document.activeElement);
       ]]></handler>
       <handler event="popupshown"><![CDATA[
         // Fire event for accessibility APIs
@@ -284,7 +285,7 @@
       ]]></handler>
       <handler event="popuphidden"><![CDATA[
         var currentFocus = this._currentFocus;
-        var prevFocus = this._prevFocus;
+        var prevFocus = this._prevFocus ? this._prevFocus.get() : null;
         this._currentFocus = null;
         this._prevFocus = null;
         if (prevFocus && currentFocus && this.getAttribute("norestorefocus") != "true") {


### PR DESCRIPTION
In Browser Console:
```
TypeError: can't access dead object
popup.xml:305:16
```

Steps to reproduce... I don't know the steps to reproduce the bug.

But see (Leaked nsFrameLoader which entrains nsInProcessTabChildGlobal):
https://bugzilla.mozilla.org/show_bug.cgi?id=1249226

---

I've created the new build (x32, Windows) and tested.
