### PR TITLE
Implement Completion MediaPromises and MediaPromise::All

### DIFF
--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -1319,7 +1319,7 @@ void MediaDecoder::ApplyStateToStateMachine(PlayState aState)
         mSeekRequest.Begin(ProxyMediaCall(mDecoderStateMachine->TaskQueue(),
                                           mDecoderStateMachine.get(), __func__,
                                           &MediaDecoderStateMachine::Seek, mRequestedSeekTarget)
-          ->RefableThen(AbstractThread::MainThread(), __func__, this,
+          ->Then(AbstractThread::MainThread(), __func__, this,
                         &MediaDecoder::OnSeekResolved, &MediaDecoder::OnSeekRejected));
         mRequestedSeekTarget.Reset();
         break;

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -1147,7 +1147,7 @@ protected:
   // been requested. When a seek is started this is reset to invalid.
   SeekTarget mRequestedSeekTarget;
 
-  MediaPromiseConsumerHolder<SeekPromise> mSeekRequest;
+  MediaPromiseRequestHolder<SeekPromise> mSeekRequest;
 
   // True when seeking or otherwise moving the play position around in
   // such a manner that progress event data is inaccurate. This is set

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -936,16 +936,16 @@ MediaDecoderStateMachine::OnNotDecoded(MediaData::Type aType,
     nsRefPtr<MediaDecoderStateMachine> self = this;
     WaitRequestRef(aType).Begin(ProxyMediaCall(DecodeTaskQueue(), mReader.get(), __func__,
                                                &MediaDecoderReader::WaitForData, aType)
-      ->RefableThen(TaskQueue(), __func__,
-                    [self] (MediaData::Type aType) -> void {
-                      ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
-                      self->WaitRequestRef(aType).Complete();
-                      self->DispatchDecodeTasksIfNeeded();
-                    },
-                    [self] (WaitForDataRejectValue aRejection) -> void {
-                      ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
-                      self->WaitRequestRef(aRejection.mType).Complete();
-                    }));
+      ->Then(TaskQueue(), __func__,
+              [self] (MediaData::Type aType) -> void {
+                ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
+                self->WaitRequestRef(aType).Complete();
+                self->DispatchDecodeTasksIfNeeded();
+              },
+              [self] (WaitForDataRejectValue aRejection) -> void {
+                ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
+                self->WaitRequestRef(aRejection.mType).Complete();
+              }));
     return;
   }
 
@@ -1910,20 +1910,20 @@ MediaDecoderStateMachine::InitiateSeek()
   mSeekRequest.Begin(ProxyMediaCall(DecodeTaskQueue(), mReader.get(), __func__,
                                     &MediaDecoderReader::Seek, mCurrentSeek.mTarget.mTime,
                                     GetEndTime())
-    ->RefableThen(TaskQueue(), __func__,
-                  [self] (int64_t) -> void {
-                    ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
-                    self->mSeekRequest.Complete();
-                    // We must decode the first samples of active streams, so we can determine
-                    // the new stream time. So dispatch tasks to do that.
-                    self->mDecodeToSeekTarget = true;
-                    self->DispatchDecodeTasksIfNeeded();
-                  }, [self] (nsresult aResult) -> void {
-                    ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
-                    self->mSeekRequest.Complete();
-                    MOZ_ASSERT(NS_FAILED(aResult), "Cancels should also disconnect mSeekRequest");
-                    self->DecodeError();
-                  }));
+    ->Then(TaskQueue(), __func__,
+           [self] (int64_t) -> void {
+             ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
+             self->mSeekRequest.Complete();
+             // We must decode the first samples of active streams, so we can determine
+             // the new stream time. So dispatch tasks to do that.
+             self->mDecodeToSeekTarget = true;
+             self->DispatchDecodeTasksIfNeeded();
+           }, [self] (nsresult aResult) -> void {
+             ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
+             self->mSeekRequest.Complete();
+             MOZ_ASSERT(NS_FAILED(aResult), "Cancels should also disconnect mSeekRequest");
+             self->DecodeError();
+           }));
 }
 
 nsresult
@@ -1969,9 +1969,9 @@ MediaDecoderStateMachine::EnsureAudioDecodeTaskQueued()
 
   mAudioDataRequest.Begin(ProxyMediaCall(DecodeTaskQueue(), mReader.get(),
                                          __func__, &MediaDecoderReader::RequestAudioData)
-    ->RefableThen(TaskQueue(), __func__, this,
-                  &MediaDecoderStateMachine::OnAudioDecoded,
-                  &MediaDecoderStateMachine::OnAudioNotDecoded));
+    ->Then(TaskQueue(), __func__, this,
+           &MediaDecoderStateMachine::OnAudioDecoded,
+           &MediaDecoderStateMachine::OnAudioNotDecoded));
 
   return NS_OK;
 }
@@ -2029,9 +2029,9 @@ MediaDecoderStateMachine::EnsureVideoDecodeTaskQueued()
   mVideoDataRequest.Begin(ProxyMediaCall(DecodeTaskQueue(), mReader.get(), __func__,
                                          &MediaDecoderReader::RequestVideoData,
                                          skipToNextKeyFrame, currentTime)
-    ->RefableThen(TaskQueue(), __func__, this,
-                  &MediaDecoderStateMachine::OnVideoDecoded,
-                  &MediaDecoderStateMachine::OnVideoNotDecoded));
+    ->Then(TaskQueue(), __func__, this,
+           &MediaDecoderStateMachine::OnVideoDecoded,
+           &MediaDecoderStateMachine::OnVideoNotDecoded));
   return NS_OK;
 }
 
@@ -2317,18 +2317,18 @@ MediaDecoderStateMachine::DecodeFirstFrame()
     if (HasAudio()) {
       mAudioDataRequest.Begin(ProxyMediaCall(DecodeTaskQueue(), mReader.get(),
                                              __func__, &MediaDecoderReader::RequestAudioData)
-        ->RefableThen(TaskQueue(), __func__, this,
-                      &MediaDecoderStateMachine::OnAudioDecoded,
-                      &MediaDecoderStateMachine::OnAudioNotDecoded));
+        ->Then(TaskQueue(), __func__, this,
+               &MediaDecoderStateMachine::OnAudioDecoded,
+               &MediaDecoderStateMachine::OnAudioNotDecoded));
     }
     if (HasVideo()) {
       mVideoDecodeStartTime = TimeStamp::Now();
       mVideoDataRequest.Begin(ProxyMediaCall(DecodeTaskQueue(), mReader.get(),
                                              __func__, &MediaDecoderReader::RequestVideoData, false,
                                              int64_t(0))
-        ->RefableThen(TaskQueue(), __func__, this,
-                      &MediaDecoderStateMachine::OnVideoDecoded,
-                      &MediaDecoderStateMachine::OnVideoNotDecoded));
+        ->Then(TaskQueue(), __func__, this,
+               &MediaDecoderStateMachine::OnVideoDecoded,
+               &MediaDecoderStateMachine::OnVideoNotDecoded));
     }
   }
 
@@ -2637,9 +2637,9 @@ nsresult MediaDecoderStateMachine::RunStateMachine()
         DECODER_LOG("Dispatching AsyncReadMetadata");
         mMetadataRequest.Begin(ProxyMediaCall(DecodeTaskQueue(), mReader.get(), __func__,
                                               &MediaDecoderReader::AsyncReadMetadata)
-          ->RefableThen(TaskQueue(), __func__, this,
-                        &MediaDecoderStateMachine::OnMetadataRead,
-                        &MediaDecoderStateMachine::OnMetadataNotRead));
+          ->Then(TaskQueue(), __func__, this,
+                 &MediaDecoderStateMachine::OnMetadataRead,
+                 &MediaDecoderStateMachine::OnMetadataNotRead));
       }
       return NS_OK;
     }

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -827,7 +827,7 @@ public:
         }
         Reset();
         mTarget = aTarget;
-        mRequest.Begin(mMediaTimer->WaitUntil(mTarget, __func__)->RefableThen(
+        mRequest.Begin(mMediaTimer->WaitUntil(mTarget, __func__)->Then(
           mSelf->TaskQueue(), __func__, mSelf,
           &MediaDecoderStateMachine::OnDelayedSchedule,
           &MediaDecoderStateMachine::NotReached));

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -842,7 +842,7 @@ public:
   private:
     MediaDecoderStateMachine* mSelf;
     nsRefPtr<MediaTimer> mMediaTimer;
-    MediaPromiseConsumerHolder<mozilla::MediaTimerPromise> mRequest;
+    MediaPromiseRequestHolder<mozilla::MediaTimerPromise> mRequest;
     TimeStamp mTarget;
 
   } mDelayedScheduler;
@@ -1143,8 +1143,8 @@ protected:
   // Only one of a given pair of ({Audio,Video}DataPromise, WaitForDataPromise)
   // should exist at any given moment.
 
-  MediaPromiseConsumerHolder<MediaDecoderReader::AudioDataPromise> mAudioDataRequest;
-  MediaPromiseConsumerHolder<MediaDecoderReader::WaitForDataPromise> mAudioWaitRequest;
+  MediaPromiseRequestHolder<MediaDecoderReader::AudioDataPromise> mAudioDataRequest;
+  MediaPromiseRequestHolder<MediaDecoderReader::WaitForDataPromise> mAudioWaitRequest;
   const char* AudioRequestStatus()
   {
     if (mAudioDataRequest.Exists()) {
@@ -1156,8 +1156,8 @@ protected:
     return "idle";
   }
 
-  MediaPromiseConsumerHolder<MediaDecoderReader::WaitForDataPromise> mVideoWaitRequest;
-  MediaPromiseConsumerHolder<MediaDecoderReader::VideoDataPromise> mVideoDataRequest;
+  MediaPromiseRequestHolder<MediaDecoderReader::WaitForDataPromise> mVideoWaitRequest;
+  MediaPromiseRequestHolder<MediaDecoderReader::VideoDataPromise> mVideoDataRequest;
   const char* VideoRequestStatus()
   {
     if (mVideoDataRequest.Exists()) {
@@ -1169,7 +1169,7 @@ protected:
     return "idle";
   }
 
-  MediaPromiseConsumerHolder<MediaDecoderReader::WaitForDataPromise>& WaitRequestRef(MediaData::Type aType)
+  MediaPromiseRequestHolder<MediaDecoderReader::WaitForDataPromise>& WaitRequestRef(MediaData::Type aType)
   {
     return aType == MediaData::AUDIO_DATA ? mAudioWaitRequest : mVideoWaitRequest;
   }
@@ -1244,7 +1244,7 @@ protected:
   bool mDecodeToSeekTarget;
 
   // Track the current seek promise made by the reader.
-  MediaPromiseConsumerHolder<MediaDecoderReader::SeekPromise> mSeekRequest;
+  MediaPromiseRequestHolder<MediaDecoderReader::SeekPromise> mSeekRequest;
 
   // We record the playback position before we seek in order to
   // determine where the seek terminated relative to the playback position
@@ -1252,7 +1252,7 @@ protected:
   int64_t mCurrentTimeBeforeSeek;
 
   // Track our request for metadata from the reader.
-  MediaPromiseConsumerHolder<MediaDecoderReader::MetadataPromise> mMetadataRequest;
+  MediaPromiseRequestHolder<MediaDecoderReader::MetadataPromise> mMetadataRequest;
 
   // Stores presentation info required for playback. The decoder monitor
   // must be held when accessing this.

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -237,10 +237,10 @@ MediaFormatReader::AsyncReadMetadata()
   nsRefPtr<MetadataPromise> p = mMetadataPromise.Ensure(__func__);
 
   mDemuxerInitRequest.Begin(mDemuxer->Init()
-                       ->RefableThen(GetTaskQueue(), __func__,
-                                     this,
-                                     &MediaFormatReader::OnDemuxerInitDone,
-                                     &MediaFormatReader::OnDemuxerInitFailed));
+                       ->Then(GetTaskQueue(), __func__,
+                              this,
+                              &MediaFormatReader::OnDemuxerInitDone,
+                              &MediaFormatReader::OnDemuxerInitFailed));
   return p;
 }
 
@@ -536,9 +536,9 @@ MediaFormatReader::DoDemuxVideo()
 {
   // TODO Use DecodeAhead value rather than 1.
   mVideo.mDemuxRequest.Begin(mVideo.mTrackDemuxer->GetSamples(1)
-                      ->RefableThen(GetTaskQueue(), __func__, this,
-                                    &MediaFormatReader::OnVideoDemuxCompleted,
-                                    &MediaFormatReader::OnVideoDemuxFailed));
+                      ->Then(GetTaskQueue(), __func__, this,
+                             &MediaFormatReader::OnVideoDemuxCompleted,
+                             &MediaFormatReader::OnVideoDemuxFailed));
 }
 
 void
@@ -591,9 +591,9 @@ MediaFormatReader::DoDemuxAudio()
 {
   // TODO Use DecodeAhead value rather than 1.
   mAudio.mDemuxRequest.Begin(mAudio.mTrackDemuxer->GetSamples(1)
-                      ->RefableThen(GetTaskQueue(), __func__, this,
-                                    &MediaFormatReader::OnAudioDemuxCompleted,
-                                    &MediaFormatReader::OnAudioDemuxFailed));
+                      ->Then(GetTaskQueue(), __func__, this,
+                             &MediaFormatReader::OnAudioDemuxCompleted,
+                             &MediaFormatReader::OnAudioDemuxFailed));
 }
 
 void
@@ -1043,9 +1043,9 @@ MediaFormatReader::SkipVideoDemuxToNextKeyFrame(media::TimeUnit aTimeThreshold)
   }
 
   mSkipRequest.Begin(mVideo.mTrackDemuxer->SkipToNextRandomAccessPoint(aTimeThreshold)
-                          ->RefableThen(GetTaskQueue(), __func__, this,
-                                        &MediaFormatReader::OnVideoSkipCompleted,
-                                        &MediaFormatReader::OnVideoSkipFailed));
+                          ->Then(GetTaskQueue(), __func__, this,
+                                 &MediaFormatReader::OnVideoSkipCompleted,
+                                 &MediaFormatReader::OnVideoSkipFailed));
   return;
 }
 
@@ -1143,9 +1143,9 @@ MediaFormatReader::DoVideoSeek()
   MOZ_ASSERT(mPendingSeekTime.isSome());
   media::TimeUnit seekTime = mPendingSeekTime.ref();
   mVideoSeekRequest.Begin(mVideo.mTrackDemuxer->Seek(seekTime)
-                          ->RefableThen(GetTaskQueue(), __func__, this,
-                                        &MediaFormatReader::OnVideoSeekCompleted,
-                                        &MediaFormatReader::OnVideoSeekFailed));
+                          ->Then(GetTaskQueue(), __func__, this,
+                                 &MediaFormatReader::OnVideoSeekCompleted,
+                                 &MediaFormatReader::OnVideoSeekFailed));
 }
 
 void
@@ -1169,9 +1169,9 @@ MediaFormatReader::DoAudioSeek()
   MOZ_ASSERT(mPendingSeekTime.isSome());
   media::TimeUnit seekTime = mPendingSeekTime.ref();
   mAudioSeekRequest.Begin(mAudio.mTrackDemuxer->Seek(seekTime)
-                         ->RefableThen(GetTaskQueue(), __func__, this,
-                                       &MediaFormatReader::OnAudioSeekCompleted,
-                                       &MediaFormatReader::OnAudioSeekFailed));
+                         ->Then(GetTaskQueue(), __func__, this,
+                                &MediaFormatReader::OnAudioSeekCompleted,
+                                &MediaFormatReader::OnAudioSeekFailed));
 }
 
 void

--- a/dom/media/MediaFormatReader.h
+++ b/dom/media/MediaFormatReader.h
@@ -231,7 +231,7 @@ private:
 
     // Queued demux samples waiting to be decoded.
     nsTArray<nsRefPtr<MediaRawData>> mQueuedSamples;
-    MediaPromiseConsumerHolder<MediaTrackDemuxer::SamplesPromise> mDemuxRequest;
+    MediaPromiseRequestHolder<MediaTrackDemuxer::SamplesPromise> mDemuxRequest;
     MediaPromiseHolder<WaitForDataPromise> mWaitingPromise;
 
     bool HasWaitingPromise()
@@ -324,7 +324,7 @@ private:
   // Demuxer objects.
   void OnDemuxerInitDone(nsresult);
   void OnDemuxerInitFailed(DemuxerFailureReason aFailure);
-  MediaPromiseConsumerHolder<MediaDataDemuxer::InitPromise> mDemuxerInitRequest;
+  MediaPromiseRequestHolder<MediaDataDemuxer::InitPromise> mDemuxerInitRequest;
   void OnDemuxFailed(TrackType aTrack, DemuxerFailureReason aFailure);
 
   void DoDemuxVideo();
@@ -342,7 +342,7 @@ private:
   }
 
   void SkipVideoDemuxToNextKeyFrame(media::TimeUnit aTimeThreshold);
-  MediaPromiseConsumerHolder<MediaTrackDemuxer::SkipAccessPointPromise> mSkipRequest;
+  MediaPromiseRequestHolder<MediaTrackDemuxer::SkipAccessPointPromise> mSkipRequest;
   void OnVideoSkipCompleted(uint32_t aSkipped);
   void OnVideoSkipFailed(MediaTrackDemuxer::SkipFailureHolder aFailure);
 
@@ -390,8 +390,8 @@ private:
   }
   // Temporary seek information while we wait for the data
   Maybe<media::TimeUnit> mPendingSeekTime;
-  MediaPromiseConsumerHolder<MediaTrackDemuxer::SeekPromise> mVideoSeekRequest;
-  MediaPromiseConsumerHolder<MediaTrackDemuxer::SeekPromise> mAudioSeekRequest;
+  MediaPromiseRequestHolder<MediaTrackDemuxer::SeekPromise> mVideoSeekRequest;
+  MediaPromiseRequestHolder<MediaTrackDemuxer::SeekPromise> mAudioSeekRequest;
   MediaPromiseHolder<SeekPromise> mSeekPromise;
 
   nsRefPtr<SharedDecoderManager> mSharedDecoderManager;

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -42,9 +42,18 @@ extern PRLogModuleInfo* gMediaPromiseLog;
  * When IsExclusive is true, the MediaPromise does a release-mode assertion that
  * there is at most one call to either Then(...) or ChainTo(...).
  */
+
+class MediaPromiseBase
+{
+public:
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(MediaPromiseBase)
+protected:
+  virtual ~MediaPromiseBase() {}
+};
+
 template<typename T> class MediaPromiseHolder;
 template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class MediaPromise
+class MediaPromise : public MediaPromiseBase
 {
 public:
   typedef ResolveValueT ResolveValueType;
@@ -74,8 +83,6 @@ public:
     Maybe<ResolveValueType> mResolveValue;
     Maybe<RejectValueType> mRejectValue;
   };
-
-  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(MediaPromise)
 
 protected:
   // MediaPromise is the public type, and never constructed directly. Construct
@@ -432,7 +439,7 @@ protected:
     }
   }
 
-  ~MediaPromise()
+  virtual ~MediaPromise()
   {
     PROMISE_LOG("MediaPromise::~MediaPromise [this=%p]", this);
     MOZ_ASSERT(!IsPending());

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -75,6 +75,33 @@ struct ReturnTypeIs {
  * callbacks to be invoked (asynchronously, on a specified thread) when the
  * request is either completed (resolved) or cannot be completed (rejected).
  *
+ * MediaPromises attempt to mirror the spirit of JS Promises to the extent that
+ * is possible (and desirable) in C++. While the intent is that MediaPromises
+ * feel familiar to programmers who are accustomed to their JS-implemented cousin,
+ * we don't shy away from imposing restrictions and adding features that make
+ * sense for the use cases we encounter.
+ *
+ * A MediaPromise is ThreadSafe, and may be ->Then()ed on any thread. The Then()
+ * call accepts resolve and reject callbacks, and returns a MediaPromise::Request.
+ * The Request object serves several purposes for the consumer.
+ *
+ *   (1) It allows the caller to cancel the delivery of the resolve/reject value
+ *       if it has not already occurred, via Disconnect() (this must be done on
+ *       the target thread to avoid racing).
+ *
+ *   (2) It provides access to a "Completion Promise", which is roughly analogous
+ *       to the Promise returned directly by ->then() calls on JS promises. If
+ *       the resolve/reject callback returns a new MediaPromise, that promise is
+ *       chained to the completion promise, such that its resolve/reject value
+ *       will be forwarded along when it arrives. If the resolve/reject callback
+ *       returns void, the completion promise is resolved/rejected with the same
+ *       value that was passed to the callback.
+ *
+ * The MediaPromise APIs skirt traditional XPCOM convention by returning nsRefPtrs
+ * (rather than already_AddRefed) from various methods. This is done to allow elegant
+ * chaining of calls without cluttering up the code with intermediate variables, and
+ * without introducing separate API variants for callers that want a return value
+ * (from, say, ->Then()) from those that don't.
  * When IsExclusive is true, the MediaPromise does a release-mode assertion that
  * there is at most one call to either Then(...) or ChainTo(...).
  */

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -33,6 +33,23 @@ extern PRLogModuleInfo* gMediaPromiseLog;
   MOZ_ASSERT(gMediaPromiseLog); \
   PR_LOG(gMediaPromiseLog, PR_LOG_DEBUG, (x, ##__VA_ARGS__))
 
+namespace detail {
+template<typename ThisType, typename Ret, typename ArgType>
+static TrueType TakesArgumentHelper(Ret (ThisType::*)(ArgType));
+template<typename ThisType, typename Ret, typename ArgType>
+static TrueType TakesArgumentHelper(Ret (ThisType::*)(ArgType) const);
+template<typename ThisType, typename Ret>
+static FalseType TakesArgumentHelper(Ret (ThisType::*)());
+template<typename ThisType, typename Ret>
+static FalseType TakesArgumentHelper(Ret (ThisType::*)() const);
+} // namespace detail
+
+template<typename MethodType>
+struct TakesArgument {
+  typedef decltype(detail::TakesArgumentHelper(DeclVal<MethodType>())) Type;
+  static const bool value = Type::value;
+};
+
 /*
  * A promise manages an asynchronous request that may or may not be able to be
  * fulfilled immediately. When an API returns a promise, the consumer may attach
@@ -241,23 +258,16 @@ protected:
    * make the resolve/reject value argument "optional".
    */
 
-  // Avoid confusing the compiler when the callback accepts T* but the ValueType
-  // is nsRefPtr<T>. See bug 1109954 comment 6.
-  template <typename T>
-  struct NonDeduced
-  {
-    typedef T type;
-  };
-
-  template<typename ThisType, typename ValueType>
-  static void InvokeCallbackMethod(ThisType* aThisVal, void(ThisType::*aMethod)(ValueType),
-                                   typename NonDeduced<ValueType>::type aValue)
+  template<typename ThisType, typename MethodType, typename ValueType>
+  static typename EnableIf<TakesArgument<MethodType>::value, void>::Type
+  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType aValue)
   {
       ((*aThisVal).*aMethod)(aValue);
   }
 
-  template<typename ThisType, typename ValueType>
-  static void InvokeCallbackMethod(ThisType* aThisVal, void(ThisType::*aMethod)(), ValueType aValue)
+  template<typename ThisType, typename MethodType, typename ValueType>
+  static typename EnableIf<!TakesArgument<MethodType>::value, void>::Type
+  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType aValue)
   {
       ((*aThisVal).*aMethod)();
   }

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -182,6 +182,8 @@ public:
     // tries to access an inherited protected member.
     bool IsDisconnected() const { return mDisconnected; }
 
+    virtual MediaPromise* CompletionPromise() = 0;
+
   protected:
     Consumer() : mComplete(false), mDisconnected(false) {}
     virtual ~Consumer() {}
@@ -229,6 +231,16 @@ protected:
     explicit ThenValueBase(AbstractThread* aResponseTarget, const char* aCallSite)
       : mResponseTarget(aResponseTarget), mCallSite(aCallSite) {}
 
+    MediaPromise* CompletionPromise() override
+    {
+      MOZ_DIAGNOSTIC_ASSERT(mResponseTarget->IsCurrentThreadIn());
+      MOZ_DIAGNOSTIC_ASSERT(!Consumer::mComplete);
+      if (!mCompletionPromise) {
+        mCompletionPromise = new MediaPromise::Private("<completion promise>");
+      }
+      return mCompletionPromise;
+    }
+
     void Dispatch(MediaPromise *aPromise)
     {
       aPromise->mMutex.AssertCurrentThreadOwns();
@@ -252,10 +264,16 @@ protected:
       MOZ_ASSERT(ThenValueBase::mResponseTarget->IsCurrentThreadIn());
       MOZ_DIAGNOSTIC_ASSERT(!Consumer::mComplete);
       Consumer::mDisconnected = true;
+
+      // We could support rejecting the completion promise on disconnection, but
+      // then we'd need to have some sort of default reject value. The use cases
+      // of disconnection and completion promise chaining seem pretty orthogonal,
+      // so let's use assert against it.
+      MOZ_DIAGNOSTIC_ASSERT(!mCompletionPromise);
     }
 
   protected:
-    virtual void DoResolveOrRejectInternal(ResolveOrRejectValue& aValue) = 0;
+    virtual already_AddRefed<MediaPromise> DoResolveOrRejectInternal(ResolveOrRejectValue& aValue) = 0;
 
     void DoResolveOrReject(ResolveOrRejectValue& aValue)
     {
@@ -265,10 +283,34 @@ protected:
         return;
       }
 
-      DoResolveOrRejectInternal(aValue);
+      // Invoke the resolve or reject method.
+      nsRefPtr<MediaPromise> p = DoResolveOrRejectInternal(aValue);
+
+      // If there's a completion promise, resolve it appropriately with the
+      // result of the method.
+      //
+      // We jump through some hoops to cast to MediaPromise::Private here. This
+      // can go away when we can just declare mCompletionPromise as
+      // MediaPromise::Private. See the declaration below.
+      nsRefPtr<MediaPromise::Private> completionPromise =
+        dont_AddRef(static_cast<MediaPromise::Private*>(mCompletionPromise.forget().take()));
+      if (completionPromise) {
+        if (p) {
+          p->ChainTo(completionPromise.forget(), "<chained completion promise>");
+        } else {
+          completionPromise->ResolveOrReject(aValue, "<completion of non-promise-returning method>");
+        }
+      }
     }
 
     nsRefPtr<AbstractThread> mResponseTarget; // May be released on any thread.
+
+    // Declaring nsRefPtr<MediaPromise::Private> here causes build failures
+    // on MSVC because MediaPromise::Private is only forward-declared at this
+    // point. This hack can go away when we inline-declare MediaPromise::Private,
+    // which is blocked on the B2G ICS compiler being too old.
+    nsRefPtr<MediaPromise> mCompletionPromise;
+
     const char* mCallSite;
   };
 
@@ -338,7 +380,7 @@ protected:
   }
 
   protected:
-    virtual void DoResolveOrRejectInternal(ResolveOrRejectValue& aValue) override
+    virtual already_AddRefed<MediaPromise> DoResolveOrRejectInternal(ResolveOrRejectValue& aValue) override
     {
       nsRefPtr<MediaPromise> completion;
       if (aValue.IsResolve()) {
@@ -352,6 +394,8 @@ protected:
       // released on whatever thread last drops its reference to the ThenValue,
       // which may or may not be ok.
       mThisVal = nullptr;
+
+      return completion.forget();
     }
 
   private:
@@ -388,7 +432,7 @@ protected:
   }
 
   protected:
-    virtual void DoResolveOrRejectInternal(ResolveOrRejectValue& aValue) override
+    virtual already_AddRefed<MediaPromise> DoResolveOrRejectInternal(ResolveOrRejectValue& aValue) override
     {
       // Note: The usage of InvokeCallbackMethod here requires that
       // ResolveFunction/RejectFunction are capture-lambdas (i.e. anonymous
@@ -408,6 +452,8 @@ protected:
       // which may or may not be ok.
       mResolveFunction.reset();
       mRejectFunction.reset();
+
+      return completion.forget();
     }
 
   private:
@@ -533,6 +579,15 @@ public:
     MOZ_ASSERT(IsPending());
     PROMISE_LOG("%s rejecting MediaPromise (%p created at %s)", aRejectSite, this, mCreationSite);
     mValue.SetReject(aRejectValue);
+    DispatchAll();
+  }
+
+  void ResolveOrReject(ResolveOrRejectValue aValue, const char* aSite)
+  {
+    MutexAutoLock lock(mMutex);
+    MOZ_ASSERT(IsPending());
+    PROMISE_LOG("%s resolveOrRejecting MediaPromise (%p created at %s)", aSite, this, mCreationSite);
+    mValue = aValue;
     DispatchAll();
   }
 };

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -140,7 +140,7 @@ protected:
   explicit MediaPromise(const char* aCreationSite)
     : mCreationSite(aCreationSite)
     , mMutex("MediaPromise Mutex")
-    , mHaveConsumer(false)
+    , mHaveRequest(false)
   {
     PROMISE_LOG("%s creating MediaPromise (%p)", mCreationSite, this);
   }
@@ -171,7 +171,7 @@ public:
     return Move(p);
   }
 
-  class Consumer : public MediaPromiseRefcountable
+  class Request : public MediaPromiseRefcountable
   {
   public:
     virtual void Disconnect() = 0;
@@ -183,8 +183,8 @@ public:
     virtual MediaPromise* CompletionPromise() = 0;
 
   protected:
-    Consumer() : mComplete(false), mDisconnected(false) {}
-    virtual ~Consumer() {}
+    Request() : mComplete(false), mDisconnected(false) {}
+    virtual ~Request() {}
 
     bool mComplete;
     bool mDisconnected;
@@ -198,7 +198,7 @@ protected:
    * resolved or rejected, a {Resolve,Reject}Runnable is dispatched, which
    * invokes the resolve/reject method and then deletes the ThenValue.
    */
-  class ThenValueBase : public Consumer
+  class ThenValueBase : public Request
   {
   public:
     class ResolveOrRejectRunnable : public nsRunnable
@@ -232,7 +232,7 @@ protected:
     MediaPromise* CompletionPromise() override
     {
       MOZ_DIAGNOSTIC_ASSERT(mResponseTarget->IsCurrentThreadIn());
-      MOZ_DIAGNOSTIC_ASSERT(!Consumer::mComplete);
+      MOZ_DIAGNOSTIC_ASSERT(!Request::mComplete);
       if (!mCompletionPromise) {
         mCompletionPromise = new MediaPromise::Private("<completion promise>");
       }
@@ -250,7 +250,7 @@ protected:
                   aPromise->mValue.IsResolve() ? "Resolving" : "Rejecting", ThenValueBase::mCallSite,
                   runnable.get(), aPromise, this);
 
-      // Promise consumers are allowed to disconnect the Consumer object and
+      // Promise consumers are allowed to disconnect the Request object and
       // then shut down the thread or task queue that the promise result would
       // be dispatched on. So we unfortunately can't assert that promise
       // dispatch succeeds. :-(
@@ -260,8 +260,8 @@ protected:
     virtual void Disconnect() override
     {
       MOZ_ASSERT(ThenValueBase::mResponseTarget->IsCurrentThreadIn());
-      MOZ_DIAGNOSTIC_ASSERT(!Consumer::mComplete);
-      Consumer::mDisconnected = true;
+      MOZ_DIAGNOSTIC_ASSERT(!Request::mComplete);
+      Request::mDisconnected = true;
 
       // We could support rejecting the completion promise on disconnection, but
       // then we'd need to have some sort of default reject value. The use cases
@@ -275,8 +275,8 @@ protected:
 
     void DoResolveOrReject(ResolveOrRejectValue& aValue)
     {
-      Consumer::mComplete = true;
-      if (Consumer::mDisconnected) {
+      Request::mComplete = true;
+      if (Request::mDisconnected) {
         PROMISE_LOG("ThenValue::DoResolveOrReject disconnected - bailing out [this=%p]", this);
         return;
       }
@@ -371,7 +371,7 @@ protected:
   {
     ThenValueBase::Disconnect();
 
-    // If a Consumer has been disconnected, we don't guarantee that the
+    // If a Request has been disconnected, we don't guarantee that the
     // resolve/reject runnable will be dispatched. Null out our refcounted
     // this-value now so that it's released predictably on the dispatch thread.
     mThisVal = nullptr;
@@ -421,7 +421,7 @@ protected:
   {
     ThenValueBase::Disconnect();
 
-    // If a Consumer has been disconnected, we don't guarantee that the
+    // If a Request has been disconnected, we don't guarantee that the
     // resolve/reject runnable will be dispatched. Destroy our callbacks
     // now so that any references in closures are released predictable on
     // the dispatch thread.
@@ -465,8 +465,8 @@ public:
   {
     MutexAutoLock lock(mMutex);
     MOZ_ASSERT(aResponseThread->IsDispatchReliable());
-    MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveConsumer);
-    mHaveConsumer = true;
+    MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveRequest);
+    mHaveRequest = true;
     PROMISE_LOG("%s invoking Then() [this=%p, aThenValue=%p, isPending=%d]",
                 aCallSite, this, aThenValue, (int) IsPending());
     if (!IsPending()) {
@@ -479,30 +479,30 @@ public:
 public:
 
   template<typename ThisType, typename ResolveMethodType, typename RejectMethodType>
-  nsRefPtr<Consumer> Then(AbstractThread* aResponseThread, const char* aCallSite, ThisType* aThisVal,
-                          ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod)
+  nsRefPtr<Request> Then(AbstractThread* aResponseThread, const char* aCallSite, ThisType* aThisVal,
+                         ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod)
   {
     nsRefPtr<ThenValueBase> thenValue = new MethodThenValue<ThisType, ResolveMethodType, RejectMethodType>(
                                               aResponseThread, aThisVal, aResolveMethod, aRejectMethod, aCallSite);
     ThenInternal(aResponseThread, thenValue, aCallSite);
-    return thenValue.forget(); // Implicit conversion from already_AddRefed<ThenValueBase> to nsRefPtr<Consumer>.
+    return thenValue.forget(); // Implicit conversion from already_AddRefed<ThenValueBase> to nsRefPtr<Request>.
   }
 
   template<typename ResolveFunction, typename RejectFunction>
-  nsRefPtr<Consumer> Then(AbstractThread* aResponseThread, const char* aCallSite,
-                          ResolveFunction&& aResolveFunction, RejectFunction&& aRejectFunction)
+  nsRefPtr<Request> Then(AbstractThread* aResponseThread, const char* aCallSite,
+                         ResolveFunction&& aResolveFunction, RejectFunction&& aRejectFunction)
   {
     nsRefPtr<ThenValueBase> thenValue = new FunctionThenValue<ResolveFunction, RejectFunction>(aResponseThread,
                                               Move(aResolveFunction), Move(aRejectFunction), aCallSite);
     ThenInternal(aResponseThread, thenValue, aCallSite);
-    return thenValue.forget(); // Implicit conversion from already_AddRefed<ThenValueBase> to nsRefPtr<Consumer>.
+    return thenValue.forget(); // Implicit conversion from already_AddRefed<ThenValueBase> to nsRefPtr<Request>.
   }
 
   void ChainTo(already_AddRefed<Private> aChainedPromise, const char* aCallSite)
   {
     MutexAutoLock lock(mMutex);
-    MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveConsumer);
-    mHaveConsumer = true;
+    MOZ_DIAGNOSTIC_ASSERT(!IsExclusive || !mHaveRequest);
+    mHaveRequest = true;
     nsRefPtr<Private> chainedPromise = aChainedPromise;
     PROMISE_LOG("%s invoking Chain() [this=%p, chainedPromise=%p, isPending=%d]",
                 aCallSite, this, chainedPromise.get(), (int) IsPending());
@@ -552,7 +552,7 @@ protected:
   ResolveOrRejectValue mValue;
   nsTArray<nsRefPtr<ThenValueBase>> mThenValues;
   nsTArray<nsRefPtr<Private>> mChainedPromises;
-  bool mHaveConsumer;
+  bool mHaveRequest;
 };
 
 template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
@@ -690,34 +690,34 @@ private:
 };
 
 /*
- * Class to encapsulate a MediaPromise::Consumer reference. Use this as the member
+ * Class to encapsulate a MediaPromise::Request reference. Use this as the member
  * variable for a class waiting on a media promise.
  */
 template<typename PromiseType>
-class MediaPromiseConsumerHolder
+class MediaPromiseRequestHolder
 {
 public:
-  MediaPromiseConsumerHolder() {}
-  ~MediaPromiseConsumerHolder() { MOZ_ASSERT(!mConsumer); }
+  MediaPromiseRequestHolder() {}
+  ~MediaPromiseRequestHolder() { MOZ_ASSERT(!mRequest); }
 
-  void Begin(typename PromiseType::Consumer* aConsumer)
+  void Begin(typename PromiseType::Request* aRequest)
   {
     MOZ_DIAGNOSTIC_ASSERT(!Exists());
-    mConsumer = aConsumer;
+    mRequest = aRequest;
   }
 
   void Complete()
   {
     MOZ_DIAGNOSTIC_ASSERT(Exists());
-    mConsumer = nullptr;
+    mRequest = nullptr;
   }
 
   // Disconnects and forgets an outstanding promise. The resolve/reject methods
   // will never be called.
   void Disconnect() {
     MOZ_ASSERT(Exists());
-    mConsumer->Disconnect();
-    mConsumer = nullptr;
+    mRequest->Disconnect();
+    mRequest = nullptr;
   }
 
   void DisconnectIfExists() {
@@ -726,10 +726,10 @@ public:
     }
   }
 
-  bool Exists() { return !!mConsumer; }
+  bool Exists() { return !!mRequest; }
 
 private:
-  nsRefPtr<typename PromiseType::Consumer> mConsumer;
+  nsRefPtr<typename PromiseType::Request> mRequest;
 };
 
 // Proxy Media Calls.

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -79,17 +79,17 @@ struct ReturnTypeIs {
  * there is at most one call to either Then(...) or ChainTo(...).
  */
 
-class MediaPromiseBase
+class MediaPromiseRefcountable
 {
 public:
-  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(MediaPromiseBase)
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(MediaPromiseRefcountable)
 protected:
-  virtual ~MediaPromiseBase() {}
+  virtual ~MediaPromiseRefcountable() {}
 };
 
 template<typename T> class MediaPromiseHolder;
 template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class MediaPromise : public MediaPromiseBase
+class MediaPromise : public MediaPromiseRefcountable
 {
 public:
   typedef ResolveValueT ResolveValueType;
@@ -171,11 +171,9 @@ public:
     return Move(p);
   }
 
-  class Consumer
+  class Consumer : public MediaPromiseRefcountable
   {
   public:
-    NS_INLINE_DECL_THREADSAFE_REFCOUNTING(Consumer)
-
     virtual void Disconnect() = 0;
 
     // MSVC complains when an inner class (ThenValueBase::{Resolve,Reject}Runnable)

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -124,29 +124,33 @@ public:
   class ResolveOrRejectValue
   {
   public:
-    void SetResolve(const ResolveValueType& aResolveValue)
+    template<typename ResolveValueType_>
+    void SetResolve(ResolveValueType_&& aResolveValue)
     {
       MOZ_ASSERT(IsNothing());
-      mResolveValue.emplace(aResolveValue);
+      mResolveValue.emplace(Forward<ResolveValueType_>(aResolveValue));
     }
 
-    void SetReject(const RejectValueType& aRejectValue)
+    template<typename RejectValueType_>
+    void SetReject(RejectValueType_&& aRejectValue)
     {
       MOZ_ASSERT(IsNothing());
-      mRejectValue.emplace(aRejectValue);
+      mRejectValue.emplace(Forward<RejectValueType_>(aRejectValue));
     }
 
-    static ResolveOrRejectValue MakeResolve(const ResolveValueType aResolveValue)
+    template<typename ResolveValueType_>
+    static ResolveOrRejectValue MakeResolve(ResolveValueType_&& aResolveValue)
     {
       ResolveOrRejectValue val;
-      val.SetResolve(aResolveValue);
+      val.SetResolve(Forward<ResolveValueType_>(aResolveValue));
       return val;
     }
 
-    static ResolveOrRejectValue MakeReject(const RejectValueType aRejectValue)
+    template<typename RejectValueType_>
+    static ResolveOrRejectValue MakeReject(RejectValueType_&& aRejectValue)
     {
       ResolveOrRejectValue val;
-      val.SetReject(aRejectValue);
+      val.SetReject(Forward<RejectValueType_>(aRejectValue));
       return val;
     }
 
@@ -182,19 +186,21 @@ public:
   // NB: We can include the definition of this class inline once B2G ICS is gone.
   class Private;
 
+  template<typename ResolveValueType_>
   static nsRefPtr<MediaPromise>
-  CreateAndResolve(ResolveValueType aResolveValue, const char* aResolveSite)
+  CreateAndResolve(ResolveValueType_&& aResolveValue, const char* aResolveSite)
   {
     nsRefPtr<typename MediaPromise::Private> p = new MediaPromise::Private(aResolveSite);
-    p->Resolve(aResolveValue, aResolveSite);
+    p->Resolve(Forward<ResolveValueType_>(aResolveValue), aResolveSite);
     return Move(p);
   }
 
+  template<typename RejectValueType_>
   static nsRefPtr<MediaPromise>
-  CreateAndReject(RejectValueType aRejectValue, const char* aRejectSite)
+  CreateAndReject(RejectValueType_&& aRejectValue, const char* aRejectSite)
   {
     nsRefPtr<typename MediaPromise::Private> p = new MediaPromise::Private(aRejectSite);
-    p->Reject(aRejectValue, aRejectSite);
+    p->Reject(Forward<RejectValueType_>(aRejectValue), aRejectSite);
     return Move(p);
   }
 
@@ -352,18 +358,18 @@ protected:
   static typename EnableIf<ReturnTypeIs<MethodType, nsRefPtr<MediaPromise>>::value &&
                            TakesArgument<MethodType>::value,
                            already_AddRefed<MediaPromise>>::Type
-  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType aValue)
+  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType&& aValue)
   {
-    return ((*aThisVal).*aMethod)(aValue).forget();
+    return ((*aThisVal).*aMethod)(Forward<ValueType>(aValue)).forget();
   }
 
   template<typename ThisType, typename MethodType, typename ValueType>
   static typename EnableIf<ReturnTypeIs<MethodType, void>::value &&
                            TakesArgument<MethodType>::value,
                            already_AddRefed<MediaPromise>>::Type
-  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType aValue)
+  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType&& aValue)
   {
-    ((*aThisVal).*aMethod)(aValue);
+    ((*aThisVal).*aMethod)(Forward<ValueType>(aValue));
     return nullptr;
   }
 
@@ -371,7 +377,7 @@ protected:
   static typename EnableIf<ReturnTypeIs<MethodType, nsRefPtr<MediaPromise>>::value &&
                            !TakesArgument<MethodType>::value,
                            already_AddRefed<MediaPromise>>::Type
-  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType aValue)
+  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType&& aValue)
   {
     return ((*aThisVal).*aMethod)().forget();
   }
@@ -380,7 +386,7 @@ protected:
   static typename EnableIf<ReturnTypeIs<MethodType, void>::value &&
                            !TakesArgument<MethodType>::value,
                            already_AddRefed<MediaPromise>>::Type
-  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType aValue)
+  InvokeCallbackMethod(ThisType* aThisVal, MethodType aMethod, ValueType&& aValue)
   {
     ((*aThisVal).*aMethod)();
     return nullptr;
@@ -601,30 +607,33 @@ class MediaPromise<ResolveValueT, RejectValueT, IsExclusive>::Private
 public:
   explicit Private(const char* aCreationSite) : MediaPromise(aCreationSite) {}
 
-  void Resolve(ResolveValueT aResolveValue, const char* aResolveSite)
+  template<typename ResolveValueT_>
+  void Resolve(ResolveValueT_&& aResolveValue, const char* aResolveSite)
   {
     MutexAutoLock lock(mMutex);
     MOZ_ASSERT(IsPending());
     PROMISE_LOG("%s resolving MediaPromise (%p created at %s)", aResolveSite, this, mCreationSite);
-    mValue.SetResolve(aResolveValue);
+    mValue.SetResolve(Forward<ResolveValueT_>(aResolveValue));
     DispatchAll();
   }
 
-  void Reject(RejectValueT aRejectValue, const char* aRejectSite)
+  template<typename RejectValueT_>
+  void Reject(RejectValueT_&& aRejectValue, const char* aRejectSite)
   {
     MutexAutoLock lock(mMutex);
     MOZ_ASSERT(IsPending());
     PROMISE_LOG("%s rejecting MediaPromise (%p created at %s)", aRejectSite, this, mCreationSite);
-    mValue.SetReject(aRejectValue);
+    mValue.SetReject(Forward<RejectValueT_>(aRejectValue));
     DispatchAll();
   }
 
-  void ResolveOrReject(ResolveOrRejectValue aValue, const char* aSite)
+  template<typename ResolveOrRejectValue_>
+  void ResolveOrReject(ResolveOrRejectValue_&& aValue, const char* aSite)
   {
     MutexAutoLock lock(mMutex);
     MOZ_ASSERT(IsPending());
     PROMISE_LOG("%s resolveOrRejecting MediaPromise (%p created at %s)", aSite, this, mCreationSite);
-    mValue = aValue;
+    mValue = Forward<ResolveOrRejectValue_>(aValue);
     DispatchAll();
   }
 };

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -192,7 +192,7 @@ public:
   {
     nsRefPtr<typename MediaPromise::Private> p = new MediaPromise::Private(aResolveSite);
     p->Resolve(Forward<ResolveValueType_>(aResolveValue), aResolveSite);
-    return Move(p);
+    return p.forget();
   }
 
   template<typename RejectValueType_>
@@ -201,7 +201,7 @@ public:
   {
     nsRefPtr<typename MediaPromise::Private> p = new MediaPromise::Private(aRejectSite);
     p->Reject(Forward<RejectValueType_>(aRejectValue), aRejectSite);
-    return Move(p);
+    return p.forget();
   }
 
   typedef MediaPromise<nsTArray<ResolveValueType>, RejectValueType, IsExclusive> AllPromiseType;
@@ -931,7 +931,7 @@ ProxyInternal(AbstractThread* aTarget, MethodCallBase<PromiseType>* aMethodCall,
   nsRefPtr<ProxyRunnable<PromiseType>> r = new ProxyRunnable<PromiseType>(p, aMethodCall);
   MOZ_ASSERT(aTarget->IsDispatchReliable());
   aTarget->Dispatch(r.forget());
-  return Move(p);
+  return p.forget();
 }
 
 } // namespace detail

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -389,7 +389,7 @@ public:
     return;
   }
 
-  template<typename ThisType, typename ResolveFunction, typename RejectFunction>
+  template<typename ResolveFunction, typename RejectFunction>
   void Then(AbstractThread* aResponseThread, const char* aCallSite,
             ResolveFunction&& aResolveFunction, RejectFunction&& aRejectFunction)
   {

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -336,10 +336,15 @@ protected:
   protected:
     virtual void DoResolveOrRejectInternal(ResolveOrRejectValue& aValue) override
     {
+      // Note: The usage of InvokeCallbackMethod here requires that
+      // ResolveFunction/RejectFunction are capture-lambdas (i.e. anonymous
+      // classes with ::operator()), since it allows us to share code more easily.
+      // We could fix this if need be, though it's quite easy to work around by
+      // just capturing something.
       if (aValue.IsResolve()) {
-        mResolveFunction.ref()(aValue.ResolveValue());
+        InvokeCallbackMethod(mResolveFunction.ptr(), &ResolveFunction::operator(), aValue.ResolveValue());
       } else {
-        mRejectFunction.ref()(aValue.RejectValue());
+        InvokeCallbackMethod(mRejectFunction.ptr(), &RejectFunction::operator(), aValue.RejectValue());
       }
 
       // Destroy callbacks after invocation so that any references in closures are

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -61,16 +61,30 @@ public:
   class ResolveOrRejectValue
   {
   public:
-    void SetResolve(ResolveValueType& aResolveValue)
+    void SetResolve(const ResolveValueType& aResolveValue)
     {
       MOZ_ASSERT(IsNothing());
       mResolveValue.emplace(aResolveValue);
     }
 
-    void SetReject(RejectValueType& aRejectValue)
+    void SetReject(const RejectValueType& aRejectValue)
     {
       MOZ_ASSERT(IsNothing());
       mRejectValue.emplace(aRejectValue);
+    }
+
+    static ResolveOrRejectValue MakeResolve(const ResolveValueType aResolveValue)
+    {
+      ResolveOrRejectValue val;
+      val.SetResolve(aResolveValue);
+      return val;
+    }
+
+    static ResolveOrRejectValue MakeReject(const RejectValueType aRejectValue)
+    {
+      ResolveOrRejectValue val;
+      val.SetReject(aRejectValue);
+      return val;
     }
 
     bool IsResolve() const { return mResolveValue.isSome(); }

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -375,41 +375,23 @@ public:
 public:
 
   template<typename ThisType, typename ResolveMethodType, typename RejectMethodType>
-  already_AddRefed<Consumer> RefableThen(AbstractThread* aResponseThread, const char* aCallSite, ThisType* aThisVal,
-                                         ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod)
+  nsRefPtr<Consumer> Then(AbstractThread* aResponseThread, const char* aCallSite, ThisType* aThisVal,
+                          ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod)
   {
     nsRefPtr<ThenValueBase> thenValue = new MethodThenValue<ThisType, ResolveMethodType, RejectMethodType>(
                                               aResponseThread, aThisVal, aResolveMethod, aRejectMethod, aCallSite);
     ThenInternal(aResponseThread, thenValue, aCallSite);
-    return thenValue.forget();
+    return thenValue.forget(); // Implicit conversion from already_AddRefed<ThenValueBase> to nsRefPtr<Consumer>.
   }
 
   template<typename ResolveFunction, typename RejectFunction>
-  already_AddRefed<Consumer> RefableThen(AbstractThread* aResponseThread, const char* aCallSite,
-                                         ResolveFunction&& aResolveFunction, RejectFunction&& aRejectFunction)
+  nsRefPtr<Consumer> Then(AbstractThread* aResponseThread, const char* aCallSite,
+                          ResolveFunction&& aResolveFunction, RejectFunction&& aRejectFunction)
   {
     nsRefPtr<ThenValueBase> thenValue = new FunctionThenValue<ResolveFunction, RejectFunction>(aResponseThread,
                                               Move(aResolveFunction), Move(aRejectFunction), aCallSite);
     ThenInternal(aResponseThread, thenValue, aCallSite);
-    return thenValue.forget();
-  }
-
-  template<typename ThisType, typename ResolveMethodType, typename RejectMethodType>
-  void Then(AbstractThread* aResponseThread, const char* aCallSite, ThisType* aThisVal,
-            ResolveMethodType aResolveMethod, RejectMethodType aRejectMethod)
-  {
-    nsRefPtr<Consumer> c =
-      RefableThen(aResponseThread, aCallSite, aThisVal, aResolveMethod, aRejectMethod);
-    return;
-  }
-
-  template<typename ResolveFunction, typename RejectFunction>
-  void Then(AbstractThread* aResponseThread, const char* aCallSite,
-            ResolveFunction&& aResolveFunction, RejectFunction&& aRejectFunction)
-  {
-    nsRefPtr<Consumer> c =
-      RefableThen(aResponseThread, aCallSite, Move(aResolveFunction), Move(aRejectFunction));
-    return;
+    return thenValue.forget(); // Implicit conversion from already_AddRefed<ThenValueBase> to nsRefPtr<Consumer>.
   }
 
   void ChainTo(already_AddRefed<Private> aChainedPromise, const char* aCallSite)
@@ -605,7 +587,7 @@ public:
   MediaPromiseConsumerHolder() {}
   ~MediaPromiseConsumerHolder() { MOZ_ASSERT(!mConsumer); }
 
-  void Begin(already_AddRefed<typename PromiseType::Consumer> aConsumer)
+  void Begin(typename PromiseType::Consumer* aConsumer)
   {
     MOZ_DIAGNOSTIC_ASSERT(!Exists());
     mConsumer = aConsumer;

--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -204,6 +204,67 @@ public:
     return Move(p);
   }
 
+  typedef MediaPromise<nsTArray<ResolveValueType>, RejectValueType, IsExclusive> AllPromiseType;
+private:
+  class AllPromiseHolder : public MediaPromiseRefcountable
+  {
+  public:
+    explicit AllPromiseHolder(size_t aDependentPromises)
+      : mPromise(new typename AllPromiseType::Private(__func__))
+      , mOutstandingPromises(aDependentPromises)
+    {
+      mResolveValues.SetLength(aDependentPromises);
+    }
+
+    void Resolve(size_t aIndex, const ResolveValueType& aResolveValue)
+    {
+      if (!mPromise) {
+        // Already rejected.
+        return;
+      }
+
+      mResolveValues[aIndex].emplace(aResolveValue);
+      if (--mOutstandingPromises == 0) {
+        nsTArray<ResolveValueType> resolveValues;
+        resolveValues.SetCapacity(mResolveValues.Length());
+        for (size_t i = 0; i < mResolveValues.Length(); ++i) {
+          resolveValues.AppendElement(mResolveValues[i].ref());
+        }
+
+        mPromise->Resolve(resolveValues, __func__);
+        mPromise = nullptr;
+        mResolveValues.Clear();
+      }
+    }
+
+    void Reject(const RejectValueType& aRejectValue)
+    {
+      mPromise->Reject(aRejectValue, __func__);
+      mPromise = nullptr;
+      mResolveValues.Clear();
+    }
+
+    AllPromiseType* Promise() { return mPromise; }
+
+  private:
+    nsTArray<Maybe<ResolveValueType>> mResolveValues;
+    nsRefPtr<typename AllPromiseType::Private> mPromise;
+    size_t mOutstandingPromises;
+  };
+public:
+
+  static nsRefPtr<AllPromiseType> All(AbstractThread* aProcessingThread, nsTArray<nsRefPtr<MediaPromise>>& aPromises)
+  {
+    nsRefPtr<AllPromiseHolder> holder = new AllPromiseHolder(aPromises.Length());
+    for (size_t i = 0; i < aPromises.Length(); ++i) {
+      aPromises[i]->Then(aProcessingThread, __func__,
+        [holder, i] (ResolveValueType aResolveValue) -> void { holder->Resolve(i, aResolveValue); },
+        [holder] (RejectValueType aRejectValue) -> void { holder->Reject(aRejectValue); }
+      );
+    }
+    return holder->Promise();
+  }
+
   class Request : public MediaPromiseRefcountable
   {
   public:

--- a/dom/media/gtest/TestMediaPromise.cpp
+++ b/dom/media/gtest/TestMediaPromise.cpp
@@ -1,0 +1,176 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "gtest/gtest.h"
+#include "nsISupportsImpl.h"
+#include "MediaTaskQueue.h"
+#include "MediaPromise.h"
+#include "SharedThreadPool.h"
+#include "VideoUtils.h"
+
+using namespace mozilla;
+
+typedef MediaPromise<int, double, false> TestPromise;
+typedef TestPromise::ResolveOrRejectValue RRValue;
+
+class MOZ_STACK_CLASS AutoTaskQueue
+{
+public:
+  AutoTaskQueue()
+    : mTaskQueue(new MediaTaskQueue(GetMediaThreadPool(MediaThreadType::PLAYBACK)))
+  {}
+
+  ~AutoTaskQueue()
+  {
+    mTaskQueue->AwaitShutdownAndIdle();
+  }
+
+  MediaTaskQueue* TaskQueue() { return mTaskQueue; }
+private:
+  nsRefPtr<MediaTaskQueue> mTaskQueue;
+};
+
+class DelayedResolveOrReject : public nsRunnable
+{
+public:
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(DelayedResolveOrReject)
+
+  DelayedResolveOrReject(MediaTaskQueue* aTaskQueue,
+                         TestPromise::Private* aPromise,
+                         TestPromise::ResolveOrRejectValue aValue,
+                         int aIterations)
+  : mTaskQueue(aTaskQueue)
+  , mPromise(aPromise)
+  , mValue(aValue)
+  , mIterations(aIterations)
+  {}
+
+  NS_IMETHODIMP Run()
+  {
+    MOZ_ASSERT(mTaskQueue->IsCurrentThreadIn());
+    if (!mPromise) {
+      // Canceled.
+      return NS_OK;
+    }
+
+    if (--mIterations == 0) {
+      mPromise->ResolveOrReject(mValue, __func__);
+    } else {
+      nsCOMPtr<nsIRunnable> r = this;
+      mTaskQueue->Dispatch(r.forget());
+    }
+
+    return NS_OK;
+  }
+
+  void Cancel() {
+    mPromise = nullptr;
+  }
+
+protected:
+  ~DelayedResolveOrReject() {}
+
+private:
+  nsRefPtr<MediaTaskQueue> mTaskQueue;
+  nsRefPtr<TestPromise::Private> mPromise;
+  TestPromise::ResolveOrRejectValue mValue;
+  int mIterations;
+};
+
+template<typename FunctionType>
+void
+RunOnTaskQueue(MediaTaskQueue* aQueue, FunctionType aFun)
+{
+  nsCOMPtr<nsIRunnable> r = NS_NewRunnableFunction(aFun);
+  aQueue->Dispatch(r.forget());
+}
+
+// std::function can't come soon enough. :-(
+#define DO_FAIL []()->void { EXPECT_TRUE(false); }
+
+TEST(MediaPromise, BasicResolve)
+{
+  AutoTaskQueue atq;
+  nsRefPtr<MediaTaskQueue> queue = atq.TaskQueue();
+  RunOnTaskQueue(queue, [queue] () -> void {
+    TestPromise::CreateAndResolve(42, __func__)->Then(queue, __func__,
+      [queue] (int aResolveValue) -> void { EXPECT_EQ(aResolveValue, 42); queue->BeginShutdown(); },
+      DO_FAIL);
+  });
+}
+
+TEST(MediaPromise, BasicReject)
+{
+  AutoTaskQueue atq;
+  nsRefPtr<MediaTaskQueue> queue = atq.TaskQueue();
+  RunOnTaskQueue(queue, [queue] () -> void {
+    TestPromise::CreateAndReject(42.0, __func__)->Then(queue, __func__,
+      DO_FAIL,
+      [queue] (int aRejectValue) -> void { EXPECT_EQ(aRejectValue, 42.0); queue->BeginShutdown(); });
+  });
+}
+
+TEST(MediaPromise, AsyncResolve)
+{
+  AutoTaskQueue atq;
+  nsRefPtr<MediaTaskQueue> queue = atq.TaskQueue();
+  RunOnTaskQueue(queue, [queue] () -> void {
+    nsRefPtr<TestPromise::Private> p = new TestPromise::Private(__func__);
+
+    // Kick off three racing tasks, and make sure we get the one that finishes earliest.
+    nsRefPtr<DelayedResolveOrReject> a = new DelayedResolveOrReject(queue, p, RRValue::MakeResolve(32), 10);
+    nsRefPtr<DelayedResolveOrReject> b = new DelayedResolveOrReject(queue, p, RRValue::MakeResolve(42), 5);
+    nsRefPtr<DelayedResolveOrReject> c = new DelayedResolveOrReject(queue, p, RRValue::MakeReject(32.0), 7);
+
+    nsCOMPtr<nsIRunnable> ref = a.get();
+    queue->Dispatch(ref.forget());
+    ref = b.get();
+    queue->Dispatch(ref.forget());
+    ref = c.get();
+    queue->Dispatch(ref.forget());
+
+    p->Then(queue, __func__, [queue, a, b, c] (int aResolveValue) -> void {
+      EXPECT_EQ(aResolveValue, 42);
+      a->Cancel();
+      b->Cancel();
+      c->Cancel();
+      queue->BeginShutdown();
+    }, DO_FAIL);
+  });
+}
+
+TEST(MediaPromise, CompletionPromises)
+{
+  bool invokedPass = false;
+  AutoTaskQueue atq;
+  nsRefPtr<MediaTaskQueue> queue = atq.TaskQueue();
+  RunOnTaskQueue(queue, [queue, &invokedPass] () -> void {
+    TestPromise::CreateAndResolve(40, __func__)
+    ->Then(queue, __func__,
+      [] (int aVal) -> nsRefPtr<TestPromise> { return TestPromise::CreateAndResolve(aVal + 10, __func__); },
+      DO_FAIL)
+    ->CompletionPromise()
+    ->Then(queue, __func__, [&invokedPass] () -> void { invokedPass = true; }, DO_FAIL)
+    ->CompletionPromise()
+    ->Then(queue, __func__,
+      [queue] (int aVal) -> nsRefPtr<TestPromise> {
+        nsRefPtr<TestPromise::Private> p = new TestPromise::Private(__func__);
+        nsCOMPtr<nsIRunnable> resolver = new DelayedResolveOrReject(queue, p, RRValue::MakeResolve(aVal - 8), 10);
+        queue->Dispatch(resolver.forget());
+        return nsRefPtr<TestPromise>(p);
+      },
+      DO_FAIL)
+    ->CompletionPromise()
+    ->Then(queue, __func__,
+      [queue] (int aVal) -> nsRefPtr<TestPromise> { return TestPromise::CreateAndReject(double(aVal - 42) + 42.0, __func__); },
+      DO_FAIL)
+    ->CompletionPromise()
+    ->Then(queue, __func__,
+      DO_FAIL,
+      [queue, &invokedPass] (double aVal) -> void { EXPECT_EQ(aVal, 42.0); EXPECT_TRUE(invokedPass); queue->BeginShutdown(); });
+  });
+}
+
+#undef DO_FAIL

--- a/dom/media/gtest/moz.build
+++ b/dom/media/gtest/moz.build
@@ -9,6 +9,7 @@ SOURCES += [
     'TestAudioCompactor.cpp',
     'TestGMPCrossOrigin.cpp',
     'TestIntervalSet.cpp',
+    'TestMediaPromise.cpp',
     'TestMP3Demuxer.cpp',
     'TestMP4Demuxer.cpp',
     'TestMP4Reader.cpp',

--- a/dom/media/mediasource/MediaSourceReader.cpp
+++ b/dom/media/mediasource/MediaSourceReader.cpp
@@ -142,9 +142,9 @@ MediaSourceReader::RequestAudioData()
     case SOURCE_NEW:
       GetAudioReader()->ResetDecode();
       mAudioSeekRequest.Begin(GetAudioReader()->Seek(GetReaderAudioTime(mLastAudioTime), 0)
-                              ->RefableThen(GetTaskQueue(), __func__, this,
-                                            &MediaSourceReader::CompleteAudioSeekAndDoRequest,
-                                            &MediaSourceReader::CompleteAudioSeekAndRejectPromise));
+                              ->Then(GetTaskQueue(), __func__, this,
+                                     &MediaSourceReader::CompleteAudioSeekAndDoRequest,
+                                     &MediaSourceReader::CompleteAudioSeekAndRejectPromise));
       break;
     case SOURCE_NONE:
       if (!mLastAudioTime) {
@@ -167,9 +167,9 @@ MediaSourceReader::RequestAudioData()
 void MediaSourceReader::DoAudioRequest()
 {
   mAudioRequest.Begin(GetAudioReader()->RequestAudioData()
-                      ->RefableThen(GetTaskQueue(), __func__, this,
-                                    &MediaSourceReader::OnAudioDecoded,
-                                    &MediaSourceReader::OnAudioNotDecoded));
+                      ->Then(GetTaskQueue(), __func__, this,
+                             &MediaSourceReader::OnAudioDecoded,
+                             &MediaSourceReader::OnAudioNotDecoded));
 }
 
 void
@@ -190,9 +190,9 @@ MediaSourceReader::OnAudioDecoded(AudioData* aSample)
       MSE_DEBUG("mTime=%lld < mTimeThreshold=%lld",
                 ourTime, mTimeThreshold);
       mAudioRequest.Begin(GetAudioReader()->RequestAudioData()
-                          ->RefableThen(GetTaskQueue(), __func__, this,
-                                        &MediaSourceReader::OnAudioDecoded,
-                                        &MediaSourceReader::OnAudioNotDecoded));
+                          ->Then(GetTaskQueue(), __func__, this,
+                                 &MediaSourceReader::OnAudioDecoded,
+                                 &MediaSourceReader::OnAudioNotDecoded));
       return;
     }
     mDropAudioBeforeThreshold = false;
@@ -260,9 +260,9 @@ MediaSourceReader::OnAudioNotDecoded(NotDecodedReason aReason)
   if (result == SOURCE_NEW) {
     GetAudioReader()->ResetDecode();
     mAudioSeekRequest.Begin(GetAudioReader()->Seek(GetReaderAudioTime(mLastAudioTime), 0)
-                            ->RefableThen(GetTaskQueue(), __func__, this,
-                                          &MediaSourceReader::CompleteAudioSeekAndDoRequest,
-                                          &MediaSourceReader::CompleteAudioSeekAndRejectPromise));
+                            ->Then(GetTaskQueue(), __func__, this,
+                                   &MediaSourceReader::CompleteAudioSeekAndDoRequest,
+                                   &MediaSourceReader::CompleteAudioSeekAndRejectPromise));
     return;
   }
 
@@ -315,9 +315,9 @@ MediaSourceReader::RequestVideoData(bool aSkipToNextKeyframe, int64_t aTimeThres
     case SOURCE_NEW:
       GetVideoReader()->ResetDecode();
       mVideoSeekRequest.Begin(GetVideoReader()->Seek(GetReaderVideoTime(mLastVideoTime), 0)
-                             ->RefableThen(GetTaskQueue(), __func__, this,
-                                           &MediaSourceReader::CompleteVideoSeekAndDoRequest,
-                                           &MediaSourceReader::CompleteVideoSeekAndRejectPromise));
+                             ->Then(GetTaskQueue(), __func__, this,
+                                    &MediaSourceReader::CompleteVideoSeekAndDoRequest,
+                                    &MediaSourceReader::CompleteVideoSeekAndRejectPromise));
       break;
     case SOURCE_NONE:
       if (!mLastVideoTime) {
@@ -342,9 +342,9 @@ void
 MediaSourceReader::DoVideoRequest()
 {
   mVideoRequest.Begin(GetVideoReader()->RequestVideoData(mDropVideoBeforeThreshold, GetReaderVideoTime(mTimeThreshold))
-                      ->RefableThen(GetTaskQueue(), __func__, this,
-                                    &MediaSourceReader::OnVideoDecoded,
-                                    &MediaSourceReader::OnVideoNotDecoded));
+                      ->Then(GetTaskQueue(), __func__, this,
+                             &MediaSourceReader::OnVideoDecoded,
+                             &MediaSourceReader::OnVideoNotDecoded));
 }
 
 void
@@ -412,9 +412,9 @@ MediaSourceReader::OnVideoNotDecoded(NotDecodedReason aReason)
   if (result == SOURCE_NEW) {
     GetVideoReader()->ResetDecode();
     mVideoSeekRequest.Begin(GetVideoReader()->Seek(GetReaderVideoTime(mLastVideoTime), 0)
-                           ->RefableThen(GetTaskQueue(), __func__, this,
-                                         &MediaSourceReader::CompleteVideoSeekAndDoRequest,
-                                         &MediaSourceReader::CompleteVideoSeekAndRejectPromise));
+                           ->Then(GetTaskQueue(), __func__, this,
+                                  &MediaSourceReader::CompleteVideoSeekAndDoRequest,
+                                  &MediaSourceReader::CompleteVideoSeekAndRejectPromise));
     return;
   }
 
@@ -901,9 +901,9 @@ MediaSourceReader::DoAudioSeek()
   }
   GetAudioReader()->ResetDecode();
   mAudioSeekRequest.Begin(GetAudioReader()->Seek(GetReaderAudioTime(seekTime), 0)
-                         ->RefableThen(GetTaskQueue(), __func__, this,
-                                       &MediaSourceReader::OnAudioSeekCompleted,
-                                       &MediaSourceReader::OnAudioSeekFailed));
+                         ->Then(GetTaskQueue(), __func__, this,
+                                &MediaSourceReader::OnAudioSeekCompleted,
+                                &MediaSourceReader::OnAudioSeekFailed));
   MSE_DEBUG("reader=%p", GetAudioReader());
 }
 
@@ -973,9 +973,9 @@ MediaSourceReader::DoVideoSeek()
   }
   GetVideoReader()->ResetDecode();
   mVideoSeekRequest.Begin(GetVideoReader()->Seek(GetReaderVideoTime(seekTime), 0)
-                          ->RefableThen(GetTaskQueue(), __func__, this,
-                                        &MediaSourceReader::OnVideoSeekCompleted,
-                                        &MediaSourceReader::OnVideoSeekFailed));
+                          ->Then(GetTaskQueue(), __func__, this,
+                                 &MediaSourceReader::OnVideoSeekCompleted,
+                                 &MediaSourceReader::OnVideoSeekFailed));
   MSE_DEBUG("reader=%p", GetVideoReader());
 }
 

--- a/dom/media/mediasource/MediaSourceReader.h
+++ b/dom/media/mediasource/MediaSourceReader.h
@@ -230,8 +230,8 @@ private:
   nsRefPtr<TrackBuffer> mAudioTrack;
   nsRefPtr<TrackBuffer> mVideoTrack;
 
-  MediaPromiseConsumerHolder<AudioDataPromise> mAudioRequest;
-  MediaPromiseConsumerHolder<VideoDataPromise> mVideoRequest;
+  MediaPromiseRequestHolder<AudioDataPromise> mAudioRequest;
+  MediaPromiseRequestHolder<VideoDataPromise> mVideoRequest;
 
   MediaPromiseHolder<AudioDataPromise> mAudioPromise;
   MediaPromiseHolder<VideoDataPromise> mVideoPromise;
@@ -247,8 +247,8 @@ private:
   int64_t mLastAudioTime;
   int64_t mLastVideoTime;
 
-  MediaPromiseConsumerHolder<SeekPromise> mAudioSeekRequest;
-  MediaPromiseConsumerHolder<SeekPromise> mVideoSeekRequest;
+  MediaPromiseRequestHolder<SeekPromise> mAudioSeekRequest;
+  MediaPromiseRequestHolder<SeekPromise> mVideoSeekRequest;
   MediaPromiseHolder<SeekPromise> mSeekPromise;
 
   // Temporary seek information while we wait for the data

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -451,9 +451,9 @@ SourceBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset,
   }
 
   mPendingAppend.Begin(mContentManager->AppendData(aData, aTimestampOffset)
-                       ->RefableThen(AbstractThread::MainThread(), __func__, this,
-                                     &SourceBuffer::AppendDataCompletedWithSuccess,
-                                     &SourceBuffer::AppendDataErrored));
+                       ->Then(AbstractThread::MainThread(), __func__, this,
+                              &SourceBuffer::AppendDataCompletedWithSuccess,
+                              &SourceBuffer::AppendDataErrored));
 }
 
 void

--- a/dom/media/mediasource/SourceBuffer.h
+++ b/dom/media/mediasource/SourceBuffer.h
@@ -189,7 +189,7 @@ private:
   // aborted and another AppendData queued.
   uint32_t mUpdateID;
 
-  MediaPromiseConsumerHolder<SourceBufferContentManager::AppendPromise> mPendingAppend;
+  MediaPromiseRequestHolder<SourceBufferContentManager::AppendPromise> mPendingAppend;
   const nsCString mType;
 };
 

--- a/dom/media/mediasource/TrackBuffer.cpp
+++ b/dom/media/mediasource/TrackBuffer.cpp
@@ -675,10 +675,10 @@ TrackBuffer::InitializeDecoder(SourceBufferDecoder* aDecoder)
   }
 
   mMetadataRequest.Begin(promise
-                           ->RefableThen(reader->GetTaskQueue(), __func__,
-                                         recipient.get(),
-                                         &MetadataRecipient::OnMetadataRead,
-                                         &MetadataRecipient::OnMetadataNotRead));
+                           ->Then(reader->GetTaskQueue(), __func__,
+                                  recipient.get(),
+                                  &MetadataRecipient::OnMetadataRead,
+                                  &MetadataRecipient::OnMetadataNotRead));
 }
 
 void

--- a/dom/media/mediasource/TrackBuffer.h
+++ b/dom/media/mediasource/TrackBuffer.h
@@ -208,7 +208,7 @@ private:
 
   MediaPromiseHolder<AppendPromise> mInitializationPromise;
   // Track our request for metadata from the reader.
-  MediaPromiseConsumerHolder<MediaDecoderReader::MetadataPromise> mMetadataRequest;
+  MediaPromiseRequestHolder<MediaDecoderReader::MetadataPromise> mMetadataRequest;
 };
 
 } // namespace mozilla

--- a/dom/media/omx/MediaOmxCommonDecoder.cpp
+++ b/dom/media/omx/MediaOmxCommonDecoder.cpp
@@ -221,8 +221,8 @@ MediaOmxCommonDecoder::ChangeState(PlayState aState)
   switch (mPlayState) {
     case PLAY_STATE_SEEKING:
     mSeekRequest.Begin(mAudioOffloadPlayer->Seek(mRequestedSeekTarget)
-      ->RefableThen(AbstractThread::MainThread(), __func__, static_cast<MediaDecoder*>(this),
-                    &MediaDecoder::OnSeekResolved, &MediaDecoder::OnSeekRejected));
+      ->Then(AbstractThread::MainThread(), __func__, static_cast<MediaDecoder*>(this),
+             &MediaDecoder::OnSeekResolved, &MediaDecoder::OnSeekRejected));
     mRequestedSeekTarget.Reset();
     break;
   default: {

--- a/mfbt/TypeTraits.h
+++ b/mfbt/TypeTraits.h
@@ -637,10 +637,29 @@ public:
  * For obscure reasons, you can't use IsConvertible when the types being tested
  * are related through private inheritance, and you'll get a compile error if
  * you try.  Just don't do it!
+ * 
+ * Note - we need special handling for void, which ConvertibleTester doesn't
+ * handle. The void handling here doesn't handle const/volatile void correctly,
+ * which could be easily fixed if the need arises.
  */
 template<typename From, typename To>
 struct IsConvertible
   : IntegralConstant<bool, detail::ConvertibleTester<From, To>::value>
+{};
+
+template<typename B>
+struct IsConvertible<void, B>
+  : IntegralConstant<bool, IsVoid<B>::value>
+{};
+
+template<typename A>
+struct IsConvertible<A, void>
+  : IntegralConstant<bool, IsVoid<A>::value>
+{};
+
+template<>
+struct IsConvertible<void, void>
+  : TrueType
 {};
 
 /* 20.9.7 Transformations between types [meta.trans] */

--- a/mfbt/tests/TestTypeTraits.cpp
+++ b/mfbt/tests/TestTypeTraits.cpp
@@ -354,6 +354,10 @@ TestIsConvertible()
   static_assert((!IsConvertible<A, D>::value),
                 "A and D are unrelated");
 
+  static_assert(IsConvertible<void, void>::value, "void is void");
+  static_assert(!IsConvertible<A, void>::value, "A shouldn't convert to void");
+  static_assert(!IsConvertible<void, B>::value, "void shouldn't convert to B");
+
   // These cases seem to require C++11 support to properly implement them, so
   // for now just disable them.
   //static_assert((!IsConvertible<C*, A*>::value),


### PR DESCRIPTION
TL;DR see the added comments in MediaPromise.h. This PR makes necessary changes/improvements to our MediaPromises that will be used by our new MSE code (and will also allow us to simplify more code in /dom/media in the future). This PR also includes a couple small renames that will help reduce headaches when porting media patches in the future.

Tested on Linux and appears to be working as intended.

