### PR TITLE
Misc. media fixes

### DIFF
--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -477,8 +477,7 @@ void MediaDecoder::UpdateStreamBlockingForStateMachinePlaying()
     return;
   }
   bool blockForStateMachineNotPlaying =
-    mDecoderStateMachine && !mDecoderStateMachine->IsPlaying() &&
-    mDecoderStateMachine->GetState() != MediaDecoderStateMachine::DECODER_STATE_COMPLETED;
+    mDecoderStateMachine && !mDecoderStateMachine->IsPlaying();
   if (blockForStateMachineNotPlaying != mDecodedStream->mHaveBlockedForStateMachineNotPlaying) {
     mDecodedStream->mHaveBlockedForStateMachineNotPlaying = blockForStateMachineNotPlaying;
     int32_t delta = blockForStateMachineNotPlaying ? 1 : -1;

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -1051,6 +1051,17 @@ MediaDecoderStateMachine::OnVideoDecoded(VideoData* aVideoSample)
         StopPrerollingVideo();
       }
 
+      // Schedule the state machine to send stream data as soon as possible or
+      // the VideoQueue() is empty before the Push().
+      // VideoQueue() is empty implies the state machine thread doesn't have
+      // precise time information about video frames. Once the first video
+      // frame pushed in the queue, schedule the state machine as soon as
+      // possible to render the video frame or delay the state machine thread
+      // accurately.
+      if (mAudioCaptured || VideoQueue().GetSize() == 1) {
+        ScheduleStateMachine();
+      }
+
       // For non async readers, if the requested video sample was slow to
       // arrive, increase the amount of audio we buffer to ensure that we
       // don't run out of audio. This is unnecessary for async readers,
@@ -1069,11 +1080,6 @@ MediaDecoderStateMachine::OnVideoDecoded(VideoData* aVideoSample)
                                               mAmpleAudioThresholdUsecs);
         DECODER_LOG("Slow video decode, set mLowAudioThresholdUsecs=%lld mAmpleAudioThresholdUsecs=%lld",
                     mLowAudioThresholdUsecs, mAmpleAudioThresholdUsecs);
-      }
-
-      // Schedule the state machine to send stream data as soon as possible.
-      if (mAudioCaptured) {
-        ScheduleStateMachine();
       }
       return;
     }
@@ -2977,9 +2983,7 @@ void MediaDecoderStateMachine::AdvanceFrame()
     // Current frame has already been presented, wait until it's time to
     // present the next frame.
     if (frame && !currentFrame) {
-      int64_t now = IsPlaying() ? clock_time : mStartTime + mPlayDuration;
-
-      remainingTime = frame->mTime - now;
+      remainingTime = frame->mTime - clock_time;
     }
   }
 
@@ -3057,6 +3061,22 @@ void MediaDecoderStateMachine::AdvanceFrame()
     frameStats.NotifyPresentedFrame();
     remainingTime = currentFrame->GetEndTime() - clock_time;
     currentFrame = nullptr;
+  }
+
+  // The remainingTime is negative (include zero):
+  // 1. When the clock_time is larger than the latest video frame's endtime.
+  // All the video frames should be rendered or dropped, nothing left in
+  // VideoQueue. And since the VideoQueue is empty, we don't need to wake up
+  // statemachine thread immediately, so set the remainingTime to default value.
+  // 2. Current frame's endtime is smaller than clock_time but there still exist
+  // newer frames in queue. Re-calculate the remainingTime.
+  if (remainingTime <= 0) {
+    VideoData* nextFrame = VideoQueue().PeekFront();
+    if (nextFrame) {
+      remainingTime = nextFrame->mTime - clock_time;
+    } else {
+      remainingTime = AUDIO_DURATION_USECS;
+    }
   }
 
   int64_t delay = remainingTime / mPlaybackRate;

--- a/dom/media/mediasource/ResourceQueue.h
+++ b/dom/media/mediasource/ResourceQueue.h
@@ -123,6 +123,16 @@ public:
       SBR_DEBUG("item=%p length=%d offset=%llu",
                 item, item->mData->Length(), mOffset);
       if (item->mData->Length() + mOffset >= aOffset) {
+        if (aOffset <= mOffset) {
+          break;
+        }
+        uint32_t offset = aOffset - mOffset;
+        mOffset += offset;
+        evicted += offset;
+        nsRefPtr<MediaLargeByteBuffer> data = new MediaLargeByteBuffer;
+        data->AppendElements(item->mData->Elements() + offset,
+                             item->mData->Length() - offset);
+        item->mData = data;
         break;
       }
       mOffset += item->mData->Length();

--- a/media/libstagefright/binding/Adts.cpp
+++ b/media/libstagefright/binding/Adts.cpp
@@ -13,14 +13,14 @@ namespace mp4_demuxer
 {
 
 int8_t
-Adts::GetFrequencyIndex(uint16_t aSamplesPerSecond)
+Adts::GetFrequencyIndex(uint32_t aSamplesPerSecond)
 {
-  static const int freq_lookup[] = { 96000, 88200, 64000, 48000, 44100,
-                                     32000, 24000, 22050, 16000, 12000,
-                                     11025, 8000,  7350,  0 };
+  static const uint32_t freq_lookup[] = { 96000, 88200, 64000, 48000, 44100,
+                                          32000, 24000, 22050, 16000, 12000,
+                                          11025, 8000,  7350,  0 };
 
   int8_t i = 0;
-  while (aSamplesPerSecond < freq_lookup[i]) {
+  while (freq_lookup[i] && aSamplesPerSecond < freq_lookup[i]) {
     i++;
   }
 

--- a/media/libstagefright/binding/include/mp4_demuxer/Adts.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/Adts.h
@@ -17,7 +17,7 @@ namespace mp4_demuxer
 class Adts
 {
 public:
-  static int8_t GetFrequencyIndex(uint16_t aSamplesPerSecond);
+  static int8_t GetFrequencyIndex(uint32_t aSamplesPerSecond);
   static bool ConvertSample(uint16_t aChannelCount, int8_t aFrequencyIndex,
                             int8_t aProfile, mozilla::MediaRawData* aSample);
 };


### PR DESCRIPTION
This PR contains several small media fixes I came across while researching improving our MSE code. Changes:

Fixes a bug/prevents out-of-bounds memory access in libstagefright.
Makes small adjustment to improve A/V sync in some situations.
Fixes a small calculation bug in MediaDecoder::UpdateStreamBlockingForStateMachinePlaying().
Prevents a promise being disconnected prematurely if it is still waiting on calls from another thread (only affects MSE).
Fixes a data eviction issue that would leave MP4 + MSE streams unplayable or cause a stall when changing resolutions.

Tested on Linux and appears to be working as intended.