### PR TITLE
Analysis error improvements, window.onerror catches JSON.parse error in Promise fulfillment, maybe fix #1024

### DIFF
--- a/dom/base/DOMException.cpp
+++ b/dom/base/DOMException.cpp
@@ -173,7 +173,6 @@ NS_IMPL_CYCLE_COLLECTION_CLASS(Exception)
 
 NS_IMPL_CYCLE_COLLECTION_TRAVERSE_BEGIN(Exception)
   NS_IMPL_CYCLE_COLLECTION_TRAVERSE(mLocation)
-  NS_IMPL_CYCLE_COLLECTION_TRAVERSE(mInner)
   NS_IMPL_CYCLE_COLLECTION_TRAVERSE_SCRIPT_OBJECTS
 NS_IMPL_CYCLE_COLLECTION_TRAVERSE_END
 
@@ -184,7 +183,6 @@ NS_IMPL_CYCLE_COLLECTION_TRACE_END
 
 NS_IMPL_CYCLE_COLLECTION_UNLINK_BEGIN(Exception)
   NS_IMPL_CYCLE_COLLECTION_UNLINK(mLocation)
-  NS_IMPL_CYCLE_COLLECTION_UNLINK(mInner)
   NS_IMPL_CYCLE_COLLECTION_UNLINK_PRESERVED_WRAPPER
   tmp->mThrownJSVal.setNull();
 NS_IMPL_CYCLE_COLLECTION_UNLINK_END
@@ -244,7 +242,7 @@ Exception::Exception(const nsACString& aMessage,
     }
   }
 
-  Initialize(aMessage, aResult, aName, location, aData, nullptr);
+  Initialize(aMessage, aResult, aName, location, aData);
 }
 
 Exception::Exception()
@@ -403,18 +401,6 @@ Exception::GetData(nsISupports** aData)
   return NS_OK;
 }
 
-/* readonly attribute nsIException inner; */
-NS_IMETHODIMP
-Exception::GetInner(nsIException** aException)
-{
-  NS_ENSURE_ARG_POINTER(aException);
-  NS_ENSURE_TRUE(mInitialized, NS_ERROR_NOT_INITIALIZED);
-
-  nsCOMPtr<nsIException> inner = mInner;
-  inner.forget(aException);
-  return NS_OK;
-}
-
 /* AUTF8String toString (); */
 NS_IMETHODIMP
 Exception::ToString(nsACString& _retval)
@@ -463,7 +449,7 @@ Exception::ToString(nsACString& _retval)
 NS_IMETHODIMP
 Exception::Initialize(const nsACString& aMessage, nsresult aResult,
                       const nsACString& aName, nsIStackFrame *aLocation,
-                      nsISupports *aData, nsIException *aInner)
+                      nsISupports *aData)
 {
   NS_ENSURE_FALSE(mInitialized, NS_ERROR_ALREADY_INITIALIZED);
 
@@ -483,7 +469,6 @@ Exception::Initialize(const nsACString& aMessage, nsresult aResult,
   }
 
   mData = aData;
-  mInner = aInner;
 
   mInitialized = true;
   return NS_OK;
@@ -550,13 +535,6 @@ Exception::GetLocation() const
 {
   nsCOMPtr<nsIStackFrame> location = mLocation;
   return location.forget();
-}
-
-already_AddRefed<nsISupports>
-Exception::GetInner() const
-{
-  nsCOMPtr<nsIException> inner = mInner;
-  return inner.forget();
 }
 
 already_AddRefed<nsISupports>
@@ -631,25 +609,6 @@ DOMException::ToString(nsACString& aReturn)
     "[Exception... \"%s\"  code: \"%d\" nsresult: \"0x%x (%s)\"  location: \"%s\"]";
 
   nsAutoCString location;
-
-  if (mInner) {
-    nsString filename;
-    mInner->GetFilename(filename);
-
-    if (!filename.IsEmpty()) {
-      uint32_t line_nr = 0;
-
-      mInner->GetLineNumber(&line_nr);
-
-      char *temp = PR_smprintf("%s Line: %d",
-                               NS_ConvertUTF16toUTF8(filename).get(),
-                               line_nr);
-      if (temp) {
-        location.Assign(temp);
-        PR_smprintf_free(temp);
-      }
-    }
-  }
 
   if (location.IsEmpty()) {
     location = defaultLocation;

--- a/dom/base/DOMException.h
+++ b/dom/base/DOMException.h
@@ -83,8 +83,6 @@ public:
 
   already_AddRefed<nsIStackFrame> GetLocation() const;
 
-  already_AddRefed<nsISupports> GetInner() const;
-
   already_AddRefed<nsISupports> GetData() const;
 
   void GetStack(nsAString& aStack, ErrorResult& aRv) const;
@@ -110,7 +108,6 @@ protected:
   nsCOMPtr<nsISupports> mData;
   nsString        mFilename;
   int             mLineNumber;
-  nsCOMPtr<nsIException> mInner;
   bool            mInitialized;
 
   bool mHoldingJSVal;

--- a/dom/base/ScriptSettings.h
+++ b/dom/base/ScriptSettings.h
@@ -273,6 +273,9 @@ public:
   // while keeping the old behavior as the default.
   void TakeOwnershipOfErrorReporting();
   bool OwnsErrorReporting() { return mOwnErrorReporting; }
+  // If HasException, report it.  Otherwise, a no-op.  This must be
+  // called only if OwnsErrorReporting().
+  void ReportException();
 
   bool HasException() const {
     MOZ_ASSERT(CxPusherIsStackTop());
@@ -286,6 +289,14 @@ public:
   // Note that this fails if and only if we OOM while wrapping the exception
   // into the current compartment.
   bool StealException(JS::MutableHandle<JS::Value> aVal);
+
+  // Peek the current exception from the JS engine, without stealing it.
+  // Callers must ensure that HasException() is true, and that cx() is in a
+  // non-null compartment.
+  //
+  // Note that this fails if and only if we OOM while wrapping the exception
+  // into the current compartment.
+  bool PeekException(JS::MutableHandle<JS::Value> aVal);
 
   void ClearException() {
     MOZ_ASSERT(CxPusherIsStackTop());

--- a/dom/base/nsGlobalWindow.cpp
+++ b/dom/base/nsGlobalWindow.cpp
@@ -12413,6 +12413,7 @@ nsGlobalWindow::RunTimeoutHandler(nsTimeout* aTimeout,
     // New script entry point required, due to the "Create a script" sub-step of
     // http://www.whatwg.org/specs/web-apps/current-work/#timer-initialization-steps
     AutoEntryScript entryScript(this, true, aScx->GetNativeContext());
+    entryScript.TakeOwnershipOfErrorReporting();
     JS::CompileOptions options(entryScript.cx());
     options.setFileAndLine(filename, lineNo)
            .setVersion(JSVERSION_DEFAULT);

--- a/dom/base/nsJSUtils.cpp
+++ b/dom/base/nsJSUtils.cpp
@@ -98,41 +98,6 @@ nsJSUtils::GetCurrentlyRunningCodeInnerWindowID(JSContext *aContext)
   return innerWindowID;
 }
 
-void
-nsJSUtils::ReportPendingException(JSContext *aContext)
-{
-  if (JS_IsExceptionPending(aContext)) {
-    bool saved = JS_SaveFrameChain(aContext);
-    {
-      // JS_SaveFrameChain set the compartment of aContext to null, so we need
-      // to enter a compartment.  The question is, which one? We don't want to
-      // enter the original compartment of aContext (or the compartment of the
-      // current exception on aContext, for that matter) because when we
-      // JS_ReportPendingException the JS engine can try to duck-type the
-      // exception and produce a JSErrorReport.  It will then pass that
-      // JSErrorReport to the error reporter on aContext, which might expose
-      // information from it to script via onerror handlers.  So it's very
-      // important that the duck typing happen in the same compartment as the
-      // onerror handler.  In practice, that's the compartment of the window (or
-      // otherwise default global) of aContext, so use that here.
-      nsIScriptContext* scx = GetScriptContextFromJSContext(aContext);
-      JS::Rooted<JSObject*> scope(aContext);
-      scope = scx ? scx->GetWindowProxy() : nullptr;
-      if (!scope) {
-        // The SafeJSContext has no default object associated with it.
-        MOZ_ASSERT(NS_IsMainThread());
-        MOZ_ASSERT(aContext == nsContentUtils::GetSafeJSContext());
-        scope = xpc::UnprivilegedJunkScope(); // Usage approved by bholley
-      }
-      JSAutoCompartment ac(aContext, scope);
-      JS_ReportPendingException(aContext);
-    }
-    if (saved) {
-      JS_RestoreFrameChain(aContext);
-    }
-  }
-}
-
 nsresult
 nsJSUtils::CompileFunction(AutoJSAPI& jsapi,
                            JS::AutoObjectVector& aScopeChain,
@@ -199,12 +164,11 @@ nsJSUtils::EvaluateString(JSContext* aCx,
   PROFILER_LABEL("nsJSUtils", "EvaluateString",
     js::ProfileEntry::Category::JS);
 
+  MOZ_ASSERT(JS::ContextOptionsRef(aCx).autoJSAPIOwnsErrorReporting(),
+             "Caller must own error reporting");
   MOZ_ASSERT_IF(aCompileOptions.versionSet,
                 aCompileOptions.version != JSVERSION_UNKNOWN);
   MOZ_ASSERT_IF(aEvaluateOptions.coerceToString, !aCompileOptions.noScriptRval);
-  MOZ_ASSERT_IF(!aEvaluateOptions.reportUncaught, !aCompileOptions.noScriptRval);
-  // Note that the above assert means that if aCompileOptions.noScriptRval then
-  // also aEvaluateOptions.reportUncaught.
   MOZ_ASSERT(aCx == nsContentUtils::GetCurrentJSContext());
   MOZ_ASSERT(aSrcBuf.get());
   MOZ_ASSERT(js::GetGlobalForObjectCrossCompartment(aEvaluationGlobal) ==
@@ -224,13 +188,6 @@ nsJSUtils::EvaluateString(JSContext* aCx,
 
   nsIScriptSecurityManager* ssm = nsContentUtils::GetSecurityManager();
   NS_ENSURE_TRUE(ssm->ScriptAllowed(aEvaluationGlobal), NS_OK);
-
-  mozilla::Maybe<AutoDontReportUncaught> dontReport;
-  if (!aEvaluateOptions.reportUncaught) {
-    // We need to prevent AutoLastFrameCheck from reporting and clearing
-    // any pending exceptions.
-    dontReport.emplace(aCx);
-  }
 
   bool ok = true;
   // Scope the JSAutoCompartment so that we can later wrap the return value
@@ -275,24 +232,14 @@ nsJSUtils::EvaluateString(JSContext* aCx,
   }
 
   if (!ok) {
-    if (aEvaluateOptions.reportUncaught) {
-      ReportPendingException(aCx);
-      if (!aCompileOptions.noScriptRval) {
-        aRetValue.setUndefined();
-      }
-    } else {
-      rv = JS_IsExceptionPending(aCx) ? NS_ERROR_FAILURE
-                                      : NS_ERROR_OUT_OF_MEMORY;
-      JS::Rooted<JS::Value> exn(aCx);
-      JS_GetPendingException(aCx, &exn);
-      MOZ_ASSERT(!aCompileOptions.noScriptRval); // we asserted this on entry
-      aRetValue.set(exn);
-      JS_ClearPendingException(aCx);
+    rv = NS_SUCCESS_DOM_SCRIPT_EVALUATION_THREW;
+    if (!aCompileOptions.noScriptRval) {
+      aRetValue.setUndefined();    
     }
   }
 
   // Wrap the return value into whatever compartment aCx was in.
-  if (!aCompileOptions.noScriptRval) {
+  if (ok && !aCompileOptions.noScriptRval) {
     if (!JS_WrapValue(aCx, aRetValue)) {
       return NS_ERROR_OUT_OF_MEMORY;
     }

--- a/dom/base/nsJSUtils.h
+++ b/dom/base/nsJSUtils.h
@@ -52,13 +52,6 @@ public:
    */
   static uint64_t GetCurrentlyRunningCodeInnerWindowID(JSContext *aContext);
 
-  /**
-   * Report a pending exception on aContext, if any.  Note that this
-   * can be called when the context has a JS stack.  If that's the
-   * case, the stack will be set aside before reporting the exception.
-   */
-  static void ReportPendingException(JSContext *aContext);
-
   static nsresult CompileFunction(mozilla::dom::AutoJSAPI& jsapi,
                                   JS::AutoObjectVector& aScopeChain,
                                   JS::CompileOptions& aOptions,
@@ -70,12 +63,10 @@ public:
 
   struct MOZ_STACK_CLASS EvaluateOptions {
     bool coerceToString;
-    bool reportUncaught;
     JS::AutoObjectVector scopeChain;
 
     explicit EvaluateOptions(JSContext* cx)
       : coerceToString(false)
-      , reportUncaught(true)
       , scopeChain(cx)
     {}
 
@@ -83,16 +74,13 @@ public:
       coerceToString = aCoerce;
       return *this;
     }
-
-    EvaluateOptions& setReportUncaught(bool aReport) {
-      reportUncaught = aReport;
-      return *this;
-    }
   };
 
   // aEvaluationGlobal is the global to evaluate in.  The return value
   // will then be wrapped back into the compartment aCx is in when
-  // this function is called.
+  // this function is called.  For all the EvaluateString overloads,
+  // the JSContext must come from an AutoJSAPI that has had
+  // TakeOwnershipOfErrorReporting() called on it.
   static nsresult EvaluateString(JSContext* aCx,
                                  const nsAString& aScript,
                                  JS::Handle<JSObject*> aEvaluationGlobal,

--- a/dom/base/nsScriptLoader.cpp
+++ b/dom/base/nsScriptLoader.cpp
@@ -1138,6 +1138,7 @@ nsScriptLoader::EvaluateScript(nsScriptLoadRequest* aRequest,
   // New script entry point required, due to the "Create a script" sub-step of
   // http://www.whatwg.org/specs/web-apps/current-work/#execute-the-script-block
   AutoEntryScript entryScript(globalObject, true, context->GetNativeContext());
+  entryScript.TakeOwnershipOfErrorReporting();
   JS::Rooted<JSObject*> global(entryScript.cx(),
                                globalObject->GetGlobalJSObject());
 

--- a/dom/bindings/CallbackObject.cpp
+++ b/dom/bindings/CallbackObject.cpp
@@ -180,12 +180,8 @@ CallbackObject::CallSetup::CallSetup(CallbackObject* aCallback,
   // And now we're ready to go.
   mCx = cx;
 
-  // Make sure the JS engine doesn't report exceptions we want to re-throw
-  if ((mCompartment && mExceptionHandling == eRethrowContentExceptions) ||
-      mExceptionHandling == eRethrowExceptions) {
-    mSavedJSContextOptions = JS::ContextOptionsRef(cx);
-    JS::ContextOptionsRef(cx).setDontReportUncaught(true);
-  }
+  // Make sure the JS engine doesn't report exceptions we want to re-throw.
+  mAutoEntryScript->TakeOwnershipOfErrorReporting();
 }
 
 bool
@@ -251,18 +247,18 @@ CallbackObject::CallSetup::~CallSetup()
   // Now, if we have a JSContext, report any pending errors on it, unless we
   // were told to re-throw them.
   if (mCx) {
-    bool needToDealWithException = JS_IsExceptionPending(mCx);
+    bool needToDealWithException = mAutoEntryScript->HasException();
     if ((mCompartment && mExceptionHandling == eRethrowContentExceptions) ||
         mExceptionHandling == eRethrowExceptions) {
-      // Restore the old context options
-      JS::ContextOptionsRef(mCx) = mSavedJSContextOptions;
       mErrorResult.MightThrowJSException();
+      MOZ_ASSERT(mAutoEntryScript->OwnsErrorReporting());
       if (needToDealWithException) {
         JS::Rooted<JS::Value> exn(mCx);
-        if (JS_GetPendingException(mCx, &exn) &&
+        if (mAutoEntryScript->PeekException(&exn) &&
             ShouldRethrowException(exn)) {
+          mAutoEntryScript->ClearException();
+          MOZ_ASSERT(!mAutoEntryScript->HasException());
           mErrorResult.ThrowJSException(mCx, exn);
-          JS_ClearPendingException(mCx);
           needToDealWithException = false;
         }
       }
@@ -270,7 +266,7 @@ CallbackObject::CallSetup::~CallSetup()
 
     if (needToDealWithException) {
       // Either we're supposed to report our exceptions, or we're supposed to
-      // re-throw them but we failed to JS_GetPendingException.  Either way,
+      // re-throw them but we failed to get the exception value.  Either way,
       // just report the pending exception, if any.
       //
       // We don't use nsJSUtils::ReportPendingException here because all it
@@ -281,7 +277,9 @@ CallbackObject::CallSetup::~CallSetup()
       // screw up our compartment, which is exactly what we do not want.
       //
       // XXXbz FIXME: bug 979525 means we don't always JS_SaveFrameChain here,
-      // so we need to go ahead and do that.
+      // so we need to go ahead and do that.  This is also the reason we don't
+      // just rely on ~AutoJSAPI reporting the exception for us.  I think if we
+      // didn't need to JS_SaveFrameChain here, we could just rely on that.
       JS::Rooted<JSObject*> oldGlobal(mCx, JS::CurrentGlobalOrNull(mCx));
       MOZ_ASSERT(oldGlobal, "How can we not have a global here??");
       bool saved = JS_SaveFrameChain(mCx);
@@ -292,7 +290,10 @@ CallbackObject::CallSetup::~CallSetup()
         MOZ_ASSERT(!JS::DescribeScriptedCaller(mCx),
                    "Our comment above about JS_SaveFrameChain having been "
                    "called is a lie?");
-        JS_ReportPendingException(mCx);
+        // Note that we don't JS_ReportPendingException here because we want to
+        // go through our AutoEntryScript's reporting mechanism instead, since
+        // it currently owns error reporting.
+        mAutoEntryScript->ReportException();
       }
       if (saved) {
         JS_RestoreFrameChain(mCx);

--- a/dom/bindings/CallbackObject.h
+++ b/dom/bindings/CallbackObject.h
@@ -218,7 +218,6 @@ protected:
     // we should re-throw them.
     ErrorResult& mErrorResult;
     const ExceptionHandling mExceptionHandling;
-    JS::ContextOptions mSavedJSContextOptions;
     const bool mIsMainThread;
   };
 };

--- a/dom/bindings/test/mochitest.ini
+++ b/dom/bindings/test/mochitest.ini
@@ -59,3 +59,4 @@ skip-if = debug == false
 skip-if = debug == false
 [test_worker_UnwrapArg.html]
 [test_crossOriginWindowSymbolAccess.html]
+[test_callback_exceptions.html]

--- a/dom/bindings/test/test_callback_exceptions.html
+++ b/dom/bindings/test/test_callback_exceptions.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Test for ...</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+promise_test(function(t) {
+  var iterator = document.createNodeIterator(document, NodeFilter.SHOW_ALL, JSON.parse);
+  return promise_rejects(t, new SyntaxError,
+                         Promise.resolve().then(iterator.nextNode.bind(iterator)));
+}, "Trying to use JSON.parse as filter should throw a catchable SyntaxError exception even when the filter is invoked async");
+
+promise_test(function(t) {
+  return promise_rejects(t, new SyntaxError, Promise.resolve('{').then(JSON.parse));
+}, "Trying to use JSON.parse as a promise callback should allow the next promise to handle the resulting exception.");
+</script>

--- a/dom/canvas/WebGLContextUtils.cpp
+++ b/dom/canvas/WebGLContextUtils.cpp
@@ -425,7 +425,16 @@ WebGLContext::GenerateWarning(const char* fmt, va_list ap)
 
     // no need to print to stderr, as JS_ReportWarning takes care of this for us.
 
-    AutoJSContext cx;
+    if (!mCanvasElement) {
+        return;
+    }
+
+    AutoJSAPI api;
+    if (!api.Init(mCanvasElement->OwnerDoc()->GetScopeObject())) {
+        return;
+    }
+
+    JSContext* cx = api.cx();
     JS_ReportWarning(cx, "WebGL: %s", buf);
     if (!ShouldGenerateWarnings()) {
         JS_ReportWarning(cx,

--- a/dom/jsurl/nsJSProtocolHandler.cpp
+++ b/dom/jsurl/nsJSProtocolHandler.cpp
@@ -249,6 +249,10 @@ nsresult nsJSThunk::EvaluateScript(nsIChannel *aChannel,
     // http://www.whatwg.org/specs/web-apps/current-work/#javascript-protocol
     AutoEntryScript entryScript(innerGlobal, true,
                                 scriptContext->GetNativeContext());
+    // We want to make sure we report any exceptions that happen before we
+    // return, since whatever happens inside our execution shouldn't affect any
+    // other scripts that might happen to be running.
+    entryScript.TakeOwnershipOfErrorReporting();
     JSContext* cx = entryScript.cx();
     JS::Rooted<JSObject*> globalJSObject(cx, innerGlobal->GetGlobalJSObject());
     NS_ENSURE_TRUE(globalJSObject, NS_ERROR_UNEXPECTED);
@@ -276,20 +280,13 @@ nsresult nsJSThunk::EvaluateScript(nsIChannel *aChannel,
     rv = nsJSUtils::EvaluateString(cx, NS_ConvertUTF8toUTF16(script),
                                    globalJSObject, options, evalOptions, &v);
 
-    // If there's an error on cx as a result of that call, report
-    // it now -- either we're just running under the event loop,
-    // so we shouldn't propagate JS exceptions out of here, or we
-    // can't be sure that our caller is JS (and if it's not we'll
-    // lose the error), or it might be JS that then proceeds to
-    // cause an error of its own (which will also make us lose
-    // this error).
-    ::JS_ReportPendingException(cx);
-
     if (NS_FAILED(rv) || !(v.isString() || v.isUndefined())) {
         return NS_ERROR_MALFORMED_URI;
     } else if (v.isUndefined()) {
         return NS_ERROR_DOM_RETVAL_UNDEFINED;
     } else {
+        MOZ_ASSERT(rv != NS_SUCCESS_DOM_SCRIPT_EVALUATION_THREW,
+                   "How did we get a non-undefined return value?");
         nsAutoJSString result;
         if (!result.init(cx, v)) {
             return NS_ERROR_OUT_OF_MEMORY;

--- a/dom/plugins/base/nsNPAPIPlugin.cpp
+++ b/dom/plugins/base/nsNPAPIPlugin.cpp
@@ -1508,6 +1508,7 @@ _evaluate(NPP npp, NPObject* npobj, NPString *script, NPVariant *result)
   }
 
   dom::AutoEntryScript aes(win);
+  aes.TakeOwnershipOfErrorReporting();
   JSContext* cx = aes.cx();
 
   JS::Rooted<JSObject*> obj(cx, nsNPObjWrapper::GetNewOrUsed(npp, cx, npobj));

--- a/dom/webidl/DOMException.webidl
+++ b/dom/webidl/DOMException.webidl
@@ -52,8 +52,6 @@ interface ExceptionMembers
   // this was only ever usefully available to chrome JS.
   [ChromeOnly]
   readonly attribute StackFrame?             location;
-  // An inner exception that triggered this, if available.
-  readonly attribute nsISupports?            inner;
 
   // Arbitary data for the implementation.
   readonly attribute nsISupports?            data;

--- a/dom/xbl/nsXBLProtoImplField.cpp
+++ b/dom/xbl/nsXBLProtoImplField.cpp
@@ -405,6 +405,7 @@ nsXBLProtoImplField::InstallField(JS::Handle<JSObject*> aBoundNode,
   // We are going to run script via EvaluateString, so we need a script entry
   // point, but as this is XBL related it does not appear in the HTML spec.
   AutoEntryScript entryScript(globalObject, true);
+  entryScript.TakeOwnershipOfErrorReporting();
   JSContext* cx = entryScript.cx();
 
   NS_ASSERTION(!::JS_IsExceptionPending(cx),
@@ -438,6 +439,12 @@ nsXBLProtoImplField::InstallField(JS::Handle<JSObject*> aBoundNode,
                                  scopeObject, options, evalOptions, &result);
   if (NS_FAILED(rv)) {
     return rv;
+  }
+
+  if (rv == NS_SUCCESS_DOM_SCRIPT_EVALUATION_THREW) {
+    // Report the exception now, before we try using the JSContext for
+    // the JS_DefineUCProperty call.
+    entryScript.ReportException();
   }
 
   // Now, enter the node's compartment, wrap the eval result, and define it on

--- a/js/src/frontend/TokenStream.cpp
+++ b/js/src/frontend/TokenStream.cpp
@@ -637,6 +637,7 @@ TokenStream::reportCompileErrorNumberVA(uint32_t offset, unsigned flags, unsigne
     if (offset != NoOffset && !err.report.filename && cx->isJSContext()) {
         NonBuiltinFrameIter iter(cx->asJSContext(),
                                  FrameIter::ALL_CONTEXTS, FrameIter::GO_THROUGH_SAVED,
+                                 FrameIter::FOLLOW_DEBUGGER_EVAL_PREV_LINK,
                                  cx->compartment()->principals);
         if (!iter.done() && iter.scriptFilename()) {
             callerFilename = true;

--- a/js/src/jit-test/tests/debug/bug1148917.js
+++ b/js/src/jit-test/tests/debug/bug1148917.js
@@ -1,0 +1,14 @@
+// |jit-test| error: Error
+
+var g = newGlobal();
+g.eval('function f(a) { evaluate("f(" + " - 1);", {newContext: true}); }');
+var dbg = new Debugger(g);
+var frames = [];
+dbg.onEnterFrame = function (frame) {
+  if (frames.length == 3)
+    return;
+  frames.push(frame);
+  for (var f of frames)
+    f.eval('a').return
+};
+g.f();

--- a/js/src/jscntxt.cpp
+++ b/js/src/jscntxt.cpp
@@ -229,6 +229,14 @@ ReportError(JSContext* cx, const char* message, JSErrorReport* reportp,
         if (js_ErrorToException(cx, message, reportp, callback, userRef)) {
             return;
         }
+
+        /*
+         * The AutoJSAPI error reporter only allows warnings to be reported so
+         * just ignore this error rather than try to report it.
+         */
+        if (cx->options().autoJSAPIOwnsErrorReporting() && !JSREPORT_IS_WARNING(reportp->flags))
+            return;
+
     }
 
     /*

--- a/js/src/jscntxt.cpp
+++ b/js/src/jscntxt.cpp
@@ -248,9 +248,9 @@ PopulateReportBlame(JSContext* cx, JSErrorReport* report)
 {
     /*
      * Walk stack until we find a frame that is associated with a non-builtin
-     * rather than a builtin frame.
+     * rather than a builtin frame and which we're allowed to know about.
      */
-    NonBuiltinFrameIter iter(cx);
+    NonBuiltinFrameIter iter(cx, cx->compartment()->principals);
     if (iter.done())
         return;
 

--- a/js/src/jsexn.cpp
+++ b/js/src/jsexn.cpp
@@ -271,6 +271,7 @@ js::ComputeStackString(JSContext* cx)
         RootedAtom atom(cx);
         SuppressErrorsGuard seg(cx);
         for (NonBuiltinFrameIter i(cx, FrameIter::ALL_CONTEXTS, FrameIter::GO_THROUGH_SAVED,
+                                   FrameIter::FOLLOW_DEBUGGER_EVAL_PREV_LINK,
                                    cx->compartment()->principals);
              !i.done();
              ++i)
@@ -363,8 +364,8 @@ Error(JSContext* cx, unsigned argc, Value* vp)
             return false;
     }
 
-    /* Find the scripted caller. */
-    NonBuiltinFrameIter iter(cx);
+    /* Find the scripted caller, but only ones we're allowed to know about. */
+    NonBuiltinFrameIter iter(cx, cx->compartment()->principals);
 
     /* Set the 'fileName' property. */
     RootedString fileName(cx);
@@ -885,7 +886,7 @@ ErrorReport::populateUncaughtExceptionReportVA(JSContext* cx, va_list ap)
     // XXXbz this assumes the stack we have right now is still
     // related to our exception object.  It would be better if we
     // could accept a passed-in stack of some sort instead.
-    NonBuiltinFrameIter iter(cx);
+    NonBuiltinFrameIter iter(cx, cx->compartment()->principals);
     if (!iter.done()) {
         ownedReport.filename = iter.scriptFilename();
         ownedReport.lineno = iter.computeLine(&ownedReport.column);

--- a/js/src/jsexn.cpp
+++ b/js/src/jsexn.cpp
@@ -607,6 +607,12 @@ js_ErrorToException(JSContext* cx, const char* message, JSErrorReport* reportp,
 static bool
 IsDuckTypedErrorObject(JSContext* cx, HandleObject exnObject, const char** filename_strp)
 {
+    /*
+     * This function is called from ErrorReport::init and so should not generate
+     * any new exceptions.
+     */
+    AutoClearPendingException acpe(cx);
+
     bool found;
     if (!JS_HasProperty(cx, exnObject, js_message_str, &found) || !found)
         return false;

--- a/js/src/jsexn.h
+++ b/js/src/jsexn.h
@@ -116,4 +116,18 @@ ExnTypeFromProtoKey(JSProtoKey key)
     return type;
 }
 
+class AutoClearPendingException
+{
+    JSContext *cx;
+
+  public:
+    explicit AutoClearPendingException(JSContext *cxArg)
+      : cx(cxArg)
+    { }
+
+    ~AutoClearPendingException() {
+        cx->clearPendingException();
+    }
+};
+
 #endif /* jsexn_h */

--- a/js/src/vm/Debugger.cpp
+++ b/js/src/vm/Debugger.cpp
@@ -5578,7 +5578,7 @@ CheckThisFrame(JSContext* cx, const CallArgs& args, const char* fnname, bool che
     THIS_FRAME_THISOBJ(cx, argc, vp, fnname, args, thisobj);                   \
     AbstractFramePtr frame = AbstractFramePtr::FromRaw(thisobj->getPrivate()); \
     if (frame.isScriptFrameIterData()) {                                       \
-        ScriptFrameIter iter(*(ScriptFrameIter::Data*)(frame.raw()));         \
+        ScriptFrameIter iter(*(ScriptFrameIter::Data*)(frame.raw()));          \
         frame = iter.abstractFramePtr();                                       \
     }
 
@@ -5588,10 +5588,11 @@ CheckThisFrame(JSContext* cx, const CallArgs& args, const char* fnname, bool che
     {                                                                          \
         AbstractFramePtr f = AbstractFramePtr::FromRaw(thisobj->getPrivate()); \
         if (f.isScriptFrameIterData()) {                                       \
-            maybeIter.emplace(*(ScriptFrameIter::Data*)(f.raw()));            \
+            maybeIter.emplace(*(ScriptFrameIter::Data*)(f.raw()));             \
         } else {                                                               \
             maybeIter.emplace(cx, ScriptFrameIter::ALL_CONTEXTS,               \
-                              ScriptFrameIter::GO_THROUGH_SAVED);              \
+                              ScriptFrameIter::GO_THROUGH_SAVED,               \
+                              ScriptFrameIter::IGNORE_DEBUGGER_EVAL_PREV_LINK); \
             ScriptFrameIter& iter = *maybeIter;                                \
             while (!iter.hasUsableAbstractFramePtr() || iter.abstractFramePtr() != f) \
                 ++iter;                                                        \
@@ -6294,7 +6295,7 @@ DebuggerObject_checkThis(JSContext* cx, const CallArgs& args, const char* fnname
     RootedObject obj(cx, DebuggerObject_checkThis(cx, args, fnname));         \
     if (!obj)                                                                 \
         return false;                                                         \
-    obj = (JSObject*) obj->as<NativeObject>().getPrivate();                  \
+    obj = (JSObject*) obj->as<NativeObject>().getPrivate();                   \
     MOZ_ASSERT(obj)
 
 #define THIS_DEBUGOBJECT_OWNER_REFERENT(cx, argc, vp, fnname, args, dbg, obj) \
@@ -6303,7 +6304,7 @@ DebuggerObject_checkThis(JSContext* cx, const CallArgs& args, const char* fnname
    if (!obj)                                                                  \
        return false;                                                          \
    Debugger* dbg = Debugger::fromChildJSObject(obj);                          \
-   obj = (JSObject*) obj->as<NativeObject>().getPrivate();                   \
+   obj = (JSObject*) obj->as<NativeObject>().getPrivate();                    \
    MOZ_ASSERT(obj)
 
 static bool
@@ -7227,7 +7228,7 @@ DebuggerEnv_checkThis(JSContext* cx, const CallArgs& args, const char* fnname,
     NativeObject* envobj = DebuggerEnv_checkThis(cx, args, fnname);           \
     if (!envobj)                                                              \
         return false;                                                         \
-    Rooted<Env*> env(cx, static_cast<Env*>(envobj->getPrivate()));           \
+    Rooted<Env*> env(cx, static_cast<Env*>(envobj->getPrivate()));            \
     MOZ_ASSERT(env);                                                          \
     MOZ_ASSERT(!env->is<ScopeObject>())
  

--- a/js/src/vm/Stack.cpp
+++ b/js/src/vm/Stack.cpp
@@ -582,10 +582,12 @@ FrameIter::settleOnActivation()
 }
 
 FrameIter::Data::Data(JSContext* cx, SavedOption savedOption,
-                      ContextOption contextOption, JSPrincipals* principals)
+                      ContextOption contextOption, DebuggerEvalOption debuggerEvalOption,
+                      JSPrincipals* principals)
   : cx_(cx),
     savedOption_(savedOption),
     contextOption_(contextOption),
+    debuggerEvalOption_(debuggerEvalOption),
     principals_(principals),
     pc_(nullptr),
     interpFrames_(nullptr),
@@ -600,6 +602,7 @@ FrameIter::Data::Data(const FrameIter::Data& other)
   : cx_(other.cx_),
     savedOption_(other.savedOption_),
     contextOption_(other.contextOption_),
+    debuggerEvalOption_(other.debuggerEvalOption_),
     principals_(other.principals_),
     state_(other.state_),
     pc_(other.pc_),
@@ -612,7 +615,7 @@ FrameIter::Data::Data(const FrameIter::Data& other)
 }
 
 FrameIter::FrameIter(JSContext* cx, SavedOption savedOption)
-  : data_(cx, savedOption, CURRENT_CONTEXT, nullptr),
+  : data_(cx, savedOption, CURRENT_CONTEXT, FOLLOW_DEBUGGER_EVAL_PREV_LINK, nullptr),
     ionInlineFrames_(cx, (js::jit::JitFrameIterator*) nullptr)
 {
     // settleOnActivation can only GC if principals are given.
@@ -621,8 +624,8 @@ FrameIter::FrameIter(JSContext* cx, SavedOption savedOption)
 }
 
 FrameIter::FrameIter(JSContext* cx, ContextOption contextOption,
-                     SavedOption savedOption)
-  : data_(cx, savedOption, contextOption, nullptr),
+                     SavedOption savedOption, DebuggerEvalOption debuggerEvalOption)
+  : data_(cx, savedOption, contextOption, debuggerEvalOption, nullptr),
     ionInlineFrames_(cx, (js::jit::JitFrameIterator*) nullptr)
 {
     // settleOnActivation can only GC if principals are given.
@@ -631,8 +634,9 @@ FrameIter::FrameIter(JSContext* cx, ContextOption contextOption,
 }
 
 FrameIter::FrameIter(JSContext* cx, ContextOption contextOption,
-                     SavedOption savedOption, JSPrincipals* principals)
-  : data_(cx, savedOption, contextOption, principals),
+                     SavedOption savedOption, DebuggerEvalOption debuggerEvalOption,
+                     JSPrincipals* principals)
+  : data_(cx, savedOption, contextOption, debuggerEvalOption, principals),
     ionInlineFrames_(cx, (js::jit::JitFrameIterator*) nullptr)
 {
     settleOnActivation();
@@ -709,7 +713,10 @@ FrameIter::operator++()
       case DONE:
         MOZ_CRASH("Unexpected state");
       case INTERP:
-        if (interpFrame()->isDebuggerEvalFrame() && interpFrame()->evalInFramePrev()) {
+        if (interpFrame()->isDebuggerEvalFrame() &&
+            interpFrame()->evalInFramePrev() &&
+            data_.debuggerEvalOption_ == FOLLOW_DEBUGGER_EVAL_PREV_LINK)
+        {
             AbstractFramePtr eifPrev = interpFrame()->evalInFramePrev();
 
             // Eval-in-frame can cross contexts and works across saved frame

--- a/js/xpconnect/idl/xpcexception.idl
+++ b/js/xpconnect/idl/xpcexception.idl
@@ -7,7 +7,7 @@
 #include "nsISupports.idl"
 #include "nsIException.idl"
 
-[scriptable, uuid(dd250248-2586-4ec1-a68f-8d14ef452517)]
+[scriptable, uuid(875e6645-e762-4da6-9ec8-bf19ab0050df)]
 interface nsIXPCException : nsIException
 {
     // inherits methods from nsIException
@@ -16,8 +16,7 @@ interface nsIXPCException : nsIException
                     in nsresult         aResult,
                     in AUTF8String      aName,
                     in nsIStackFrame    aLocation,
-                    in nsISupports      aData,
-                    in nsIException     aInner);
+                    in nsISupports      aData);
 };
 
 /* this goes into the C++ header verbatim. */

--- a/js/xpconnect/tests/chrome/test_xrayToJS.xul
+++ b/js/xpconnect/tests/chrome/test_xrayToJS.xul
@@ -565,13 +565,13 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=933681
         is(e[name], undefined, name + " property censored after suspicious replacement");
       }
       testProperty('message', x => x == 'some message', 'some other message', 42);
-      testProperty('fileName', x => /xul/.test(x), 'otherFilename.html', new iwin.Object());
+      testProperty('fileName', x => x == '', 'otherFilename.html', new iwin.Object());
       // Note - an Exception newed via Xrays is going to have an empty stack given the
       // current semantics and implementation. This tests the current behavior, but that
       // may change in bug 1036527 or similar.
       testProperty('stack', x => /^\s*$/.test(x), 'some other stack', new iwin.WeakMap());
-      testProperty('columnNumber', x => x > 5 && x < 100, 99, 99.5);
-      testProperty('lineNumber', x => x > 100 && x < 10000, 50, 'foo');
+      testProperty('columnNumber', x => x == 1, 99, 99.5);
+      testProperty('lineNumber', x => x == 0, 50, 'foo');
     }
   }
 

--- a/xpcom/base/ErrorList.h
+++ b/xpcom/base/ErrorList.h
@@ -529,6 +529,12 @@
    * the second assignment throws NS_SUCCESS_DOM_NO_OPERATION.
    */
   ERROR(NS_SUCCESS_DOM_NO_OPERATION,               SUCCESS(1)),
+
+  /*
+   * A success code that indicates that evaluating a string of JS went
+   * just fine except it threw an exception.
+   */
+  ERROR(NS_SUCCESS_DOM_SCRIPT_EVALUATION_THREW,    SUCCESS(2)),
 #undef MODULE
 
 

--- a/xpcom/base/nsIException.idl
+++ b/xpcom/base/nsIException.idl
@@ -12,7 +12,7 @@
 
 [ptr] native JSContext(JSContext);
 
-[scriptable, uuid(4ed5cd87-401a-425a-8d8d-c28fbc1e88b2)]
+[scriptable, uuid(4371b5bf-6845-487f-8d9d-3f1e4a9badd2)]
 interface nsIStackFrame : nsISupports
 {
     // see nsIProgrammingLanguage for list of language consts
@@ -69,8 +69,6 @@ interface nsIException : nsISupports
 
     // A stack trace, if available.
     readonly attribute nsIStackFrame           location;
-    // An inner exception that triggered this, if available.
-    readonly attribute nsIException            inner;
 
     // Arbitary data for the implementation.
     readonly attribute nsISupports             data;


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/issues/1024#issuecomment-299524537

---

# 1)

__Analysis error improvements.__

Throws an error in Browser Console:

```
uncaught exception: 2147500033
<unknown>
```

vs.

```
uncaught exception: 2147500033
FeedWriter.js:1284:26
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1173638

\+ A potential crash [@ js::FrameIter::operator++] or Hit MOZ_CRASH(Unexpected state)
https://bugzilla.mozilla.org/show_bug.cgi?id=1148917

# 2)

__window.onerror catches JSON.parse error in Promise fulfillment.__

An example:
http://jsbin.com/meviyuxiha/edit?js,console

Throws an error in Browser Console:
(of course - see also https://bugzilla.mozilla.org/show_bug.cgi?id=911216)
```
SyntaxError: JSON.parse: end of data while reading object contents
at line 1 column 2 of the JSON data
<unknown>
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1144750
https://bugzilla.mozilla.org/show_bug.cgi?id=1174486
https://bugzilla.mozilla.org/show_bug.cgi?id=1172246

\+ A code cleanup:
https://bugzilla.mozilla.org/show_bug.cgi?id=1229664

---

It also may solve "uncaught exception"... But I don't know.

__You add the label `Verification needed`, please.__

---

I've created the new build (x32, Windows) and tested.
