### PR TITLE
[suggestion, minor fix] Plugins - A problem - CSS (Ask to Activate)

### DIFF
--- a/toolkit/mozapps/plugins/content/pluginProblemContent.css
+++ b/toolkit/mozapps/plugins/content/pluginProblemContent.css
@@ -111,6 +111,10 @@ html|applet:not([height]), html|applet[height=""] {
 :-moz-handler-blocked .msgBlocked,
 :-moz-handler-crashed .msgCrashed {
   display: block;
+  position: relative;
+  left: 0;
+  top: 0;
+  z-index: 9999;
 }
 
 .submitStatus[status] {


### PR DESCRIPTION
A non-clickable link:
![0](https://cloud.githubusercontent.com/assets/2373486/25581157/53a706de-2e86-11e7-9964-e221e740ba00.png)

vs.

A clickable link:
![1](https://cloud.githubusercontent.com/assets/2373486/25581164/5af91a94-2e86-11e7-8777-be61bf227c0b.png)

...when "something" overlaps it.

If `Adobe Flash` == `Ask to Activate` - an example:
http://www1.wdr.de/fernsehen/tiere-suchen-ein-zuhause/sendungen/uebersicht-tiere-suchen-ein-zuhause-230.html

---

I've created the new build (x32, Windows) and tested.
