### PR TITLE
Security - Unsafe negotiation warning with TLS 1.3

### DIFF
--- a/security/manager/ssl/src/nsNSSCallbacks.cpp
+++ b/security/manager/ssl/src/nsNSSCallbacks.cpp
@@ -1242,11 +1242,16 @@ void HandshakeCallback(PRFileDesc* fd, void* client_data) {
   }
 
   PRBool siteSupportsSafeRenego;
-  rv = SSL_HandshakeNegotiatedExtension(fd, ssl_renegotiation_info_xtn,
-                                        &siteSupportsSafeRenego);
-  MOZ_ASSERT(rv == SECSuccess);
-  if (rv != SECSuccess) {
-    siteSupportsSafeRenego = false;
+  if (channelInfo.protocolVersion != SSL_LIBRARY_VERSION_TLS_1_3) {
+    rv = SSL_HandshakeNegotiatedExtension(fd, ssl_renegotiation_info_xtn,
+                                          &siteSupportsSafeRenego);
+    MOZ_ASSERT(rv == SECSuccess);
+    if (rv != SECSuccess) {
+      siteSupportsSafeRenego = false;
+    }
+  } else {
+    // TLS 1.3 dropped support for renegotiation.
+    siteSupportsSafeRenego = true;
   }
   bool renegotiationUnsafe = !siteSupportsSafeRenego &&
                              ioLayerHelpers.treatUnsafeNegotiationAsBroken();


### PR DESCRIPTION
__Steps to reproduce__
`about:config`:
`security.ssl.require_safe_negotiation` = `true`
`security.ssl.treat_unsafe_negotiation_as_broken` = `true`

https://blog.cloudflare.com/

![1](https://cloud.githubusercontent.com/assets/2373486/25816951/10048532-3426-11e7-915e-0228685cb46a.png)

vs.

![2](https://cloud.githubusercontent.com/assets/2373486/25816959/16f45232-3426-11e7-9ce2-989288eedbf9.png)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1305561

---

I've created the new build (x32, Windows) and tested.
