### PR TITLE
[minor fix] Places - Restoring live bookmarks from backup file (throws an error)

### DIFF
--- a/toolkit/components/places/nsLivemarkService.js
+++ b/toolkit/components/places/nsLivemarkService.js
@@ -430,7 +430,7 @@ LivemarkService.prototype = {
       if (this._itemAdded && this._itemAdded.id == aItemId) {
         this._itemAdded.lastModified = aLastModified;
       }
-      if (aItemId in this._livemarks) {
+      if (this._livemark && (aItemId in this._livemarks)) {
         if (aProperty == "title") {
           this._livemarks[aItemId].title = aValue;
         }


### PR DESCRIPTION
__Steps to reproduce__

1) Open Library
2) Click on Import and Backup
3) Select Restore/Choose file
4) Choose the attached .json/.jsonlz4

Throws an error in Browser Console:
```
TypeError: this._livemark is undefined
nsLivemarkService.js
```

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1110185
But ad https://bugzilla.mozilla.org/show_bug.cgi?id=1094900
\- this change is too big (new Map(), Promise, etc.).

---

I've created the new build (x32, Windows) and tested.
