### PR TITLE
Re-land "Fix data race in AudioSink::mWritten"

### DIFF
--- a/dom/media/AudioSink.cpp
+++ b/dom/media/AudioSink.cpp
@@ -216,7 +216,8 @@ AudioSink::AudioLoop()
     CheckedInt64 sampleTime = UsecsToFrames(AudioQueue().PeekFront()->mTime, mInfo.mRate);
 
     // Calculate the number of frames that have been pushed onto the audio hardware.
-    CheckedInt64 playedFrames = UsecsToFrames(mStartTime, mInfo.mRate) + mWritten;
+    CheckedInt64 playedFrames = UsecsToFrames(mStartTime, mInfo.mRate) +
+                                static_cast<int64_t>(mWritten);
 
     CheckedInt64 missingFrames = sampleTime - playedFrames;
     if (!missingFrames.isValid() || !sampleTime.isValid()) {

--- a/dom/media/AudioSink.h
+++ b/dom/media/AudioSink.h
@@ -9,6 +9,7 @@
 #include "nsISupportsImpl.h"
 #include "MediaDecoderReader.h"
 #include "mozilla/dom/AudioChannelBinding.h"
+#include "mozilla/Atomics.h"
 
 namespace mozilla {
 
@@ -118,7 +119,7 @@ private:
   int64_t mStartTime;
 
   // PCM frames written to the stream so far.
-  int64_t mWritten;
+  Atomic<int64_t> mWritten;
 
   // Keep the last good position returned from the audio stream. Used to ensure
   // position returned by GetPosition() is mono-increasing in spite of audio


### PR DESCRIPTION
This PR fixes a potential race condition which could lead to a crash.

Was previously part of #1017, and now thanks to #1075 this is build-able on Windows 32-bit.