### PR TITLE
[Windows] Allow Atomic to hold 64-bit types everywhere

### DIFF
--- a/mfbt/Atomics.h
+++ b/mfbt/Atomics.h
@@ -895,10 +895,8 @@ namespace detail {
 template<typename T, MemoryOrdering Order>
 class AtomicBase
 {
-  // We only support 32-bit types on 32-bit Windows, which constrains our
-  // implementation elsewhere.  But we support pointer-sized types everywhere.
-  static_assert(sizeof(T) == 4 || (sizeof(uintptr_t) == 8 && sizeof(T) == 8),
-                "mozilla/Atomics.h only supports 32-bit and pointer-sized types");
+  static_assert(sizeof(T) == 4 || sizeof(T) == 8,
+                "mozilla/Atomics.h only supports 32-bit and 64-bit types");
 
 protected:
   typedef typename detail::AtomicIntrinsics<T, Order> Intrinsics;

--- a/mfbt/tests/TestAtomics.cpp
+++ b/mfbt/tests/TestAtomics.cpp
@@ -239,6 +239,8 @@ main()
 {
   TestType<uint32_t>();
   TestType<int32_t>();
+  TestType<uint64_t>();
+  TestType<int64_t>();
   TestType<intptr_t>();
   TestType<uintptr_t>();
   TestPointer<int>();


### PR DESCRIPTION
Currently, we only support 32-bit Atomics types on 32-bit Windows. This PR allows us to support 64-bit types on 32-bit Windows as well.

I believe that this was the cause of the build bustage in #1017 (which used a 64-bit Atomic). Additionally, our new MSE code will be using 64-bit Atomics as well, so #1033 is dependent on this as well.

Unfortunately I have no way to test this, so am adding the `Verification Needed` label. For more in-depth information and the discussion of this at Mozilla, see [BMO 1155864](https://bugzilla.mozilla.org/show_bug.cgi?id=1155864).