### PR TITLE
Add TrackBuffersManager object

### DIFF
--- a/dom/media/AbstractMediaDecoder.h
+++ b/dom/media/AbstractMediaDecoder.h
@@ -41,7 +41,7 @@ enum class MediaDecoderEventVisibility : int8_t {
  * The AbstractMediaDecoder class describes the public interface for a media decoder
  * and is used by the MediaReader classes.
  */
-class AbstractMediaDecoder : public nsISupports
+class AbstractMediaDecoder : public nsIObserver
 {
 public:
   // Returns the monitor for other threads to synchronise access to
@@ -150,6 +150,10 @@ public:
     AbstractMediaDecoder* mDecoder;
   };
 
+  // Classes directly inheriting from AbstractMediaDecoder do not support
+  // Observe and it should never be called directly.
+  NS_IMETHOD Observe(nsISupports *aSubject, const char * aTopic, const char16_t * aData) override
+  { MOZ_CRASH("Forbidden method"); return NS_OK; }
 };
 
 class MetadataContainer

--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -389,6 +389,30 @@ public:
     return intervals;
   }
 
+  // Excludes an interval from an IntervalSet.
+  // This is done by inverting aInterval within the bounds of mIntervals
+  // and then doing the intersection.
+  SelfType& operator-= (const ElemType& aInterval)
+  {
+    if (aInterval.IsEmpty() || mIntervals.IsEmpty()) {
+      return *this;
+    }
+    T firstEnd = std::max(mIntervals[0].mStart, aInterval.mStart);
+    T secondStart = std::min(mIntervals.LastElement().mEnd, aInterval.mEnd);
+    ElemType startInterval(mIntervals[0].mStart, firstEnd, aInterval.mFuzz);
+    ElemType endInterval(secondStart, mIntervals.LastElement().mEnd, aInterval.mFuzz);
+    SelfType intervals(Move(startInterval));
+    intervals += Move(endInterval);
+    return Intersection(intervals);
+  }
+
+  SelfType operator- (const ElemType& aInterval)
+  {
+    SelfType intervals(*this);
+    intervals -= aInterval;
+    return intervals;
+  }
+
   // Mutate this IntervalSet to be the union of this and aOther.
   SelfType& Union(const SelfType& aOther)
   {

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -264,8 +264,7 @@ struct SeekTarget {
   MediaDecoderEventVisibility mEventVisibility;
 };
 
-class MediaDecoder : public nsIObserver,
-                     public AbstractMediaDecoder
+class MediaDecoder : public AbstractMediaDecoder
 {
 public:
   struct SeekResolveValue {

--- a/dom/media/TimeUnits.h
+++ b/dom/media/TimeUnits.h
@@ -173,6 +173,21 @@ public:
     MOZ_ASSERT(!IsInfinite() && !aOther.IsInfinite());
     return TimeUnit(mValue - aOther.mValue);
   }
+  TimeUnit& operator += (const TimeUnit& aOther) {
+    *this = *this + aOther;
+    return *this;
+  }
+  TimeUnit& operator -= (const TimeUnit& aOther) {
+    *this = *this - aOther;
+    return *this;
+  }
+
+  friend TimeUnit operator* (int aVal, const TimeUnit& aUnit) {
+    return TimeUnit(aUnit.mValue * aVal);
+  }
+  friend TimeUnit operator* (const TimeUnit& aUnit, int aVal) {
+    return TimeUnit(aUnit.mValue * aVal);
+  }
 
   bool IsValid() const
   {

--- a/dom/media/fmp4/MP4Demuxer.cpp
+++ b/dom/media/fmp4/MP4Demuxer.cpp
@@ -207,7 +207,7 @@ MP4TrackDemuxer::MP4TrackDemuxer(MP4Demuxer* aParent,
   , mIterator(MakeUnique<mp4_demuxer::SampleIterator>(mIndex))
   , mNeedReIndex(true)
 {
-  NotifyDataArrived(); // Force update of index
+  EnsureUpToDateIndex(); // Force update of index
 }
 
 UniquePtr<TrackInfo>
@@ -255,6 +255,7 @@ MP4TrackDemuxer::Seek(media::TimeUnit aTime)
 nsRefPtr<MP4TrackDemuxer::SamplesPromise>
 MP4TrackDemuxer::GetSamples(int32_t aNumSamples)
 {
+  EnsureUpToDateIndex();
   nsRefPtr<SamplesHolder> samples = new SamplesHolder;
   if (!aNumSamples) {
     return SamplesPromise::CreateAndReject(DemuxerFailureReason::DEMUXER_ERROR, __func__);

--- a/dom/media/gtest/TestIntervalSet.cpp
+++ b/dom/media/gtest/TestIntervalSet.cpp
@@ -14,6 +14,7 @@ using namespace mozilla;
 
 typedef media::Interval<uint8_t> ByteInterval;
 typedef media::Interval<int> IntInterval;
+typedef media::IntervalSet<int> IntIntervals;
 
 ByteInterval CreateByteInterval(int32_t aStart, int32_t aEnd)
 {
@@ -150,18 +151,18 @@ TEST(IntervalSet, Equals)
 
 TEST(IntervalSet, IntersectionIntervalSet)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(5, 10);
   i0 += IntInterval(20, 25);
   i0 += IntInterval(40, 60);
 
-  media::IntervalSet<int> i1;
+  IntIntervals i1;
   i1.Add(IntInterval(7, 15));
   i1.Add(IntInterval(16, 27));
   i1.Add(IntInterval(45, 50));
   i1.Add(IntInterval(53, 57));
 
-  media::IntervalSet<int> i = media::Intersection(i0, i1);
+  IntIntervals i = media::Intersection(i0, i1);
 
   EXPECT_EQ(4u, i.Length());
 
@@ -192,10 +193,10 @@ static void Compare(const media::IntervalSet<T>& aI1,
   }
 }
 
-static void GeneratePermutations(media::IntervalSet<int> aI1,
-                                 media::IntervalSet<int> aI2)
+static void GeneratePermutations(IntIntervals aI1,
+                                 IntIntervals aI2)
 {
-  media::IntervalSet<int> i_ref = media::Intersection(aI1, aI2);
+  IntIntervals i_ref = media::Intersection(aI1, aI2);
   // Test all permutations possible
   std::vector<uint32_t> comb1;
   for (uint32_t i = 0; i < aI1.Length(); i++) {
@@ -209,13 +210,13 @@ static void GeneratePermutations(media::IntervalSet<int> aI1,
   do {
     do {
       // Create intervals according to new indexes.
-      media::IntervalSet<int> i_0;
+      IntIntervals i_0;
       for (uint32_t i = 0; i < comb1.size(); i++) {
         i_0 += aI1[comb1[i]];
       }
       // Test that intervals are always normalized.
       Compare(aI1, i_0);
-      media::IntervalSet<int> i_1;
+      IntIntervals i_1;
       for (uint32_t i = 0; i < comb2.size(); i++) {
         i_1 += aI2[comb2[i]];
       }
@@ -228,12 +229,12 @@ static void GeneratePermutations(media::IntervalSet<int> aI1,
 
 TEST(IntervalSet, IntersectionNormalizedIntervalSet)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(5, 10);
   i0 += IntInterval(20, 25);
   i0 += IntInterval(40, 60);
 
-  media::IntervalSet<int> i1;
+  IntIntervals i1;
   i1.Add(IntInterval(7, 15));
   i1.Add(IntInterval(16, 27));
   i1.Add(IntInterval(45, 50));
@@ -244,12 +245,12 @@ TEST(IntervalSet, IntersectionNormalizedIntervalSet)
 
 TEST(IntervalSet, IntersectionUnorderedNonNormalizedIntervalSet)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(5, 10);
   i0 += IntInterval(8, 25);
   i0 += IntInterval(24, 60);
 
-  media::IntervalSet<int> i1;
+  IntIntervals i1;
   i1.Add(IntInterval(7, 15));
   i1.Add(IntInterval(10, 27));
   i1.Add(IntInterval(45, 50));
@@ -260,7 +261,7 @@ TEST(IntervalSet, IntersectionUnorderedNonNormalizedIntervalSet)
 
 TEST(IntervalSet, IntersectionNonNormalizedInterval)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(5, 10);
   i0 += IntInterval(8, 25);
   i0 += IntInterval(30, 60);
@@ -274,7 +275,7 @@ TEST(IntervalSet, IntersectionNonNormalizedInterval)
 
 TEST(IntervalSet, IntersectionUnorderedNonNormalizedInterval)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(1, 3);
   i0 += IntInterval(1, 10);
   i0 += IntInterval(9, 12);
@@ -291,22 +292,22 @@ TEST(IntervalSet, IntersectionUnorderedNonNormalizedInterval)
   EXPECT_EQ(i0[0].mEnd, i1.mEnd);
 }
 
-static media::IntervalSet<int> Duplicate(const media::IntervalSet<int>& aValue)
+static IntIntervals Duplicate(const IntIntervals& aValue)
 {
-  media::IntervalSet<int> value(aValue);
+  IntIntervals value(aValue);
   return value;
 }
 
 TEST(IntervalSet, Normalize)
 {
-  media::IntervalSet<int> i;
+  IntIntervals i;
   // Test IntervalSet<T> + Interval<T> operator.
   i = i + IntInterval(20, 30);
   // Test Internal<T> + IntervalSet<T> operator.
   i = IntInterval(2, 7) + i;
   // Test Interval<T> + IntervalSet<T> operator
   i = IntInterval(1, 8) + i;
-  media::IntervalSet<int> interval;
+  IntIntervals interval;
   interval += IntInterval(5, 10);
   // Test += with rval move.
   i += Duplicate(interval);
@@ -333,7 +334,7 @@ TEST(IntervalSet, Normalize)
 
 TEST(IntervalSet, ContainValue)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(0, 10);
   i0 += IntInterval(15, 20);
   i0 += IntInterval(30, 50);
@@ -345,7 +346,7 @@ TEST(IntervalSet, ContainValue)
 
 TEST(IntervalSet, ContainValueWithFuzz)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(0, 10);
   i0 += IntInterval(15, 20, 1);
   i0 += IntInterval(30, 50);
@@ -357,7 +358,7 @@ TEST(IntervalSet, ContainValueWithFuzz)
 
 TEST(IntervalSet, ContainInterval)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(0, 10);
   i0 += IntInterval(15, 20);
   i0 += IntInterval(30, 50);
@@ -373,7 +374,7 @@ TEST(IntervalSet, ContainInterval)
 
 TEST(IntervalSet, ContainIntervalWithFuzz)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(0, 10);
   i0 += IntInterval(15, 20);
   i0 += IntInterval(30, 50);
@@ -386,7 +387,7 @@ TEST(IntervalSet, ContainIntervalWithFuzz)
   EXPECT_FALSE(i0.Contains(IntInterval(15, 30)));
   EXPECT_FALSE(i0.Contains(IntInterval(30, 55)));
 
-  media::IntervalSet<int> i1;
+  IntIntervals i1;
   i1 += IntInterval(0, 10, 1);
   i1 += IntInterval(15, 20, 1);
   i1 += IntInterval(30, 50, 1);
@@ -408,18 +409,18 @@ TEST(IntervalSet, Span)
 
 TEST(IntervalSet, Union)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(5, 10);
   i0 += IntInterval(20, 25);
   i0 += IntInterval(40, 60);
 
-  media::IntervalSet<int> i1;
+  IntIntervals i1;
   i1.Add(IntInterval(7, 15));
   i1.Add(IntInterval(16, 27));
   i1.Add(IntInterval(45, 50));
   i1.Add(IntInterval(53, 57));
 
-  media::IntervalSet<int> i = media::Union(i0, i1);
+  IntIntervals i = media::Union(i0, i1);
 
   EXPECT_EQ(3u, i.Length());
 
@@ -435,18 +436,18 @@ TEST(IntervalSet, Union)
 
 TEST(IntervalSet, UnionNotOrdered)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(20, 25);
   i0 += IntInterval(40, 60);
   i0 += IntInterval(5, 10);
 
-  media::IntervalSet<int> i1;
+  IntIntervals i1;
   i1.Add(IntInterval(16, 27));
   i1.Add(IntInterval(7, 15));
   i1.Add(IntInterval(53, 57));
   i1.Add(IntInterval(45, 50));
 
-  media::IntervalSet<int> i = media::Union(i0, i1);
+  IntIntervals i = media::Union(i0, i1);
 
   EXPECT_EQ(3u, i.Length());
 
@@ -462,7 +463,7 @@ TEST(IntervalSet, UnionNotOrdered)
 
 TEST(IntervalSet, NormalizeFuzz)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(11, 25, 0);
   i0 += IntInterval(5, 10, 1);
   i0 += IntInterval(40, 60, 1);
@@ -478,7 +479,7 @@ TEST(IntervalSet, NormalizeFuzz)
 
 TEST(IntervalSet, UnionFuzz)
 {
-  media::IntervalSet<int> i0;
+  IntIntervals i0;
   i0 += IntInterval(5, 10, 1);
   i0 += IntInterval(11, 25, 0);
   i0 += IntInterval(40, 60, 1);
@@ -488,7 +489,7 @@ TEST(IntervalSet, UnionFuzz)
   EXPECT_EQ(40, i0[1].mStart);
   EXPECT_EQ(60, i0[1].mEnd);
 
-  media::IntervalSet<int> i1;
+  IntIntervals i1;
   i1.Add(IntInterval(7, 15, 1));
   i1.Add(IntInterval(16, 27, 1));
   i1.Add(IntInterval(45, 50, 1));
@@ -501,7 +502,7 @@ TEST(IntervalSet, UnionFuzz)
   EXPECT_EQ(53, i1[2].mStart);
   EXPECT_EQ(57, i1[2].mEnd);
 
-  media::IntervalSet<int> i = media::Union(i0, i1);
+  IntIntervals i = media::Union(i0, i1);
 
   EXPECT_EQ(2u, i.Length());
 
@@ -708,4 +709,72 @@ TEST(IntervalSet, FooIntervalSet)
   EXPECT_EQ(1u, is.Length());
   EXPECT_EQ(Foo<int>(), is[0].mStart);
   EXPECT_EQ(Foo<int>(4,5,6), is[0].mEnd);
+}
+
+TEST(IntervalSet, StaticAssert)
+{
+  typedef media::IntervalSet<int> IntIntervals;
+  media::Interval<int> i;
+
+  static_assert(mozilla::IsSame<nsTArray_CopyChooser<IntIntervals>::Type, nsTArray_CopyWithConstructors<IntIntervals>>::value, "Must use copy constructor");
+  static_assert(mozilla::IsSame<nsTArray_CopyChooser<media::TimeIntervals>::Type, nsTArray_CopyWithConstructors<media::TimeIntervals>>::value, "Must use copy constructor");
+}
+
+TEST(IntervalSet, Substraction)
+{
+  IntIntervals i0;
+  i0 += IntInterval(5, 10);
+  i0 += IntInterval(20, 25);
+  i0 += IntInterval(40, 60);
+
+  IntInterval i1(8, 15);
+  i0 -= i1;
+
+  EXPECT_EQ(3u, i0.Length());
+  EXPECT_EQ(5, i0[0].mStart);
+  EXPECT_EQ(8, i0[0].mEnd);
+  EXPECT_EQ(20, i0[1].mStart);
+  EXPECT_EQ(25, i0[1].mEnd);
+  EXPECT_EQ(40, i0[2].mStart);
+  EXPECT_EQ(60, i0[2].mEnd);
+
+  i0 = IntIntervals();
+  i0 += IntInterval(5, 10);
+  i0 += IntInterval(20, 25);
+  i0 += IntInterval(40, 60);
+  i1 = IntInterval(0, 60);
+  i0 -= i1;
+  EXPECT_EQ(0u, i0.Length());
+
+  i0 = IntIntervals();
+  i0 += IntInterval(5, 10);
+  i0 += IntInterval(20, 25);
+  i0 += IntInterval(40, 60);
+  i1 = IntInterval(0, 45);
+  i0 -= i1;
+  EXPECT_EQ(1u, i0.Length());
+  EXPECT_EQ(45, i0[0].mStart);
+  EXPECT_EQ(60, i0[0].mEnd);
+
+  i0 = IntIntervals();
+  i0 += IntInterval(5, 10);
+  i0 += IntInterval(20, 25);
+  i0 += IntInterval(40, 60);
+  i1 = IntInterval(8, 45);
+  i0 -= i1;
+  EXPECT_EQ(2u, i0.Length());
+  EXPECT_EQ(5, i0[0].mStart);
+  EXPECT_EQ(8, i0[0].mEnd);
+  EXPECT_EQ(45, i0[1].mStart);
+  EXPECT_EQ(60, i0[1].mEnd);
+
+  i0 = IntIntervals();
+  i0 += IntInterval(5, 10);
+  i0 += IntInterval(20, 25);
+  i0 += IntInterval(40, 60);
+  i1 = IntInterval(8, 70);
+  i0 -= i1;
+  EXPECT_EQ(1u, i0.Length());
+  EXPECT_EQ(5, i0[0].mStart);
+  EXPECT_EQ(8, i0[0].mEnd);
 }

--- a/dom/media/mediasource/ContainerParser.cpp
+++ b/dom/media/mediasource/ContainerParser.cpp
@@ -13,6 +13,8 @@
 #include "MediaData.h"
 #ifdef MOZ_FMP4
 #include "MP4Stream.h"
+#include "mp4_demuxer/AtomType.h"
+#include "mp4_demuxer/ByteReader.h"
 #endif
 #include "SourceBufferResource.h"
 
@@ -27,6 +29,7 @@ extern PRLogModuleInfo* GetMediaSourceLog();
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 #define MSE_DEBUG(name, arg, ...) PR_LOG(GetMediaSourceLog(), PR_LOG_DEBUG, (TOSTRING(name) "(%p:%s)::%s: " arg, this, mType.get(), __func__, ##__VA_ARGS__))
+#define MSE_DEBUGV(name, arg, ...) PR_LOG(GetMediaSourceLog(), PR_LOG_DEBUG, (TOSTRING(name) "(%p:%s)::%s: " arg, this, mType.get(), __func__, ##__VA_ARGS__))
 #else
 #define MSE_DEBUG(...)
 #endif
@@ -281,44 +284,53 @@ public:
     , mMonitor("MP4ContainerParser Index Monitor")
   {}
 
+  bool HasAtom(const mp4_demuxer::AtomType& aAtom, const MediaLargeByteBuffer* aData) {
+    mp4_demuxer::ByteReader reader(aData);
+
+    while (reader.Remaining() >= 8) {
+      uint64_t size = reader.ReadU32();
+      const uint8_t* typec = reader.Peek(4);
+      uint32_t type = reader.ReadU32();
+      MSE_DEBUGV(MP4ContainerParser ,"Checking atom:'%c%c%c%c'",
+                typec[0], typec[1], typec[2], typec[3]);
+      if (mp4_demuxer::AtomType(type) == aAtom) {
+        reader.DiscardRemaining();
+        return true;
+      }
+      if (size == 1) {
+        // 64 bits size.
+        if (!reader.CanReadType<uint64_t>()) {
+          break;
+        }
+        size = reader.ReadU64();
+      } else if (size == 0) {
+        // Atom extends to the end of the buffer, it can't have what we're
+        // looking for.
+        break;
+      }
+      if (reader.Remaining() < size - 8) {
+        // Incomplete atom.
+        break;
+      }
+      reader.Read(size - 8);
+    }
+    reader.DiscardRemaining();
+    return false;
+  }
+
   bool IsInitSegmentPresent(MediaLargeByteBuffer* aData) override
   {
     ContainerParser::IsInitSegmentPresent(aData);
     // Each MP4 atom has a chunk size and chunk type. The root chunk in an MP4
     // file is the 'ftyp' atom followed by a file type. We just check for a
     // vaguely valid 'ftyp' atom.
-
-    if (aData->Length() < 8) {
-      return false;
-    }
-
-    uint32_t chunk_size = BigEndian::readUint32(aData->Elements());
-    if (chunk_size < 8) {
-      return false;
-    }
-
-    return (*aData)[4] == 'f' && (*aData)[5] == 't' && (*aData)[6] == 'y' &&
-           (*aData)[7] == 'p';
+    return HasAtom(mp4_demuxer::AtomType("ftyp"), aData);
   }
 
   bool IsMediaSegmentPresent(MediaLargeByteBuffer* aData) override
   {
     ContainerParser::IsMediaSegmentPresent(aData);
-    if (aData->Length() < 8) {
-      return false;
-    }
-
-    uint32_t chunk_size = BigEndian::readUint32(aData->Elements());
-    if (chunk_size < 8) {
-      return false;
-    }
-
-    return ((*aData)[4] == 'm' && (*aData)[5] == 'o' && (*aData)[6] == 'o' &&
-            (*aData)[7] == 'f') ||
-           ((*aData)[4] == 's' && (*aData)[5] == 't' && (*aData)[6] == 'y' &&
-            (*aData)[7] == 'p') ||
-           ((*aData)[4] == 's' && (*aData)[5] == 'i' && (*aData)[6] == 'd' &&
-            (*aData)[7] == 'x');
+    return HasAtom(mp4_demuxer::AtomType("moof"), aData);
   }
 
   bool ParseStartAndEndTimestamps(MediaLargeByteBuffer* aData,
@@ -414,5 +426,6 @@ ContainerParser::CreateForMIMEType(const nsACString& aType)
 }
 
 #undef MSE_DEBUG
+#undef MSE_DEBUGV
 
 } // namespace mozilla

--- a/dom/media/mediasource/ContainerParser.cpp
+++ b/dom/media/mediasource/ContainerParser.cpp
@@ -96,15 +96,21 @@ ContainerParser::InitData()
 }
 
 MediaByteRange
-ContainerParser::MediaSegmentRange()
-{
-  return mCompleteMediaSegmentRange;
-}
-
-MediaByteRange
 ContainerParser::InitSegmentRange()
 {
   return mCompleteInitSegmentRange;
+}
+
+MediaByteRange
+ContainerParser::MediaHeaderRange()
+{
+  return mCompleteMediaHeaderRange;
+}
+
+MediaByteRange
+ContainerParser::MediaSegmentRange()
+{
+  return mCompleteMediaSegmentRange;
 }
 
 class WebMContainerParser : public ContainerParser {
@@ -362,6 +368,7 @@ public:
     mp4_demuxer::Interval<mp4_demuxer::Microseconds> compositionRange =
       mParser->GetCompositionRange(byteRanges);
 
+    mCompleteMediaHeaderRange = mParser->FirstCompleteMediaHeader();
     mCompleteMediaSegmentRange = mParser->FirstCompleteMediaSegment();
     mResource->EvictData(mParser->mOffset, mParser->mOffset);
 

--- a/dom/media/mediasource/ContainerParser.cpp
+++ b/dom/media/mediasource/ContainerParser.cpp
@@ -370,7 +370,9 @@ public:
 
     mCompleteMediaHeaderRange = mParser->FirstCompleteMediaHeader();
     mCompleteMediaSegmentRange = mParser->FirstCompleteMediaSegment();
-    mResource->EvictData(mParser->mOffset, mParser->mOffset);
+    if (HasCompleteInitData()) {
+      mResource->EvictData(mParser->mOffset, mParser->mOffset);
+    }
 
     if (compositionRange.IsNull()) {
       return false;

--- a/dom/media/mediasource/ContainerParser.cpp
+++ b/dom/media/mediasource/ContainerParser.cpp
@@ -95,6 +95,12 @@ ContainerParser::InitData()
   return mInitData;
 }
 
+MediaByteRange
+ContainerParser::MediaSegmentRange()
+{
+  return mCompleteByteRange;
+}
+
 class WebMContainerParser : public ContainerParser {
 public:
   explicit WebMContainerParser(const nsACString& aType)
@@ -106,7 +112,7 @@ public:
   static const unsigned NS_PER_USEC = 1000;
   static const unsigned USEC_PER_SEC = 1000000;
 
-  bool IsInitSegmentPresent(MediaLargeByteBuffer* aData)
+  bool IsInitSegmentPresent(MediaLargeByteBuffer* aData) override
   {
     ContainerParser::IsInitSegmentPresent(aData);
     // XXX: This is overly primitive, needs to collect data as it's appended
@@ -131,7 +137,7 @@ public:
     return false;
   }
 
-  bool IsMediaSegmentPresent(MediaLargeByteBuffer* aData)
+  bool IsMediaSegmentPresent(MediaLargeByteBuffer* aData) override
   {
     ContainerParser::IsMediaSegmentPresent(aData);
     // XXX: This is overly primitive, needs to collect data as it's appended
@@ -171,7 +177,7 @@ public:
   }
 
   bool ParseStartAndEndTimestamps(MediaLargeByteBuffer* aData,
-                                  int64_t& aStart, int64_t& aEnd)
+                                  int64_t& aStart, int64_t& aEnd) override
   {
     bool initSegment = IsInitSegmentPresent(aData);
     if (initSegment) {
@@ -242,7 +248,7 @@ public:
     return true;
   }
 
-  int64_t GetRoundingError()
+  int64_t GetRoundingError() override
   {
     int64_t error = mParser.GetTimecodeScale() / NS_PER_USEC;
     return error * 2;
@@ -262,7 +268,7 @@ public:
     , mMonitor("MP4ContainerParser Index Monitor")
   {}
 
-  bool IsInitSegmentPresent(MediaLargeByteBuffer* aData)
+  bool IsInitSegmentPresent(MediaLargeByteBuffer* aData) override
   {
     ContainerParser::IsInitSegmentPresent(aData);
     // Each MP4 atom has a chunk size and chunk type. The root chunk in an MP4
@@ -282,7 +288,7 @@ public:
            (*aData)[7] == 'p';
   }
 
-  bool IsMediaSegmentPresent(MediaLargeByteBuffer* aData)
+  bool IsMediaSegmentPresent(MediaLargeByteBuffer* aData) override
   {
     ContainerParser::IsMediaSegmentPresent(aData);
     if (aData->Length() < 8) {
@@ -303,7 +309,7 @@ public:
   }
 
   bool ParseStartAndEndTimestamps(MediaLargeByteBuffer* aData,
-                                  int64_t& aStart, int64_t& aEnd)
+                                  int64_t& aStart, int64_t& aEnd) override
   {
     MonitorAutoLock mon(mMonitor); // We're not actually racing against anything,
                                    // but mParser requires us to hold a monitor.
@@ -329,17 +335,16 @@ public:
     mParser->RebuildFragmentedIndex(byteRanges);
 
     if (initSegment || !HasCompleteInitData()) {
-      const MediaByteRange& range = mParser->mInitRange;
-      uint32_t length = range.mEnd - range.mStart;
-      if (length) {
-        if (!mInitData->SetLength(length)) {
+      MediaByteRange& range = mParser->mInitRange;
+      if (range.Length()) {
+        if (!mInitData->SetLength(range.Length())) {
           // Super unlikely OOM
           return false;
         }
         char* buffer = reinterpret_cast<char*>(mInitData->Elements());
-        mResource->ReadFromCache(buffer, range.mStart, length);
+        mResource->ReadFromCache(buffer, range.mStart, range.Length());
         MSE_DEBUG(MP4ContainerParser ,"Stashed init of %u bytes.",
-                  length);
+                  range.Length());
       } else {
         MSE_DEBUG(MP4ContainerParser, "Incomplete init found.");
       }
@@ -348,6 +353,8 @@ public:
 
     mp4_demuxer::Interval<mp4_demuxer::Microseconds> compositionRange =
       mParser->GetCompositionRange(byteRanges);
+
+    mCompleteByteRange = mParser->FirstCompleteMediaSegment();
     mResource->EvictData(mParser->mOffset, mParser->mOffset);
 
     if (compositionRange.IsNull()) {
@@ -362,7 +369,7 @@ public:
 
   // Gaps of up to 35ms (marginally longer than a single frame at 30fps) are considered
   // to be sequential frames.
-  int64_t GetRoundingError()
+  int64_t GetRoundingError() override
   {
     return 35000;
   }

--- a/dom/media/mediasource/ContainerParser.cpp
+++ b/dom/media/mediasource/ContainerParser.cpp
@@ -98,7 +98,13 @@ ContainerParser::InitData()
 MediaByteRange
 ContainerParser::MediaSegmentRange()
 {
-  return mCompleteByteRange;
+  return mCompleteMediaSegmentRange;
+}
+
+MediaByteRange
+ContainerParser::InitSegmentRange()
+{
+  return mCompleteInitSegmentRange;
 }
 
 class WebMContainerParser : public ContainerParser {
@@ -209,6 +215,7 @@ public:
           // Super unlikely OOM
           return false;
         }
+        mCompleteInitSegmentRange = MediaByteRange(0, mParser.mInitEndOffset);
         char* buffer = reinterpret_cast<char*>(mInitData->Elements());
         mResource->ReadFromCache(buffer, 0, mParser.mInitEndOffset);
         MSE_DEBUG(WebMContainerParser, "Stashed init of %u bytes.",
@@ -337,6 +344,7 @@ public:
     if (initSegment || !HasCompleteInitData()) {
       MediaByteRange& range = mParser->mInitRange;
       if (range.Length()) {
+        mCompleteInitSegmentRange = range;
         if (!mInitData->SetLength(range.Length())) {
           // Super unlikely OOM
           return false;
@@ -354,7 +362,7 @@ public:
     mp4_demuxer::Interval<mp4_demuxer::Microseconds> compositionRange =
       mParser->GetCompositionRange(byteRanges);
 
-    mCompleteByteRange = mParser->FirstCompleteMediaSegment();
+    mCompleteMediaSegmentRange = mParser->FirstCompleteMediaSegment();
     mResource->EvictData(mParser->mOffset, mParser->mOffset);
 
     if (compositionRange.IsNull()) {

--- a/dom/media/mediasource/ContainerParser.h
+++ b/dom/media/mediasource/ContainerParser.h
@@ -52,10 +52,15 @@ public:
   }
 
   bool HasCompleteInitData();
-  // Return the byte range of the first complete media segment or an empty
+  // Returns the byte range of the first complete init segment, or an empty
+  // range if not complete.
+  MediaByteRange InitSegmentRange();
+  // Returns the byte range of the first complete media segment header,
+  // or an empty range if not complete.
+  MediaByteRange MediaHeaderRange();
+  // Returns the byte range of the first complete media segment or an empty
   // range if not complete.
   MediaByteRange MediaSegmentRange();
-  MediaByteRange InitSegmentRange();
 
   static ContainerParser* CreateForMIMEType(const nsACString& aType);
 
@@ -63,8 +68,9 @@ protected:
   nsRefPtr<MediaLargeByteBuffer> mInitData;
   nsRefPtr<SourceBufferResource> mResource;
   bool mHasInitData;
-  MediaByteRange mCompleteMediaSegmentRange;
   MediaByteRange mCompleteInitSegmentRange;
+  MediaByteRange mCompleteMediaHeaderRange;
+  MediaByteRange mCompleteMediaSegmentRange;
   const nsCString mType;
 };
 

--- a/dom/media/mediasource/ContainerParser.h
+++ b/dom/media/mediasource/ContainerParser.h
@@ -9,6 +9,7 @@
 
 #include "nsRefPtr.h"
 #include "nsString.h"
+#include "MediaResource.h"
 
 namespace mozilla {
 
@@ -51,6 +52,9 @@ public:
   }
 
   bool HasCompleteInitData();
+  // Return the byte range of the first complete media segment or an empty
+  // range if not complete.
+  MediaByteRange MediaSegmentRange();
 
   static ContainerParser* CreateForMIMEType(const nsACString& aType);
 
@@ -58,6 +62,7 @@ protected:
   nsRefPtr<MediaLargeByteBuffer> mInitData;
   nsRefPtr<SourceBufferResource> mResource;
   bool mHasInitData;
+  MediaByteRange mCompleteByteRange;
   const nsCString mType;
 };
 

--- a/dom/media/mediasource/ContainerParser.h
+++ b/dom/media/mediasource/ContainerParser.h
@@ -55,6 +55,7 @@ public:
   // Return the byte range of the first complete media segment or an empty
   // range if not complete.
   MediaByteRange MediaSegmentRange();
+  MediaByteRange InitSegmentRange();
 
   static ContainerParser* CreateForMIMEType(const nsACString& aType);
 
@@ -62,7 +63,8 @@ protected:
   nsRefPtr<MediaLargeByteBuffer> mInitData;
   nsRefPtr<SourceBufferResource> mResource;
   bool mHasInitData;
-  MediaByteRange mCompleteByteRange;
+  MediaByteRange mCompleteMediaSegmentRange;
+  MediaByteRange mCompleteInitSegmentRange;
   const nsCString mType;
 };
 

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -64,34 +64,6 @@ private:
   uint32_t mUpdateID;
 };
 
-class RangeRemovalRunnable : public nsRunnable {
-public:
-  RangeRemovalRunnable(SourceBuffer* aSourceBuffer,
-                       double aStart,
-                       double aEnd)
-  : mSourceBuffer(aSourceBuffer)
-  , mStart(aStart)
-  , mEnd(aEnd)
-  { }
-
-  NS_IMETHOD Run() override final {
-
-    if (!mSourceBuffer->mUpdating) {
-      // abort was called in between.
-      return NS_OK;
-    }
-    mSourceBuffer->DoRangeRemoval(mStart, mEnd);
-    mSourceBuffer->StopUpdating();
-
-    return NS_OK;
-  }
-
-private:
-  nsRefPtr<SourceBuffer> mSourceBuffer;
-  double mStart;
-  double mEnd;
-};
-
 void
 SourceBuffer::SetMode(SourceBufferAppendMode aMode, ErrorResult& aRv)
 {
@@ -251,29 +223,19 @@ SourceBuffer::Remove(double aStart, double aEnd, ErrorResult& aRv)
     mMediaSource->SetReadyState(MediaSourceReadyState::Open);
   }
 
-  StartUpdating();
-  nsRefPtr<nsIRunnable> task = new RangeRemovalRunnable(this, aStart, aEnd);
-  NS_DispatchToMainThread(task);
+  RangeRemoval(aStart, aEnd);
 }
 
 void
 SourceBuffer::RangeRemoval(double aStart, double aEnd)
 {
   StartUpdating();
-  DoRangeRemoval(aStart, aEnd);
-  nsRefPtr<nsIRunnable> task =
-    NS_NewRunnableMethod(this, &SourceBuffer::StopUpdating);
-  NS_DispatchToMainThread(task);
-}
-
-void
-SourceBuffer::DoRangeRemoval(double aStart, double aEnd)
-{
-  MSE_DEBUG("DoRangeRemoval(%f, %f)", aStart, aEnd);
-  if (mContentManager && !IsInfinite(aStart)) {
-    mContentManager->RangeRemoval(TimeUnit::FromSeconds(aStart),
-                                  TimeUnit::FromSeconds(aEnd));
-  }
+  nsRefPtr<SourceBuffer> self = this;
+  mContentManager->RangeRemoval(TimeUnit::FromSeconds(aStart),
+                                TimeUnit::FromSeconds(aEnd))
+    ->Then(AbstractThread::MainThread(), __func__,
+           [self] (bool) { self->StopUpdating(); },
+           []() { MOZ_ASSERT(false); });
 }
 
 void

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -67,28 +67,46 @@ private:
 void
 SourceBuffer::SetMode(SourceBufferAppendMode aMode, ErrorResult& aRv)
 {
+  typedef mozilla::SourceBufferContentManager::AppendState AppendState;
+
   MOZ_ASSERT(NS_IsMainThread());
   MSE_API("SetMode(aMode=%d)", aMode);
   if (!IsAttached() || mUpdating) {
     aRv.Throw(NS_ERROR_DOM_INVALID_STATE_ERR);
     return;
   }
-  if (aMode == SourceBufferAppendMode::Sequence) {
+  if (!mIsUsingFormatReader && aMode == SourceBufferAppendMode::Sequence) {
     aRv.Throw(NS_ERROR_DOM_NOT_SUPPORTED_ERR);
+    return;
+  }
+  if (mIsUsingFormatReader && mGenerateTimestamp &&
+      aMode == SourceBufferAppendMode::Segments) {
+    aRv.Throw(NS_ERROR_DOM_INVALID_ACCESS_ERR);
     return;
   }
   MOZ_ASSERT(mMediaSource->ReadyState() != MediaSourceReadyState::Closed);
   if (mMediaSource->ReadyState() == MediaSourceReadyState::Ended) {
     mMediaSource->SetReadyState(MediaSourceReadyState::Open);
   }
-  // TODO: Test append state.
-  // TODO: If aMode is "sequence", set sequence start time.
+  if (mIsUsingFormatReader &&
+      mContentManager->GetAppendState() == AppendState::PARSING_MEDIA_SEGMENT){
+    aRv.Throw(NS_ERROR_DOM_INVALID_STATE_ERR);
+    return;
+  }
+
+  if (mIsUsingFormatReader && aMode == SourceBufferAppendMode::Sequence) {
+    // Will set GroupStartTimestamp to GroupEndTimestamp.
+    mContentManager->RestartGroupStartTimestamp();
+  }
+
   mAppendMode = aMode;
 }
 
 void
 SourceBuffer::SetTimestampOffset(double aTimestampOffset, ErrorResult& aRv)
 {
+  typedef mozilla::SourceBufferContentManager::AppendState AppendState;
+
   MOZ_ASSERT(NS_IsMainThread());
   MSE_API("SetTimestampOffset(aTimestampOffset=%f)", aTimestampOffset);
   if (!IsAttached() || mUpdating) {
@@ -99,9 +117,25 @@ SourceBuffer::SetTimestampOffset(double aTimestampOffset, ErrorResult& aRv)
   if (mMediaSource->ReadyState() == MediaSourceReadyState::Ended) {
     mMediaSource->SetReadyState(MediaSourceReadyState::Open);
   }
-  // TODO: Test append state.
-  // TODO: If aMode is "sequence", set sequence start time.
+  if (mIsUsingFormatReader &&
+      mContentManager->GetAppendState() == AppendState::PARSING_MEDIA_SEGMENT){
+    aRv.Throw(NS_ERROR_DOM_INVALID_STATE_ERR);
+    return;
+  }
+  mApparentTimestampOffset = aTimestampOffset;
+  mTimestampOffset = TimeUnit::FromSeconds(aTimestampOffset);
+  if (mIsUsingFormatReader && mAppendMode == SourceBufferAppendMode::Sequence) {
+    mContentManager->SetGroupStartTimestamp(mTimestampOffset);
+  }
+}
+
+void
+SourceBuffer::SetTimestampOffset(const TimeUnit& aTimestampOffset)
+{
+  MOZ_ASSERT(NS_IsMainThread());
+
   mTimestampOffset = aTimestampOffset;
+  mApparentTimestampOffset = aTimestampOffset.ToSeconds();
 }
 
 already_AddRefed<TimeRanges>
@@ -193,7 +227,7 @@ SourceBuffer::AbortBufferAppend()
 {
   if (mUpdating) {
     mPendingAppend.DisconnectIfExists();
-    // TODO: Abort segment parser loop, and stream append loop algorithms.
+    // TODO: Abort stream append loop algorithms.
     // cancel any pending buffer append.
     mContentManager->AbortAppendData();
     AbortUpdating();
@@ -265,7 +299,7 @@ SourceBuffer::SourceBuffer(MediaSource* aMediaSource, const nsACString& aType)
   , mMediaSource(aMediaSource)
   , mAppendWindowStart(0)
   , mAppendWindowEnd(PositiveInfinity<double>())
-  , mTimestampOffset(0)
+  , mApparentTimestampOffset(0)
   , mAppendMode(SourceBufferAppendMode::Segments)
   , mUpdating(false)
   , mActive(false)
@@ -276,9 +310,26 @@ SourceBuffer::SourceBuffer(MediaSource* aMediaSource, const nsACString& aType)
   MOZ_ASSERT(aMediaSource);
   mEvictionThreshold = Preferences::GetUint("media.mediasource.eviction_threshold",
                                             75 * (1 << 20));
-  mContentManager = SourceBufferContentManager::CreateManager(aMediaSource->GetDecoder(), aType);
+  mContentManager =
+    SourceBufferContentManager::CreateManager(this,
+                                              aMediaSource->GetDecoder(),
+                                              aType);
   MSE_DEBUG("Create mContentManager=%p",
             mContentManager.get());
+  if (aType.LowerCaseEqualsLiteral("audio/mpeg") ||
+      aType.LowerCaseEqualsLiteral("audio/aac")) {
+    mGenerateTimestamp = true;
+  } else {
+    mGenerateTimestamp = false;
+  }
+  mIsUsingFormatReader =
+    Preferences::GetBool("media.mediasource.format-reader", false);
+  ErrorResult dummy;
+  if (mGenerateTimestamp) {
+    SetMode(SourceBufferAppendMode::Sequence, dummy);
+  } else {
+    SetMode(SourceBufferAppendMode::Segments, dummy);
+  }
 }
 
 SourceBuffer::~SourceBuffer()
@@ -375,7 +426,7 @@ SourceBuffer::AppendData(const uint8_t* aData, uint32_t aLength, ErrorResult& aR
   if (!data) {
     return;
   }
-  mContentManager->AppendData(data, TimeUnit::FromSeconds(mTimestampOffset));
+  mContentManager->AppendData(data, mTimestampOffset);
 
   StartUpdating();
 

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -43,30 +43,24 @@ namespace mozilla {
 
 namespace dom {
 
-class AppendDataRunnable : public nsRunnable {
+class BufferAppendRunnable : public nsRunnable {
 public:
-  AppendDataRunnable(SourceBuffer* aSourceBuffer,
-                     MediaLargeByteBuffer* aData,
-                     TimeUnit aTimestampOffset,
-                     uint32_t aUpdateID)
+  BufferAppendRunnable(SourceBuffer* aSourceBuffer,
+                       uint32_t aUpdateID)
   : mSourceBuffer(aSourceBuffer)
-  , mData(aData)
-  , mTimestampOffset(aTimestampOffset)
   , mUpdateID(aUpdateID)
   {
   }
 
   NS_IMETHOD Run() override final {
 
-    mSourceBuffer->AppendData(mData, mTimestampOffset, mUpdateID);
+    mSourceBuffer->BufferAppend(mUpdateID);
 
     return NS_OK;
   }
 
 private:
   nsRefPtr<SourceBuffer> mSourceBuffer;
-  nsRefPtr<MediaLargeByteBuffer> mData;
-  TimeUnit mTimestampOffset;
   uint32_t mUpdateID;
 };
 
@@ -419,18 +413,18 @@ SourceBuffer::AppendData(const uint8_t* aData, uint32_t aLength, ErrorResult& aR
   if (!data) {
     return;
   }
+  mContentManager->AppendData(data, TimeUnit::FromSeconds(mTimestampOffset));
+
   StartUpdating();
 
   MOZ_ASSERT(mAppendMode == SourceBufferAppendMode::Segments,
              "We don't handle timestampOffset for sequence mode yet");
-  nsRefPtr<nsIRunnable> task =
-    new AppendDataRunnable(this, data, TimeUnit::FromSeconds(mTimestampOffset), mUpdateID);
+  nsRefPtr<nsIRunnable> task = new BufferAppendRunnable(this, mUpdateID);
   NS_DispatchToMainThread(task);
 }
 
 void
-SourceBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset,
-                         uint32_t aUpdateID)
+SourceBuffer::BufferAppend(uint32_t aUpdateID)
 {
   if (!mUpdating || aUpdateID != mUpdateID) {
     // The buffer append algorithm has been interrupted by abort().
@@ -445,12 +439,7 @@ SourceBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset,
   MOZ_ASSERT(mMediaSource);
   MOZ_ASSERT(!mPendingAppend.Exists());
 
-  if (!aData->Length()) {
-    StopUpdating();
-    return;
-  }
-
-  mPendingAppend.Begin(mContentManager->AppendData(aData, aTimestampOffset)
+  mPendingAppend.Begin(mContentManager->BufferAppend()
                        ->Then(AbstractThread::MainThread(), __func__, this,
                               &SourceBuffer::AppendDataCompletedWithSuccess,
                               &SourceBuffer::AppendDataErrored));

--- a/dom/media/mediasource/SourceBuffer.h
+++ b/dom/media/mediasource/SourceBuffer.h
@@ -117,8 +117,6 @@ public:
 
   // Runs the range removal algorithm as defined by the MSE spec.
   void RangeRemoval(double aStart, double aEnd);
-  // Actually remove data between aStart and aEnd
-  void DoRangeRemoval(double aStart, double aEnd);
 
   bool IsActive() const
   {
@@ -134,7 +132,6 @@ private:
 
   friend class AsyncEventRunner<SourceBuffer>;
   friend class BufferAppendRunnable;
-  friend class RangeRemovalRunnable;
   void DispatchSimpleEvent(const char* aName);
   void QueueAsyncSimpleEvent(const char* aName);
 

--- a/dom/media/mediasource/SourceBuffer.h
+++ b/dom/media/mediasource/SourceBuffer.h
@@ -133,7 +133,7 @@ private:
   ~SourceBuffer();
 
   friend class AsyncEventRunner<SourceBuffer>;
-  friend class AppendDataRunnable;
+  friend class BufferAppendRunnable;
   friend class RangeRemovalRunnable;
   void DispatchSimpleEvent(const char* aName);
   void QueueAsyncSimpleEvent(const char* aName);
@@ -150,8 +150,7 @@ private:
 
   // Shared implementation of AppendBuffer overloads.
   void AppendData(const uint8_t* aData, uint32_t aLength, ErrorResult& aRv);
-  void AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset,
-                  uint32_t aAppendID);
+  void BufferAppend(uint32_t aAppendID);
 
   // Implement the "Append Error Algorithm".
   // Will call endOfStream() with "decode" error if aDecodeError is true.

--- a/dom/media/mediasource/SourceBufferContentManager.cpp
+++ b/dom/media/mediasource/SourceBufferContentManager.cpp
@@ -5,15 +5,24 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "SourceBufferContentManager.h"
+#include "TrackBuffer.h"
+#include "TrackBuffersManager.h"
 
 namespace mozilla {
 
 already_AddRefed<SourceBufferContentManager>
-SourceBufferContentManager::CreateManager(MediaSourceDecoder* aParentDecoder,
+SourceBufferContentManager::CreateManager(dom::SourceBuffer* aParent,
+                                          MediaSourceDecoder* aParentDecoder,
                                           const nsACString &aType)
 {
   nsRefPtr<SourceBufferContentManager> manager;
-  manager = new TrackBuffer(aParentDecoder, aType);
+  bool useFormatReader =
+    Preferences::GetBool("media.mediasource.format-reader", false);
+  if (useFormatReader) {
+    manager = new TrackBuffersManager(aParent, aParentDecoder, aType);
+  } else {
+    manager = new TrackBuffer(aParentDecoder, aType);
+  }
   return  manager.forget();
 }
 

--- a/dom/media/mediasource/SourceBufferContentManager.h
+++ b/dom/media/mediasource/SourceBufferContentManager.h
@@ -24,6 +24,7 @@ public:
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(SourceBufferContentManager);
 
   typedef MediaPromise<bool, nsresult, /* IsExclusive = */ true> AppendPromise;
+  typedef AppendPromise RangeRemovalPromise;
 
   static already_AddRefed<SourceBufferContentManager>
   CreateManager(MediaSourceDecoder* aParentDecoder, const nsACString& aType);
@@ -48,7 +49,7 @@ public:
 
   // Runs MSE range removal algorithm.
   // http://w3c.github.io/media-source/#sourcebuffer-coded-frame-removal
-  virtual bool RangeRemoval(TimeUnit aStart, TimeUnit aEnd) = 0;
+  virtual nsRefPtr<RangeRemovalPromise> RangeRemoval(TimeUnit aStart, TimeUnit aEnd) = 0;
 
   enum class EvictDataResult : int8_t
   {

--- a/dom/media/mediasource/SourceBufferContentManager.h
+++ b/dom/media/mediasource/SourceBufferContentManager.h
@@ -27,7 +27,8 @@ public:
   typedef AppendPromise RangeRemovalPromise;
 
   static already_AddRefed<SourceBufferContentManager>
-  CreateManager(MediaSourceDecoder* aParentDecoder, const nsACString& aType);
+  CreateManager(dom::SourceBuffer* aParent, MediaSourceDecoder* aParentDecoder,
+                const nsACString& aType);
 
   // Add data to the end of the input buffer.
   // Returns false if the append failed.
@@ -81,6 +82,23 @@ public:
 
   // The parent SourceBuffer is about to be destroyed.
   virtual void Detach() = 0;
+
+  // Current state as per Segment Parser Loop Algorithm
+  // http://w3c.github.io/media-source/index.html#sourcebuffer-segment-parser-loop
+  enum class AppendState : int32_t
+  {
+    WAITING_FOR_SEGMENT,
+    PARSING_INIT_SEGMENT,
+    PARSING_MEDIA_SEGMENT,
+  };
+
+  virtual AppendState GetAppendState()
+  {
+    return AppendState::WAITING_FOR_SEGMENT;
+  }
+
+  virtual void SetGroupStartTimestamp(const TimeUnit& aGroupStartTimestamp) {}
+  virtual void RestartGroupStartTimestamp() {}
 
 #if defined(DEBUG)
   virtual void Dump(const char* aPath) { }

--- a/dom/media/mediasource/SourceBufferContentManager.h
+++ b/dom/media/mediasource/SourceBufferContentManager.h
@@ -28,11 +28,15 @@ public:
   static already_AddRefed<SourceBufferContentManager>
   CreateManager(MediaSourceDecoder* aParentDecoder, const nsACString& aType);
 
-  // Append data to the current decoder.  Also responsible for calling
-  // NotifyDataArrived on the decoder to keep buffered range computation up
-  // to date.  Returns false if the append failed.
-  virtual nsRefPtr<AppendPromise>
-  AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset /* microseconds */) = 0;
+  // Add data to the end of the input buffer.
+  // Returns false if the append failed.
+  virtual bool
+  AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset) = 0;
+
+  // Run MSE Buffer Append Algorithm
+  // 3.5.5 Buffer Append Algorithm.
+  // http://w3c.github.io/media-source/index.html#sourcebuffer-buffer-append
+  virtual nsRefPtr<AppendPromise> BufferAppend() = 0;
 
   // Abort any pending AppendData.
   virtual void AbortAppendData() = 0;

--- a/dom/media/mediasource/TrackBuffer.cpp
+++ b/dom/media/mediasource/TrackBuffer.cpp
@@ -1068,7 +1068,7 @@ TrackBuffer::RemoveDecoder(SourceBufferDecoder* aDecoder)
   aDecoder->GetReader()->GetTaskQueue()->Dispatch(task);
 }
 
-bool
+nsRefPtr<TrackBuffer::RangeRemovalPromise>
 TrackBuffer::RangeRemoval(TimeUnit aStart, TimeUnit aEnd)
 {
   MOZ_ASSERT(NS_IsMainThread());
@@ -1080,14 +1080,14 @@ TrackBuffer::RangeRemoval(TimeUnit aStart, TimeUnit aEnd)
 
   if (!buffered.Length() || aStart > bufferedEnd || aEnd < bufferedStart) {
     // Nothing to remove.
-    return false;
+    return RangeRemovalPromise::CreateAndResolve(false, __func__);
   }
 
   if (aStart > bufferedStart && aEnd < bufferedEnd) {
     // TODO. We only handle trimming and removal from the start.
     NS_WARNING("RangeRemoval unsupported arguments. "
                "Can only handle trimming (trim left or trim right");
-    return false;
+    return RangeRemovalPromise::CreateAndResolve(false, __func__);
   }
 
   nsTArray<SourceBufferDecoder*> decoders;
@@ -1130,7 +1130,7 @@ TrackBuffer::RangeRemoval(TimeUnit aStart, TimeUnit aEnd)
   RemoveEmptyDecoders(decoders);
 
   NotifyTimeRangesChanged();
-  return true;
+  return RangeRemovalPromise::CreateAndResolve(true, __func__);
 }
 
 void

--- a/dom/media/mediasource/TrackBuffer.cpp
+++ b/dom/media/mediasource/TrackBuffer.cpp
@@ -141,18 +141,32 @@ TrackBuffer::ContinueShutdown()
   mShutdownPromise.Resolve(true, __func__);
 }
 
-nsRefPtr<TrackBuffer::AppendPromise>
+bool
 TrackBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset)
 {
   MOZ_ASSERT(NS_IsMainThread());
+  mInputBuffer = aData;
+  mTimestampOffset = aTimestampOffset;
+  return true;
+}
+
+nsRefPtr<TrackBuffer::AppendPromise>
+TrackBuffer::BufferAppend()
+{
+  MOZ_ASSERT(NS_IsMainThread());
   MOZ_ASSERT(mInitializationPromise.IsEmpty());
+  MOZ_ASSERT(mInputBuffer);
+
+  if (mInputBuffer->IsEmpty()) {
+    return AppendPromise::CreateAndResolve(false, __func__);
+  }
 
   DecodersToInitialize decoders(this);
   nsRefPtr<AppendPromise> p = mInitializationPromise.Ensure(__func__);
   bool hadInitData = mParser->HasInitData();
   bool hadCompleteInitData = mParser->HasCompleteInitData();
   nsRefPtr<MediaLargeByteBuffer> oldInit = mParser->InitData();
-  bool newInitData = mParser->IsInitSegmentPresent(aData);
+  bool newInitData = mParser->IsInitSegmentPresent(mInputBuffer);
 
   // TODO: Run more of the buffer append algorithm asynchronously.
   if (newInitData) {
@@ -164,14 +178,14 @@ TrackBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset)
   }
 
   int64_t start = 0, end = 0;
-  bool gotMedia = mParser->ParseStartAndEndTimestamps(aData, start, end);
+  bool gotMedia = mParser->ParseStartAndEndTimestamps(mInputBuffer, start, end);
   bool gotInit = mParser->HasCompleteInitData();
 
   if (newInitData) {
     if (!gotInit) {
       // We need a new decoder, but we can't initialize it yet.
       nsRefPtr<SourceBufferDecoder> decoder =
-        NewDecoder(aTimestampOffset);
+        NewDecoder(mTimestampOffset);
       // The new decoder is stored in mDecoders/mCurrentDecoder, so we
       // don't need to do anything with 'decoder'. It's only a placeholder.
       if (!decoder) {
@@ -179,7 +193,7 @@ TrackBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset)
         return p;
       }
     } else {
-      if (!decoders.NewDecoder(aTimestampOffset)) {
+      if (!decoders.NewDecoder(mTimestampOffset)) {
         mInitializationPromise.Reject(NS_ERROR_FAILURE, __func__);
         return p;
       }
@@ -192,9 +206,9 @@ TrackBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset)
   }
 
   if (gotMedia) {
-    if (mParser->IsMediaSegmentPresent(aData) && mLastEndTimestamp &&
+    if (mParser->IsMediaSegmentPresent(mInputBuffer) && mLastEndTimestamp &&
         (!mParser->TimestampsFuzzyEqual(start, mLastEndTimestamp.value()) ||
-         mLastTimestampOffset != aTimestampOffset ||
+         mLastTimestampOffset != mTimestampOffset ||
          mDecoderPerSegment ||
          (mCurrentDecoder && mCurrentDecoder->WasTrimmed()))) {
       MSE_DEBUG("Data last=[%lld, %lld] overlaps [%lld, %lld]",
@@ -205,7 +219,7 @@ TrackBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset)
         // processed or not continuous, so we must create a new decoder
         // to handle the decoding.
         if (!hadCompleteInitData ||
-            !decoders.NewDecoder(aTimestampOffset)) {
+            !decoders.NewDecoder(mTimestampOffset)) {
           mInitializationPromise.Reject(NS_ERROR_FAILURE, __func__);
           return p;
         }
@@ -231,7 +245,7 @@ TrackBuffer::AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset)
     mAdjustedTimestamp = starttu;
   }
 
-  if (!AppendDataToCurrentResource(aData, end - start)) {
+  if (!AppendDataToCurrentResource(mInputBuffer, end - start)) {
     mInitializationPromise.Reject(NS_ERROR_FAILURE, __func__);
     return p;
   }
@@ -950,6 +964,7 @@ TrackBuffer::ResetParserState()
     mParser = ContainerParser::CreateForMIMEType(mType);
     DiscardCurrentDecoder();
   }
+  mInputBuffer = nullptr;
 }
 
 void

--- a/dom/media/mediasource/TrackBuffer.h
+++ b/dom/media/mediasource/TrackBuffer.h
@@ -48,7 +48,7 @@ public:
   // of the buffer through to aTime.
   void EvictBefore(TimeUnit aTime) override;
 
-  bool RangeRemoval(TimeUnit aStart, TimeUnit aEnd) override;
+  nsRefPtr<RangeRemovalPromise> RangeRemoval(TimeUnit aStart, TimeUnit aEnd) override;
 
   void AbortAppendData() override;
 

--- a/dom/media/mediasource/TrackBuffer.h
+++ b/dom/media/mediasource/TrackBuffer.h
@@ -30,11 +30,12 @@ public:
 
   nsRefPtr<ShutdownPromise> Shutdown();
 
+  bool AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset) override;
+
   // Append data to the current decoder.  Also responsible for calling
   // NotifyDataArrived on the decoder to keep buffered range computation up
-  // to date.  Returns false if the append failed.
-  nsRefPtr<AppendPromise> AppendData(MediaLargeByteBuffer* aData,
-                                     TimeUnit aTimestampOffset /* microseconds */) override;
+  // to date.
+  nsRefPtr<AppendPromise> BufferAppend() override;
 
   // Evicts data held in the current decoders SourceBufferResource from the
   // start of the buffer through to aPlaybackTime. aThreshold is used to
@@ -158,6 +159,7 @@ private:
                          SourceBufferDecoder* aDecoder);
 
   nsAutoPtr<ContainerParser> mParser;
+  nsRefPtr<MediaLargeByteBuffer> mInputBuffer;
 
   // A task queue using the shared media thread pool.  Used exclusively to
   // initialize (i.e. call ReadMetadata on) decoders as they are created via
@@ -192,6 +194,7 @@ private:
 
   // The timestamp offset used by our current decoder.
   TimeUnit mLastTimestampOffset;
+  TimeUnit mTimestampOffset;
   TimeUnit mAdjustedTimestamp;
 
   // True if at least one of our decoders has encrypted content.

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -574,10 +574,9 @@ TrackBuffersManager::SegmentParserLoop()
         continue;
       }
       // We have neither an init segment nor a media segment, this is invalid
-      // data. However, as we do not remove any bytes that are supposed to be
-      // ignored, we simply ignore them.
-      MSE_DEBUG("Found invalid data, ignoring for now");
-      NeedMoreData();
+      // data.
+      MSE_DEBUG("Found invalid data");
+      RejectAppend(NS_ERROR_FAILURE, __func__);
       return;
     }
 

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -16,8 +16,8 @@
 
 extern PRLogModuleInfo* GetMediaSourceLog();
 
-#define MSE_DEBUG(arg, ...) MOZ_LOG(GetMediaSourceLog(), mozilla::LogLevel::Debug, ("TrackBuffersManager(%p:%s)::%s: " arg, this, mType.get(), __func__, ##__VA_ARGS__))
-#define MSE_DEBUGV(arg, ...) MOZ_LOG(GetMediaSourceLog(), mozilla::LogLevel::Verbose, ("TrackBuffersManager(%p:%s)::%s: " arg, this, mType.get(), __func__, ##__VA_ARGS__))
+#define MSE_DEBUG(arg, ...) PR_LOG(GetMediaSourceLog(), PR_LOG_DEBUG, ("TrackBuffersManager(%p:%s)::%s: " arg, this, mType.get(), __func__, ##__VA_ARGS__))
+#define MSE_DEBUGV(arg, ...) PR_LOG(GetMediaSourceLog(), PR_LOG_DEBUG, ("TrackBuffersManager(%p:%s)::%s: " arg, this, mType.get(), __func__, ##__VA_ARGS__))
 
 namespace mozilla {
 

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -45,6 +45,7 @@ TrackBuffersManager::TrackBuffersManager(dom::SourceBuffer* aParent, MediaSource
   , mType(aType)
   , mParser(ContainerParser::CreateForMIMEType(aType))
   , mProcessedInput(0)
+  , mAppendRunning(false)
   , mTaskQueue(new MediaTaskQueue(GetMediaThreadPool(MediaThreadType::PLAYBACK)))
   , mParent(new nsMainThreadPtrHolder<dom::SourceBuffer>(aParent, false /* strict */))
   , mParentDecoder(new nsMainThreadPtrHolder<MediaSourceDecoder>(aParentDecoder, false /* strict */))
@@ -75,6 +76,7 @@ TrackBuffersManager::AppendIncomingBuffer(IncomingBuffer aData)
 {
   MOZ_ASSERT(OnTaskQueue());
   mIncomingBuffers.AppendElement(aData);
+  mAbort = false;
 }
 
 nsRefPtr<TrackBuffersManager::AppendPromise>
@@ -92,6 +94,9 @@ TrackBuffersManager::BufferAppend()
 // process is happening asynchronously, as such where and when we would abort is
 // non-deterministic. The SourceBuffer also makes sure BufferAppend
 // isn't called should the appendBuffer be immediately aborted.
+// We do however want to ensure that no new task will be dispatched on our task
+// queue and only let the current one finish its job. For this we set mAbort
+// to true.
 void
 TrackBuffersManager::AbortAppendData()
 {
@@ -105,6 +110,7 @@ void
 TrackBuffersManager::ResetParserState()
 {
   MOZ_ASSERT(NS_IsMainThread());
+  MOZ_ASSERT(!mAppendRunning, "AbortAppendData must have been called");
   MSE_DEBUG("");
 
   // 1. If the append state equals PARSING_MEDIA_SEGMENT and the input buffer contains some complete coded frames, then run the coded frame processing algorithm until all of these complete coded frames have been processed.
@@ -117,6 +123,13 @@ TrackBuffersManager::ResetParserState()
       NS_NewRunnableMethod(this, &TrackBuffersManager::CompleteResetParserState);
     GetTaskQueue()->Dispatch(task.forget());
   }
+
+  // Our ResetParserState is really asynchronous, the current task has been
+  // interrupted and will complete shortly (or has already completed).
+  // We must however present to the main thread a stable, reset state.
+  // So we run the following operation now in the main thread.
+  // 7. Set append state to WAITING_FOR_SEGMENT.
+  SetAppendState(AppendState::WAITING_FOR_SEGMENT);
 }
 
 nsRefPtr<TrackBuffersManager::RangeRemovalPromise>
@@ -138,12 +151,13 @@ TrackBuffersManager::EvictData(TimeUnit aPlaybackTime,
                                TimeUnit* aBufferStartTime)
 {
   MOZ_ASSERT(NS_IsMainThread());
+  MSE_DEBUG("");
 
   int64_t toEvict = GetSize() - aThreshold;
   if (toEvict <= 0) {
     return EvictDataResult::NO_DATA_EVICTED;
   }
-  MSE_DEBUG("Reaching our size limit, schedule eviction of %lld bytes", toEvict);
+  MSE_DEBUG("Reaching our size limit, schedule eviction of %lld bytes", toEvict);
 
   nsCOMPtr<nsIRunnable> task =
     NS_NewRunnableMethodWithArgs<TimeUnit, uint32_t>(
@@ -158,6 +172,8 @@ void
 TrackBuffersManager::EvictBefore(TimeUnit aTime)
 {
   MOZ_ASSERT(NS_IsMainThread());
+  MSE_DEBUG("");
+
   nsCOMPtr<nsIRunnable> task =
     NS_NewRunnableMethodWithArg<TimeInterval>(
         this, &TrackBuffersManager::CodedFrameRemoval,
@@ -168,6 +184,7 @@ TrackBuffersManager::EvictBefore(TimeUnit aTime)
 media::TimeIntervals
 TrackBuffersManager::Buffered()
 {
+  MSE_DEBUG("");
   MonitorAutoLock mon(mMonitor);
   // http://w3c.github.io/media-source/index.html#widl-SourceBuffer-buffered
   // 2. Let highest end time be the largest track buffer ranges end time across all the track buffers managed by this SourceBuffer object.
@@ -256,7 +273,8 @@ void
 TrackBuffersManager::CompleteResetParserState()
 {
   MOZ_ASSERT(OnTaskQueue());
-  MOZ_ASSERT(mAppendPromise.IsEmpty());
+  MOZ_ASSERT(!mAppendRunning);
+  MSE_DEBUG("");
 
   for (auto track : GetTracksList()) {
     // 2. Unset the last decode timestamp on all track buffers.
@@ -299,9 +317,6 @@ TrackBuffersManager::CompleteResetParserState()
 
   // 7. Set append state to WAITING_FOR_SEGMENT.
   SetAppendState(AppendState::WAITING_FOR_SEGMENT);
-
-  // We're done.
-  mAbort = false;
 }
 
 void
@@ -380,7 +395,7 @@ bool
 TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
 {
   MOZ_ASSERT(OnTaskQueue());
-  MOZ_ASSERT(mAppendPromise.IsEmpty(), "Logic error: Append in progress");
+  MOZ_ASSERT(!mAppendRunning, "Logic error: Append in progress");
   MSE_DEBUG("From %.2fs to %.2f",
             aInterval.mStart.ToSeconds(), aInterval.mEnd.ToSeconds());
 
@@ -502,7 +517,7 @@ TrackBuffersManager::InitSegmentParserLoop()
 {
   MOZ_ASSERT(OnTaskQueue());
 
-  MOZ_ASSERT(mAppendPromise.IsEmpty());
+  MOZ_ASSERT(mAppendPromise.IsEmpty() && !mAppendRunning);
   nsRefPtr<AppendPromise> p = mAppendPromise.Ensure(__func__);
 
   AppendIncomingBuffers();
@@ -616,7 +631,10 @@ void
 TrackBuffersManager::NeedMoreData()
 {
   MSE_DEBUG("");
-  RestoreCachedVariables();
+  if (!mAbort) {
+    RestoreCachedVariables();
+  }
+  mAppendRunning = false;
   mAppendPromise.ResolveIfExists(mActiveTrack, __func__);
 }
 
@@ -624,6 +642,7 @@ void
 TrackBuffersManager::RejectAppend(nsresult aRejectValue, const char* aName)
 {
   MSE_DEBUG("rv=%d", aRejectValue);
+  mAppendRunning = false;
   mAppendPromise.RejectIfExists(aRejectValue, aName);
 }
 
@@ -688,6 +707,8 @@ TrackBuffersManager::InitializationSegmentReceived()
 void
 TrackBuffersManager::OnDemuxerInitDone(nsresult)
 {
+  MOZ_ASSERT(OnTaskQueue());
+  MSE_DEBUG("mAbort:%d", static_cast<bool>(mAbort));
   mDemuxerInitRequest.Complete();
 
   if (mAbort) {
@@ -871,6 +892,7 @@ TrackBuffersManager::OnDemuxerInitFailed(DemuxerFailureReason aFailure)
 nsRefPtr<TrackBuffersManager::CodedFrameProcessingPromise>
 TrackBuffersManager::CodedFrameProcessing()
 {
+  MOZ_ASSERT(OnTaskQueue());
   MOZ_ASSERT(mProcessingPromise.IsEmpty());
   nsRefPtr<CodedFrameProcessingPromise> p = mProcessingPromise.Ensure(__func__);
 
@@ -903,12 +925,10 @@ void
 TrackBuffersManager::OnDemuxFailed(TrackType aTrack,
                                    DemuxerFailureReason aFailure)
 {
-  MSE_DEBUG("Failed to demux %s, failure = %d",
-      aTrack == TrackType::kVideoTrack ? "video" : "audio", aFailure);
-  if (mAbort) {
-    mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
-    return;
-  }
+  MOZ_ASSERT(OnTaskQueue());
+  MSE_DEBUG("Failed to demux %s, failure:%d mAbort:%d",
+            aTrack == TrackType::kVideoTrack ? "video" : "audio",
+            aFailure, static_cast<bool>(mAbort));
   switch (aFailure) {
     case DemuxerFailureReason::END_OF_STREAM:
     case DemuxerFailureReason::WAITING_FOR_DATA:
@@ -919,11 +939,11 @@ TrackBuffersManager::OnDemuxFailed(TrackType aTrack,
       }
       break;
     case DemuxerFailureReason::DEMUXER_ERROR:
-      mProcessingPromise.RejectIfExists(NS_ERROR_FAILURE, __func__);
+      RejectProcessing(NS_ERROR_FAILURE, __func__);
       break;
     case DemuxerFailureReason::CANCELED:
     case DemuxerFailureReason::SHUTDOWN:
-      mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
+      RejectProcessing(NS_ERROR_ABORT, __func__);
       break;
     default:
       MOZ_ASSERT(false);
@@ -934,8 +954,14 @@ TrackBuffersManager::OnDemuxFailed(TrackType aTrack,
 void
 TrackBuffersManager::DoDemuxVideo()
 {
+  MOZ_ASSERT(OnTaskQueue());
+  MSE_DEBUG("mAbort:%d", static_cast<bool>(mAbort));
   if (!HasVideo()) {
     DoDemuxAudio();
+    return;
+  }
+  if (mAbort) {
+    RejectProcessing(NS_ERROR_ABORT, __func__);
     return;
   }
   mVideoTracks.mDemuxRequest.Begin(mVideoTracks.mDemuxer->GetSamples(-1)
@@ -947,12 +973,9 @@ TrackBuffersManager::DoDemuxVideo()
 void
 TrackBuffersManager::OnVideoDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHolder> aSamples)
 {
+  MOZ_ASSERT(OnTaskQueue());
   MSE_DEBUG("%d video samples demuxed", aSamples->mSamples.Length());
   mVideoTracks.mDemuxRequest.Complete();
-  if (mAbort) {
-    mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
-    return;
-  }
   mVideoTracks.mQueuedSamples.AppendElements(aSamples->mSamples);
   DoDemuxAudio();
 }
@@ -960,8 +983,10 @@ TrackBuffersManager::OnVideoDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHo
 void
 TrackBuffersManager::DoDemuxAudio()
 {
+  MOZ_ASSERT(OnTaskQueue());
+  MSE_DEBUG("mAbort:%d", static_cast<bool>(mAbort));
   if (mAbort) {
-    mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
+    RejectProcessing(NS_ERROR_ABORT, __func__);
     return;
   }
   if (!HasAudio()) {
@@ -977,12 +1002,9 @@ TrackBuffersManager::DoDemuxAudio()
 void
 TrackBuffersManager::OnAudioDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHolder> aSamples)
 {
+  MOZ_ASSERT(OnTaskQueue());
   MSE_DEBUG("%d audio samples demuxed", aSamples->mSamples.Length());
   mAudioTracks.mDemuxRequest.Complete();
-  if (mAbort) {
-    mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
-    return;
-  }
   mAudioTracks.mQueuedSamples.AppendElements(aSamples->mSamples);
   CompleteCodedFrameProcessing();
 }
@@ -990,6 +1012,7 @@ TrackBuffersManager::OnAudioDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHo
 void
 TrackBuffersManager::CompleteCodedFrameProcessing()
 {
+  MSE_DEBUG("mAbort:%d", static_cast<bool>(mAbort));
   MOZ_ASSERT(OnTaskQueue());
 
   // 1. For each coded frame in the media segment run the following steps:
@@ -1038,7 +1061,7 @@ TrackBuffersManager::CompleteCodedFrameProcessing()
 
   // 5. If the input buffer does not contain a complete media segment, then jump to the need more data step below.
   if (mParser->MediaSegmentRange().IsNull()) {
-    mProcessingPromise.ResolveIfExists(true, __func__);
+    ResolveProcessing(true, __func__);
     return;
   }
 
@@ -1054,7 +1077,29 @@ TrackBuffersManager::CompleteCodedFrameProcessing()
   SetAppendState(AppendState::WAITING_FOR_SEGMENT);
 
   // 8. Jump to the loop top step above.
-  mProcessingPromise.ResolveIfExists(false, __func__);
+  ResolveProcessing(false, __func__);
+}
+
+void
+TrackBuffersManager::RejectProcessing(nsresult aRejectValue, const char* aName)
+{
+  if (mAbort) {
+    // mAppendPromise will be resolved immediately upon mProcessingPromise
+    // completing.
+    mAppendRunning = false;
+  }
+  mProcessingPromise.RejectIfExists(aRejectValue, __func__);
+}
+
+void
+TrackBuffersManager::ResolveProcessing(bool aResolveValue, const char* aName)
+{
+  if (mAbort) {
+    // mAppendPromise will be resolved immediately upon mProcessingPromise
+    // completing.
+    mAppendRunning = false;
+  }
+  mProcessingPromise.ResolveIfExists(aResolveValue, __func__);
 }
 
 bool
@@ -1306,6 +1351,7 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
 void
 TrackBuffersManager::RecreateParser()
 {
+  MOZ_ASSERT(OnTaskQueue());
   // Recreate our parser for only the data remaining. This is required
   // as it has parsed the entire InputBuffer provided.
   // Once the old TrackBuffer/MediaSource implementation is removed
@@ -1324,6 +1370,7 @@ TrackBuffersManager::RecreateParser()
 nsTArray<TrackBuffersManager::TrackData*>
 TrackBuffersManager::GetTracksList()
 {
+  MOZ_ASSERT(OnTaskQueue());
   nsTArray<TrackData*> tracks;
   if (HasVideo()) {
     tracks.AppendElement(&mVideoTracks);
@@ -1337,6 +1384,7 @@ TrackBuffersManager::GetTracksList()
 void
 TrackBuffersManager::RestoreCachedVariables()
 {
+  MOZ_ASSERT(OnTaskQueue());
   if (mTimestampOffset != mLastTimestampOffset) {
     nsCOMPtr<nsIRunnable> task =
       NS_NewRunnableMethodWithArg<TimeUnit>(

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -46,7 +46,7 @@ TrackBuffersManager::TrackBuffersManager(dom::SourceBuffer* aParent, MediaSource
   , mParser(ContainerParser::CreateForMIMEType(aType))
   , mProcessedInput(0)
   , mAppendRunning(false)
-  , mTaskQueue(new MediaTaskQueue(GetMediaThreadPool(MediaThreadType::PLAYBACK)))
+  , mTaskQueue(new MediaTaskQueue(GetMediaThreadPool()))
   , mParent(new nsMainThreadPtrHolder<dom::SourceBuffer>(aParent, false /* strict */))
   , mParentDecoder(new nsMainThreadPtrHolder<MediaSourceDecoder>(aParentDecoder, false /* strict */))
   , mAbort(false)

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -44,6 +44,7 @@ TrackBuffersManager::TrackBuffersManager(dom::SourceBuffer* aParent, MediaSource
   , mActiveTrack(false)
   , mType(aType)
   , mParser(ContainerParser::CreateForMIMEType(aType))
+  , mProcessedInput(0)
   , mTaskQueue(new MediaTaskQueue(GetMediaThreadPool(MediaThreadType::PLAYBACK)))
   , mParent(new nsMainThreadPtrHolder<dom::SourceBuffer>(aParent, false /* strict */))
   , mParentDecoder(new nsMainThreadPtrHolder<MediaSourceDecoder>(aParentDecoder, false /* strict */))
@@ -267,7 +268,7 @@ TrackBuffersManager::CompleteResetParserState()
   }
   // 6. Remove all bytes from the input buffer.
   mIncomingBuffers.Clear();
-  mInputBuffer->Clear();
+  mInputBuffer = nullptr;
   if (mCurrentInputBuffer) {
     mCurrentInputBuffer->EvictAll();
     mCurrentInputBuffer = new SourceBufferResource(mType);
@@ -282,7 +283,10 @@ TrackBuffersManager::CompleteResetParserState()
     MOZ_ASSERT(initData->Length(), "we must have an init segment");
     // The aim here is really to destroy our current demuxer.
     CreateDemuxerforMIMEType();
-    mInputBuffer->AppendElements(*initData);
+    // Recreate our input buffer. We can't directly assign the initData buffer
+    // to mInputBuffer as it will get modified in the Segment Parser Loop.
+    mInputBuffer = new MediaLargeByteBuffer;
+    MOZ_ALWAYS_TRUE(mInputBuffer->AppendElements(*initData));
   }
   RecreateParser();
 
@@ -362,11 +366,25 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
 {
   MSE_DEBUG("From %.2fs to %.2f",
             aInterval.mStart.ToSeconds(), aInterval.mEnd.ToSeconds());
-  TimeUnit duration{TimeUnit::FromSeconds(mParentDecoder->GetMediaSourceDuration())};
+
+  double mediaSourceDuration = mParentDecoder->GetMediaSourceDuration();
+  if (IsNaN(mediaSourceDuration)) {
+    MSE_DEBUG("Nothing to remove, aborting");
+    MonitorAutoLock mon(mMonitor);
+    mRangeRemovalPromise.ResolveIfExists(false, __func__);
+    return;
+  }
+  TimeUnit duration{TimeUnit::FromSeconds(mediaSourceDuration)};
 
   MSE_DEBUG("duration:%.2f", duration.ToSeconds());
-  MSE_DEBUG("before video ranges=%s", DumpTimeRanges(mVideoTracks.mBufferedRanges).get());
-  MSE_DEBUG("before audio ranges=%s", DumpTimeRanges(mAudioTracks.mBufferedRanges).get());
+  if (HasAudio()) {
+    MSE_DEBUG("before video ranges=%s",
+              DumpTimeRanges(mVideoTracks.mBufferedRanges).get());
+  }
+  if (HasVideo()) {
+    MSE_DEBUG("before audio ranges=%s",
+              DumpTimeRanges(mAudioTracks.mBufferedRanges).get());
+  }
 
   // 1. Let start be the starting presentation timestamp for the removal range.
   TimeUnit start = aInterval.mStart;
@@ -445,8 +463,15 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
     mVideoBufferedRanges = mVideoTracks.mBufferedRanges;
     mAudioBufferedRanges = mAudioTracks.mBufferedRanges;
   }
-  MSE_DEBUG("after video ranges=%s", DumpTimeRanges(mVideoTracks.mBufferedRanges).get());
-  MSE_DEBUG("after audio ranges=%s", DumpTimeRanges(mAudioTracks.mBufferedRanges).get());
+
+  if (HasAudio()) {
+    MSE_DEBUG("after video ranges=%s",
+              DumpTimeRanges(mVideoTracks.mBufferedRanges).get());
+  }
+  if (HasVideo()) {
+    MSE_DEBUG("after audio ranges=%s",
+              DumpTimeRanges(mAudioTracks.mBufferedRanges).get());
+  }
 
   // Update our reported total size.
   mSizeSourceBuffer = mVideoTracks.mSizeBuffer + mAudioTracks.mSizeBuffer;
@@ -467,12 +492,12 @@ TrackBuffersManager::AppendIncomingBuffers()
   MOZ_ASSERT(OnTaskQueue());
   MonitorAutoLock mon(mMonitor);
   for (auto& incomingBuffer : mIncomingBuffers) {
-    if (!mInputBuffer->AppendElements(*incomingBuffer.first())) {
+    if (!mInputBuffer) {
+      mInputBuffer = incomingBuffer.first();
+    } else if (!mInputBuffer->AppendElements(*incomingBuffer.first())) {
       RejectAppend(NS_ERROR_OUT_OF_MEMORY, __func__);
     }
-  }
-  if (!mIncomingBuffers.IsEmpty()) {
-    mTimestampOffset = mIncomingBuffers.LastElement().second();
+    mTimestampOffset = incomingBuffer.second();
     mLastTimestampOffset = mTimestampOffset;
   }
   mIncomingBuffers.Clear();
@@ -483,7 +508,6 @@ TrackBuffersManager::SegmentParserLoop()
 {
   MOZ_ASSERT(OnTaskQueue());
   while (true) {
-    bool completeMediaHeader;
     // 1. If the input buffer is empty, then jump to the need more data step below.
     if (!mInputBuffer || mInputBuffer->IsEmpty()) {
       NeedMoreData();
@@ -518,8 +542,8 @@ TrackBuffersManager::SegmentParserLoop()
     }
 
     int64_t start, end;
-    completeMediaHeader =
-      mParser->ParseStartAndEndTimestamps(mInputBuffer, start, end);
+    mParser->ParseStartAndEndTimestamps(mInputBuffer, start, end);
+    mProcessedInput += mInputBuffer->Length();
 
     // 5. If the append state equals PARSING_INIT_SEGMENT, then run the
     // following steps:
@@ -538,7 +562,7 @@ TrackBuffersManager::SegmentParserLoop()
         return;
       }
       // 2. If the input buffer does not contain a complete media segment header yet, then jump to the need more data step below.
-      if (!completeMediaHeader) {
+      if (mParser->MediaHeaderRange().IsNull()) {
         NeedMoreData();
         return;
       }
@@ -567,10 +591,6 @@ void
 TrackBuffersManager::NeedMoreData()
 {
   MSE_DEBUG("");
-  // The entire mInputBuffer will be reparsed on the next Segment Parser Loop
-  // run, clear the current ContainerParser so it won't treat the same data
-  // twice which would shift all our offsets incorrectly.
-  RecreateParser();
   RestoreCachedVariables();
   mAppendPromise.ResolveIfExists(mActiveTrack, __func__);
 }
@@ -622,6 +642,12 @@ TrackBuffersManager::InitializationSegmentReceived()
   MOZ_ASSERT(mParser->HasCompleteInitData());
   mCurrentInputBuffer = new SourceBufferResource(mType);
   mCurrentInputBuffer->AppendData(mParser->InitData());
+  uint32_t initLength = mParser->InitSegmentRange().mEnd;
+  if (mInputBuffer->Length() == initLength) {
+    mInputBuffer = nullptr;
+  } else {
+    mInputBuffer->RemoveElementsAt(0, initLength);
+  }
   CreateDemuxerforMIMEType();
   if (!mInputDemuxer) {
     MOZ_ASSERT(false, "TODO type not supported");
@@ -797,7 +823,9 @@ TrackBuffersManager::OnDemuxerInitDone(nsresult)
   }
 
   // 3. Remove the initialization segment bytes from the beginning of the input buffer.
-  mInputBuffer->RemoveElementsAt(0, mParser->InitSegmentRange().mEnd);
+  // This step has already been done in InitializationSegmentReceived when we
+  // transferred the content into mCurrentInputBuffer.
+  mCurrentInputBuffer->EvictAll();
   RecreateParser();
 
   // 4. Set append state to WAITING_FOR_SEGMENT.
@@ -823,23 +851,21 @@ TrackBuffersManager::CodedFrameProcessing()
 
   int64_t offset = mCurrentInputBuffer->GetLength();
   MediaByteRange mediaRange = mParser->MediaSegmentRange();
-  // The mediaRange is offset by the init segment position previously added.
-  int64_t rangeOffset = mParser->InitData()->Length();
-  int64_t length;
+  uint32_t length;
   if (mediaRange.IsNull()) {
     length = mInputBuffer->Length();
     mCurrentInputBuffer->AppendData(mInputBuffer);
+    mInputBuffer = nullptr;
   } else {
+    // The mediaRange is offset by the init segment position previously added.
+    length = mediaRange.mEnd - (mProcessedInput - mInputBuffer->Length());
     nsRefPtr<MediaLargeByteBuffer> segment = new MediaLargeByteBuffer;
-    length = mediaRange.Length();
-    MOZ_ASSERT(mInputBuffer->Length() >= uint64_t(mediaRange.mEnd - rangeOffset),
-               "We're missing some data");
-    MOZ_ASSERT(mediaRange.mStart >= rangeOffset, "Invalid media segment range");
-    if (!segment->AppendElements(mInputBuffer->Elements() +
-                                 mediaRange.mStart - rangeOffset, length)) {
+    MOZ_ASSERT(mInputBuffer->Length() >= length);
+    if (!segment->AppendElements(mInputBuffer->Elements(), length)) {
       return CodedFrameProcessingPromise::CreateAndReject(NS_ERROR_OUT_OF_MEMORY, __func__);
     }
     mCurrentInputBuffer->AppendData(segment);
+    mInputBuffer->RemoveElementsAt(0, length);
   }
   mInputDemuxer->NotifyDataArrived(length, offset);
 
@@ -967,6 +993,14 @@ TrackBuffersManager::CompleteCodedFrameProcessing()
     // Save our final tracks buffered ranges.
     mVideoBufferedRanges = mVideoTracks.mBufferedRanges;
     mAudioBufferedRanges = mAudioTracks.mBufferedRanges;
+    if (HasAudio()) {
+      MSE_DEBUG("audio new buffered range = %s",
+                DumpTimeRanges(mAudioBufferedRanges).get());
+    }
+    if (HasVideo()) {
+      MSE_DEBUG("video new buffered range = %s",
+                DumpTimeRanges(mVideoBufferedRanges).get());
+    }
   }
 
    // Update our reported total size.
@@ -984,15 +1018,12 @@ TrackBuffersManager::CompleteCodedFrameProcessing()
   }
 
   // 6. Remove the media segment bytes from the beginning of the input buffer.
-  int64_t rangeOffset = mParser->InitSegmentRange().mEnd;
-  mInputBuffer->RemoveElementsAt(0, mParser->MediaSegmentRange().mEnd - rangeOffset);
-  RecreateParser();
-
   // Clear our demuxer from any already processed data.
   // As we have handled a complete media segment, it is safe to evict all data
   // from the resource.
   mCurrentInputBuffer->EvictAll();
   mInputDemuxer->NotifyDataRemoved();
+  RecreateParser();
 
   // 7. Set append state to WAITING_FOR_SEGMENT.
   SetAppendState(AppendState::WAITING_FOR_SEGMENT);
@@ -1259,6 +1290,9 @@ TrackBuffersManager::RecreateParser()
   if (initData) {
     int64_t start, end;
     mParser->ParseStartAndEndTimestamps(initData, start, end);
+    mProcessedInput = initData->Length();
+  } else {
+    mProcessedInput = 0;
   }
 }
 

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -129,7 +129,20 @@ TrackBuffersManager::EvictData(TimeUnit aPlaybackTime,
                                uint32_t aThreshold,
                                TimeUnit* aBufferStartTime)
 {
-  // TODO.
+  MOZ_ASSERT(NS_IsMainThread());
+
+  int64_t toEvict = GetSize() - aThreshold;
+  if (toEvict <= 0) {
+    return EvictDataResult::NO_DATA_EVICTED;
+  }
+  MSE_DEBUG("Reaching our size limit, schedule eviction of %lld bytes", toEvict);
+
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethodWithArgs<TimeUnit, uint32_t>(
+      this, &TrackBuffersManager::DoEvictData,
+      aPlaybackTime, toEvict);
+  GetTaskQueue()->Dispatch(task.forget());
+
   return EvictDataResult::NO_DATA_EVICTED;
 }
 
@@ -182,8 +195,7 @@ TrackBuffersManager::Buffered()
 int64_t
 TrackBuffersManager::GetSize()
 {
-  // TODO
-  return 0;
+  return mSizeSourceBuffer;
 }
 
 void
@@ -281,6 +293,70 @@ TrackBuffersManager::CompleteResetParserState()
 }
 
 void
+TrackBuffersManager::DoEvictData(const TimeUnit& aPlaybackTime,
+                                 uint32_t aSizeToEvict)
+{
+  MOZ_ASSERT(OnTaskQueue());
+
+  // Remove any data we've already played, up to 5s behind.
+  TimeUnit lowerLimit = aPlaybackTime - TimeUnit::FromSeconds(5);
+  TimeUnit to;
+  // Video is what takes the most space, only evict there if we have video.
+  const auto& track = HasVideo() ? mVideoTracks : mAudioTracks;
+  const auto& buffer = track.mBuffers.LastElement();
+  uint32_t lastKeyFrameIndex = 0;
+  int64_t toEvict = aSizeToEvict;
+  uint32_t partialEvict = 0;
+  for (uint32_t i = 0; i < buffer.Length(); i++) {
+    const auto& frame = buffer[i];
+    if (frame->mKeyframe) {
+      lastKeyFrameIndex = i;
+      toEvict -= partialEvict;
+      if (toEvict < 0) {
+        break;
+      }
+      partialEvict = 0;
+    }
+    if (frame->mTime >= lowerLimit.ToMicroseconds()) {
+      break;
+    }
+    partialEvict += sizeof(*frame) + frame->Size();
+  }
+  if (lastKeyFrameIndex > 0) {
+    CodedFrameRemoval(
+      TimeInterval(TimeUnit::FromMicroseconds(0),
+                   TimeUnit::FromMicroseconds(buffer[lastKeyFrameIndex-1]->mTime)));
+  }
+  if (toEvict <= 0) {
+    return;
+  }
+
+  // Still some to remove. Remove data starting from the end, up to 5s ahead
+  // of our playtime.
+  TimeUnit upperLimit = aPlaybackTime + TimeUnit::FromSeconds(5);
+  for (int32_t i = buffer.Length() - 1; i >= 0; i--) {
+    const auto& frame = buffer[i];
+    if (frame->mKeyframe) {
+      lastKeyFrameIndex = i;
+      toEvict -= partialEvict;
+      if (toEvict < 0) {
+        break;
+      }
+      partialEvict = 0;
+    }
+    if (frame->mTime <= upperLimit.ToMicroseconds()) {
+      break;
+    }
+    partialEvict += sizeof(*frame) + frame->Size();
+  }
+  if (lastKeyFrameIndex < buffer.Length()) {
+    CodedFrameRemoval(
+      TimeInterval(TimeUnit::FromMicroseconds(buffer[lastKeyFrameIndex+1]->mTime),
+                   TimeUnit::FromInfinity()));
+  }
+}
+
+void
 TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
 {
   MSE_DEBUG("From %.2fs to %.2f",
@@ -332,6 +408,7 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
             TimeInterval(TimeUnit::FromMicroseconds(frame->mTime),
                          TimeUnit::FromMicroseconds(frame->mTime + frame->mDuration)));
         }
+        track->mSizeBuffer -= sizeof(*frame) + frame->Size();
         data.RemoveElementAt(i);
       }
     }
@@ -346,6 +423,7 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
         removedInterval = removedInterval.Span(
           TimeInterval(TimeUnit::FromMicroseconds(frame->mTime),
                        TimeUnit::FromMicroseconds(frame->mTime + frame->mDuration)));
+        track->mSizeBuffer -= sizeof(*frame) + frame->Size();
         data.RemoveElementAt(i);
       }
     }
@@ -368,6 +446,9 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
   }
   MSE_DEBUG("after video ranges=%s", DumpTimeRanges(mVideoTracks.mBufferedRanges).get());
   MSE_DEBUG("after audio ranges=%s", DumpTimeRanges(mAudioTracks.mBufferedRanges).get());
+
+  // Update our reported total size.
+  mSizeSourceBuffer = mVideoTracks.mSizeBuffer + mAudioTracks.mSizeBuffer;
 
   mRangeRemovalPromise.ResolveIfExists(true, __func__);
 }
@@ -884,6 +965,9 @@ TrackBuffersManager::CompleteCodedFrameProcessing()
     mAudioBufferedRanges = mAudioTracks.mBufferedRanges;
   }
 
+   // Update our reported total size.
+  mSizeSourceBuffer = mVideoTracks.mSizeBuffer + mAudioTracks.mSizeBuffer;
+
   // Return to step 6.4 of Segment Parser Loop algorithm
   // 4. If this SourceBuffer is full and cannot accept more media data, then set the buffer full flag to true.
   // TODO
@@ -1039,6 +1123,7 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
               TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
                            TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration)));
           }
+          trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
           data.RemoveElementAt(i);
         }
       }
@@ -1057,6 +1142,7 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
               TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
                            TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration)));
           }
+          trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
           data.RemoveElementAt(i);
         }
       }
@@ -1073,6 +1159,7 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
       removedInterval = removedInterval.Span(
         TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
                      TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration)));
+      trackBuffer.mSizeBuffer -= sizeof(*aSample) + sample->Size();
       data.RemoveElementAt(i);
     }
     // Update our buffered range to exclude the range just removed.
@@ -1087,6 +1174,8 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
   } else {
     data.AppendElement(aSample);
   }
+  trackBuffer.mSizeBuffer += sizeof(*aSample) + aSample->Size();
+
   // 17. Set last decode timestamp for track buffer to decode timestamp.
   trackBuffer.mLastDecodeTimestamp = Some(decodeTimestamp);
   // 18. Set last frame duration for track buffer to frame duration.

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -692,13 +692,22 @@ void
 TrackBuffersManager::InitializationSegmentReceived()
 {
   MOZ_ASSERT(mParser->HasCompleteInitData());
+
+  int64_t endInit = mParser->InitSegmentRange().mEnd;
+  if (mInputBuffer->Length() > mProcessedInput ||
+      int64_t(mProcessedInput - mInputBuffer->Length()) > endInit) {
+    // Something is not quite right with the data appended. Refuse it.
+    RejectAppend(NS_ERROR_FAILURE, __func__);
+    return;
+  }
+
   mCurrentInputBuffer = new SourceBufferResource(mType);
   mCurrentInputBuffer->AppendData(mParser->InitData());
-  uint32_t length =
-    mParser->InitSegmentRange().mEnd - (mProcessedInput - mInputBuffer->Length());
+  uint32_t length = endInit - (mProcessedInput - mInputBuffer->Length());
   if (mInputBuffer->Length() == length) {
     mInputBuffer = nullptr;
   } else {
+    MOZ_RELEASE_ASSERT(length <= mInputBuffer->Length());
     mInputBuffer->RemoveElementsAt(0, length);
   }
   CreateDemuxerforMIMEType();

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -263,6 +263,7 @@ TrackBuffersManager::CompleteResetParserState()
     // if we have been aborted, we may have pending frames that we are going
     // to discard now.
     track->mQueuedSamples.Clear();
+    track->mLongestFrameDuration.reset();
   }
   // 6. Remove all bytes from the input buffer.
   mIncomingBuffers.Clear();
@@ -699,6 +700,9 @@ TrackBuffersManager::OnDemuxerInitDone(nsresult)
     // 3. Set the need random access point flag on all track buffers to true.
     mVideoTracks.mNeedRandomAccessPoint = true;
     mAudioTracks.mNeedRandomAccessPoint = true;
+
+    mVideoTracks.mLongestFrameDuration = mVideoTracks.mLastFrameDuration;
+    mAudioTracks.mLongestFrameDuration = mAudioTracks.mLastFrameDuration;
   }
 
   // 4. Let active track flag equal false.
@@ -1047,10 +1051,15 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
 
   // TODO: Maybe we should be using TimeStamp and TimeDuration instead?
 
+  // Some MP4 content may exhibit an extremely short frame duration.
+  // As such, we can't use the last frame duration as a way to detect
+  // discontinuities as required per step 6 above.
+  // Instead we use the biggest duration seen so far in this run (init + media
+  // segment).
   if ((trackBuffer.mLastDecodeTimestamp.isSome() &&
        decodeTimestamp < trackBuffer.mLastDecodeTimestamp.ref()) ||
       (trackBuffer.mLastDecodeTimestamp.isSome() &&
-       decodeTimestamp - trackBuffer.mLastDecodeTimestamp.ref() > 2*trackBuffer.mLastFrameDuration.ref())) {
+       decodeTimestamp - trackBuffer.mLastDecodeTimestamp.ref() > 2*trackBuffer.mLongestFrameDuration.ref())) {
 
     // 1a. If mode equals "segments":
     if (mParent->mAppendMode == SourceBufferAppendMode::Segments) {
@@ -1071,6 +1080,8 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
       track->mHighestEndTimestamp.reset();
       // 5. Set the need random access point flag on all track buffers to true.
       track->mNeedRandomAccessPoint = true;
+
+      trackBuffer.mLongestFrameDuration.reset();
     }
     MSE_DEBUG("Detected discontinuity. Restarting process");
     // 6. Jump to the Loop Top step above to restart processing of the current coded frame.
@@ -1201,7 +1212,17 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
   // 17. Set last decode timestamp for track buffer to decode timestamp.
   trackBuffer.mLastDecodeTimestamp = Some(decodeTimestamp);
   // 18. Set last frame duration for track buffer to frame duration.
-  trackBuffer.mLastFrameDuration = Some(TimeUnit::FromMicroseconds(aSample->mDuration));
+  trackBuffer.mLastFrameDuration =
+    Some(TimeUnit::FromMicroseconds(aSample->mDuration));
+
+  if (trackBuffer.mLongestFrameDuration.isNothing()) {
+    trackBuffer.mLongestFrameDuration = trackBuffer.mLastFrameDuration;
+  } else {
+    trackBuffer.mLongestFrameDuration =
+      Some(std::max(trackBuffer.mLongestFrameDuration.ref(),
+               trackBuffer.mLastFrameDuration.ref()));
+  }
+
   // 19. If highest end timestamp for track buffer is unset or frame end timestamp is greater than highest end timestamp, then set highest end timestamp for track buffer to frame end timestamp.
   if (trackBuffer.mHighestEndTimestamp.isNothing() ||
       frameEndTimestamp > trackBuffer.mHighestEndTimestamp.ref()) {

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -1051,18 +1051,29 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
        decodeTimestamp < trackBuffer.mLastDecodeTimestamp.ref()) ||
       (trackBuffer.mLastDecodeTimestamp.isSome() &&
        decodeTimestamp - trackBuffer.mLastDecodeTimestamp.ref() > 2*trackBuffer.mLastFrameDuration.ref())) {
+
+    // 1a. If mode equals "segments":
     if (mParent->mAppendMode == SourceBufferAppendMode::Segments) {
+      // Set group end timestamp to presentation timestamp.
       mGroupEndTimestamp = presentationTimestamp;
     }
+    // 1b. If mode equals "sequence":
     if (mParent->mAppendMode == SourceBufferAppendMode::Sequence) {
+      // Set group start timestamp equal to the group end timestamp.
       mGroupStartTimestamp = Some(mGroupEndTimestamp);
     }
     for (auto& track : tracks) {
+      // 2. Unset the last decode timestamp on all track buffers.
       track->mLastDecodeTimestamp.reset();
+      // 3. Unset the last frame duration on all track buffers.
       track->mLastFrameDuration.reset();
+      // 4. Unset the highest end timestamp on all track buffers.
       track->mHighestEndTimestamp.reset();
+      // 5. Set the need random access point flag on all track buffers to true.
       track->mNeedRandomAccessPoint = true;
     }
+    MSE_DEBUG("Detected discontinuity. Restarting process");
+    // 6. Jump to the Loop Top step above to restart processing of the current coded frame.
     return true;
   }
 
@@ -1172,7 +1183,18 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
   if (firstRemovedIndex >= 0) {
     data.InsertElementAt(firstRemovedIndex, aSample);
   } else {
-    data.AppendElement(aSample);
+    if (data.IsEmpty() || aSample->mTimecode > data.LastElement()->mTimecode) {
+      data.AppendElement(aSample);
+    } else {
+      // Find where to insert frame.
+      for (uint32_t i = 0; i < data.Length(); i++) {
+        const auto& sample = data[i];
+        if (sample->mTimecode > aSample->mTimecode) {
+          data.InsertElementAt(i, aSample);
+          break;
+        }
+      }
+    }
   }
   trackBuffer.mSizeBuffer += sizeof(*aSample) + aSample->Size();
 

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -563,7 +563,9 @@ TrackBuffersManager::SegmentParserLoop()
 
     // 3. Remove any bytes that the byte stream format specifications say must be
     // ignored from the start of the input buffer.
-    // TODO
+    // We do not remove bytes from our input buffer. Instead we enforce that
+    // our ContainerParser is able to skip over all data that is supposed to be
+    // ignored.
 
     // 4. If the append state equals WAITING_FOR_SEGMENT, then run the following
     // steps:
@@ -577,9 +579,10 @@ TrackBuffersManager::SegmentParserLoop()
         continue;
       }
       // We have neither an init segment nor a media segment, this is invalid
-      // data.
-      MSE_DEBUG("Found invalid data");
-      RejectAppend(NS_ERROR_FAILURE, __func__);
+      // data. We can ignore it.
+      MSE_DEBUG("Found invalid data, ignoring.");
+      mInputBuffer = nullptr;
+      NeedMoreData();
       return;
     }
 
@@ -693,7 +696,11 @@ TrackBuffersManager::InitializationSegmentReceived()
   mCurrentInputBuffer->AppendData(mParser->InitData());
   uint32_t length =
     mParser->InitSegmentRange().mEnd - (mProcessedInput - mInputBuffer->Length());
-  mInputBuffer->RemoveElementsAt(0, length);
+  if (mInputBuffer->Length() == length) {
+    mInputBuffer = nullptr;
+  } else {
+    mInputBuffer->RemoveElementsAt(0, length);
+  }
   CreateDemuxerforMIMEType();
   if (!mInputDemuxer) {
     MOZ_ASSERT(false, "TODO type not supported");

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -1,0 +1,1224 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "TrackBuffersManager.h"
+#include "SourceBufferResource.h"
+#include "SourceBuffer.h"
+
+#ifdef MOZ_FMP4
+#include "MP4Demuxer.h"
+#endif
+
+#include <limits>
+
+extern PRLogModuleInfo* GetMediaSourceLog();
+
+#define MSE_DEBUG(arg, ...) MOZ_LOG(GetMediaSourceLog(), mozilla::LogLevel::Debug, ("TrackBuffersManager(%p:%s)::%s: " arg, this, mType.get(), __func__, ##__VA_ARGS__))
+#define MSE_DEBUGV(arg, ...) MOZ_LOG(GetMediaSourceLog(), mozilla::LogLevel::Verbose, ("TrackBuffersManager(%p:%s)::%s: " arg, this, mType.get(), __func__, ##__VA_ARGS__))
+
+namespace mozilla {
+
+static const char*
+AppendStateToStr(TrackBuffersManager::AppendState aState)
+{
+  switch (aState) {
+    case TrackBuffersManager::AppendState::WAITING_FOR_SEGMENT:
+      return "WAITING_FOR_SEGMENT";
+    case TrackBuffersManager::AppendState::PARSING_INIT_SEGMENT:
+      return "PARSING_INIT_SEGMENT";
+    case TrackBuffersManager::AppendState::PARSING_MEDIA_SEGMENT:
+      return "PARSING_MEDIA_SEGMENT";
+    default:
+      return "IMPOSSIBLE";
+  }
+}
+
+TrackBuffersManager::TrackBuffersManager(dom::SourceBuffer* aParent, MediaSourceDecoder* aParentDecoder, const nsACString& aType)
+  : mInputBuffer(new MediaLargeByteBuffer)
+  , mAppendState(AppendState::WAITING_FOR_SEGMENT)
+  , mBufferFull(false)
+  , mFirstInitializationSegmentReceived(false)
+  , mActiveTrack(false)
+  , mType(aType)
+  , mParser(ContainerParser::CreateForMIMEType(aType))
+  , mTaskQueue(new MediaTaskQueue(GetMediaThreadPool(MediaThreadType::PLAYBACK)))
+  , mParent(new nsMainThreadPtrHolder<dom::SourceBuffer>(aParent, false /* strict */))
+  , mParentDecoder(new nsMainThreadPtrHolder<MediaSourceDecoder>(aParentDecoder, false /* strict */))
+  , mAbort(false)
+  , mMonitor("TrackBuffersManager")
+{
+  MOZ_ASSERT(NS_IsMainThread(), "Must be instantiated on the main thread");
+}
+
+bool
+TrackBuffersManager::AppendData(MediaLargeByteBuffer* aData,
+                                TimeUnit aTimestampOffset)
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  MonitorAutoLock mon(mMonitor);
+  MSE_DEBUG("Appending %lld bytes", aData->Length());
+  mIncomingBuffers.AppendElement(IncomingBuffer(aData, aTimestampOffset));
+  mEnded = false;
+  return true;
+}
+
+nsRefPtr<TrackBuffersManager::AppendPromise>
+TrackBuffersManager::BufferAppend()
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  MOZ_ASSERT(mAppendPromise.IsEmpty());
+  nsRefPtr<AppendPromise> p = mAppendPromise.Ensure(__func__);
+
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethod(this, &TrackBuffersManager::InitSegmentParserLoop);
+  GetTaskQueue()->Dispatch(task.forget());
+
+  return p;
+}
+
+// Abort any pending AppendData.
+// We don't really care about really aborting our inner loop as by spec the
+// process is happening asynchronously, as such where and when we would abort is
+// non-deterministic. The SourceBuffer also makes sure BufferAppend
+// isn't called should the appendBuffer be immediately aborted.
+void
+TrackBuffersManager::AbortAppendData()
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  mAppendPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
+}
+
+void
+TrackBuffersManager::ResetParserState()
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  MOZ_ASSERT(mAppendPromise.IsEmpty(), "AbortAppendData must have been called");
+
+  // 1. If the append state equals PARSING_MEDIA_SEGMENT and the input buffer contains some complete coded frames, then run the coded frame processing algorithm until all of these complete coded frames have been processed.
+  if (mAppendState == AppendState::PARSING_MEDIA_SEGMENT) {
+    nsCOMPtr<nsIRunnable> task =
+      NS_NewRunnableMethod(this, &TrackBuffersManager::FinishCodedFrameProcessing);
+    GetTaskQueue()->Dispatch(task.forget());
+  } else {
+    nsCOMPtr<nsIRunnable> task =
+      NS_NewRunnableMethod(this, &TrackBuffersManager::CompleteResetParserState);
+    GetTaskQueue()->Dispatch(task.forget());
+  }
+}
+
+nsRefPtr<TrackBuffersManager::RangeRemovalPromise>
+TrackBuffersManager::RangeRemoval(TimeUnit aStart, TimeUnit aEnd)
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  mEnded = false;
+
+  nsRefPtr<RangeRemovalPromise> p = mRangeRemovalPromise.Ensure(__func__);
+
+  nsCOMPtr<nsIRunnable> task =
+  NS_NewRunnableMethodWithArg<TimeInterval>(
+    this, &TrackBuffersManager::CodedFrameRemoval, TimeInterval(aStart, aEnd));
+  GetTaskQueue()->Dispatch(task.forget());
+  return p;
+}
+
+TrackBuffersManager::EvictDataResult
+TrackBuffersManager::EvictData(TimeUnit aPlaybackTime,
+                               uint32_t aThreshold,
+                               TimeUnit* aBufferStartTime)
+{
+  // TODO.
+  return EvictDataResult::NO_DATA_EVICTED;
+}
+
+void
+TrackBuffersManager::EvictBefore(TimeUnit aTime)
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  nsCOMPtr<nsIRunnable> task =
+  NS_NewRunnableMethodWithArg<TimeInterval>(
+    this, &TrackBuffersManager::CodedFrameRemoval,
+    TimeInterval(TimeUnit::FromSeconds(0), aTime));
+  GetTaskQueue()->Dispatch(task.forget());
+}
+
+media::TimeIntervals
+TrackBuffersManager::Buffered()
+{
+  MonitorAutoLock mon(mMonitor);
+  // http://w3c.github.io/media-source/index.html#widl-SourceBuffer-buffered
+  // 2. Let highest end time be the largest track buffer ranges end time across all the track buffers managed by this SourceBuffer object.
+  TimeUnit highestEndTime;
+
+  nsTArray<TimeIntervals*> tracks;
+  if (HasVideo()) {
+    tracks.AppendElement(&mVideoBufferedRanges);
+  }
+  if (HasAudio()) {
+    tracks.AppendElement(&mAudioBufferedRanges);
+  }
+  for (auto trackRanges : tracks) {
+    highestEndTime = std::max(trackRanges->GetEnd(), highestEndTime);
+  }
+
+  // 3. Let intersection ranges equal a TimeRange object containing a single range from 0 to highest end time.
+  TimeIntervals intersection{TimeInterval(TimeUnit::FromSeconds(0), highestEndTime)};
+
+  // 4. For each track buffer managed by this SourceBuffer, run the following steps:
+  //   1. Let track ranges equal the track buffer ranges for the current track buffer.
+  for (auto trackRanges : tracks) {
+    // 2. If readyState is "ended", then set the end time on the last range in track ranges to highest end time.
+    if (mEnded) {
+      trackRanges->Add(TimeInterval(trackRanges->GetEnd(), highestEndTime));
+    }
+    // 3. Let new intersection ranges equal the intersection between the intersection ranges and the track ranges.
+    intersection.Intersection(*trackRanges);
+  }
+  return intersection;
+}
+
+int64_t
+TrackBuffersManager::GetSize()
+{
+  // TODO
+  return 0;
+}
+
+void
+TrackBuffersManager::Ended()
+{
+  mEnded = true;
+}
+
+void
+TrackBuffersManager::Detach()
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  MOZ_ASSERT(mAppendPromise.IsEmpty(), "Abort wasn't called");
+  // Abort any pending promises.
+  mRangeRemovalPromise.ResolveIfExists(false, __func__);
+  // Clear our sourcebuffer
+  nsCOMPtr<nsIRunnable> task =
+  NS_NewRunnableMethodWithArg<TimeInterval>(
+    this, &TrackBuffersManager::CodedFrameRemoval,
+    TimeInterval(TimeUnit::FromSeconds(0), TimeUnit::FromInfinity()));
+  GetTaskQueue()->Dispatch(task.forget());
+}
+
+#if defined(DEBUG)
+void
+TrackBuffersManager::Dump(const char* aPath)
+{
+
+}
+#endif
+
+void
+TrackBuffersManager::FinishCodedFrameProcessing()
+{
+  MOZ_ASSERT(OnTaskQueue());
+
+  if (mProcessingRequest.Exists()) {
+    NS_WARNING("Processing request pending");
+    mProcessingRequest.Disconnect();
+  }
+  // The spec requires us to complete parsing synchronously any outstanding
+  // frames in the current media segment. This can't be implemented in a way
+  // that makes sense.
+  // As such we simply completely ignore the result of any pending input buffer.
+  // TODO: Link to W3C bug.
+
+  CompleteResetParserState();
+}
+
+void
+TrackBuffersManager::CompleteResetParserState()
+{
+  MOZ_ASSERT(OnTaskQueue());
+
+  for (auto track : GetTracksList()) {
+    // 2. Unset the last decode timestamp on all track buffers.
+    track->mLastDecodeTimestamp.reset();
+    // 3. Unset the last frame duration on all track buffers.
+    track->mLastFrameDuration.reset();
+    // 4. Unset the highest end timestamp on all track buffers.
+    track->mHighestEndTimestamp.reset();
+    // 5. Set the need random access point flag on all track buffers to true.
+    track->mNeedRandomAccessPoint = true;
+
+    // if we have been aborted, we may have pending frames that we are going
+    // to discard now.
+    track->mQueuedSamples.Clear();
+  }
+  // 6. Remove all bytes from the input buffer.
+  mIncomingBuffers.Clear();
+  mInputBuffer->Clear();
+  if (mCurrentInputBuffer) {
+    mCurrentInputBuffer->EvictAll();
+    mCurrentInputBuffer = new SourceBufferResource(mType);
+  }
+
+  // We could be left with a demuxer in an unusable state. It needs to be
+  // recreated. We store in the InputBuffer an init segment which will be parsed
+  // during the next Segment Parser Loop and a new demuxer will be created and
+  // initialized.
+  if (mFirstInitializationSegmentReceived) {
+    nsRefPtr<MediaLargeByteBuffer> initData = mParser->InitData();
+    MOZ_ASSERT(initData->Length(), "we must have an init segment");
+    // The aim here is really to destroy our current demuxer.
+    CreateDemuxerforMIMEType();
+    mInputBuffer->AppendElements(*initData);
+  }
+  RecreateParser();
+
+  // 7. Set append state to WAITING_FOR_SEGMENT.
+  SetAppendState(AppendState::WAITING_FOR_SEGMENT);
+
+  // We're done.
+  mAbort = false;
+}
+
+void
+TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
+{
+  MSE_DEBUG("From %.2fs to %.2f",
+            aInterval.mStart.ToSeconds(), aInterval.mEnd.ToSeconds());
+  TimeUnit duration{TimeUnit::FromSeconds(mParentDecoder->GetMediaSourceDuration())};
+
+  MSE_DEBUG("duration:%.2f", duration.ToSeconds());
+  MSE_DEBUG("before video ranges=%s", DumpTimeRanges(mVideoTracks.mBufferedRanges).get());
+  MSE_DEBUG("before audio ranges=%s", DumpTimeRanges(mAudioTracks.mBufferedRanges).get());
+
+  // 1. Let start be the starting presentation timestamp for the removal range.
+  TimeUnit start = aInterval.mStart;
+  // 2. Let end be the end presentation timestamp for the removal range.
+  TimeUnit end = aInterval.mEnd;
+
+  // 3. For each track buffer in this source buffer, run the following steps:
+  for (auto track : GetTracksList()) {
+    MSE_DEBUGV("Processing %s track", track->mInfo->mMimeType.get());
+    // 1. Let remove end timestamp be the current value of duration
+    // See bug: https://www.w3.org/Bugs/Public/show_bug.cgi?id=28727
+    TimeUnit removeEndTimestamp = std::max(duration, track->mBufferedRanges.GetEnd());
+
+    // 2. If this track buffer has a random access point timestamp that is greater than or equal to end,
+    // then update remove end timestamp to that random access point timestamp.
+    if (end < track->mBufferedRanges.GetEnd()) {
+      for (auto& frame : track->mBuffers.LastElement()) {
+        if (frame->mKeyframe && frame->mTime >= end.ToMicroseconds()) {
+          removeEndTimestamp = TimeUnit::FromMicroseconds(frame->mTime);
+          break;
+        }
+      }
+    }
+    // 3. Remove all media data, from this track buffer, that contain starting
+    // timestamps greater than or equal to start and less than the remove end timestamp.
+    TimeInterval removedInterval;
+    int32_t firstRemovedIndex = -1;
+    TrackBuffer& data = track->mBuffers.LastElement();
+    for (uint32_t i = 0; i < data.Length(); i++) {
+      const auto& frame = data[i];
+      if (frame->mTime >= start.ToMicroseconds() &&
+          frame->mTime < removeEndTimestamp.ToMicroseconds()) {
+        if (firstRemovedIndex < 0) {
+          removedInterval =
+            TimeInterval(TimeUnit::FromMicroseconds(frame->mTime),
+                         TimeUnit::FromMicroseconds(frame->mTime + frame->mDuration));
+          firstRemovedIndex = i;
+        } else {
+          removedInterval = removedInterval.Span(
+            TimeInterval(TimeUnit::FromMicroseconds(frame->mTime),
+                         TimeUnit::FromMicroseconds(frame->mTime + frame->mDuration)));
+        }
+        data.RemoveElementAt(i);
+      }
+    }
+    // 4. Remove decoding dependencies of the coded frames removed in the previous step:
+    // Remove all coded frames between the coded frames removed in the previous step and the next random access point after those removed frames.
+    if (firstRemovedIndex >= 0) {
+      for (uint32_t i = firstRemovedIndex; i < data.Length(); i++) {
+        const auto& frame = data[i];
+        if (frame->mKeyframe) {
+          break;
+        }
+        removedInterval = removedInterval.Span(
+          TimeInterval(TimeUnit::FromMicroseconds(frame->mTime),
+                       TimeUnit::FromMicroseconds(frame->mTime + frame->mDuration)));
+        data.RemoveElementAt(i);
+      }
+    }
+    track->mBufferedRanges -= removedInterval;
+
+    // 5. If this object is in activeSourceBuffers, the current playback position
+    // is greater than or equal to start and less than the remove end timestamp,
+    // and HTMLMediaElement.readyState is greater than HAVE_METADATA, then set the
+    // HTMLMediaElement.readyState attribute to HAVE_METADATA and stall playback.
+    // This will be done by the MDSM during playback.
+    // TODO properly, so it works even if paused.
+  }
+  // 4. If buffer full flag equals true and this object is ready to accept more bytes, then set the buffer full flag to false.
+  // TODO.
+  mBufferFull = false;
+  {
+    MonitorAutoLock mon(mMonitor);
+    mVideoBufferedRanges = mVideoTracks.mBufferedRanges;
+    mAudioBufferedRanges = mAudioTracks.mBufferedRanges;
+  }
+  MSE_DEBUG("after video ranges=%s", DumpTimeRanges(mVideoTracks.mBufferedRanges).get());
+  MSE_DEBUG("after audio ranges=%s", DumpTimeRanges(mAudioTracks.mBufferedRanges).get());
+
+  mRangeRemovalPromise.ResolveIfExists(true, __func__);
+}
+
+void
+TrackBuffersManager::InitSegmentParserLoop()
+{
+  AppendIncomingBuffers();
+  SegmentParserLoop();
+}
+
+void
+TrackBuffersManager::AppendIncomingBuffers()
+{
+  MOZ_ASSERT(OnTaskQueue());
+  MonitorAutoLock mon(mMonitor);
+  for (auto& incomingBuffer : mIncomingBuffers) {
+    if (!mInputBuffer->AppendElements(*incomingBuffer.first())) {
+      RejectAppend(NS_ERROR_OUT_OF_MEMORY, __func__);
+    }
+  }
+  if (!mIncomingBuffers.IsEmpty()) {
+    mTimestampOffset = mIncomingBuffers.LastElement().second();
+    mLastTimestampOffset = mTimestampOffset;
+  }
+  mIncomingBuffers.Clear();
+}
+
+void
+TrackBuffersManager::SegmentParserLoop()
+{
+  MOZ_ASSERT(OnTaskQueue());
+  while (true) {
+    bool completeMediaHeader;
+    // 1. If the input buffer is empty, then jump to the need more data step below.
+    if (!mInputBuffer || mInputBuffer->IsEmpty()) {
+      NeedMoreData();
+      return;
+    }
+    // 2. If the input buffer contains bytes that violate the SourceBuffer
+    // byte stream format specification, then run the append error algorithm with
+    // the decode error parameter set to true and abort this algorithm.
+    // TODO
+
+    // 3. Remove any bytes that the byte stream format specifications say must be
+    // ignored from the start of the input buffer.
+    // TODO
+
+    // 4. If the append state equals WAITING_FOR_SEGMENT, then run the following
+    // steps:
+    if (mAppendState == AppendState::WAITING_FOR_SEGMENT) {
+      if (mParser->IsInitSegmentPresent(mInputBuffer)) {
+        SetAppendState(AppendState::PARSING_INIT_SEGMENT);
+        continue;
+      }
+      if (mParser->IsMediaSegmentPresent(mInputBuffer)) {
+        SetAppendState(AppendState::PARSING_MEDIA_SEGMENT);
+        continue;
+      }
+      // We have neither an init segment nor a media segment, this is invalid
+      // data. However, as we do not remove any bytes that are supposed to be
+      // ignored, we simply ignore them.
+      MSE_DEBUG("Found invalid data, ignoring for now");
+      NeedMoreData();
+      return;
+    }
+
+    int64_t start, end;
+    completeMediaHeader =
+      mParser->ParseStartAndEndTimestamps(mInputBuffer, start, end);
+
+    // 5. If the append state equals PARSING_INIT_SEGMENT, then run the
+    // following steps:
+    if (mAppendState == AppendState::PARSING_INIT_SEGMENT) {
+      if (mParser->InitSegmentRange().IsNull()) {
+        NeedMoreData();
+        return;
+      }
+      InitializationSegmentReceived();
+      return;
+    }
+    if (mAppendState == AppendState::PARSING_MEDIA_SEGMENT) {
+      // 1. If the first initialization segment received flag is false, then run the append error algorithm with the decode error parameter set to true and abort this algorithm.
+      if (!mFirstInitializationSegmentReceived) {
+        RejectAppend(NS_ERROR_FAILURE, __func__);
+        return;
+      }
+      // 2. If the input buffer does not contain a complete media segment header yet, then jump to the need more data step below.
+      if (!completeMediaHeader) {
+        NeedMoreData();
+        return;
+      }
+      // 3. If the input buffer contains one or more complete coded frames, then run the coded frame processing algorithm.
+      nsRefPtr<TrackBuffersManager> self = this;
+      mProcessingRequest.Begin(CodedFrameProcessing()
+          ->Then(GetTaskQueue(), __func__,
+                 [self] (bool aNeedMoreData) {
+                   self->mProcessingRequest.Complete();
+                   if (aNeedMoreData || self->mAbort) {
+                     self->NeedMoreData();
+                   } else {
+                     self->ScheduleSegmentParserLoop();
+                   }
+                 },
+                 [self] (nsresult aRejectValue) {
+                   self->mProcessingRequest.Complete();
+                   self->RejectAppend(aRejectValue, __func__);
+                 }));
+      return;
+    }
+  }
+}
+
+void
+TrackBuffersManager::NeedMoreData()
+{
+  MSE_DEBUG("");
+  // The entire mInputBuffer will be reparsed on the next Segment Parser Loop
+  // run, clear the current ContainerParser so it won't treat the same data
+  // twice which would shift all our offsets incorrectly.
+  RecreateParser();
+  RestoreCachedVariables();
+  mAppendPromise.ResolveIfExists(mActiveTrack, __func__);
+}
+
+void
+TrackBuffersManager::RejectAppend(nsresult aRejectValue, const char* aName)
+{
+  MSE_DEBUG("rv=%d", aRejectValue);
+  mAppendPromise.RejectIfExists(aRejectValue, aName);
+}
+
+void
+TrackBuffersManager::ScheduleSegmentParserLoop()
+{
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethod(this, &TrackBuffersManager::SegmentParserLoop);
+  GetTaskQueue()->Dispatch(task.forget());
+}
+
+void
+TrackBuffersManager::CreateDemuxerforMIMEType()
+{
+  if (mVideoTracks.mDemuxer) {
+    mVideoTracks.mDemuxer->BreakCycles();
+    mVideoTracks.mDemuxer = nullptr;
+  }
+  if (mAudioTracks.mDemuxer) {
+    mAudioTracks.mDemuxer->BreakCycles();
+    mAudioTracks.mDemuxer = nullptr;
+  }
+  mInputDemuxer = nullptr;
+  if (mType.LowerCaseEqualsLiteral("video/webm") || mType.LowerCaseEqualsLiteral("audio/webm")) {
+    MOZ_ASSERT(false, "Waiting on WebMDemuxer");
+  // mInputDemuxer = new WebMDemuxer(mCurrentInputBuffer);
+  }
+
+#ifdef MOZ_FMP4
+  if (mType.LowerCaseEqualsLiteral("video/mp4") || mType.LowerCaseEqualsLiteral("audio/mp4")) {
+    mInputDemuxer = new MP4Demuxer(mCurrentInputBuffer);
+    return;
+  }
+#endif
+  MOZ_ASSERT(false, "Not supported (yet)");
+}
+
+void
+TrackBuffersManager::InitializationSegmentReceived()
+{
+  MOZ_ASSERT(mParser->HasCompleteInitData());
+  mCurrentInputBuffer = new SourceBufferResource(mType);
+  mCurrentInputBuffer->AppendData(mParser->InitData());
+  CreateDemuxerforMIMEType();
+  if (!mInputDemuxer) {
+    MOZ_ASSERT(false, "TODO type not supported");
+    return;
+  }
+  mDemuxerInitRequest.Begin(mInputDemuxer->Init()
+                      ->Then(GetTaskQueue(), __func__,
+                             this,
+                             &TrackBuffersManager::OnDemuxerInitDone,
+                             &TrackBuffersManager::OnDemuxerInitFailed));
+}
+
+void
+TrackBuffersManager::OnDemuxerInitDone(nsresult)
+{
+  mDemuxerInitRequest.Complete();
+
+  if (mAbort) {
+    RejectAppend(NS_ERROR_ABORT, __func__);
+    return;
+  }
+
+  MediaInfo info;
+
+  uint32_t numVideos = mInputDemuxer->GetNumberTracks(TrackInfo::kVideoTrack);
+  if (numVideos) {
+    // We currently only handle the first video track.
+    mVideoTracks.mDemuxer = mInputDemuxer->GetTrackDemuxer(TrackInfo::kVideoTrack, 0);
+    MOZ_ASSERT(mVideoTracks.mDemuxer);
+    info.mVideo = *mVideoTracks.mDemuxer->GetInfo()->GetAsVideoInfo();
+  }
+
+  uint32_t numAudios = mInputDemuxer->GetNumberTracks(TrackInfo::kAudioTrack);
+  if (numAudios) {
+    // We currently only handle the first audio track.
+    mAudioTracks.mDemuxer = mInputDemuxer->GetTrackDemuxer(TrackInfo::kAudioTrack, 0);
+    MOZ_ASSERT(mAudioTracks.mDemuxer);
+    info.mAudio = *mAudioTracks.mDemuxer->GetInfo()->GetAsAudioInfo();
+  }
+
+  int64_t videoDuration = numVideos ? info.mVideo.mDuration : 0;
+  int64_t audioDuration = numAudios ? info.mAudio.mDuration : 0;
+
+  int64_t duration = std::max(videoDuration, audioDuration);
+  // 1. Update the duration attribute if it currently equals NaN.
+  // Those steps are performed by the MediaSourceDecoder::SetInitialDuration
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethodWithArg<int64_t>(mParentDecoder,
+                                         &MediaSourceDecoder::SetInitialDuration,
+                                         duration ? duration : -1);
+  AbstractThread::MainThread()->Dispatch(task.forget());
+
+  // 2. If the initialization segment has no audio, video, or text tracks, then
+  // run the append error algorithm with the decode error parameter set to true
+  // and abort these steps.
+  if (!numVideos && !numAudios) {
+    RejectAppend(NS_ERROR_FAILURE, __func__);
+    return;
+  }
+
+  // 3. If the first initialization segment received flag is true, then run the following steps:
+  if (mFirstInitializationSegmentReceived) {
+    if (numVideos != mVideoTracks.mNumTracks ||
+        numAudios != mAudioTracks.mNumTracks ||
+        (numVideos && info.mVideo.mMimeType != mVideoTracks.mInfo->mMimeType) ||
+        (numAudios && info.mAudio.mMimeType != mAudioTracks.mInfo->mMimeType)) {
+      RejectAppend(NS_ERROR_FAILURE, __func__);
+      return;
+    }
+    // 1. If more than one track for a single type are present (ie 2 audio tracks),
+    // then the Track IDs match the ones in the first initialization segment.
+    // TODO
+    // 2. Add the appropriate track descriptions from this initialization
+    // segment to each of the track buffers.
+    // TODO
+    // 3. Set the need random access point flag on all track buffers to true.
+    mVideoTracks.mNeedRandomAccessPoint = true;
+    mAudioTracks.mNeedRandomAccessPoint = true;
+  }
+
+  // 4. Let active track flag equal false.
+  mActiveTrack = false;
+
+  // 5. If the first initialization segment received flag is false, then run the following steps:
+  if (!mFirstInitializationSegmentReceived) {
+    mAudioTracks.mNumTracks = numAudios;
+    // TODO:
+    // 1. If the initialization segment contains tracks with codecs the user agent
+    // does not support, then run the append error algorithm with the decode
+    // error parameter set to true and abort these steps.
+
+    // 2. For each audio track in the initialization segment, run following steps:
+    // for (uint32_t i = 0; i < numAudios; i++) {
+    if (numAudios) {
+      // 1. Let audio byte stream track ID be the Track ID for the current track being processed.
+      // 2. Let audio language be a BCP 47 language tag for the language specified in the initialization segment for this track or an empty string if no language info is present.
+      // 3. If audio language equals an empty string or the 'und' BCP 47 value, then run the default track language algorithm with byteStreamTrackID set to audio byte stream track ID and type set to "audio" and assign the value returned by the algorithm to audio language.
+      // 4. Let audio label be a label specified in the initialization segment for this track or an empty string if no label info is present.
+      // 5. If audio label equals an empty string, then run the default track label algorithm with byteStreamTrackID set to audio byte stream track ID and type set to "audio" and assign the value returned by the algorithm to audio label.
+      // 6. Let audio kinds be an array of kind strings specified in the initialization segment for this track or an empty array if no kind information is provided.
+      // 7. If audio kinds equals an empty array, then run the default track kinds algorithm with byteStreamTrackID set to audio byte stream track ID and type set to "audio" and assign the value returned by the algorithm to audio kinds.
+      // 8. For each value in audio kinds, run the following steps:
+      //   1. Let current audio kind equal the value from audio kinds for this iteration of the loop.
+      //   2. Let new audio track be a new AudioTrack object.
+      //   3. Generate a unique ID and assign it to the id property on new audio track.
+      //   4. Assign audio language to the language property on new audio track.
+      //   5. Assign audio label to the label property on new audio track.
+      //   6. Assign current audio kind to the kind property on new audio track.
+      //   7. If audioTracks.length equals 0, then run the following steps:
+      //     1. Set the enabled property on new audio track to true.
+      //     2. Set active track flag to true.
+      mActiveTrack = true;
+      //   8. Add new audio track to the audioTracks attribute on this SourceBuffer object.
+      //   9. Queue a task to fire a trusted event named addtrack, that does not bubble and is not cancelable, and that uses the TrackEvent interface, at the AudioTrackList object referenced by the audioTracks attribute on this SourceBuffer object.
+      //   10. Add new audio track to the audioTracks attribute on the HTMLMediaElement.
+      //   11. Queue a task to fire a trusted event named addtrack, that does not bubble and is not cancelable, and that uses the TrackEvent interface, at the AudioTrackList object referenced by the audioTracks attribute on the HTMLMediaElement.
+      mAudioTracks.mBuffers.AppendElement(TrackBuffer());
+      // 10. Add the track description for this track to the track buffer.
+      mAudioTracks.mInfo = info.mAudio.Clone();
+    }
+
+    mVideoTracks.mNumTracks = numVideos;
+    // 3. For each video track in the initialization segment, run following steps:
+    // for (uint32_t i = 0; i < numVideos; i++) {
+    if (numVideos) {
+      // 1. Let video byte stream track ID be the Track ID for the current track being processed.
+      // 2. Let video language be a BCP 47 language tag for the language specified in the initialization segment for this track or an empty string if no language info is present.
+      // 3. If video language equals an empty string or the 'und' BCP 47 value, then run the default track language algorithm with byteStreamTrackID set to video byte stream track ID and type set to "video" and assign the value returned by the algorithm to video language.
+      // 4. Let video label be a label specified in the initialization segment for this track or an empty string if no label info is present.
+      // 5. If video label equals an empty string, then run the default track label algorithm with byteStreamTrackID set to video byte stream track ID and type set to "video" and assign the value returned by the algorithm to video label.
+      // 6. Let video kinds be an array of kind strings specified in the initialization segment for this track or an empty array if no kind information is provided.
+      // 7. If video kinds equals an empty array, then run the default track kinds algorithm with byteStreamTrackID set to video byte stream track ID and type set to "video" and assign the value returned by the algorithm to video kinds.
+      // 8. For each value in video kinds, run the following steps:
+      //   1. Let current video kind equal the value from video kinds for this iteration of the loop.
+      //   2. Let new video track be a new VideoTrack object.
+      //   3. Generate a unique ID and assign it to the id property on new video track.
+      //   4. Assign video language to the language property on new video track.
+      //   5. Assign video label to the label property on new video track.
+      //   6. Assign current video kind to the kind property on new video track.
+      //   7. If videoTracks.length equals 0, then run the following steps:
+      //     1. Set the selected property on new video track to true.
+      //     2. Set active track flag to true.
+      mActiveTrack = true;
+      //   8. Add new video track to the videoTracks attribute on this SourceBuffer object.
+      //   9. Queue a task to fire a trusted event named addtrack, that does not bubble and is not cancelable, and that uses the TrackEvent interface, at the VideoTrackList object referenced by the videoTracks attribute on this SourceBuffer object.
+      //   10. Add new video track to the videoTracks attribute on the HTMLMediaElement.
+      //   11. Queue a task to fire a trusted event named addtrack, that does not bubble and is not cancelable, and that uses the TrackEvent interface, at the VideoTrackList object referenced by the videoTracks attribute on the HTMLMediaElement.
+      mVideoTracks.mBuffers.AppendElement(TrackBuffer());
+      // 10. Add the track description for this track to the track buffer.
+      mVideoTracks.mInfo = info.mVideo.Clone();
+    }
+    // 4. For each text track in the initialization segment, run following steps:
+    // 5. If active track flag equals true, then run the following steps:
+    // This is handled by SourceBuffer once the promise is resolved.
+
+    // 6. Set first initialization segment received flag to true.
+    mFirstInitializationSegmentReceived = true;
+  }
+
+  // TODO CHECK ENCRYPTION
+  UniquePtr<EncryptionInfo> crypto = mInputDemuxer->GetCrypto();
+  if (crypto && crypto->IsEncrypted()) {
+    info.mCrypto = *crypto;
+    mEncrypted = true;
+  }
+
+  {
+    MonitorAutoLock mon(mMonitor);
+    mInfo = info;
+  }
+
+  // 3. Remove the initialization segment bytes from the beginning of the input buffer.
+  mInputBuffer->RemoveElementsAt(0, mParser->InitSegmentRange().mEnd);
+  RecreateParser();
+
+  // 4. Set append state to WAITING_FOR_SEGMENT.
+  SetAppendState(AppendState::WAITING_FOR_SEGMENT);
+  // 5. Jump to the loop top step above.
+  ScheduleSegmentParserLoop();
+}
+
+void
+TrackBuffersManager::OnDemuxerInitFailed(DemuxerFailureReason aFailure)
+{
+  MOZ_ASSERT(aFailure != DemuxerFailureReason::WAITING_FOR_DATA);
+  mDemuxerInitRequest.Complete();
+
+  RejectAppend(NS_ERROR_FAILURE, __func__);
+}
+
+nsRefPtr<TrackBuffersManager::CodedFrameProcessingPromise>
+TrackBuffersManager::CodedFrameProcessing()
+{
+  MOZ_ASSERT(mProcessingPromise.IsEmpty());
+  nsRefPtr<CodedFrameProcessingPromise> p = mProcessingPromise.Ensure(__func__);
+
+  int64_t offset = mCurrentInputBuffer->GetLength();
+  MediaByteRange mediaRange = mParser->MediaSegmentRange();
+  // The mediaRange is offset by the init segment position previously added.
+  int64_t rangeOffset = mParser->InitData()->Length();
+  int64_t length;
+  if (mediaRange.IsNull()) {
+    length = mInputBuffer->Length();
+    mCurrentInputBuffer->AppendData(mInputBuffer);
+  } else {
+    nsRefPtr<MediaLargeByteBuffer> segment = new MediaLargeByteBuffer;
+    length = mediaRange.Length();
+    MOZ_ASSERT(mInputBuffer->Length() >= uint64_t(mediaRange.mEnd - rangeOffset),
+               "We're missing some data");
+    MOZ_ASSERT(mediaRange.mStart >= rangeOffset, "Invalid media segment range");
+    if (!segment->AppendElements(mInputBuffer->Elements() +
+                                 mediaRange.mStart - rangeOffset, length)) {
+      return CodedFrameProcessingPromise::CreateAndReject(NS_ERROR_OUT_OF_MEMORY, __func__);
+    }
+    mCurrentInputBuffer->AppendData(segment);
+  }
+  mInputDemuxer->NotifyDataArrived(length, offset);
+
+  DoDemuxVideo();
+
+  return p;
+}
+
+void
+TrackBuffersManager::OnDemuxFailed(TrackType aTrack,
+                                   DemuxerFailureReason aFailure)
+{
+  MSE_DEBUG("Failed to demux %s, failure = %d",
+      aTrack == TrackType::kVideoTrack ? "video" : "audio", aFailure);
+  if (mAbort) {
+    mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
+    return;
+  }
+  switch (aFailure) {
+    case DemuxerFailureReason::END_OF_STREAM:
+    case DemuxerFailureReason::WAITING_FOR_DATA:
+      if (aTrack == TrackType::kVideoTrack) {
+        DoDemuxAudio();
+      } else {
+        CompleteCodedFrameProcessing();
+      }
+      break;
+    case DemuxerFailureReason::DEMUXER_ERROR:
+      mProcessingPromise.RejectIfExists(NS_ERROR_FAILURE, __func__);
+      break;
+    case DemuxerFailureReason::CANCELED:
+    case DemuxerFailureReason::SHUTDOWN:
+      mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
+      break;
+    default:
+      MOZ_ASSERT(false);
+      break;
+  }
+}
+
+void
+TrackBuffersManager::DoDemuxVideo()
+{
+  if (!HasVideo()) {
+    DoDemuxAudio();
+    return;
+  }
+  mVideoTracks.mDemuxRequest.Begin(mVideoTracks.mDemuxer->GetSamples(-1)
+                             ->Then(GetTaskQueue(), __func__, this,
+                                    &TrackBuffersManager::OnVideoDemuxCompleted,
+                                    &TrackBuffersManager::OnVideoDemuxFailed));
+}
+
+void
+TrackBuffersManager::OnVideoDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHolder> aSamples)
+{
+  MSE_DEBUG("%d video samples demuxed", aSamples->mSamples.Length());
+  mVideoTracks.mDemuxRequest.Complete();
+  if (mAbort) {
+    mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
+    return;
+  }
+  mVideoTracks.mQueuedSamples.AppendElements(aSamples->mSamples);
+  DoDemuxAudio();
+}
+
+void
+TrackBuffersManager::DoDemuxAudio()
+{
+  if (mAbort) {
+    mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
+    return;
+  }
+  if (!HasAudio()) {
+    CompleteCodedFrameProcessing();
+    return;
+  }
+  mAudioTracks.mDemuxRequest.Begin(mAudioTracks.mDemuxer->GetSamples(-1)
+                             ->Then(GetTaskQueue(), __func__, this,
+                                    &TrackBuffersManager::OnAudioDemuxCompleted,
+                                    &TrackBuffersManager::OnAudioDemuxFailed));
+}
+
+void
+TrackBuffersManager::OnAudioDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHolder> aSamples)
+{
+  MSE_DEBUG("%d audio samples demuxed", aSamples->mSamples.Length());
+  mAudioTracks.mDemuxRequest.Complete();
+  if (mAbort) {
+    mProcessingPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
+    return;
+  }
+  mAudioTracks.mQueuedSamples.AppendElements(aSamples->mSamples);
+  CompleteCodedFrameProcessing();
+}
+
+void
+TrackBuffersManager::CompleteCodedFrameProcessing()
+{
+  MOZ_ASSERT(OnTaskQueue());
+
+  // 1. For each coded frame in the media segment run the following steps:
+
+  for (auto& sample : mVideoTracks.mQueuedSamples) {
+    while (true) {
+      if (!ProcessFrame(sample, mVideoTracks)) {
+        break;
+      }
+    }
+  }
+  mVideoTracks.mQueuedSamples.Clear();
+
+  for (auto& sample : mAudioTracks.mQueuedSamples) {
+    while (true) {
+      if (!ProcessFrame(sample, mAudioTracks)) {
+        break;
+      }
+    }
+  }
+  mAudioTracks.mQueuedSamples.Clear();
+
+  {
+    MonitorAutoLock mon(mMonitor);
+
+    // Save our final tracks buffered ranges.
+    mVideoBufferedRanges = mVideoTracks.mBufferedRanges;
+    mAudioBufferedRanges = mAudioTracks.mBufferedRanges;
+  }
+
+  // Return to step 6.4 of Segment Parser Loop algorithm
+  // 4. If this SourceBuffer is full and cannot accept more media data, then set the buffer full flag to true.
+  // TODO
+  mBufferFull = false;
+
+  // 5. If the input buffer does not contain a complete media segment, then jump to the need more data step below.
+  if (mParser->MediaSegmentRange().IsNull()) {
+    mProcessingPromise.ResolveIfExists(true, __func__);
+    return;
+  }
+
+  // 6. Remove the media segment bytes from the beginning of the input buffer.
+  int64_t rangeOffset = mParser->InitSegmentRange().mEnd;
+  mInputBuffer->RemoveElementsAt(0, mParser->MediaSegmentRange().mEnd - rangeOffset);
+  RecreateParser();
+
+  // Clear our demuxer from any already processed data.
+  // As we have handled a complete media segment, it is safe to evict all data
+  // from the resource.
+  mCurrentInputBuffer->EvictAll();
+  mInputDemuxer->NotifyDataRemoved();
+
+  // 7. Set append state to WAITING_FOR_SEGMENT.
+  SetAppendState(AppendState::WAITING_FOR_SEGMENT);
+
+  // 8. Jump to the loop top step above.
+  mProcessingPromise.ResolveIfExists(false, __func__);
+}
+
+bool
+TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
+                                  TrackData& aTrackData)
+{
+  TrackData* tracks[] = { &mVideoTracks, &mAudioTracks };
+  TimeUnit presentationTimestamp;
+  TimeUnit decodeTimestamp;
+
+  if (!mParent->mGenerateTimestamp) {
+    presentationTimestamp = TimeUnit::FromMicroseconds(aSample->mTime);
+    decodeTimestamp = TimeUnit::FromMicroseconds(aSample->mTimecode);
+  }
+
+  // 2. Let frame duration be a double precision floating point representation of the coded frame's duration in seconds.
+  TimeUnit frameDuration{TimeUnit::FromMicroseconds(aSample->mDuration)};
+
+  // 3. If mode equals "sequence" and group start timestamp is set, then run the following steps:
+  if (mParent->mAppendMode == SourceBufferAppendMode::Sequence &&
+      mGroupStartTimestamp.isSome()) {
+    mTimestampOffset = mGroupStartTimestamp.ref();
+    mGroupEndTimestamp = mGroupStartTimestamp.ref();
+    mVideoTracks.mNeedRandomAccessPoint = true;
+    mAudioTracks.mNeedRandomAccessPoint = true;
+    mGroupStartTimestamp.reset();
+  }
+
+  // 4. If timestampOffset is not 0, then run the following steps:
+  if (mTimestampOffset != TimeUnit::FromSeconds(0)) {
+    presentationTimestamp += mTimestampOffset;
+    decodeTimestamp += mTimestampOffset;
+  }
+
+  MSE_DEBUGV("Processing %s frame(pts:%lld end:%lld, dts:%lld, duration:%lld, "
+             "kf:%d)",
+             aTrackData.mInfo->mMimeType.get(),
+             presentationTimestamp.ToMicroseconds(),
+             (presentationTimestamp + frameDuration).ToMicroseconds(),
+             decodeTimestamp.ToMicroseconds(),
+             frameDuration.ToMicroseconds(),
+             aSample->mKeyframe);
+
+  // 5. Let track buffer equal the track buffer that the coded frame will be added to.
+  auto& trackBuffer = aTrackData;
+
+  // 6. If last decode timestamp for track buffer is set and decode timestamp is less than last decode timestamp:
+  // OR
+  // If last decode timestamp for track buffer is set and the difference between decode timestamp and last decode timestamp is greater than 2 times last frame duration:
+
+  // TODO: Maybe we should be using TimeStamp and TimeDuration instead?
+
+  if ((trackBuffer.mLastDecodeTimestamp.isSome() &&
+       decodeTimestamp < trackBuffer.mLastDecodeTimestamp.ref()) ||
+      (trackBuffer.mLastDecodeTimestamp.isSome() &&
+       decodeTimestamp - trackBuffer.mLastDecodeTimestamp.ref() > 2*trackBuffer.mLastFrameDuration.ref())) {
+    if (mParent->mAppendMode == SourceBufferAppendMode::Segments) {
+      mGroupEndTimestamp = presentationTimestamp;
+    }
+    if (mParent->mAppendMode == SourceBufferAppendMode::Sequence) {
+      mGroupStartTimestamp = Some(mGroupEndTimestamp);
+    }
+    for (auto& track : tracks) {
+      track->mLastDecodeTimestamp.reset();
+      track->mLastFrameDuration.reset();
+      track->mHighestEndTimestamp.reset();
+      track->mNeedRandomAccessPoint = true;
+    }
+    return true;
+  }
+
+  // 7. Let frame end timestamp equal the sum of presentation timestamp and frame duration.
+  TimeUnit frameEndTimestamp = presentationTimestamp + frameDuration;
+
+  // 8. If presentation timestamp is less than appendWindowStart, then set the need random access point flag to true, drop the coded frame, and jump to the top of the loop to start processing the next coded frame.
+  if (presentationTimestamp.ToSeconds() < mParent->mAppendWindowStart) {
+    trackBuffer.mNeedRandomAccessPoint = true;
+    return false;
+  }
+
+  // 9. If frame end timestamp is greater than appendWindowEnd, then set the need random access point flag to true, drop the coded frame, and jump to the top of the loop to start processing the next coded frame.
+  if (frameEndTimestamp.ToSeconds() > mParent->mAppendWindowEnd) {
+    trackBuffer.mNeedRandomAccessPoint = true;
+    return false;
+  }
+
+  // 10. If the need random access point flag on track buffer equals true, then run the following steps:
+  if (trackBuffer.mNeedRandomAccessPoint) {
+    // 1. If the coded frame is not a random access point, then drop the coded frame and jump to the top of the loop to start processing the next coded frame.
+    if (!aSample->mKeyframe) {
+      return false;
+    }
+    // 2. Set the need random access point flag on track buffer to false.
+    trackBuffer.mNeedRandomAccessPoint = false;
+  }
+
+  // TODO: Handle splicing of audio (and text) frames.
+  // 11. Let spliced audio frame be an unset variable for holding audio splice information
+  // 12. Let spliced timed text frame be an unset variable for holding timed text splice information
+
+  // 13. If last decode timestamp for track buffer is unset and presentation timestamp falls within the presentation interval of a coded frame in track buffer,then run the following steps:
+  // For now we only handle replacing existing frames with the new ones. So we
+  // skip this step.
+
+  // 14. Remove existing coded frames in track buffer:
+
+  // There is an ambiguity on how to remove frames, which was lodged with:
+  // https://www.w3.org/Bugs/Public/show_bug.cgi?id=28710, implementing as per
+  // bug description.
+  int firstRemovedIndex = -1;
+  TimeInterval removedInterval;
+  TrackBuffer& data = trackBuffer.mBuffers.LastElement();
+  if (trackBuffer.mBufferedRanges.Contains(presentationTimestamp)) {
+    if (trackBuffer.mHighestEndTimestamp.isNothing()) {
+      for (uint32_t i = 0; i < data.Length(); i++) {
+        MediaRawData* sample = data[i].get();
+        if (sample->mTime >= presentationTimestamp.ToMicroseconds() &&
+            sample->mTime < frameEndTimestamp.ToMicroseconds()) {
+          if (firstRemovedIndex < 0) {
+            removedInterval =
+              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                           TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration));
+            firstRemovedIndex = i;
+          } else {
+            removedInterval = removedInterval.Span(
+              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                           TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration)));
+          }
+          data.RemoveElementAt(i);
+        }
+      }
+    } else if (trackBuffer.mHighestEndTimestamp.ref() <= presentationTimestamp) {
+      for (uint32_t i = 0; i < data.Length(); i++) {
+        MediaRawData* sample = data[i].get();
+        if (sample->mTime >= trackBuffer.mHighestEndTimestamp.ref().ToMicroseconds() &&
+            sample->mTime < frameEndTimestamp.ToMicroseconds()) {
+          if (firstRemovedIndex < 0) {
+            removedInterval =
+              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                           TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration));
+            firstRemovedIndex = i;
+          } else {
+            removedInterval = removedInterval.Span(
+              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                           TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration)));
+          }
+          data.RemoveElementAt(i);
+        }
+      }
+    }
+  }
+  // 15. Remove decoding dependencies of the coded frames removed in the previous step:
+  // Remove all coded frames between the coded frames removed in the previous step and the next random access point after those removed frames.
+  if (firstRemovedIndex >= 0) {
+    for (uint32_t i = firstRemovedIndex; i < data.Length(); i++) {
+      MediaRawData* sample = data[i].get();
+      if (sample->mKeyframe) {
+        break;
+      }
+      removedInterval = removedInterval.Span(
+        TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                     TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration)));
+      data.RemoveElementAt(i);
+    }
+    // Update our buffered range to exclude the range just removed.
+    trackBuffer.mBufferedRanges -= removedInterval;
+  }
+
+  // 16. Add the coded frame with the presentation timestamp, decode timestamp, and frame duration to the track buffer.
+  aSample->mTime = presentationTimestamp.ToMicroseconds();
+  aSample->mTimecode = decodeTimestamp.ToMicroseconds();
+  if (firstRemovedIndex >= 0) {
+    data.InsertElementAt(firstRemovedIndex, aSample);
+  } else {
+    data.AppendElement(aSample);
+  }
+  // 17. Set last decode timestamp for track buffer to decode timestamp.
+  trackBuffer.mLastDecodeTimestamp = Some(decodeTimestamp);
+  // 18. Set last frame duration for track buffer to frame duration.
+  trackBuffer.mLastFrameDuration = Some(TimeUnit::FromMicroseconds(aSample->mDuration));
+  // 19. If highest end timestamp for track buffer is unset or frame end timestamp is greater than highest end timestamp, then set highest end timestamp for track buffer to frame end timestamp.
+  if (trackBuffer.mHighestEndTimestamp.isNothing() ||
+      frameEndTimestamp > trackBuffer.mHighestEndTimestamp.ref()) {
+    trackBuffer.mHighestEndTimestamp = Some(frameEndTimestamp);
+  }
+  // 20. If frame end timestamp is greater than group end timestamp, then set group end timestamp equal to frame end timestamp.
+  if (frameEndTimestamp > mGroupEndTimestamp) {
+    mGroupEndTimestamp = frameEndTimestamp;
+  }
+  // 21. If generate timestamps flag equals true, then set timestampOffset equal to frame end timestamp.
+  if (mParent->mGenerateTimestamp) {
+    mTimestampOffset = frameEndTimestamp;
+  }
+
+  // Update our buffered range with new sample interval.
+  // We allow a fuzz factor in our interval of half a frame length,
+  // as fuzz is +/- value, giving an effective leeway of a full frame
+  // length.
+  trackBuffer.mBufferedRanges +=
+    TimeInterval(presentationTimestamp, frameEndTimestamp,
+                 TimeUnit::FromMicroseconds(aSample->mDuration / 2));
+  return false;
+}
+
+void
+TrackBuffersManager::RecreateParser()
+{
+  // Recreate our parser for only the data remaining. This is required
+  // as it has parsed the entire InputBuffer provided.
+  // Once the old TrackBuffer/MediaSource implementation is removed
+  // we can optimize this part. TODO
+  nsRefPtr<MediaLargeByteBuffer> initData = mParser->InitData();
+  mParser = ContainerParser::CreateForMIMEType(mType);
+  if (initData) {
+    int64_t start, end;
+    mParser->ParseStartAndEndTimestamps(initData, start, end);
+  }
+}
+
+nsTArray<TrackBuffersManager::TrackData*>
+TrackBuffersManager::GetTracksList()
+{
+  nsTArray<TrackData*> tracks;
+  if (HasVideo()) {
+    tracks.AppendElement(&mVideoTracks);
+  }
+  if (HasAudio()) {
+    tracks.AppendElement(&mAudioTracks);
+  }
+  return tracks;
+}
+
+void
+TrackBuffersManager::RestoreCachedVariables()
+{
+  if (mTimestampOffset != mLastTimestampOffset) {
+    nsCOMPtr<nsIRunnable> task =
+      NS_NewRunnableMethodWithArg<TimeUnit>(
+        mParent.get(),
+        static_cast<void (dom::SourceBuffer::*)(const TimeUnit&)>(&dom::SourceBuffer::SetTimestampOffset), /* beauty uh? :) */
+        mTimestampOffset);
+    AbstractThread::MainThread()->Dispatch(task.forget());
+  }
+}
+
+void
+TrackBuffersManager::SetAppendState(TrackBuffersManager::AppendState aAppendState)
+{
+  MSE_DEBUG("AppendState changed from %s to %s",
+            AppendStateToStr(mAppendState), AppendStateToStr(aAppendState));
+  mAppendState = aAppendState;
+}
+
+void
+TrackBuffersManager::SetGroupStartTimestamp(const TimeUnit& aGroupStartTimestamp)
+{
+  if (NS_IsMainThread()) {
+    nsCOMPtr<nsIRunnable> task =
+      NS_NewRunnableMethodWithArg<TimeUnit>(
+        this,
+        &TrackBuffersManager::SetGroupStartTimestamp,
+        aGroupStartTimestamp);
+    GetTaskQueue()->Dispatch(task.forget());
+    return;
+  }
+  MOZ_ASSERT(OnTaskQueue());
+  mGroupStartTimestamp = Some(aGroupStartTimestamp);
+}
+
+void
+TrackBuffersManager::RestartGroupStartTimestamp()
+{
+  if (NS_IsMainThread()) {
+    nsCOMPtr<nsIRunnable> task =
+      NS_NewRunnableMethod(this, &TrackBuffersManager::RestartGroupStartTimestamp);
+    GetTaskQueue()->Dispatch(task.forget());
+    return;
+  }
+  MOZ_ASSERT(OnTaskQueue());
+  mGroupStartTimestamp = Some(mGroupEndTimestamp);
+}
+
+TrackBuffersManager::~TrackBuffersManager()
+{
+  mTaskQueue->BeginShutdown();
+  mTaskQueue = nullptr;
+}
+
+MediaInfo
+TrackBuffersManager::GetMetadata()
+{
+  MonitorAutoLock mon(mMonitor);
+  return mInfo;
+}
+
+const TimeIntervals&
+TrackBuffersManager::Buffered(TrackInfo::TrackType aTrack)
+{
+  MOZ_ASSERT(OnTaskQueue());
+  return GetTracksData(aTrack).mBufferedRanges;
+}
+
+const TrackBuffersManager::TrackBuffer&
+TrackBuffersManager::GetTrackBuffer(TrackInfo::TrackType aTrack)
+{
+  MOZ_ASSERT(OnTaskQueue());
+  return GetTracksData(aTrack).mBuffers.LastElement();
+}
+
+}
+#undef MSE_DEBUG

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -190,7 +190,7 @@ TrackBuffersManager::Buffered()
   // 2. Let highest end time be the largest track buffer ranges end time across all the track buffers managed by this SourceBuffer object.
   TimeUnit highestEndTime;
 
-  nsTArray<TimeIntervals*> tracks;
+  nsTArray<const TimeIntervals*> tracks;
   if (HasVideo()) {
     tracks.AppendElement(&mVideoBufferedRanges);
   }
@@ -206,13 +206,16 @@ TrackBuffersManager::Buffered()
 
   // 4. For each track buffer managed by this SourceBuffer, run the following steps:
   //   1. Let track ranges equal the track buffer ranges for the current track buffer.
-  for (auto trackRanges : tracks) {
+  for (const TimeIntervals* trackRanges : tracks) {
     // 2. If readyState is "ended", then set the end time on the last range in track ranges to highest end time.
-    if (mEnded) {
-      trackRanges->Add(TimeInterval(trackRanges->GetEnd(), highestEndTime));
-    }
     // 3. Let new intersection ranges equal the intersection between the intersection ranges and the track ranges.
-    intersection.Intersection(*trackRanges);
+    if (mEnded) {
+      TimeIntervals tR = *trackRanges;
+      tR.Add(TimeInterval(tR.GetEnd(), highestEndTime));
+      intersection.Intersection(tR);
+    } else {
+      intersection.Intersection(*trackRanges);
+    }
   }
   return intersection;
 }

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -59,25 +59,32 @@ TrackBuffersManager::AppendData(MediaLargeByteBuffer* aData,
                                 TimeUnit aTimestampOffset)
 {
   MOZ_ASSERT(NS_IsMainThread());
-  MonitorAutoLock mon(mMonitor);
   MSE_DEBUG("Appending %lld bytes", aData->Length());
-  mIncomingBuffers.AppendElement(IncomingBuffer(aData, aTimestampOffset));
+
   mEnded = false;
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethodWithArg<IncomingBuffer>(
+      this, &TrackBuffersManager::AppendIncomingBuffer,
+      IncomingBuffer(aData, aTimestampOffset));
+  GetTaskQueue()->Dispatch(task.forget());
   return true;
+}
+
+void
+TrackBuffersManager::AppendIncomingBuffer(IncomingBuffer aData)
+{
+  MOZ_ASSERT(OnTaskQueue());
+  mIncomingBuffers.AppendElement(aData);
 }
 
 nsRefPtr<TrackBuffersManager::AppendPromise>
 TrackBuffersManager::BufferAppend()
 {
   MOZ_ASSERT(NS_IsMainThread());
-  MOZ_ASSERT(mAppendPromise.IsEmpty());
-  nsRefPtr<AppendPromise> p = mAppendPromise.Ensure(__func__);
+  MSE_DEBUG("");
 
-  nsCOMPtr<nsIRunnable> task =
-    NS_NewRunnableMethod(this, &TrackBuffersManager::InitSegmentParserLoop);
-  GetTaskQueue()->Dispatch(task.forget());
-
-  return p;
+  return ProxyMediaCall(GetTaskQueue(), this,
+                        __func__, &TrackBuffersManager::InitSegmentParserLoop);
 }
 
 // Abort any pending AppendData.
@@ -89,14 +96,16 @@ void
 TrackBuffersManager::AbortAppendData()
 {
   MOZ_ASSERT(NS_IsMainThread());
-  mAppendPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
+  MSE_DEBUG("");
+
+  mAbort = true;
 }
 
 void
 TrackBuffersManager::ResetParserState()
 {
   MOZ_ASSERT(NS_IsMainThread());
-  MOZ_ASSERT(mAppendPromise.IsEmpty(), "AbortAppendData must have been called");
+  MSE_DEBUG("");
 
   // 1. If the append state equals PARSING_MEDIA_SEGMENT and the input buffer contains some complete coded frames, then run the coded frame processing algorithm until all of these complete coded frames have been processed.
   if (mAppendState == AppendState::PARSING_MEDIA_SEGMENT) {
@@ -114,15 +123,13 @@ nsRefPtr<TrackBuffersManager::RangeRemovalPromise>
 TrackBuffersManager::RangeRemoval(TimeUnit aStart, TimeUnit aEnd)
 {
   MOZ_ASSERT(NS_IsMainThread());
+  MSE_DEBUG("From %.2f to %.2f", aStart.ToSeconds(), aEnd.ToSeconds());
+
   mEnded = false;
 
-  nsRefPtr<RangeRemovalPromise> p = mRangeRemovalPromise.Ensure(__func__);
-
-  nsCOMPtr<nsIRunnable> task =
-  NS_NewRunnableMethodWithArg<TimeInterval>(
-    this, &TrackBuffersManager::CodedFrameRemoval, TimeInterval(aStart, aEnd));
-  GetTaskQueue()->Dispatch(task.forget());
-  return p;
+  return ProxyMediaCall(GetTaskQueue(), this, __func__,
+                        &TrackBuffersManager::CodedFrameRemovalWithPromise,
+                        TimeInterval(aStart, aEnd));
 }
 
 TrackBuffersManager::EvictDataResult
@@ -152,9 +159,9 @@ TrackBuffersManager::EvictBefore(TimeUnit aTime)
 {
   MOZ_ASSERT(NS_IsMainThread());
   nsCOMPtr<nsIRunnable> task =
-  NS_NewRunnableMethodWithArg<TimeInterval>(
-    this, &TrackBuffersManager::CodedFrameRemoval,
-    TimeInterval(TimeUnit::FromSeconds(0), aTime));
+    NS_NewRunnableMethodWithArg<TimeInterval>(
+        this, &TrackBuffersManager::CodedFrameRemoval,
+        TimeInterval(TimeUnit::FromSeconds(0), aTime));
   GetTaskQueue()->Dispatch(task.forget());
 }
 
@@ -209,14 +216,13 @@ void
 TrackBuffersManager::Detach()
 {
   MOZ_ASSERT(NS_IsMainThread());
-  MOZ_ASSERT(mAppendPromise.IsEmpty(), "Abort wasn't called");
-  // Abort any pending promises.
-  mRangeRemovalPromise.ResolveIfExists(false, __func__);
+  MSE_DEBUG("");
+
   // Clear our sourcebuffer
   nsCOMPtr<nsIRunnable> task =
-  NS_NewRunnableMethodWithArg<TimeInterval>(
-    this, &TrackBuffersManager::CodedFrameRemoval,
-    TimeInterval(TimeUnit::FromSeconds(0), TimeUnit::FromInfinity()));
+    NS_NewRunnableMethodWithArg<TimeInterval>(
+      this, &TrackBuffersManager::CodedFrameRemoval,
+      TimeInterval(TimeUnit::FromSeconds(0), TimeUnit::FromInfinity()));
   GetTaskQueue()->Dispatch(task.forget());
 }
 
@@ -250,6 +256,7 @@ void
 TrackBuffersManager::CompleteResetParserState()
 {
   MOZ_ASSERT(OnTaskQueue());
+  MOZ_ASSERT(mAppendPromise.IsEmpty());
 
   for (auto track : GetTracksList()) {
     // 2. Unset the last decode timestamp on all track buffers.
@@ -361,18 +368,26 @@ TrackBuffersManager::DoEvictData(const TimeUnit& aPlaybackTime,
   }
 }
 
-void
+nsRefPtr<TrackBuffersManager::RangeRemovalPromise>
+TrackBuffersManager::CodedFrameRemovalWithPromise(TimeInterval aInterval)
+{
+  MOZ_ASSERT(OnTaskQueue());
+  bool rv = CodedFrameRemoval(aInterval);
+  return RangeRemovalPromise::CreateAndResolve(rv, __func__);
+}
+
+bool
 TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
 {
+  MOZ_ASSERT(OnTaskQueue());
+  MOZ_ASSERT(mAppendPromise.IsEmpty(), "Logic error: Append in progress");
   MSE_DEBUG("From %.2fs to %.2f",
             aInterval.mStart.ToSeconds(), aInterval.mEnd.ToSeconds());
 
   double mediaSourceDuration = mParentDecoder->GetMediaSourceDuration();
   if (IsNaN(mediaSourceDuration)) {
     MSE_DEBUG("Nothing to remove, aborting");
-    MonitorAutoLock mon(mMonitor);
-    mRangeRemovalPromise.ResolveIfExists(false, __func__);
-    return;
+    return false;
   }
   TimeUnit duration{TimeUnit::FromSeconds(mediaSourceDuration)};
 
@@ -390,6 +405,8 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
   TimeUnit start = aInterval.mStart;
   // 2. Let end be the end presentation timestamp for the removal range.
   TimeUnit end = aInterval.mEnd;
+
+  bool dataRemoved = false;
 
   // 3. For each track buffer in this source buffer, run the following steps:
   for (auto track : GetTracksList()) {
@@ -445,6 +462,7 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
         track->mSizeBuffer -= sizeof(*frame) + frame->Size();
         data.RemoveElementAt(i);
       }
+      dataRemoved = true;
     }
     track->mBufferedRanges -= removedInterval;
 
@@ -476,14 +494,21 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
   // Update our reported total size.
   mSizeSourceBuffer = mVideoTracks.mSizeBuffer + mAudioTracks.mSizeBuffer;
 
-  mRangeRemovalPromise.ResolveIfExists(true, __func__);
+  return dataRemoved;
 }
 
-void
+nsRefPtr<TrackBuffersManager::AppendPromise>
 TrackBuffersManager::InitSegmentParserLoop()
 {
+  MOZ_ASSERT(OnTaskQueue());
+
+  MOZ_ASSERT(mAppendPromise.IsEmpty());
+  nsRefPtr<AppendPromise> p = mAppendPromise.Ensure(__func__);
+
   AppendIncomingBuffers();
   SegmentParserLoop();
+
+  return p;
 }
 
 void

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -591,6 +591,7 @@ TrackBuffersManager::SegmentParserLoop()
     // following steps:
     if (mAppendState == AppendState::PARSING_INIT_SEGMENT) {
       if (mParser->InitSegmentRange().IsNull()) {
+        mInputBuffer = nullptr;
         NeedMoreData();
         return;
       }
@@ -605,6 +606,8 @@ TrackBuffersManager::SegmentParserLoop()
       }
       // 2. If the input buffer does not contain a complete media segment header yet, then jump to the need more data step below.
       if (mParser->MediaHeaderRange().IsNull()) {
+        mCurrentInputBuffer->AppendData(mInputBuffer);
+        mInputBuffer = nullptr;
         NeedMoreData();
         return;
       }
@@ -688,12 +691,9 @@ TrackBuffersManager::InitializationSegmentReceived()
   MOZ_ASSERT(mParser->HasCompleteInitData());
   mCurrentInputBuffer = new SourceBufferResource(mType);
   mCurrentInputBuffer->AppendData(mParser->InitData());
-  uint32_t initLength = mParser->InitSegmentRange().mEnd;
-  if (mInputBuffer->Length() == initLength) {
-    mInputBuffer = nullptr;
-  } else {
-    mInputBuffer->RemoveElementsAt(0, initLength);
-  }
+  uint32_t length =
+    mParser->InitSegmentRange().mEnd - (mProcessedInput - mInputBuffer->Length());
+  mInputBuffer->RemoveElementsAt(0, length);
   CreateDemuxerforMIMEType();
   if (!mInputDemuxer) {
     MOZ_ASSERT(false, "TODO type not supported");

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -217,11 +217,18 @@ private:
     // TrackInfo of the first metadata received.
     UniquePtr<TrackInfo> mInfo;
   };
+
   bool ProcessFrame(MediaRawData* aSample, TrackData& aTrackData);
+  void RejectProcessing(nsresult aRejectValue, const char* aName);
+  void ResolveProcessing(bool aResolveValue, const char* aName);
   MediaPromiseRequestHolder<CodedFrameProcessingPromise> mProcessingRequest;
   MediaPromiseHolder<CodedFrameProcessingPromise> mProcessingPromise;
 
   MediaPromiseHolder<AppendPromise> mAppendPromise;
+  // Set to true while SegmentParserLoop is running. This is used for diagnostic
+  // purposes only. We can't rely on mAppendPromise to be empty as it is only
+  // cleared in a follow up task.
+  bool mAppendRunning;
 
   // Trackbuffers definition.
   nsTArray<TrackData*> GetTracksList();

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -171,6 +171,8 @@ private:
     Maybe<TimeUnit> mLastDecodeTimestamp;
     Maybe<TimeUnit> mLastFrameDuration;
     Maybe<TimeUnit> mHighestEndTimestamp;
+    // Longest frame duration seen in a coded frame group.
+    Maybe<TimeUnit> mLongestFrameDuration;
     bool mNeedRandomAccessPoint;
     nsRefPtr<MediaTrackDemuxer> mDemuxer;
     TrackBuffer mQueuedSamples;

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -159,10 +159,13 @@ private:
     OnDemuxFailed(TrackType::kAudioTrack, aFailure);
   }
 
+  void DoEvictData(const TimeUnit& aPlaybackTime, uint32_t aThreshold);
+
   struct TrackData {
     TrackData()
       : mNumTracks(0)
       , mNeedRandomAccessPoint(true)
+      , mSizeBuffer(0)
     {}
     uint32_t mNumTracks;
     Maybe<TimeUnit> mLastDecodeTimestamp;
@@ -176,6 +179,7 @@ private:
     // We only manage a single track of each type at this time.
     nsTArray<TrackBuffer> mBuffers;
     TimeIntervals mBufferedRanges;
+    uint32_t mSizeBuffer;
   };
   bool ProcessFrame(MediaRawData* aSample, TrackData& aTrackData);
   MediaPromiseRequestHolder<CodedFrameProcessingPromise> mProcessingRequest;
@@ -222,6 +226,9 @@ private:
   Atomic<bool> mAbort;
   // Set to true if mediasource state changed to ended.
   Atomic<bool> mEnded;
+
+  // Global size of this source buffer content.
+  Atomic<int64_t> mSizeSourceBuffer;
 
   // Monitor to protect following objects accessed across multiple threads.
   mutable Monitor mMonitor;

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -84,7 +84,8 @@ public:
 
 private:
   virtual ~TrackBuffersManager();
-  void InitSegmentParserLoop();
+  // All following functions run on the taskqueue.
+  nsRefPtr<AppendPromise> InitSegmentParserLoop();
   void ScheduleSegmentParserLoop();
   void SegmentParserLoop();
   void AppendIncomingBuffers();
@@ -95,12 +96,13 @@ private:
   // Will return a promise that will be resolved once all frames of the current
   // media segment have been processed.
   nsRefPtr<CodedFrameProcessingPromise> CodedFrameProcessing();
-  // Called by ResetParserState. Complete parsing the input buffer for the
-  // current media segment
-  void FinishCodedFrameProcessing();
   void CompleteCodedFrameProcessing();
+  // Called by ResetParserState. Complete parsing the input buffer for the
+  // current media segment.
+  void FinishCodedFrameProcessing();
   void CompleteResetParserState();
-  void CodedFrameRemoval(TimeInterval aInterval);
+  nsRefPtr<RangeRemovalPromise> CodedFrameRemovalWithPromise(TimeInterval aInterval);
+  bool CodedFrameRemoval(TimeInterval aInterval);
   void SetAppendState(AppendState aAppendState);
 
   bool HasVideo() const
@@ -111,6 +113,10 @@ private:
   {
     return mAudioTracks.mNumTracks > 0;
   }
+
+  typedef Pair<nsRefPtr<MediaLargeByteBuffer>, TimeUnit> IncomingBuffer;
+  void AppendIncomingBuffer(IncomingBuffer aData);
+  nsTArray<IncomingBuffer> mIncomingBuffers;
 
   // The input buffer as per http://w3c.github.io/media-source/index.html#sourcebuffer-input-buffer
   nsRefPtr<MediaLargeByteBuffer> mInputBuffer;
@@ -215,9 +221,7 @@ private:
   MediaPromiseRequestHolder<CodedFrameProcessingPromise> mProcessingRequest;
   MediaPromiseHolder<CodedFrameProcessingPromise> mProcessingPromise;
 
-  // SourceBuffer media promise (resolved on the main thread)
   MediaPromiseHolder<AppendPromise> mAppendPromise;
-  MediaPromiseHolder<RangeRemovalPromise> mRangeRemovalPromise;
 
   // Trackbuffers definition.
   nsTArray<TrackData*> GetTracksList();
@@ -262,8 +266,6 @@ private:
 
   // Monitor to protect following objects accessed across multiple threads.
   mutable Monitor mMonitor;
-  typedef Pair<nsRefPtr<MediaLargeByteBuffer>, TimeUnit> IncomingBuffer;
-  nsTArray<IncomingBuffer> mIncomingBuffers;
   // Stable audio and video track time ranges.
   TimeIntervals mVideoBufferedRanges;
   TimeIntervals mAudioBufferedRanges;

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -138,6 +138,9 @@ private:
   // Demuxer objects and methods.
   nsRefPtr<SourceBufferResource> mCurrentInputBuffer;
   nsRefPtr<MediaDataDemuxer> mInputDemuxer;
+  // Length already processed in current media segment.
+  uint32_t mProcessedInput;
+
   void OnDemuxerInitDone(nsresult);
   void OnDemuxerInitFailed(DemuxerFailureReason aFailure);
   MediaPromiseRequestHolder<MediaDataDemuxer::InitPromise> mDemuxerInitRequest;
@@ -168,20 +171,45 @@ private:
       , mSizeBuffer(0)
     {}
     uint32_t mNumTracks;
+    // Definition of variables:
+    // https://w3c.github.io/media-source/#track-buffers
+    // Last decode timestamp variable that stores the decode timestamp of the
+    // last coded frame appended in the current coded frame group.
+    // The variable is initially unset to indicate that no coded frames have
+    // been appended yet.
     Maybe<TimeUnit> mLastDecodeTimestamp;
+    // Last frame duration variable that stores the coded frame duration of the
+    // last coded frame appended in the current coded frame group.
+    // The variable is initially unset to indicate that no coded frames have
+    // been appended yet.
     Maybe<TimeUnit> mLastFrameDuration;
+    // Highest end timestamp variable that stores the highest coded frame end
+    // timestamp across all coded frames in the current coded frame group that
+    // were appended to this track buffer.
+    // The variable is initially unset to indicate that no coded frames have
+    // been appended yet.
     Maybe<TimeUnit> mHighestEndTimestamp;
     // Longest frame duration seen in a coded frame group.
     Maybe<TimeUnit> mLongestFrameDuration;
+    // Need random access point flag variable that keeps track of whether the
+    // track buffer is waiting for a random access point coded frame.
+    // The variable is initially set to true to indicate that random access
+    // point coded frame is needed before anything can be added to the track
+    // buffer.
     bool mNeedRandomAccessPoint;
     nsRefPtr<MediaTrackDemuxer> mDemuxer;
-    TrackBuffer mQueuedSamples;
     MediaPromiseRequestHolder<MediaTrackDemuxer::SamplesPromise> mDemuxRequest;
-    UniquePtr<TrackInfo> mInfo;
+    // Samples just demuxed, but not yet parsed.
+    TrackBuffer mQueuedSamples;
     // We only manage a single track of each type at this time.
     nsTArray<TrackBuffer> mBuffers;
+    // Track buffer ranges variable that represents the presentation time ranges
+    // occupied by the coded frames currently stored in the track buffer.
     TimeIntervals mBufferedRanges;
+    // Byte size of all samples contained in this track buffer.
     uint32_t mSizeBuffer;
+    // TrackInfo of the first metadata received.
+    UniquePtr<TrackInfo> mInfo;
   };
   bool ProcessFrame(MediaRawData* aSample, TrackData& aTrackData);
   MediaPromiseRequestHolder<CodedFrameProcessingPromise> mProcessingRequest;
@@ -234,13 +262,12 @@ private:
 
   // Monitor to protect following objects accessed across multiple threads.
   mutable Monitor mMonitor;
-  // Set by the main thread, but only when all our tasks are completes
-  // (e.g. when SourceBuffer.updating is false). So the monitor isn't
-  // technically required for mIncomingBuffer.
   typedef Pair<nsRefPtr<MediaLargeByteBuffer>, TimeUnit> IncomingBuffer;
   nsTArray<IncomingBuffer> mIncomingBuffers;
+  // Stable audio and video track time ranges.
   TimeIntervals mVideoBufferedRanges;
   TimeIntervals mAudioBufferedRanges;
+  // MediaInfo of the first init segment read.
   MediaInfo mInfo;
 };
 

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -145,7 +145,7 @@ private:
   nsRefPtr<SourceBufferResource> mCurrentInputBuffer;
   nsRefPtr<MediaDataDemuxer> mInputDemuxer;
   // Length already processed in current media segment.
-  uint32_t mProcessedInput;
+  uint64_t mProcessedInput;
 
   void OnDemuxerInitDone(nsresult);
   void OnDemuxerInitFailed(DemuxerFailureReason aFailure);

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -1,0 +1,239 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef MOZILLA_TRACKBUFFERSMANAGER_H_
+#define MOZILLA_TRACKBUFFERSMANAGER_H_
+
+#include "SourceBufferContentManager.h"
+#include "MediaSourceDecoder.h"
+#include "mozilla/Atomics.h"
+#include "mozilla/Maybe.h"
+#include "mozilla/Monitor.h"
+#include "mozilla/Pair.h"
+#include "nsProxyRelease.h"
+#include "nsTArray.h"
+
+namespace mozilla {
+
+class ContainerParser;
+class MediaLargeByteBuffer;
+class MediaRawData;
+class SourceBuffer;
+class SourceBufferResource;
+
+using media::TimeUnit;
+using media::TimeInterval;
+using media::TimeIntervals;
+using dom::SourceBufferAppendMode;
+
+class TrackBuffersManager : public SourceBufferContentManager {
+public:
+  typedef MediaPromise<bool, nsresult, /* IsExclusive = */ true> CodedFrameProcessingPromise;
+  typedef TrackInfo::TrackType TrackType;
+  typedef MediaData::Type MediaType;
+  typedef nsTArray<nsRefPtr<MediaRawData>> TrackBuffer;
+
+  TrackBuffersManager(dom::SourceBuffer* aParent, MediaSourceDecoder* aParentDecoder, const nsACString& aType);
+
+  bool AppendData(MediaLargeByteBuffer* aData, TimeUnit aTimestampOffset) override;
+
+  nsRefPtr<AppendPromise> BufferAppend() override;
+
+  void AbortAppendData() override;
+
+  void ResetParserState() override;
+
+  nsRefPtr<RangeRemovalPromise> RangeRemoval(TimeUnit aStart, TimeUnit aEnd) override;
+
+  EvictDataResult
+  EvictData(TimeUnit aPlaybackTime, uint32_t aThreshold, TimeUnit* aBufferStartTime) override;
+
+  void EvictBefore(TimeUnit aTime) override;
+
+  TimeIntervals Buffered() override;
+
+  int64_t GetSize() override;
+
+  void Ended() override;
+
+  void Detach() override;
+
+  AppendState GetAppendState() override
+  {
+    return mAppendState;
+  }
+
+  void SetGroupStartTimestamp(const TimeUnit& aGroupStartTimestamp) override;
+  void RestartGroupStartTimestamp() override;
+
+  // Interface for MediaSourceDemuxer
+  MediaInfo GetMetadata();
+  const TrackBuffer& GetTrackBuffer(TrackInfo::TrackType aTrack);
+  const TimeIntervals& Buffered(TrackInfo::TrackType);
+  bool IsEnded() const
+  {
+    return mEnded;
+  }
+
+#if defined(DEBUG)
+  void Dump(const char* aPath) override;
+#endif
+
+private:
+  virtual ~TrackBuffersManager();
+  void InitSegmentParserLoop();
+  void ScheduleSegmentParserLoop();
+  void SegmentParserLoop();
+  void AppendIncomingBuffers();
+  void InitializationSegmentReceived();
+  void CreateDemuxerforMIMEType();
+  void NeedMoreData();
+  void RejectAppend(nsresult aRejectValue, const char* aName);
+  // Will return a promise that will be resolved once all frames of the current
+  // media segment have been processed.
+  nsRefPtr<CodedFrameProcessingPromise> CodedFrameProcessing();
+  // Called by ResetParserState. Complete parsing the input buffer for the
+  // current media segment
+  void FinishCodedFrameProcessing();
+  void CompleteCodedFrameProcessing();
+  void CompleteResetParserState();
+  void CodedFrameRemoval(TimeInterval aInterval);
+  void SetAppendState(AppendState aAppendState);
+
+  bool HasVideo() const
+  {
+    return mVideoTracks.mNumTracks > 0;
+  }
+  bool HasAudio() const
+  {
+    return mAudioTracks.mNumTracks > 0;
+  }
+
+  // The input buffer as per http://w3c.github.io/media-source/index.html#sourcebuffer-input-buffer
+  nsRefPtr<MediaLargeByteBuffer> mInputBuffer;
+  // The current append state as per https://w3c.github.io/media-source/#sourcebuffer-append-state
+  // Accessed on both the main thread and the task queue.
+  Atomic<AppendState> mAppendState;
+  // Buffer full flag as per https://w3c.github.io/media-source/#sourcebuffer-buffer-full-flag.
+  // Accessed on both the main thread and the task queue.
+  // TODO: Unused for now.
+  Atomic<bool> mBufferFull;
+  bool mFirstInitializationSegmentReceived;
+  bool mActiveTrack;
+  Maybe<TimeUnit> mGroupStartTimestamp;
+  TimeUnit mGroupEndTimestamp;
+  nsCString mType;
+
+  // ContainerParser objects and methods.
+  // Those are used to parse the incoming input buffer.
+
+  // Recreate the ContainerParser and only feed it with the previous init
+  // segment found.
+  void RecreateParser();
+  nsAutoPtr<ContainerParser> mParser;
+
+  // Demuxer objects and methods.
+  nsRefPtr<SourceBufferResource> mCurrentInputBuffer;
+  nsRefPtr<MediaDataDemuxer> mInputDemuxer;
+  void OnDemuxerInitDone(nsresult);
+  void OnDemuxerInitFailed(DemuxerFailureReason aFailure);
+  MediaPromiseRequestHolder<MediaDataDemuxer::InitPromise> mDemuxerInitRequest;
+  bool mEncrypted;
+
+  void OnDemuxFailed(TrackType aTrack, DemuxerFailureReason aFailure);
+  void DoDemuxVideo();
+  void OnVideoDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHolder> aSamples);
+  void OnVideoDemuxFailed(DemuxerFailureReason aFailure)
+  {
+    mVideoTracks.mDemuxRequest.Complete();
+    OnDemuxFailed(TrackType::kVideoTrack, aFailure);
+  }
+  void DoDemuxAudio();
+  void OnAudioDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHolder> aSamples);
+  void OnAudioDemuxFailed(DemuxerFailureReason aFailure)
+  {
+    mAudioTracks.mDemuxRequest.Complete();
+    OnDemuxFailed(TrackType::kAudioTrack, aFailure);
+  }
+
+  struct TrackData {
+    TrackData()
+      : mNumTracks(0)
+      , mNeedRandomAccessPoint(true)
+    {}
+    uint32_t mNumTracks;
+    Maybe<TimeUnit> mLastDecodeTimestamp;
+    Maybe<TimeUnit> mLastFrameDuration;
+    Maybe<TimeUnit> mHighestEndTimestamp;
+    bool mNeedRandomAccessPoint;
+    nsRefPtr<MediaTrackDemuxer> mDemuxer;
+    TrackBuffer mQueuedSamples;
+    MediaPromiseRequestHolder<MediaTrackDemuxer::SamplesPromise> mDemuxRequest;
+    UniquePtr<TrackInfo> mInfo;
+    // We only manage a single track of each type at this time.
+    nsTArray<TrackBuffer> mBuffers;
+    TimeIntervals mBufferedRanges;
+  };
+  bool ProcessFrame(MediaRawData* aSample, TrackData& aTrackData);
+  MediaPromiseRequestHolder<CodedFrameProcessingPromise> mProcessingRequest;
+  MediaPromiseHolder<CodedFrameProcessingPromise> mProcessingPromise;
+
+  // SourceBuffer media promise (resolved on the main thread)
+  MediaPromiseHolder<AppendPromise> mAppendPromise;
+  MediaPromiseHolder<RangeRemovalPromise> mRangeRemovalPromise;
+
+  // Trackbuffers definition.
+  nsTArray<TrackData*> GetTracksList();
+  TrackData& GetTracksData(TrackType aTrack)
+  {
+    switch(aTrack) {
+      case TrackType::kVideoTrack:
+        return mVideoTracks;
+      case TrackType::kAudioTrack:
+      default:
+        return mAudioTracks;
+    }
+  }
+  TrackData mVideoTracks;
+  TrackData mAudioTracks;
+
+  // TaskQueue methods and objects.
+  AbstractThread* GetTaskQueue() {
+    return mTaskQueue;
+  }
+  bool OnTaskQueue()
+  {
+    return !GetTaskQueue() || GetTaskQueue()->IsCurrentThreadIn();
+  }
+  RefPtr<MediaTaskQueue> mTaskQueue;
+
+  TimeUnit mTimestampOffset;
+  TimeUnit mLastTimestampOffset;
+  void RestoreCachedVariables();
+
+  // Strong references to external objects.
+  nsMainThreadPtrHandle<dom::SourceBuffer> mParent;
+  nsMainThreadPtrHandle<MediaSourceDecoder> mParentDecoder;
+
+  // Set to true if abort is called.
+  Atomic<bool> mAbort;
+  // Set to true if mediasource state changed to ended.
+  Atomic<bool> mEnded;
+
+  // Monitor to protect following objects accessed across multiple threads.
+  mutable Monitor mMonitor;
+  // Set by the main thread, but only when all our tasks are completes
+  // (e.g. when SourceBuffer.updating is false). So the monitor isn't
+  // technically required for mIncomingBuffer.
+  typedef Pair<nsRefPtr<MediaLargeByteBuffer>, TimeUnit> IncomingBuffer;
+  nsTArray<IncomingBuffer> mIncomingBuffers;
+  TimeIntervals mVideoBufferedRanges;
+  TimeIntervals mAudioBufferedRanges;
+  MediaInfo mInfo;
+};
+
+} // namespace mozilla
+#endif /* MOZILLA_TRACKBUFFERSMANAGER_H_ */

--- a/dom/media/mediasource/moz.build
+++ b/dom/media/mediasource/moz.build
@@ -30,6 +30,7 @@ UNIFIED_SOURCES += [
     'SourceBufferList.cpp',
     'SourceBufferResource.cpp',
     'TrackBuffer.cpp',
+    'TrackBuffersManager.cpp',
 ]
 
 FAIL_ON_WARNINGS = True

--- a/media/libstagefright/binding/MoofParser.cpp
+++ b/media/libstagefright/binding/MoofParser.cpp
@@ -82,6 +82,15 @@ MoofParser::RebuildFragmentedIndex(BoxContext& aContext)
 }
 
 MediaByteRange
+MoofParser::FirstCompleteMediaHeader()
+{
+  if (Moofs().IsEmpty()) {
+    return MediaByteRange();
+  }
+  return Moofs()[0].mRange;
+}
+
+MediaByteRange
 MoofParser::FirstCompleteMediaSegment()
 {
   for (uint32_t i = 0 ; i < mMediaRanges.Length(); i++) {

--- a/media/libstagefright/binding/MoofParser.cpp
+++ b/media/libstagefright/binding/MoofParser.cpp
@@ -6,6 +6,7 @@
 #include "mp4_demuxer/Box.h"
 #include "mp4_demuxer/SinfParser.h"
 #include <limits>
+#include "Intervals.h"
 
 #include "prlog.h"
 
@@ -42,6 +43,7 @@ bool
 MoofParser::RebuildFragmentedIndex(BoxContext& aContext)
 {
   bool foundValidMoof = false;
+  bool foundMdat = false;
 
   for (Box box(&aContext, mOffset); box.IsAvailable(); box = box.Next()) {
     if (box.IsType("moov")) {
@@ -62,11 +64,32 @@ MoofParser::RebuildFragmentedIndex(BoxContext& aContext)
       }
 
       mMoofs.AppendElement(moof);
+      mMediaRanges.AppendElement(moof.mRange);
       foundValidMoof = true;
+    } else if (box.IsType("mdat") && !Moofs().IsEmpty()) {
+      // Check if we have all our data from last moof.
+      Moof& moof = Moofs().LastElement();
+      media::Interval<int64_t> datarange(moof.mMdatRange.mStart, moof.mMdatRange.mEnd, 0);
+      media::Interval<int64_t> mdat(box.Range().mStart, box.Range().mEnd, 0);
+      if (datarange.Intersects(mdat)) {
+        mMediaRanges.LastElement() =
+          mMediaRanges.LastElement().Extents(box.Range());
+      }
     }
     mOffset = box.NextOffset();
   }
   return foundValidMoof;
+}
+
+MediaByteRange
+MoofParser::FirstCompleteMediaSegment()
+{
+  for (uint32_t i = 0 ; i < mMediaRanges.Length(); i++) {
+    if (mMediaRanges[i].Contains(Moofs()[i].mMdatRange)) {
+      return mMediaRanges[i];
+    }
+  }
+  return MediaByteRange();
 }
 
 class BlockingStream : public Stream {

--- a/media/libstagefright/binding/include/mp4_demuxer/ByteReader.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/ByteReader.h
@@ -33,7 +33,7 @@ public:
     : mPtr(aData.Elements()), mRemaining(aData.Length()), mLength(aData.Length())
   {
   }
-  explicit ByteReader(const MediaByteBuffer* aData)
+  explicit ByteReader(const mozilla::MediaByteBuffer* aData)
     : mPtr(aData->Elements()), mRemaining(aData->Length()), mLength(aData->Length())
   {
   }

--- a/media/libstagefright/binding/include/mp4_demuxer/ByteReader.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/ByteReader.h
@@ -25,7 +25,7 @@ public:
   {
   }
   template<size_t S>
-  ByteReader(const nsAutoTArray<uint8_t, S>& aData)
+  explicit ByteReader(const nsAutoTArray<uint8_t, S>& aData)
     : mPtr(aData.Elements()), mRemaining(aData.Length()), mLength(aData.Length())
   {
   }

--- a/media/libstagefright/binding/include/mp4_demuxer/ByteReader.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/ByteReader.h
@@ -33,6 +33,10 @@ public:
     : mPtr(aData.Elements()), mRemaining(aData.Length()), mLength(aData.Length())
   {
   }
+  explicit ByteReader(const mozilla::MediaLargeByteBuffer* aData)
+    : mPtr(aData->Elements()), mRemaining(aData->Length()), mLength(aData->Length())
+  {
+  }
   explicit ByteReader(const mozilla::MediaByteBuffer* aData)
     : mPtr(aData->Elements()), mRemaining(aData->Length()), mLength(aData->Length())
   {

--- a/media/libstagefright/binding/include/mp4_demuxer/MoofParser.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/MoofParser.h
@@ -229,6 +229,7 @@ public:
   bool HasMetadata();
   already_AddRefed<mozilla::MediaLargeByteBuffer> Metadata();
   MediaByteRange FirstCompleteMediaSegment();
+  MediaByteRange FirstCompleteMediaHeader();
 
   mozilla::MediaByteRange mInitRange;
   nsRefPtr<Stream> mSource;

--- a/media/libstagefright/binding/include/mp4_demuxer/MoofParser.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/MoofParser.h
@@ -228,6 +228,7 @@ public:
   bool BlockingReadNextMoof();
   bool HasMetadata();
   already_AddRefed<mozilla::MediaLargeByteBuffer> Metadata();
+  MediaByteRange FirstCompleteMediaSegment();
 
   mozilla::MediaByteRange mInitRange;
   nsRefPtr<Stream> mSource;
@@ -245,6 +246,7 @@ private:
   void ScanForMetadata(mozilla::MediaByteRange& aFtyp,
                        mozilla::MediaByteRange& aMoov);
   nsTArray<Moof> mMoofs;
+  nsTArray<MediaByteRange> mMediaRanges;
   bool mIsAudio;
 };
 }


### PR DESCRIPTION
This massive PR is a big step towards spec-compliant MSE code. Changes (and what areas are affected):

- Add abilities to MoofParser to indicate if a media segment is complete. (Regular MP4 & MSE + MP4)
- Make changes to IntervalSet and TimeUnit. (Entire media subsystem)
- Split AppendData between a synchronous part (adding to the Input Buffer) and the Processing part (MSE only)
- Make RangeRemoval return a promise rather than messing with tasks scheduled on the main thread. (MSE only)
- Add ability to retrieve init range to ContainerParser. (MSE only)
- Check MoofParser index before demuxing. (Regular MP4 & MSE + MP4)
- Remove "Diamond Problem" with MediaDecoder inheritance (see commit comment). (media subsystem)
- Add TrackBuffersManager object (+ various fixes; see individual commits). This is essentially a rewrite of our current trackbuffer/sourcebuffer code that is closer to spec. Note that this is still largly unused (will be hooked up and used to a greater extent in a future PR). (MSE only)
- Add ContainerParser::FirstCompleteMediaHeader() method. Currently, ContainerParser doesn't return true if it has a media segment, but true if at least one sample is present with a new moof. We need to be able to detect the actual media segment header (moof). (MSE + MP4)
- Do not evict data until a full init segment has been received. (MSE + MP4)
- Properly search for the required MP4 Atoms rather than make assumptions. (MSE + MP4)
- A few minor fixes to libstagefrights' ByteReader. (Regular MP4 & MSE + MP4)

I've tested this on Linux and appears to be working as intended (though more thorough testing will continue being done). Needs verification on Windows.

Tag #1033, point 7.