### PR TITLE
element.innerText vs. display: none

### DIFF
--- a/dom/html/nsGenericHTMLElement.cpp
+++ b/dom/html/nsGenericHTMLElement.cpp
@@ -3231,15 +3231,47 @@ nsGenericHTMLElement::NewURIFromString(const nsAutoString& aURISpec,
   return NS_OK;
 }
 
+static bool
+IsOrHasAncestorWithDisplayNone(Element* aElement, nsIPresShell* aPresShell)
+{
+  nsTArray<Element*> elementsToCheck;
+  for (Element* e = aElement; e; e = e->GetParentElement()) {
+    if (e->GetPrimaryFrame()) {
+      // e definitely isn't display:none and doesn't have a display:none
+      // ancestor.
+      break;
+    }
+    elementsToCheck.AppendElement(e);
+  }
+
+  if (elementsToCheck.IsEmpty()) {
+    return false;
+  }
+
+  nsStyleSet* styleSet = aPresShell->StyleSet();
+  nsRefPtr<nsStyleContext> sc;
+  for (int32_t i = elementsToCheck.Length() - 1; i >= 0; --i) {
+    if (sc) {
+      sc = styleSet->ResolveStyleFor(elementsToCheck[i], sc);
+    } else {
+      sc = nsComputedDOMStyle::GetStyleContextForElementNoFlush(elementsToCheck[i],
+                                                                nullptr, aPresShell);
+    }
+    if (sc->StyleDisplay()->mDisplay == NS_STYLE_DISPLAY_NONE) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 void
 nsGenericHTMLElement::GetInnerText(mozilla::dom::DOMString& aValue,
                                    mozilla::ErrorResult& aError)
 {
   if (!GetPrimaryFrame(Flush_Layout)) {
-    nsRefPtr<nsStyleContext> sc =
-      nsComputedDOMStyle::GetStyleContextForElementNoFlush(this, nullptr, nullptr);
-    if (!sc || sc->StyleDisplay()->mDisplay == NS_STYLE_DISPLAY_NONE ||
-        !IsInComposedDoc()) {
+    nsIPresShell* presShell = nsComputedDOMStyle::GetPresShellForContent(this);
+    if (!presShell || IsOrHasAncestorWithDisplayNone(this, presShell)) {
       GetTextContentInternal(aValue, aError);
       return;
     }


### PR DESCRIPTION
See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1226293

An example:
https://bug1226293.bmoattachments.org/attachment.cgi?id=8689742

Actual results (in Browser Console):
`"Mozilla", "Firefox", ""`

Expected results:
`"Mozilla", "Firefox", "developers"`

See also:
https://forum.palemoon.org/viewtopic.php?f=29&p=113534

---

I've created the new build (x32, Windows) and tested.
