### PR TITLE
Fix when resetting toolbars and controls in Safe Mode prompt

### DIFF
--- a/browser/base/content/safeMode.js
+++ b/browser/base/content/safeMode.js
@@ -81,7 +81,7 @@ function deleteLocalstore() {
   xulstoreFile.append("xulstore.json");
   try {
     xulstoreFile.remove(false);
-    if (!localstoreFile.exists()) {
+    if (localstoreFile.exists()) {
       localstoreFile.remove(false);
     }
   } catch(e) {

--- a/browser/base/content/safeMode.js
+++ b/browser/base/content/safeMode.js
@@ -74,9 +74,16 @@ function deleteLocalstore() {
   const nsIProperties = Components.interfaces.nsIProperties;
   var directoryService =  Components.classes[nsIDirectoryServiceContractID]
                                     .getService(nsIProperties);
+  // Local store file
   var localstoreFile = directoryService.get("LStoreS", Components.interfaces.nsIFile);
+  // XUL store file
+  var xulstoreFile = directoryService.get("ProfD", Components.interfaces.nsIFile);
+  xulstoreFile.append("xulstore.json");
   try {
-    localstoreFile.remove(false);
+    xulstoreFile.remove(false);
+    if (!localstoreFile.exists()) {
+      localstoreFile.remove(false);
+    }
   } catch(e) {
     Components.utils.reportError(e);
   }


### PR DESCRIPTION
If you check the **Reset toolbars and controls** button and apply the changes in PM's safe mode prompt, it will only clear _localstore.rdf_, which no longer holds toolbar and window size/position settings since these were moved to _xulstore.json_.

This was also reported in the [forum](https://forum.palemoon.org/viewtopic.php?f=37&t=15658).

Please add `verification needed` label since I was only able to test this by editing omni.ja (My comp. isn't dev. class) and for me to prevent committing the mistake I did in my last PR again.