### PR TITLE
[minor fix] XMLHttpRequest: responseXML.referrer is set, expected empty string (+ minor fix: lastModified)

### DIFF
--- a/dom/base/nsIDocument.h
+++ b/dom/base/nsIDocument.h
@@ -308,6 +308,10 @@ public:
     return GetReferrerPolicy();
   }
 
+  void SetReferrer(const nsACString& aReferrer) {
+    mReferrer = aReferrer;
+  }
+
   /**
    * Set the principal responsible for this document.
    */

--- a/dom/base/nsXMLHttpRequest.cpp
+++ b/dom/base/nsXMLHttpRequest.cpp
@@ -2194,6 +2194,9 @@ nsXMLHttpRequest::OnStartRequest(nsIRequest *request, nsISupports *ctxt)
                                          !(mState & XML_HTTP_REQUEST_USE_XSITE_AC));
     NS_ENSURE_SUCCESS(rv, rv);
 
+    // the spec requires the response document.referrer to be the empty string
+    mResponseXML->SetReferrer(NS_LITERAL_CSTRING(""));
+
     mXMLParserStreamListener = listener;
     rv = mXMLParserStreamListener->OnStartRequest(request, ctxt);
     NS_ENSURE_SUCCESS(rv, rv);

--- a/testing/web-platform/meta/XMLHttpRequest/responsexml-document-properties.htm.ini
+++ b/testing/web-platform/meta/XMLHttpRequest/responsexml-document-properties.htm.ini
@@ -1,12 +1,6 @@
 [responsexml-document-properties.htm]
   type: testharness
-  [referrer]
-    expected: FAIL
-
   [cookie]
-    expected: FAIL
-
-  [lastModified set according to HTTP header]
     expected: FAIL
 
   [cookie (after setting it)]

--- a/testing/web-platform/tests/XMLHttpRequest/resources/last-modified.py
+++ b/testing/web-platform/tests/XMLHttpRequest/resources/last-modified.py
@@ -1,0 +1,7 @@
+def main(request, response):
+    import datetime, os
+    srcpath = os.path.join(os.path.dirname(__file__), "well-formed.xml")
+    srcmoddt = datetime.datetime.fromtimestamp(os.path.getmtime(srcpath))
+    response.headers.set("Last-Modified", srcmoddt.strftime("%a, %d %b %Y %H:%M:%S GMT"))
+    response.headers.set("Content-Type", "application/xml")
+    return open(srcpath).read()

--- a/testing/web-platform/tests/XMLHttpRequest/responsexml-document-properties.htm
+++ b/testing/web-platform/tests/XMLHttpRequest/responsexml-document-properties.htm
@@ -10,6 +10,7 @@
   <body>
     <div id="log"></div>
     <script>
+      var timePreXHR = Math.floor(new Date().getTime() / 1000);
       var client = new XMLHttpRequest()
       client.open("GET", "resources/well-formed.xml", false)
       client.send(null)
@@ -43,8 +44,18 @@
       }
 
       test(function() {
-        assert_equals((new Date(client.getResponseHeader('Last-Modified'))).getTime(), (new Date(client.responseXML.lastModified)).getTime()) 
-      }, 'lastModified set according to HTTP header')
+        var lastModified = Math.floor(new Date(client.responseXML.lastModified).getTime() / 1000);
+        var now = Math.floor(new Date().getTime() / 1000);
+        assert_greater_than_equal(lastModified, timePreXHR);
+        assert_less_than_equal(lastModified, now);
+      }, 'lastModified set to time of response if no HTTP header provided')
+
+      test(function() {
+        var client2 = new XMLHttpRequest()
+        client2.open("GET", "resources/last-modified.py", false)
+        client2.send(null)
+        assert_equals((new Date(client2.getResponseHeader('Last-Modified'))).getTime(), (new Date(client2.responseXML.lastModified)).getTime())
+      }, 'lastModified set to related HTTP header if provided')
 
       test(function() {
         client.responseXML.cookie = "thisshouldbeignored"


### PR DESCRIPTION
responseXML.referrer is set, expected empty string

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=918773

A test case:
https://w3c-test.org/XMLHttpRequest/responsexml-document-properties.htm

\+ minor fix - see:
https://bugzilla.mozilla.org/show_bug.cgi?id=1280454

---

I've created the new build (x32, Windows) and tested.
