### PR TITLE
Add MediaSourceDemuxer

### DIFF
--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -129,6 +129,11 @@ public:
     return mStart <= aX && aX < mEnd;
   }
 
+  bool ContainsWithStrictEnd(const T& aX) const
+  {
+    return mStart - mFuzz <= aX && aX < mEnd;
+  }
+
   bool Contains(const SelfType& aOther) const
   {
     return (mStart - mFuzz <= aOther.mStart + aOther.mFuzz) &&
@@ -138,6 +143,12 @@ public:
   bool ContainsStrict(const SelfType& aOther) const
   {
     return mStart <= aOther.mStart && aOther.mEnd <= mEnd;
+  }
+
+  bool ContainsWithStrictEnd(const SelfType& aOther) const
+  {
+    return (mStart - mFuzz <= aOther.mStart + aOther.mFuzz) &&
+      aOther.mEnd <= mEnd;
   }
 
   bool Intersects(const SelfType& aOther) const
@@ -555,6 +566,15 @@ public:
   bool ContainsStrict(const T& aX) const {
     for (const auto& interval : mIntervals) {
       if (interval.ContainsStrict(aX)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool ContainsWithStrictEnd(const T& aX) const {
+    for (const auto& interval : mIntervals) {
+      if (interval.ContainsWithStrictEnd(aX)) {
         return true;
       }
     }

--- a/dom/media/MediaData.cpp
+++ b/dom/media/MediaData.cpp
@@ -518,6 +518,7 @@ MediaRawData::Clone() const
   s->mKeyframe = mKeyframe;
   s->mExtraData = mExtraData;
   s->mCryptoInternal = mCryptoInternal;
+  s->mTrackInfo = mTrackInfo;
   if (mSize) {
     if (!s->EnsureCapacity(mSize)) {
       return nullptr;
@@ -566,9 +567,6 @@ MediaRawData::SizeOfIncludingThis(MallocSizeOf aMallocSizeOf) const
 {
   size_t size = aMallocSizeOf(this);
 
-  if (mExtraData) {
-    size += aMallocSizeOf(mExtraData.get());
-  }
   size += aMallocSizeOf(mBuffer.get());
   return size;
 }

--- a/dom/media/MediaData.h
+++ b/dom/media/MediaData.h
@@ -24,6 +24,7 @@ class ImageContainer;
 
 class MediaLargeByteBuffer;
 class MediaByteBuffer;
+class SharedTrackInfo;
 
 // Container that holds media samples.
 class MediaData {
@@ -382,6 +383,8 @@ public:
 
   const CryptoSample& mCrypto;
   nsRefPtr<MediaByteBuffer> mExtraData;
+
+  nsRefPtr<SharedTrackInfo> mTrackInfo;
 
   // Return a deep copy or nullptr if out of memory.
   virtual already_AddRefed<MediaRawData> Clone() const;

--- a/dom/media/MediaDataDemuxer.h
+++ b/dom/media/MediaDataDemuxer.h
@@ -99,6 +99,11 @@ public:
   // This will be called should the demuxer be used with MediaSource.
   virtual void NotifyDataRemoved() { }
 
+  // Indicate to MediaFormatReader if it should compute the start time
+  // of the demuxed data. If true (default) the first sample returned will be
+  // used as reference time base.
+  virtual bool ShouldComputeStartTime() const { return true; }
+
 protected:
   virtual ~MediaDataDemuxer()
   {

--- a/dom/media/MediaDataDemuxer.h
+++ b/dom/media/MediaDataDemuxer.h
@@ -156,6 +156,15 @@ public:
   // sample will contains multiple audio frames.
   virtual nsRefPtr<SamplesPromise> GetSamples(int32_t aNumSamples = 1) = 0;
 
+  // Returns true if a call to GetSamples() may block while waiting on the
+  // underlying resource to return the data.
+  // This is used by the MediaFormatReader to determine if buffering heuristics
+  // should be used.
+  virtual bool GetSamplesMayBlock() const
+  {
+    return true;
+  }
+
   // Cancel all pending actions (Seek, GetSamples) and reset current state
   // All pending promises are to be rejected with CANCEL.
   // The next call to GetSamples would return the first sample available in the

--- a/dom/media/MediaDataDemuxer.h
+++ b/dom/media/MediaDataDemuxer.h
@@ -50,6 +50,14 @@ public:
   // again to retry once more data has been received.
   virtual nsRefPtr<InitPromise> Init() = 0;
 
+  // MediaFormatReader ensures that calls to the MediaDataDemuxer are thread-safe.
+  // This is done by having multiple demuxers, created with Clone(), one per
+  // running thread.
+  // However, should the MediaDataDemuxer object guaranteed to be thread-safe
+  // such cloning is unnecessary and only one demuxer will be used across
+  // all threads.
+  virtual bool IsThreadSafe() { return false; }
+
   // Clone the demuxer and return a new initialized demuxer.
   // This can only be called once Init() has succeeded.
   // The new demuxer can be immediately use to retrieve the track demuxers.

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -298,7 +298,11 @@ MediaFormatReader::OnDemuxerInitDone(nsresult)
   mSeekable = mDemuxer->IsSeekable();
 
   // Create demuxer object for main thread.
-  mMainThreadDemuxer = mDemuxer->Clone();
+  if (mDemuxer->IsThreadSafe()) {
+    mMainThreadDemuxer = mDemuxer;
+  } else {
+    mMainThreadDemuxer = mDemuxer->Clone();
+  }
   if (!mMainThreadDemuxer) {
     mMetadataPromise.Reject(ReadMetadataFailureReason::METADATA_ERROR, __func__);
     NS_WARNING("Unable to clone current MediaDataDemuxer");

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -792,6 +792,9 @@ MediaFormatReader::DecodeDemuxedSamples(TrackType aTrack,
     aA.mParsed += decoder.mQueuedSamples.Length();
   }
   decoder.mQueuedSamples.Clear();
+
+  // We have serviced the decoder's request for more data.
+  decoder.mInputExhausted = false;
 }
 
 void
@@ -866,7 +869,6 @@ MediaFormatReader::Update(TrackType aTrack)
   }
 
   needInput = true;
-  decoder.mInputExhausted = false;
 
   // Demux samples if we don't have some.
   RequestDemuxSamples(aTrack);

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -1399,4 +1399,13 @@ MediaFormatReader::NotifyDataRemoved()
   GetTaskQueue()->Dispatch(task);
 }
 
+int64_t
+MediaFormatReader::ComputeStartTime(const VideoData* aVideo, const AudioData* aAudio)
+{
+  if (mDemuxer->ShouldComputeStartTime()) {
+    return MediaDecoderReader::ComputeStartTime(aVideo, aAudio);
+  }
+  return 0;
+}
+
 } // namespace mozilla

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -99,6 +99,9 @@ MediaFormatReader::Shutdown()
 
   if (mAudio.mDecoder) {
     Flush(TrackInfo::kAudioTrack);
+    if (mAudio.HasPromise()) {
+      mAudio.RejectPromise(CANCELED, __func__);
+    }
     mAudio.mDecoder->Shutdown();
     mAudio.mDecoder = nullptr;
   }
@@ -116,6 +119,9 @@ MediaFormatReader::Shutdown()
 
   if (mVideo.mDecoder) {
     Flush(TrackInfo::kVideoTrack);
+    if (mVideo.HasPromise()) {
+      mVideo.RejectPromise(CANCELED, __func__);
+    }
     mVideo.mDecoder->Shutdown();
     mVideo.mDecoder = nullptr;
   }
@@ -379,7 +385,9 @@ MediaFormatReader::EnsureDecodersSetup()
                   false);
 
     mAudio.mDecoder =
-      mPlatform->CreateDecoder(mInfo.mAudio,
+      mPlatform->CreateDecoder(mAudio.mInfo ?
+                                 *mAudio.mInfo->GetAsAudioInfo() :
+                                 mInfo.mAudio,
                                mAudio.mTaskQueue,
                                mAudio.mCallback);
     NS_ENSURE_TRUE(mAudio.mDecoder != nullptr, false);
@@ -395,14 +403,18 @@ MediaFormatReader::EnsureDecodersSetup()
         mPlatform->SupportsSharedDecoders(mInfo.mVideo)) {
       mVideo.mDecoder =
         mSharedDecoderManager->CreateVideoDecoder(mPlatform,
-                                                  mInfo.mVideo,
+                                                  mVideo.mInfo ?
+                                                    *mVideo.mInfo->GetAsVideoInfo() :
+                                                    mInfo.mVideo,
                                                   mLayersBackendType,
                                                   mDecoder->GetImageContainer(),
                                                   mVideo.mTaskQueue,
                                                   mVideo.mCallback);
     } else {
       mVideo.mDecoder =
-        mPlatform->CreateDecoder(mInfo.mVideo,
+        mPlatform->CreateDecoder(mVideo.mInfo ?
+                                   *mVideo.mInfo->GetAsVideoInfo() :
+                                   mInfo.mVideo,
                                  mVideo.mTaskQueue,
                                  mVideo.mCallback,
                                  mLayersBackendType,
@@ -466,8 +478,7 @@ MediaFormatReader::RequestVideoData(bool aSkipToNextKeyframe,
   MOZ_ASSERT(OnTaskQueue());
   MOZ_DIAGNOSTIC_ASSERT(mSeekPromise.IsEmpty(), "No sample requests allowed while seeking");
   MOZ_DIAGNOSTIC_ASSERT(!mVideo.HasPromise(), "No duplicate sample requests");
-  MOZ_DIAGNOSTIC_ASSERT(!mVideoSeekRequest.Exists());
-  MOZ_DIAGNOSTIC_ASSERT(!mAudioSeekRequest.Exists());
+  MOZ_DIAGNOSTIC_ASSERT(!mVideo.mSeekRequest.Exists());
   MOZ_DIAGNOSTIC_ASSERT(!mSkipRequest.Exists(), "called mid-skipping");
   MOZ_DIAGNOSTIC_ASSERT(!IsSeeking(), "called mid-seek");
   LOGV("RequestVideoData(%d, %lld)", aSkipToNextKeyframe, aTimeThreshold);
@@ -511,14 +522,13 @@ void
 MediaFormatReader::OnDemuxFailed(TrackType aTrack, DemuxerFailureReason aFailure)
 {
   MOZ_ASSERT(OnTaskQueue());
-  LOG("Failed to demux %s, failure = %d",
+  LOG("Failed to demux %s, failure:%d",
       aTrack == TrackType::kVideoTrack ? "video" : "audio", aFailure);
   auto& decoder = GetDecoderData(aTrack);
   decoder.mDemuxRequest.Complete();
   switch (aFailure) {
     case DemuxerFailureReason::END_OF_STREAM:
-      decoder.mDemuxEOS = true;
-      ScheduleUpdate(aTrack);
+      NotifyEndOfStream(aTrack);
       break;
     case DemuxerFailureReason::DEMUXER_ERROR:
       NotifyError(aTrack);
@@ -551,7 +561,9 @@ MediaFormatReader::DoDemuxVideo()
 void
 MediaFormatReader::OnVideoDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHolder> aSamples)
 {
-  LOGV("%d video samples demuxed", aSamples->mSamples.Length());
+  LOGV("%d video samples demuxed (sid:%d)",
+       aSamples->mSamples.Length(),
+       aSamples->mSamples[0]->mTrackInfo ? aSamples->mSamples[0]->mTrackInfo->GetID() : 0);
   mVideo.mDemuxRequest.Complete();
   mVideo.mQueuedSamples.AppendElements(aSamples->mSamples);
   ScheduleUpdate(TrackInfo::kVideoTrack);
@@ -562,8 +574,7 @@ MediaFormatReader::RequestAudioData()
 {
   MOZ_ASSERT(OnTaskQueue());
   MOZ_DIAGNOSTIC_ASSERT(mSeekPromise.IsEmpty(), "No sample requests allowed while seeking");
-  MOZ_DIAGNOSTIC_ASSERT(!mVideoSeekRequest.Exists());
-  MOZ_DIAGNOSTIC_ASSERT(!mAudioSeekRequest.Exists());
+  MOZ_DIAGNOSTIC_ASSERT(!mAudio.mSeekRequest.Exists());
   MOZ_DIAGNOSTIC_ASSERT(!mAudio.HasPromise(), "No duplicate sample requests");
   MOZ_DIAGNOSTIC_ASSERT(!IsSeeking(), "called mid-seek");
   LOGV("");
@@ -606,7 +617,9 @@ MediaFormatReader::DoDemuxAudio()
 void
 MediaFormatReader::OnAudioDemuxCompleted(nsRefPtr<MediaTrackDemuxer::SamplesHolder> aSamples)
 {
-  LOGV("%d audio samples demuxed", aSamples->mSamples.Length());
+  LOGV("%d audio samples demuxed (sid:%d)",
+       aSamples->mSamples.Length(),
+       aSamples->mSamples[0]->mTrackInfo ? aSamples->mSamples[0]->mTrackInfo->GetID() : 0);
   mAudio.mDemuxRequest.Complete();
   mAudio.mQueuedSamples.AppendElements(aSamples->mSamples);
   ScheduleUpdate(TrackInfo::kAudioTrack);
@@ -666,6 +679,15 @@ MediaFormatReader::NotifyWaitingForData(TrackType aTrack)
   ScheduleUpdate(aTrack);
 }
 
+void
+MediaFormatReader::NotifyEndOfStream(TrackType aTrack)
+{
+  MOZ_ASSERT(OnTaskQueue());
+  auto& decoder = GetDecoderData(aTrack);
+  decoder.mDemuxEOS = true;
+  ScheduleUpdate(aTrack);
+}
+
 bool
 MediaFormatReader::NeedInput(DecoderData& aDecoder)
 {
@@ -681,6 +703,7 @@ MediaFormatReader::NeedInput(DecoderData& aDecoder)
     !aDecoder.mDemuxRequest.Exists() &&
     aDecoder.mOutput.IsEmpty() &&
     (aDecoder.mInputExhausted || !aDecoder.mQueuedSamples.IsEmpty() ||
+     aDecoder.mTimeThreshold.isSome() ||
      aDecoder.mNumSamplesInput - aDecoder.mNumSamplesOutput < aDecoder.mDecodeAhead);
 }
 
@@ -738,7 +761,7 @@ MediaFormatReader::UpdateReceivedNewData(TrackType aTrack)
   }
   if (!mSeekPromise.IsEmpty()) {
     MOZ_ASSERT(!decoder.HasPromise());
-    if (mVideoSeekRequest.Exists() || mAudioSeekRequest.Exists()) {
+    if (mVideo.mSeekRequest.Exists() || mAudio.mSeekRequest.Exists()) {
       // Already waiting for a seek to complete. Nothing more to do.
       return true;
     }
@@ -783,18 +806,85 @@ MediaFormatReader::DecodeDemuxedSamples(TrackType aTrack,
     return;
   }
 
-  decoder.mOutputRequested = true;
-
   // Decode all our demuxed frames.
-  for (auto& samples : decoder.mQueuedSamples) {
-    decoder.mDecoder->Input(samples);
+  bool samplesPending = false;
+  while (decoder.mQueuedSamples.Length()) {
+    nsRefPtr<MediaRawData> sample = decoder.mQueuedSamples[0];
+    nsRefPtr<SharedTrackInfo> info = sample->mTrackInfo;
+
+    if (info && decoder.mLastStreamSourceID != info->GetID()) {
+      if (samplesPending) {
+        // Let existing samples complete their decoding. We'll resume later.
+        return;
+      }
+
+      LOG("%s stream id has changed from:%d to:%d, recreating decoder.",
+          TrackTypeToStr(aTrack), decoder.mLastStreamSourceID,
+          info->GetID());
+      decoder.mInfo = info;
+      decoder.mLastStreamSourceID = info->GetID();
+      // Flush will clear our array of queued samples. So make a copy now.
+      nsTArray<nsRefPtr<MediaRawData>> samples{decoder.mQueuedSamples};
+      Flush(aTrack);
+      decoder.mDecoder->Shutdown();
+      decoder.mDecoder = nullptr;
+      if (!EnsureDecodersSetup()) {
+        LOG("Unable to re-create decoder, aborting");
+        NotifyError(aTrack);
+        return;
+      }
+      LOGV("%s decoder:%p created for sid:%u",
+           TrackTypeToStr(aTrack), decoder.mDecoder.get(), info->GetID());
+      if (sample->mKeyframe) {
+        decoder.mQueuedSamples.MoveElementsFrom(samples);
+      } else {
+        MOZ_ASSERT(decoder.mTimeThreshold.isNothing());
+        LOG("Stream change occurred on a non-keyframe. Seeking to:%lld",
+            sample->mTime);
+        decoder.mTimeThreshold = Some(TimeUnit::FromMicroseconds(sample->mTime));
+        nsRefPtr<MediaFormatReader> self = this;
+        decoder.mSeekRequest.Begin(decoder.mTrackDemuxer->Seek(decoder.mTimeThreshold.ref())
+                   ->Then(GetTaskQueue(), __func__,
+                          [self, aTrack] (media::TimeUnit aTime) {
+                            auto& decoder = self->GetDecoderData(aTrack);
+                            decoder.mSeekRequest.Complete();
+                            self->ScheduleUpdate(aTrack);
+                          },
+                          [self, aTrack] (DemuxerFailureReason aResult) {
+                            auto& decoder = self->GetDecoderData(aTrack);
+                            decoder.mSeekRequest.Complete();
+                            switch (aResult) {
+                              case DemuxerFailureReason::WAITING_FOR_DATA:
+                                self->NotifyWaitingForData(aTrack);
+                                break;
+                              case DemuxerFailureReason::END_OF_STREAM:
+                                self->NotifyEndOfStream(aTrack);
+                                break;
+                              case DemuxerFailureReason::CANCELED:
+                              case DemuxerFailureReason::SHUTDOWN:
+                                break;
+                              default:
+                                self->NotifyError(aTrack);
+                                break;
+                            }
+                            decoder.mTimeThreshold.reset();
+                          }));
+        return;
+      }
+    }
+
+    LOGV("Input:%lld (dts:%lld kf:%d)",
+         sample->mTime, sample->mTimecode, sample->mKeyframe);
+    decoder.mOutputRequested = true;
+    decoder.mNumSamplesInput++;
+    decoder.mSizeOfQueue++;
+    if (aTrack == TrackInfo::kVideoTrack) {
+      aA.mParsed++;
+    }
+    decoder.mDecoder->Input(sample);
+    decoder.mQueuedSamples.RemoveElementAt(0);
+    samplesPending = true;
   }
-  decoder.mNumSamplesInput += decoder.mQueuedSamples.Length();
-  decoder.mSizeOfQueue += decoder.mQueuedSamples.Length();
-  if (aTrack == TrackInfo::kVideoTrack) {
-    aA.mParsed += decoder.mQueuedSamples.Length();
-  }
-  decoder.mQueuedSamples.Clear();
 
   // We have serviced the decoder's request for more data.
   decoder.mInputExhausted = false;
@@ -852,7 +942,16 @@ MediaFormatReader::Update(TrackType aTrack)
       nsRefPtr<MediaData> output = decoder.mOutput[0];
       decoder.mOutput.RemoveElementAt(0);
       decoder.mSizeOfQueue -= 1;
-      ReturnOutput(output, aTrack);
+      if (decoder.mTimeThreshold.isNothing() ||
+          media::TimeUnit::FromMicroseconds(output->mTime) >= decoder.mTimeThreshold.ref()) {
+        ReturnOutput(output, aTrack);
+        decoder.mTimeThreshold.reset();
+      } else {
+        LOGV("Internal Seeking: Dropping frame time:%f wanted:%f (kf:%d)",
+             media::TimeUnit::FromMicroseconds(output->mTime).ToSeconds(),
+             decoder.mTimeThreshold.ref().ToSeconds(),
+             output->mKeyframe);
+      }
     } else if (decoder.mDrainComplete) {
       decoder.RejectPromise(END_OF_STREAM, __func__);
       decoder.mDrainComplete = false;
@@ -947,8 +1046,8 @@ MediaFormatReader::ResetDecode()
 {
   MOZ_ASSERT(OnTaskQueue());
 
-  mAudioSeekRequest.DisconnectIfExists();
-  mVideoSeekRequest.DisconnectIfExists();
+  mAudio.mSeekRequest.DisconnectIfExists();
+  mVideo.mSeekRequest.DisconnectIfExists();
   mSeekPromise.RejectIfExists(NS_OK, __func__);
   mSkipRequest.DisconnectIfExists();
 
@@ -962,10 +1061,16 @@ MediaFormatReader::ResetDecode()
   if (HasVideo()) {
     mVideo.ResetDemuxer();
     Flush(TrackInfo::kVideoTrack);
+    if (mVideo.HasPromise()) {
+      mVideo.RejectPromise(CANCELED, __func__);
+    }
   }
   if (HasAudio()) {
     mAudio.ResetDemuxer();
     Flush(TrackInfo::kAudioTrack);
+    if (mAudio.HasPromise()) {
+      mAudio.RejectPromise(CANCELED, __func__);
+    }
   }
   return MediaDecoderReader::ResetDecode();
 }
@@ -1031,9 +1136,6 @@ MediaFormatReader::Flush(TrackType aTrack)
   // ResetState clears mOutputRequested flag so that we ignore all output until
   // the next request for more data.
   decoder.ResetState();
-  if (decoder.HasPromise()) {
-    decoder.RejectPromise(CANCELED, __func__);
-  }
   LOG("Flush(%s) END", TrackTypeToStr(aTrack));
 }
 
@@ -1078,15 +1180,22 @@ MediaFormatReader::OnVideoSkipFailed(MediaTrackDemuxer::SkipFailureHolder aFailu
   mSkipRequest.Complete();
   mDecoder->NotifyDecodedFrames(aFailure.mSkipped, 0, aFailure.mSkipped);
   MOZ_ASSERT(mVideo.HasPromise());
-  if (aFailure.mFailure == DemuxerFailureReason::END_OF_STREAM) {
-    mVideo.mDemuxEOS = true;
-    ScheduleUpdate(TrackType::kVideoTrack);
-    mVideo.RejectPromise(END_OF_STREAM, __func__);
-  } else if (aFailure.mFailure == DemuxerFailureReason::WAITING_FOR_DATA) {
-    NotifyWaitingForData(TrackType::kVideoTrack);
-    mVideo.RejectPromise(WAITING_FOR_DATA, __func__);
-  } else {
-    mVideo.RejectPromise(DECODE_ERROR, __func__);
+  switch (aFailure.mFailure) {
+    case DemuxerFailureReason::END_OF_STREAM:
+      NotifyEndOfStream(TrackType::kVideoTrack);
+      mVideo.RejectPromise(END_OF_STREAM, __func__);
+      break;
+    case DemuxerFailureReason::WAITING_FOR_DATA:
+      NotifyWaitingForData(TrackType::kVideoTrack);
+      mVideo.RejectPromise(WAITING_FOR_DATA, __func__);
+      break;
+    case DemuxerFailureReason::CANCELED:
+    case DemuxerFailureReason::SHUTDOWN:
+      break;
+    default:
+      NotifyError(TrackType::kVideoTrack);
+      mVideo.RejectPromise(DECODE_ERROR, __func__);
+      break;
   }
 }
 
@@ -1100,6 +1209,8 @@ MediaFormatReader::Seek(int64_t aTime, int64_t aUnused)
   MOZ_DIAGNOSTIC_ASSERT(!mVideo.HasPromise());
   MOZ_DIAGNOSTIC_ASSERT(!mAudio.HasPromise());
   MOZ_DIAGNOSTIC_ASSERT(mPendingSeekTime.isNothing());
+  MOZ_DIAGNOSTIC_ASSERT(mVideo.mTimeThreshold.isNothing());
+  MOZ_DIAGNOSTIC_ASSERT(mAudio.mTimeThreshold.isNothing());
 
   if (!mSeekable) {
     LOG("Seek() END (Unseekable)");
@@ -1137,16 +1248,16 @@ MediaFormatReader::OnSeekFailed(TrackType aTrack, DemuxerFailureReason aResult)
 {
   MOZ_ASSERT(OnTaskQueue());
   if (aTrack == TrackType::kVideoTrack) {
-    mVideoSeekRequest.Complete();
+    mVideo.mSeekRequest.Complete();
   } else {
-    mAudioSeekRequest.Complete();
+    mAudio.mSeekRequest.Complete();
   }
 
   if (aResult == DemuxerFailureReason::WAITING_FOR_DATA) {
     NotifyWaitingForData(aTrack);
     return;
   }
-  MOZ_ASSERT(!mVideoSeekRequest.Exists() && !mAudioSeekRequest.Exists());
+  MOZ_ASSERT(!mVideo.mSeekRequest.Exists() && !mAudio.mSeekRequest.Exists());
   mPendingSeekTime.reset();
   mSeekPromise.Reject(NS_ERROR_FAILURE, __func__);
 }
@@ -1156,7 +1267,7 @@ MediaFormatReader::DoVideoSeek()
 {
   MOZ_ASSERT(mPendingSeekTime.isSome());
   media::TimeUnit seekTime = mPendingSeekTime.ref();
-  mVideoSeekRequest.Begin(mVideo.mTrackDemuxer->Seek(seekTime)
+  mVideo.mSeekRequest.Begin(mVideo.mTrackDemuxer->Seek(seekTime)
                           ->Then(GetTaskQueue(), __func__, this,
                                  &MediaFormatReader::OnVideoSeekCompleted,
                                  &MediaFormatReader::OnVideoSeekFailed));
@@ -1166,7 +1277,7 @@ void
 MediaFormatReader::OnVideoSeekCompleted(media::TimeUnit aTime)
 {
   MOZ_ASSERT(OnTaskQueue());
-  mVideoSeekRequest.Complete();
+  mVideo.mSeekRequest.Complete();
 
   if (HasAudio()) {
     MOZ_ASSERT(mPendingSeekTime.isSome());
@@ -1182,7 +1293,7 @@ MediaFormatReader::DoAudioSeek()
 {
   MOZ_ASSERT(mPendingSeekTime.isSome());
   media::TimeUnit seekTime = mPendingSeekTime.ref();
-  mAudioSeekRequest.Begin(mAudio.mTrackDemuxer->Seek(seekTime)
+  mAudio.mSeekRequest.Begin(mAudio.mTrackDemuxer->Seek(seekTime)
                          ->Then(GetTaskQueue(), __func__, this,
                                 &MediaFormatReader::OnAudioSeekCompleted,
                                 &MediaFormatReader::OnAudioSeekFailed));
@@ -1192,7 +1303,7 @@ void
 MediaFormatReader::OnAudioSeekCompleted(media::TimeUnit aTime)
 {
   MOZ_ASSERT(OnTaskQueue());
-  mAudioSeekRequest.Complete();
+  mAudio.mSeekRequest.Complete();
   mPendingSeekTime.reset();
   mSeekPromise.Resolve(aTime.ToMicroseconds(), __func__);
 }

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -1074,7 +1074,12 @@ MediaFormatReader::OnVideoSkipFailed(MediaTrackDemuxer::SkipFailureHolder aFailu
   mDecoder->NotifyDecodedFrames(aFailure.mSkipped, 0, aFailure.mSkipped);
   MOZ_ASSERT(mVideo.HasPromise());
   if (aFailure.mFailure == DemuxerFailureReason::END_OF_STREAM) {
+    mVideo.mDemuxEOS = true;
+    ScheduleUpdate(TrackType::kVideoTrack);
     mVideo.RejectPromise(END_OF_STREAM, __func__);
+  } else if (aFailure.mFailure == DemuxerFailureReason::WAITING_FOR_DATA) {
+    NotifyWaitingForData(TrackType::kVideoTrack);
+    mVideo.RejectPromise(WAITING_FOR_DATA, __func__);
   } else {
     mVideo.RejectPromise(DECODE_ERROR, __func__);
   }

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -72,6 +72,7 @@ MediaFormatReader::MediaFormatReader(AbstractMediaDecoder* aDecoder,
   , mInitDone(false)
   , mSeekable(false)
   , mIsEncrypted(false)
+  , mTrackDemuxersMayBlock(false)
   , mCachedTimeRangesStale(true)
 #if defined(READER_DORMANT_HEURISTIC)
   , mDormantEnabled(Preferences::GetBool("media.decoder.heuristic.dormant.enabled", false))
@@ -264,6 +265,7 @@ MediaFormatReader::OnDemuxerInitDone(nsresult)
     mInfo.mVideo = *mVideo.mTrackDemuxer->GetInfo()->GetAsVideoInfo();
     mVideo.mCallback = new DecoderCallback(this, TrackInfo::kVideoTrack);
     mVideo.mTimeRanges = mVideo.mTrackDemuxer->GetBuffered();
+    mTrackDemuxersMayBlock |= mVideo.mTrackDemuxer->GetSamplesMayBlock();
   }
 
   bool audioActive = !!mDemuxer->GetNumberTracks(TrackInfo::kAudioTrack);
@@ -276,6 +278,7 @@ MediaFormatReader::OnDemuxerInitDone(nsresult)
     mInfo.mAudio = *mAudio.mTrackDemuxer->GetInfo()->GetAsAudioInfo();
     mAudio.mCallback = new DecoderCallback(this, TrackInfo::kAudioTrack);
     mAudio.mTimeRanges = mAudio.mTrackDemuxer->GetBuffered();
+    mTrackDemuxersMayBlock |= mAudio.mTrackDemuxer->GetSamplesMayBlock();
   }
 
   UniquePtr<EncryptionInfo> crypto = mDemuxer->GetCrypto();

--- a/dom/media/MediaFormatReader.h
+++ b/dom/media/MediaFormatReader.h
@@ -102,6 +102,8 @@ public:
 
   virtual bool IsWaitingOnCDMResource() override;
 
+  int64_t ComputeStartTime(const VideoData* aVideo, const AudioData* aAudio) override;
+
 private:
 
   bool InitDemuxer();

--- a/dom/media/MediaFormatReader.h
+++ b/dom/media/MediaFormatReader.h
@@ -104,6 +104,11 @@ public:
 
   int64_t ComputeStartTime(const VideoData* aVideo, const AudioData* aAudio) override;
 
+  bool UseBufferingHeuristics() override
+  {
+    return mTrackDemuxersMayBlock;
+  }
+
 private:
 
   bool InitDemuxer();
@@ -372,6 +377,9 @@ private:
   // TODO handle change of encryption half-way. The above assumption will then
   // become incorrect.
   bool mIsEncrypted;
+
+  // Set to true if any of our track buffers may be blocking.
+  bool mTrackDemuxersMayBlock;
 
   // Seeking objects.
   bool IsSeeking() const { return mPendingSeekTime.isSome(); }

--- a/dom/media/MediaFormatReader.h
+++ b/dom/media/MediaFormatReader.h
@@ -137,6 +137,7 @@ private:
   void NotifyDrainComplete(TrackType aTrack);
   void NotifyError(TrackType aTrack);
   void NotifyWaitingForData(TrackType aTrack);
+  void NotifyEndOfStream(TrackType aTrack);
 
   void ExtractCryptoInitData(nsTArray<uint8_t>& aInitData);
 
@@ -211,6 +212,7 @@ private:
       , mNumSamplesInput(0)
       , mNumSamplesOutput(0)
       , mSizeOfQueue(0)
+      , mLastStreamSourceID(UINT32_MAX)
       , mMonitor(aType == MediaData::AUDIO_DATA ? "audio decoder data"
                                                 : "video decoder data")
     {}
@@ -236,6 +238,9 @@ private:
     bool mReceivedNewData;
     bool mDiscontinuity;
 
+    // Pending seek.
+    MediaPromiseRequestHolder<MediaTrackDemuxer::SeekPromise> mSeekRequest;
+
     // Queued demux samples waiting to be decoded.
     nsTArray<nsRefPtr<MediaRawData>> mQueuedSamples;
     MediaPromiseRequestHolder<MediaTrackDemuxer::SamplesPromise> mDemuxRequest;
@@ -252,6 +257,10 @@ private:
     bool mInputExhausted;
     bool mError;
     bool mDrainComplete;
+    // If set, all decoded samples prior mTimeThreshold will be dropped.
+    // Used for internal seeking when a change of stream is detected.
+    Maybe<media::TimeUnit> mTimeThreshold;
+
     // Decoded samples returned my mDecoder awaiting being returned to
     // state machine upon request.
     nsTArray<nsRefPtr<MediaData>> mOutput;
@@ -283,6 +292,7 @@ private:
       mOutputRequested = false;
       mInputExhausted = false;
       mDrainComplete = false;
+      mTimeThreshold.reset();
       mOutput.Clear();
       mNumSamplesInput = 0;
       mNumSamplesOutput = 0;
@@ -290,10 +300,13 @@ private:
 
     // Used by the MDSM for logging purposes.
     Atomic<size_t> mSizeOfQueue;
+    // Sample format monitoring.
+    uint32_t mLastStreamSourceID;
     // Monitor that protects all non-threadsafe state; the primitives
     // that follow.
     Monitor mMonitor;
     media::TimeIntervals mTimeRanges;
+    nsRefPtr<SharedTrackInfo> mInfo;
   };
 
   template<typename PromiseType>
@@ -400,8 +413,6 @@ private:
   }
   // Temporary seek information while we wait for the data
   Maybe<media::TimeUnit> mPendingSeekTime;
-  MediaPromiseRequestHolder<MediaTrackDemuxer::SeekPromise> mVideoSeekRequest;
-  MediaPromiseRequestHolder<MediaTrackDemuxer::SeekPromise> mAudioSeekRequest;
   MediaPromiseHolder<SeekPromise> mSeekPromise;
 
   nsRefPtr<SharedDecoderManager> mSharedDecoderManager;

--- a/dom/media/MediaInfo.h
+++ b/dom/media/MediaInfo.h
@@ -374,6 +374,57 @@ public:
   EncryptionInfo mCrypto;
 };
 
+class SharedTrackInfo {
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(SharedTrackInfo)
+public:
+  SharedTrackInfo(const TrackInfo& aOriginal, uint32_t aStreamID)
+    : mInfo(aOriginal.Clone())
+    , mStreamSourceID(aStreamID)
+    , mMimeType(mInfo->mMimeType)
+  {
+  }
+
+  uint32_t GetID() const
+  {
+    return mStreamSourceID;
+  }
+
+  const TrackInfo* operator*() const
+  {
+    return mInfo.get();
+  }
+
+  const TrackInfo* operator->() const
+  {
+    MOZ_ASSERT(mInfo.get(), "dereferencing a UniquePtr containing nullptr");
+    return mInfo.get();
+  }
+
+  const AudioInfo* GetAsAudioInfo() const
+  {
+    return mInfo ? mInfo->GetAsAudioInfo() : nullptr;
+  }
+
+  const VideoInfo* GetAsVideoInfo() const
+  {
+    return mInfo ? mInfo->GetAsVideoInfo() : nullptr;
+  }
+
+  const TextInfo* GetAsTextInfo() const
+  {
+    return mInfo ? mInfo->GetAsTextInfo() : nullptr;
+  }
+
+private:
+  ~SharedTrackInfo() {};
+  UniquePtr<TrackInfo> mInfo;
+  // A unique ID, guaranteed to change when changing streams.
+  uint32_t mStreamSourceID;
+
+public:
+  const nsAutoCString& mMimeType;
+};
+
 } // namespace mozilla
 
 #endif // MediaInfo_h

--- a/dom/media/mediasource/MediaSource.cpp
+++ b/dom/media/mediasource/MediaSource.cpp
@@ -366,8 +366,6 @@ MediaSource::Detach()
     MOZ_ASSERT(mActiveSourceBuffers->IsEmpty() && mSourceBuffers->IsEmpty());
     return;
   }
-  mDecoder->DetachMediaSource();
-  mDecoder = nullptr;
   mMediaElement = nullptr;
   mFirstSourceBufferInitialized = false;
   SetReadyState(MediaSourceReadyState::Closed);
@@ -377,6 +375,8 @@ MediaSource::Detach()
   if (mSourceBuffers) {
     mSourceBuffers->Clear();
   }
+  mDecoder->DetachMediaSource();
+  mDecoder = nullptr;
 }
 
 MediaSource::MediaSource(nsPIDOMWindow* aWindow)

--- a/dom/media/mediasource/MediaSourceDecoder.cpp
+++ b/dom/media/mediasource/MediaSourceDecoder.cpp
@@ -33,8 +33,8 @@ class SourceBufferDecoder;
 
 MediaSourceDecoder::MediaSourceDecoder(dom::HTMLMediaElement* aElement)
   : mMediaSource(nullptr)
-  , mMediaSourceDuration(UnspecifiedNaN<double>())
   , mIsUsingFormatReader(Preferences::GetBool("media.mediasource.format-reader", false))
+  , mMediaSourceDuration(UnspecifiedNaN<double>())
   , mEnded(false)
 {
   Init(aElement);

--- a/dom/media/mediasource/MediaSourceDecoder.cpp
+++ b/dom/media/mediasource/MediaSourceDecoder.cpp
@@ -112,6 +112,7 @@ MediaSourceDecoder::Shutdown()
   if (mMediaSource) {
     mMediaSource->Detach();
   }
+  mDemuxer = nullptr;
 
   MediaDecoder::Shutdown();
   // Kick WaitForData out of its slumber.

--- a/dom/media/mediasource/MediaSourceDecoder.cpp
+++ b/dom/media/mediasource/MediaSourceDecoder.cpp
@@ -14,6 +14,8 @@
 #include "MediaSourceUtils.h"
 #include "SourceBufferDecoder.h"
 #include "VideoUtils.h"
+#include "MediaFormatReader.h"
+#include "MediaSourceDemuxer.h"
 
 #ifdef PR_LOGGING
 extern PRLogModuleInfo* GetMediaSourceLog();
@@ -32,6 +34,8 @@ class SourceBufferDecoder;
 MediaSourceDecoder::MediaSourceDecoder(dom::HTMLMediaElement* aElement)
   : mMediaSource(nullptr)
   , mMediaSourceDuration(UnspecifiedNaN<double>())
+  , mIsUsingFormatReader(Preferences::GetBool("media.mediasource.format-reader", false))
+  , mEnded(false)
 {
   Init(aElement);
 }
@@ -46,7 +50,12 @@ MediaSourceDecoder::Clone()
 MediaDecoderStateMachine*
 MediaSourceDecoder::CreateStateMachine()
 {
-  mReader = new MediaSourceReader(this);
+  if (mIsUsingFormatReader) {
+    mDemuxer = new MediaSourceDemuxer();
+    mReader = new MediaFormatReader(this, mDemuxer);
+  } else {
+    mReader = new MediaSourceReader(this);
+  }
   return new MediaDecoderStateMachine(this, mReader);
 }
 
@@ -134,29 +143,29 @@ MediaSourceDecoder::DetachMediaSource()
 already_AddRefed<SourceBufferDecoder>
 MediaSourceDecoder::CreateSubDecoder(const nsACString& aType, int64_t aTimestampOffset)
 {
-  MOZ_ASSERT(mReader);
-  return mReader->CreateSubDecoder(aType, aTimestampOffset);
+  MOZ_ASSERT(mReader && !mIsUsingFormatReader);
+  return GetReader()->CreateSubDecoder(aType, aTimestampOffset);
 }
 
 void
 MediaSourceDecoder::AddTrackBuffer(TrackBuffer* aTrackBuffer)
 {
-  MOZ_ASSERT(mReader);
-  mReader->AddTrackBuffer(aTrackBuffer);
+  MOZ_ASSERT(mReader && !mIsUsingFormatReader);
+  GetReader()->AddTrackBuffer(aTrackBuffer);
 }
 
 void
 MediaSourceDecoder::RemoveTrackBuffer(TrackBuffer* aTrackBuffer)
 {
-  MOZ_ASSERT(mReader);
-  mReader->RemoveTrackBuffer(aTrackBuffer);
+  MOZ_ASSERT(mReader && !mIsUsingFormatReader);
+  GetReader()->RemoveTrackBuffer(aTrackBuffer);
 }
 
 void
 MediaSourceDecoder::OnTrackBufferConfigured(TrackBuffer* aTrackBuffer, const MediaInfo& aInfo)
 {
-  MOZ_ASSERT(mReader);
-  mReader->OnTrackBufferConfigured(aTrackBuffer, aInfo);
+  MOZ_ASSERT(mReader && !mIsUsingFormatReader);
+  GetReader()->OnTrackBufferConfigured(aTrackBuffer, aInfo);
 }
 
 void
@@ -164,15 +173,17 @@ MediaSourceDecoder::Ended(bool aEnded)
 {
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
   static_cast<MediaSourceResource*>(GetResource())->SetEnded(aEnded);
-  mReader->Ended(aEnded);
+  if (!mIsUsingFormatReader) {
+    GetReader()->Ended(aEnded);
+  }
+  mEnded = true;
   mon.NotifyAll();
 }
 
 bool
 MediaSourceDecoder::IsExpectingMoreData()
 {
-  ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
-  return !mReader->IsEnded();
+  return !mEnded;
 }
 
 class DurationChangedRunnable : public nsRunnable {
@@ -243,8 +254,8 @@ MediaSourceDecoder::SetMediaSourceDuration(double aDuration, MSRangeRemovalActio
     GetStateMachine()->SetDuration(INT64_MAX);
     mMediaSourceDuration = PositiveInfinity<double>();
   }
-  if (mReader) {
-    mReader->SetMediaSourceDuration(mMediaSourceDuration);
+  if (!mIsUsingFormatReader && GetReader()) {
+    GetReader()->SetMediaSourceDuration(mMediaSourceDuration);
   }
   ScheduleDurationChange(oldDuration, aDuration, aAction);
 }
@@ -283,27 +294,33 @@ MediaSourceDecoder::GetMediaSourceDuration()
 void
 MediaSourceDecoder::NotifyTimeRangesChanged()
 {
-  MOZ_ASSERT(mReader);
-  mReader->NotifyTimeRangesChanged();
+  MOZ_ASSERT(mReader && !mIsUsingFormatReader);
+  GetReader()->NotifyTimeRangesChanged();
 }
 
 void
 MediaSourceDecoder::PrepareReaderInitialization()
 {
+  if (mIsUsingFormatReader) {
+    return;
+  }
   MOZ_ASSERT(mReader);
-  mReader->PrepareInitialization();
+  GetReader()->PrepareInitialization();
 }
 
 void
 MediaSourceDecoder::GetMozDebugReaderData(nsAString& aString)
 {
-  mReader->GetMozDebugReaderData(aString);
+  if (mIsUsingFormatReader) {
+    return;
+  }
+  GetReader()->GetMozDebugReaderData(aString);
 }
 
 bool
 MediaSourceDecoder::IsActiveReader(MediaDecoderReader* aReader)
 {
-  return mReader->IsActiveReader(aReader);
+  return !mIsUsingFormatReader && GetReader()->IsActiveReader(aReader);
 }
 
 double
@@ -318,6 +335,7 @@ MediaSourceDecoder::SelectDecoder(int64_t aTarget,
                                   int64_t aTolerance,
                                   const nsTArray<nsRefPtr<SourceBufferDecoder>>& aTrackDecoders)
 {
+  MOZ_ASSERT(!mIsUsingFormatReader);
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
 
   media::TimeUnit target{media::TimeUnit::FromMicroseconds(aTarget)};

--- a/dom/media/mediasource/MediaSourceDecoder.h
+++ b/dom/media/mediasource/MediaSourceDecoder.h
@@ -7,6 +7,7 @@
 #ifndef MOZILLA_MEDIASOURCEDECODER_H_
 #define MOZILLA_MEDIASOURCEDECODER_H_
 
+#include "mozilla/Atomics.h"
 #include "mozilla/Attributes.h"
 #include "nsCOMPtr.h"
 #include "nsError.h"
@@ -22,6 +23,7 @@ class MediaDecoderStateMachine;
 class SourceBufferDecoder;
 class TrackBuffer;
 enum MSRangeRemovalAction : uint8_t;
+class MediaSourceDemuxer;
 
 namespace dom {
 
@@ -72,7 +74,15 @@ public:
   // registered TrackBuffers essential for initialization.
   void PrepareReaderInitialization();
 
-  MediaSourceReader* GetReader() { return mReader; }
+  MediaSourceReader* GetReader()
+  {
+    MOZ_ASSERT(!mIsUsingFormatReader);
+    return static_cast<MediaSourceReader*>(mReader.get());
+  }
+  MediaSourceDemuxer* GetDemuxer()
+  {
+    return mDemuxer;
+  }
 
   // Returns true if aReader is a currently active audio or video
   // reader in this decoders MediaSourceReader.
@@ -98,7 +108,11 @@ private:
   // calls Attach/DetachMediaSource on this decoder to set and clear
   // mMediaSource.
   dom::MediaSource* mMediaSource;
-  nsRefPtr<MediaSourceReader> mReader;
+  nsRefPtr<MediaDecoderReader> mReader;
+  bool mIsUsingFormatReader;
+  nsRefPtr<MediaSourceDemuxer> mDemuxer;
+
+  Atomic<bool> mEnded;
 
   // Protected by GetReentrantMonitor()
   double mMediaSourceDuration;

--- a/dom/media/mediasource/MediaSourceDecoder.h
+++ b/dom/media/mediasource/MediaSourceDecoder.h
@@ -112,10 +112,9 @@ private:
   bool mIsUsingFormatReader;
   nsRefPtr<MediaSourceDemuxer> mDemuxer;
 
-  Atomic<bool> mEnded;
-
   // Protected by GetReentrantMonitor()
   double mMediaSourceDuration;
+  Atomic<bool> mEnded;
 };
 
 } // namespace mozilla

--- a/dom/media/mediasource/MediaSourceDemuxer.cpp
+++ b/dom/media/mediasource/MediaSourceDemuxer.cpp
@@ -310,6 +310,11 @@ MediaSourceTrackDemuxer::BreakCycles()
 nsRefPtr<MediaSourceTrackDemuxer::SeekPromise>
 MediaSourceTrackDemuxer::DoSeek(media::TimeUnit aTime)
 {
+  if (aTime.ToMicroseconds() && !mManager->Buffered(mType).Contains(aTime)) {
+    // We don't have the data to seek to.
+    return SeekPromise::CreateAndReject(DemuxerFailureReason::WAITING_FOR_DATA,
+                                        __func__);
+  }
   const TrackBuffersManager::TrackBuffer& track =
     mManager->GetTrackBuffer(mType);
   TimeUnit lastKeyFrameTime;

--- a/dom/media/mediasource/MediaSourceDemuxer.cpp
+++ b/dom/media/mediasource/MediaSourceDemuxer.cpp
@@ -400,7 +400,7 @@ MediaSourceTrackDemuxer::GetSample(DemuxerFailureReason& aFailure)
     // First demux, get first sample time.
     mNextSampleTime = ranges.GetStart();
   }
-  if (!ranges.Contains(mNextSampleTime)) {
+  if (!ranges.ContainsWithStrictEnd(mNextSampleTime)) {
     aFailure = DemuxerFailureReason::WAITING_FOR_DATA;
     return nullptr;
   }

--- a/dom/media/mediasource/MediaSourceDemuxer.cpp
+++ b/dom/media/mediasource/MediaSourceDemuxer.cpp
@@ -1,0 +1,456 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <algorithm>
+#include <limits>
+#include <stdint.h>
+
+#include "MediaSourceDemuxer.h"
+#include "SourceBufferList.h"
+
+namespace mozilla {
+
+typedef TrackInfo::TrackType TrackType;
+using media::TimeUnit;
+using media::TimeIntervals;
+
+MediaSourceDemuxer::MediaSourceDemuxer()
+  : mTaskQueue(new MediaTaskQueue(GetMediaThreadPool(),
+                                  /* aSupportsTailDispatch = */ true))
+  , mMonitor("MediaSourceDemuxer")
+{
+  MOZ_ASSERT(NS_IsMainThread());
+}
+
+nsRefPtr<MediaSourceDemuxer::InitPromise>
+MediaSourceDemuxer::Init()
+{
+  nsRefPtr<InitPromise> p = mInitPromise.Ensure(__func__);
+
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethod(this, &MediaSourceDemuxer::AttemptInit);
+  GetTaskQueue()->Dispatch(task.forget());
+
+  return p;
+}
+
+void
+MediaSourceDemuxer::AttemptInit()
+{
+  MOZ_ASSERT(OnTaskQueue());
+  MonitorAutoLock mon(mMonitor);
+  ScanSourceBuffersForContent();
+
+  if (mInfo.HasAudio() || mInfo.HasVideo()) {
+    mInitPromise.Resolve(NS_OK, __func__);
+  } else {
+    mInitPromise.Reject(DemuxerFailureReason::WAITING_FOR_DATA, __func__);
+  }
+}
+
+void
+MediaSourceDemuxer::ScanSourceBuffersForContent()
+{
+  mMonitor.AssertCurrentThreadOwns();
+
+  for (const auto& sourceBuffer : mSourceBuffers) {
+    MediaInfo info = sourceBuffer->GetMetadata();
+    if (info.HasAudio() && !mAudioTrack) {
+      mInfo.mAudio = info.mAudio;
+      mAudioTrack = sourceBuffer;
+    }
+    if (info.HasVideo() && !mVideoTrack) {
+      mInfo.mVideo = info.mVideo;
+      mVideoTrack = sourceBuffer;
+    }
+    if (info.IsEncrypted() && !mInfo.IsEncrypted()) {
+      mInfo.mCrypto = info.mCrypto;
+    }
+  }
+}
+
+bool
+MediaSourceDemuxer::HasTrackType(TrackType aType) const
+{
+  MonitorAutoLock mon(mMonitor);
+  switch (aType) {
+    case TrackType::kAudioTrack:
+      return mInfo.HasAudio();
+    case TrackType::kVideoTrack:
+      return mInfo.HasVideo();
+    default:
+      return false;
+  }
+}
+
+uint32_t
+MediaSourceDemuxer::GetNumberTracks(TrackType aType) const
+{
+  return HasTrackType(aType) ? 1u : 0;
+}
+
+already_AddRefed<MediaTrackDemuxer>
+MediaSourceDemuxer::GetTrackDemuxer(TrackType aType, uint32_t aTrackNumber)
+{
+  nsRefPtr<TrackBuffersManager> manager = GetManager(aType);
+  if (!manager) {
+    MOZ_CRASH("TODO: sourcebuffer was deleted from under us");
+    return nullptr;
+  }
+  nsRefPtr<MediaSourceTrackDemuxer> e =
+    new MediaSourceTrackDemuxer(this, aType, manager);
+  mDemuxers.AppendElement(e);
+  return e.forget();
+}
+
+bool
+MediaSourceDemuxer::IsSeekable() const
+{
+  return true;
+}
+
+UniquePtr<EncryptionInfo>
+MediaSourceDemuxer::GetCrypto()
+{
+  MonitorAutoLock mon(mMonitor);
+  auto crypto = MakeUnique<EncryptionInfo>();
+  *crypto = mInfo.mCrypto;
+  return crypto;
+}
+
+void
+MediaSourceDemuxer::NotifyTimeRangesChanged()
+{
+  MOZ_ASSERT(OnTaskQueue());
+  for (uint32_t i = 0; i < mDemuxers.Length(); i++) {
+    mDemuxers[i]->NotifyTimeRangesChanged();
+  }
+}
+
+void
+MediaSourceDemuxer::AttachSourceBuffer(TrackBuffersManager* aSourceBuffer)
+{
+  MonitorAutoLock mon(mMonitor);
+  mSourceBuffers.AppendElement(aSourceBuffer);
+  ScanSourceBuffersForContent();
+}
+
+void
+MediaSourceDemuxer::DetachSourceBuffer(TrackBuffersManager* aSourceBuffer)
+{
+  MonitorAutoLock mon(mMonitor);
+  for (uint32_t i = 0; i < mSourceBuffers.Length(); i++) {
+    if (mSourceBuffers[i].get() == aSourceBuffer) {
+      mSourceBuffers.RemoveElementAt(i);
+    }
+  }
+  if (aSourceBuffer == mAudioTrack) {
+    mAudioTrack = nullptr;
+  }
+  if (aSourceBuffer == mVideoTrack) {
+    mVideoTrack = nullptr;
+  }
+  ScanSourceBuffersForContent();
+}
+
+TrackInfo*
+MediaSourceDemuxer::GetTrackInfo(TrackType aTrack)
+{
+  MonitorAutoLock mon(mMonitor);
+  switch (aTrack) {
+    case TrackType::kAudioTrack:
+      return &mInfo.mAudio;
+    case TrackType::kVideoTrack:
+      return &mInfo.mVideo;
+    default:
+      return nullptr;
+  }
+}
+
+TrackBuffersManager*
+MediaSourceDemuxer::GetManager(TrackType aTrack)
+{
+  MonitorAutoLock mon(mMonitor);
+  switch (aTrack) {
+    case TrackType::kAudioTrack:
+      return mAudioTrack;
+    case TrackType::kVideoTrack:
+      return mVideoTrack;
+    default:
+      return nullptr;
+  }
+}
+
+MediaSourceDemuxer::~MediaSourceDemuxer()
+{
+  mTaskQueue->BeginShutdown();
+  mTaskQueue = nullptr;
+}
+
+MediaSourceTrackDemuxer::MediaSourceTrackDemuxer(MediaSourceDemuxer* aParent,
+                                                 TrackInfo::TrackType aType,
+                                                 TrackBuffersManager* aManager)
+  : mParent(aParent)
+  , mManager(aManager)
+  , mType(aType)
+  , mNextSampleIndex(0)
+  , mDetached(false)
+{
+}
+
+UniquePtr<TrackInfo>
+MediaSourceTrackDemuxer::GetInfo() const
+{
+  return mParent->GetTrackInfo(mType)->Clone();
+}
+
+nsRefPtr<MediaSourceTrackDemuxer::SeekPromise>
+MediaSourceTrackDemuxer::Seek(media::TimeUnit aTime)
+{
+  nsRefPtr<SeekPromise> p = mSeekPromise.Ensure(__func__);
+
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethodWithArg<TimeUnit>(
+      this, &MediaSourceTrackDemuxer::DoSeek, aTime);
+  mParent->GetTaskQueue()->Dispatch(task.forget());
+
+  return p;
+}
+
+nsRefPtr<MediaSourceTrackDemuxer::SamplesPromise>
+MediaSourceTrackDemuxer::GetSamples(int32_t aNumSamples)
+{
+  nsRefPtr<SamplesPromise> p = mSamplePromise.Ensure(__func__);
+
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethodWithArg<int32_t>(
+      this, &MediaSourceTrackDemuxer::DoGetSamples, aNumSamples);
+  mParent->GetTaskQueue()->Dispatch(task.forget());
+
+  return p;
+}
+
+void
+MediaSourceTrackDemuxer::Reset()
+{
+  mSamplePromise.RejectIfExists(DemuxerFailureReason::CANCELED, __func__);
+  mSkipPromise.RejectIfExists(SkipFailureHolder(DemuxerFailureReason::CANCELED, 0), __func__);
+  mSeekPromise.RejectIfExists(DemuxerFailureReason::CANCELED, __func__);
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethod(this, &MediaSourceTrackDemuxer::DoReset);
+  mParent->GetTaskQueue()->Dispatch(task.forget());
+}
+
+nsresult
+MediaSourceTrackDemuxer::GetNextRandomAccessPoint(media::TimeUnit* aTime)
+{
+  *aTime = mNextRandomAccessPoint;
+  return NS_OK;
+}
+
+nsRefPtr<MediaSourceTrackDemuxer::SkipAccessPointPromise>
+MediaSourceTrackDemuxer::SkipToNextRandomAccessPoint(media::TimeUnit aTimeThreshold)
+{
+  nsRefPtr<SkipAccessPointPromise> p = mSkipPromise.Ensure(__func__);
+
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableMethodWithArg<TimeUnit>(
+      this, &MediaSourceTrackDemuxer::DoSkipToNextRandomAccessPoint, aTimeThreshold);
+  mParent->GetTaskQueue()->Dispatch(task.forget());
+
+  return p;
+}
+
+int64_t
+MediaSourceTrackDemuxer::GetEvictionOffset(media::TimeUnit aTime)
+{
+  // Unused.
+  return 0;
+}
+
+media::TimeIntervals
+MediaSourceTrackDemuxer::GetBuffered()
+{
+  return mManager->Buffered();
+}
+
+void
+MediaSourceTrackDemuxer::BreakCycles()
+{
+  mDetached = true;
+  mParent = nullptr;
+  mManager = nullptr;
+}
+
+void
+MediaSourceTrackDemuxer::DoSeek(const media::TimeUnit& aTime)
+{
+  MOZ_ASSERT(mParent->OnTaskQueue());
+  if (mSeekPromise.IsEmpty()) {
+    // Got reset.
+    return;
+  }
+  const TrackBuffersManager::TrackBuffer& track = mManager->GetTrackBuffer(mType);
+  TimeUnit lastKeyFrameTime;
+  uint32_t lastKeyFrameIndex = 0;
+  for (uint32_t i = 0; i < track.Length(); i++) {
+    const nsRefPtr<MediaRawData>& sample = track[i];
+    if (sample->mKeyframe) {
+      lastKeyFrameTime = TimeUnit::FromMicroseconds(sample->mTime);
+      lastKeyFrameIndex = i;
+    }
+    if (sample->mTime >= aTime.ToMicroseconds()) {
+      break;
+    }
+  }
+  mNextSampleIndex = lastKeyFrameIndex;
+  mNextSampleTime = lastKeyFrameTime;
+  mNextRandomAccessPoint = GetNextRandomAccessPoint();
+  mSeekPromise.ResolveIfExists(mNextSampleTime, __func__);
+}
+
+void
+MediaSourceTrackDemuxer::DoGetSamples(int32_t aNumSamples)
+{
+  MOZ_ASSERT(mParent->OnTaskQueue());
+  if (mSamplePromise.IsEmpty()) {
+    // Got reset.
+    return;
+  }
+
+  DemuxerFailureReason failure;
+  nsRefPtr<MediaRawData> sample = GetSample(failure);
+  if (sample) {
+    nsRefPtr<SamplesHolder> samples = new SamplesHolder;
+    samples->mSamples.AppendElement(sample);
+    mNextRandomAccessPoint = GetNextRandomAccessPoint();
+    mSamplePromise.ResolveIfExists(samples, __func__);
+  } else {
+    mSamplePromise.RejectIfExists(failure, __func__);
+  }
+}
+
+void
+MediaSourceTrackDemuxer::DoSkipToNextRandomAccessPoint(const media::TimeUnit& aTimeThreadshold)
+{
+  MOZ_ASSERT(mParent->OnTaskQueue());
+  if (mSkipPromise.IsEmpty()) {
+    // Got reset.
+    return;
+  }
+  bool found = false;
+  int32_t parsed = 0;
+  const TrackBuffersManager::TrackBuffer& track =
+    mManager->GetTrackBuffer(mType);
+  for (uint32_t i = mNextSampleIndex; i < track.Length(); i++) {
+    const nsRefPtr<MediaRawData>& sample = track[i];
+    if (sample->mKeyframe && sample->mTime >= aTimeThreadshold.ToMicroseconds()) {
+      mNextSampleTime = TimeUnit::FromMicroseconds(sample->GetEndTime());
+      found = true;
+      break;
+    }
+    parsed++;
+  }
+
+  if (found) {
+    mSkipPromise.ResolveIfExists(parsed, __func__);
+  } else {
+    SkipFailureHolder holder(
+      mManager->IsEnded() ? DemuxerFailureReason::END_OF_STREAM :
+                            DemuxerFailureReason::WAITING_FOR_DATA, parsed);
+    mSkipPromise.RejectIfExists(holder, __func__);
+  }
+}
+
+already_AddRefed<MediaRawData>
+MediaSourceTrackDemuxer::GetSample(DemuxerFailureReason& aFailure)
+{
+  MOZ_ASSERT(mParent->OnTaskQueue());
+  const TrackBuffersManager::TrackBuffer& track =
+    mManager->GetTrackBuffer(mType);
+  const TimeIntervals& ranges = mManager->Buffered(mType);
+  if (mNextSampleTime >= ranges.GetEnd()) {
+    if (mManager->IsEnded()) {
+      aFailure = DemuxerFailureReason::END_OF_STREAM;
+    } else {
+      aFailure = DemuxerFailureReason::WAITING_FOR_DATA;
+    }
+    return nullptr;
+  }
+  if (mNextSampleTime == TimeUnit()) {
+    // First demux, get first sample time.
+    mNextSampleTime = ranges.GetStart();
+  }
+  if (!ranges.Contains(mNextSampleTime)) {
+    aFailure = DemuxerFailureReason::WAITING_FOR_DATA;
+    return nullptr;
+  }
+
+  if (mNextSampleIndex) {
+    const nsRefPtr<MediaRawData>& sample = track[mNextSampleIndex];
+    nsRefPtr<MediaRawData> p = sample->Clone();
+    if (!p) {
+      aFailure = DemuxerFailureReason::DEMUXER_ERROR;
+      return nullptr;
+    }
+    mNextSampleTime = TimeUnit::FromMicroseconds(sample->GetEndTime());
+    mNextSampleIndex++;
+    return p.forget();
+  }
+  for (uint32_t i = 0; i < track.Length(); i++) {
+    const nsRefPtr<MediaRawData>& sample = track[i];
+    if (sample->mTime >= mNextSampleTime.ToMicroseconds()) {
+      nsRefPtr<MediaRawData> p = sample->Clone();
+      mNextSampleTime = TimeUnit::FromMicroseconds(sample->GetEndTime());
+      mNextSampleIndex = i+1;
+      if (!p) {
+        // OOM
+        break;
+      }
+      return p.forget();
+    }
+  }
+  aFailure = DemuxerFailureReason::DEMUXER_ERROR;
+  return nullptr;
+}
+
+TimeUnit
+MediaSourceTrackDemuxer::GetNextRandomAccessPoint()
+{
+  MOZ_ASSERT(mParent->OnTaskQueue());
+  const TrackBuffersManager::TrackBuffer& track = mManager->GetTrackBuffer(mType);
+  for (uint32_t i = mNextSampleIndex; i < track.Length(); i++) {
+    const nsRefPtr<MediaRawData>& sample = track[i];
+    if (sample->mKeyframe) {
+      return TimeUnit::FromMicroseconds(sample->mTime);
+    }
+  }
+  return media::TimeUnit::FromInfinity();
+}
+
+void
+MediaSourceTrackDemuxer::NotifyTimeRangesChanged()
+{
+  if (mDetached) {
+    return;
+  }
+  MOZ_ASSERT(mParent->OnTaskQueue());
+  mNextSampleIndex = 0;
+}
+
+void
+MediaSourceTrackDemuxer::DoReset()
+{
+  if (mDetached) {
+    return;
+  }
+  MOZ_ASSERT(mParent->OnTaskQueue());
+  mNextSampleTime = TimeUnit();
+  mNextRandomAccessPoint = TimeUnit();
+  mNextSampleIndex = 0;
+}
+
+} // namespace mozilla

--- a/dom/media/mediasource/MediaSourceDemuxer.cpp
+++ b/dom/media/mediasource/MediaSourceDemuxer.cpp
@@ -303,7 +303,10 @@ MediaSourceTrackDemuxer::BreakCycles()
 {
   nsRefPtr<MediaSourceTrackDemuxer> self = this;
   nsCOMPtr<nsIRunnable> task =
-    NS_NewRunnableFunction([self]() { self->mParent = nullptr; } );
+    NS_NewRunnableFunction([self]() {
+      self->mParent = nullptr;
+      self->mManager = nullptr;
+    } );
   mParent->GetTaskQueue()->Dispatch(task.forget());
 }
 

--- a/dom/media/mediasource/MediaSourceDemuxer.h
+++ b/dom/media/mediasource/MediaSourceDemuxer.h
@@ -107,6 +107,11 @@ public:
 
   void BreakCycles() override;
 
+  bool GetSamplesMayBlock() const override
+  {
+    return false;
+  }
+
   // Called by TrackBuffersManager to indicate that new frames were added or
   // removed.
   void NotifyTimeRangesChanged();

--- a/dom/media/mediasource/MediaSourceDemuxer.h
+++ b/dom/media/mediasource/MediaSourceDemuxer.h
@@ -58,8 +58,8 @@ public:
 private:
   ~MediaSourceDemuxer();
   friend class MediaSourceTrackDemuxer;
-  // Scan source buffers and update information. Must own lock.
-  void ScanSourceBuffersForContent();
+  // Scan source buffers and update information.
+  bool ScanSourceBuffersForContent();
   nsRefPtr<InitPromise> AttemptInit();
   TrackBuffersManager* GetManager(TrackInfo::TrackType aType);
   TrackInfo* GetTrackInfo(TrackInfo::TrackType);

--- a/dom/media/mediasource/MediaSourceDemuxer.h
+++ b/dom/media/mediasource/MediaSourceDemuxer.h
@@ -1,0 +1,133 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#if !defined(MediaSourceDemuxer_h_)
+#define MediaSourceDemuxer_h_
+
+#include "mozilla/Maybe.h"
+#include "MediaDataDemuxer.h"
+#include "MediaDecoderReader.h"
+#include "MediaResource.h"
+#include "MediaSource.h"
+#include "MediaTaskQueue.h"
+#include "TrackBuffersManager.h"
+#include "mozilla/Atomics.h"
+#include "mozilla/Monitor.h"
+
+namespace mozilla {
+
+class MediaSourceTrackDemuxer;
+
+class MediaSourceDemuxer : public MediaDataDemuxer
+{
+public:
+  explicit MediaSourceDemuxer();
+
+  nsRefPtr<InitPromise> Init() override;
+
+  bool IsThreadSafe() override { return true; }
+
+  already_AddRefed<MediaDataDemuxer> Clone() const override
+  {
+    MOZ_CRASH("Shouldn't be called");
+    return nullptr;
+  }
+
+  bool HasTrackType(TrackInfo::TrackType aType) const override;
+
+  uint32_t GetNumberTracks(TrackInfo::TrackType aType) const override;
+
+  already_AddRefed<MediaTrackDemuxer> GetTrackDemuxer(TrackInfo::TrackType aType,
+                                                              uint32_t aTrackNumber) override;
+
+  bool IsSeekable() const override;
+
+  UniquePtr<EncryptionInfo> GetCrypto() override;
+
+  /* interface for TrackBuffersManager */
+  void AttachSourceBuffer(TrackBuffersManager* aSourceBuffer);
+  void DetachSourceBuffer(TrackBuffersManager* aSourceBuffer);
+  MediaTaskQueue* GetTaskQueue() { return mTaskQueue; }
+  void NotifyTimeRangesChanged();
+
+private:
+  ~MediaSourceDemuxer();
+  friend class MediaSourceTrackDemuxer;
+  // Scan source buffers and update information. Must own lock.
+  void ScanSourceBuffersForContent();
+  void AttemptInit();
+  TrackBuffersManager* GetManager(TrackInfo::TrackType aType);
+  TrackInfo* GetTrackInfo(TrackInfo::TrackType);
+  bool OnTaskQueue()
+  {
+    return !GetTaskQueue() || GetTaskQueue()->IsCurrentThreadIn();
+  }
+
+  RefPtr<MediaTaskQueue> mTaskQueue;
+  nsTArray<nsRefPtr<MediaSourceTrackDemuxer>> mDemuxers;
+  MediaPromiseHolder<InitPromise> mInitPromise;
+
+  // Monitor to protect members below across multiple threads.
+  mutable Monitor mMonitor;
+  MediaInfo mInfo;
+  nsTArray<nsRefPtr<TrackBuffersManager>> mSourceBuffers;
+  nsRefPtr<TrackBuffersManager> mAudioTrack;
+  nsRefPtr<TrackBuffersManager> mVideoTrack;
+};
+
+class MediaSourceTrackDemuxer : public MediaTrackDemuxer
+{
+public:
+  MediaSourceTrackDemuxer(MediaSourceDemuxer* aParent,
+                          TrackInfo::TrackType aType,
+                          TrackBuffersManager* aManager);
+
+  UniquePtr<TrackInfo> GetInfo() const override;
+
+  nsRefPtr<SeekPromise> Seek(media::TimeUnit aTime) override;
+
+  nsRefPtr<SamplesPromise> GetSamples(int32_t aNumSamples = 1) override;
+
+  void Reset() override;
+
+  nsresult GetNextRandomAccessPoint(media::TimeUnit* aTime) override;
+
+  nsRefPtr<SkipAccessPointPromise> SkipToNextRandomAccessPoint(media::TimeUnit aTimeThreshold) override;
+
+  media::TimeIntervals GetBuffered() override;
+
+  int64_t GetEvictionOffset(media::TimeUnit aTime) override;
+
+  void BreakCycles() override;
+
+  // Called by TrackBuffersManager to indicate that new frames were added or
+  // removed.
+  void NotifyTimeRangesChanged();
+
+private:
+  void DoReset();
+  void DoSeek(const media::TimeUnit& aTime);
+  void DoGetSamples(int32_t aNumSamples);
+  void DoSkipToNextRandomAccessPoint(const TimeUnit& aTimeThreadshold);
+  already_AddRefed<MediaRawData> GetSample(DemuxerFailureReason& aFailure);
+  // Return the timestamp of the next keyframe after mLastSampleIndex.
+  TimeUnit GetNextRandomAccessPoint();
+
+  nsRefPtr<MediaSourceDemuxer> mParent;
+  nsRefPtr<TrackBuffersManager> mManager;
+  TrackInfo::TrackType mType;
+  uint32_t mNextSampleIndex;
+  media::TimeUnit mNextSampleTime;
+  media::TimeUnit mNextRandomAccessPoint;
+  MediaPromiseHolder<SeekPromise> mSeekPromise;
+  MediaPromiseHolder<SamplesPromise> mSamplePromise;
+  MediaPromiseHolder<SkipAccessPointPromise> mSkipPromise;
+  Atomic<bool> mDetached;
+};
+
+} // namespace mozilla
+
+#endif

--- a/dom/media/mediasource/MediaSourceDemuxer.h
+++ b/dom/media/mediasource/MediaSourceDemuxer.h
@@ -47,6 +47,8 @@ public:
 
   UniquePtr<EncryptionInfo> GetCrypto() override;
 
+  bool ShouldComputeStartTime() const override { return false; }
+
   /* interface for TrackBuffersManager */
   void AttachSourceBuffer(TrackBuffersManager* aSourceBuffer);
   void DetachSourceBuffer(TrackBuffersManager* aSourceBuffer);

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -277,9 +277,17 @@ SourceBuffer::Detach()
 {
   MOZ_ASSERT(NS_IsMainThread());
   MSE_DEBUG("Detach");
+  if (!mMediaSource) {
+    MSE_DEBUG("Already detached");
+    return;
+  }
   AbortBufferAppend();
   if (mContentManager) {
      mContentManager->Detach();
+     if (mIsUsingFormatReader) {
+      mMediaSource->GetDecoder()->GetDemuxer()->DetachSourceBuffer(
+        static_cast<mozilla::TrackBuffersManager*>(mContentManager.get()));
+    }
   }
   mContentManager = nullptr;
   mMediaSource = nullptr;
@@ -304,6 +312,7 @@ SourceBuffer::SourceBuffer(MediaSource* aMediaSource, const nsACString& aType)
   , mUpdating(false)
   , mActive(false)
   , mUpdateID(0)
+  , mReportedOffset(0)
   , mType(aType)
 {
   MOZ_ASSERT(NS_IsMainThread());
@@ -329,6 +338,10 @@ SourceBuffer::SourceBuffer(MediaSource* aMediaSource, const nsACString& aType)
     SetMode(SourceBufferAppendMode::Sequence, dummy);
   } else {
     SetMode(SourceBufferAppendMode::Segments, dummy);
+  }
+  if (mIsUsingFormatReader) {
+    mMediaSource->GetDecoder()->GetDemuxer()->AttachSourceBuffer(
+      static_cast<mozilla::TrackBuffersManager*>(mContentManager.get()));
   }
 }
 
@@ -472,7 +485,14 @@ SourceBuffer::AppendDataCompletedWithSuccess(bool aHasActiveTracks)
       mActive = true;
       mMediaSource->SourceBufferIsActive(this);
       mMediaSource->QueueInitializationEvent();
+      if (mIsUsingFormatReader) {
+        mMediaSource->GetDecoder()->NotifyWaitingForResourcesStatusChanged();
+      }
     }
+    // Tell our parent decoder that we have received new data.
+    // The information provided do not matter much so long as it is monotonically
+    // increasing.
+    mMediaSource->GetDecoder()->NotifyDataArrived(nullptr, 1, mReportedOffset++);
   }
 
   CheckEndTime();

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -300,6 +300,9 @@ SourceBuffer::Ended()
   MOZ_ASSERT(IsAttached());
   MSE_DEBUG("Ended");
   mContentManager->Ended();
+  // We want the MediaSourceReader to refresh its buffered range as it may
+  // have been modified (end lined up).
+  mMediaSource->GetDecoder()->NotifyDataArrived(nullptr, 1, mReportedOffset++);
 }
 
 SourceBuffer::SourceBuffer(MediaSource* aMediaSource, const nsACString& aType)

--- a/dom/media/mediasource/SourceBuffer.h
+++ b/dom/media/mediasource/SourceBuffer.h
@@ -192,6 +192,7 @@ private:
   // This allows for a queued AppendData task to identify if it was earlier
   // aborted and another AppendData queued.
   uint32_t mUpdateID;
+  int64_t mReportedOffset;
 
   MediaPromiseRequestHolder<SourceBufferContentManager::AppendPromise> mPendingAppend;
   const nsCString mType;

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -37,6 +37,8 @@ AppendStateToStr(TrackBuffersManager::AppendState aState)
   }
 }
 
+static Atomic<uint32_t> sStreamSourceID(0u);
+
 TrackBuffersManager::TrackBuffersManager(dom::SourceBuffer* aParent, MediaSourceDecoder* aParentDecoder, const nsACString& aType)
   : mInputBuffer(new MediaLargeByteBuffer)
   , mAppendState(AppendState::WAITING_FOR_SEGMENT)
@@ -803,6 +805,9 @@ TrackBuffersManager::OnDemuxerInitDone(nsresult)
   // 4. Let active track flag equal false.
   mActiveTrack = false;
 
+  // Increase our stream id.
+  uint32_t streamID = sStreamSourceID++;
+
   // 5. If the first initialization segment received flag is false, then run the following steps:
   if (!mFirstInitializationSegmentReceived) {
     mAudioTracks.mNumTracks = numAudios;
@@ -838,7 +843,8 @@ TrackBuffersManager::OnDemuxerInitDone(nsresult)
       //   11. Queue a task to fire a trusted event named addtrack, that does not bubble and is not cancelable, and that uses the TrackEvent interface, at the AudioTrackList object referenced by the audioTracks attribute on the HTMLMediaElement.
       mAudioTracks.mBuffers.AppendElement(TrackBuffer());
       // 10. Add the track description for this track to the track buffer.
-      mAudioTracks.mInfo = info.mAudio.Clone();
+      mAudioTracks.mInfo = new SharedTrackInfo(info.mAudio, streamID);
+      mAudioTracks.mLastInfo = mAudioTracks.mInfo;
     }
 
     mVideoTracks.mNumTracks = numVideos;
@@ -869,7 +875,8 @@ TrackBuffersManager::OnDemuxerInitDone(nsresult)
       //   11. Queue a task to fire a trusted event named addtrack, that does not bubble and is not cancelable, and that uses the TrackEvent interface, at the VideoTrackList object referenced by the videoTracks attribute on the HTMLMediaElement.
       mVideoTracks.mBuffers.AppendElement(TrackBuffer());
       // 10. Add the track description for this track to the track buffer.
-      mVideoTracks.mInfo = info.mVideo.Clone();
+      mVideoTracks.mInfo = new SharedTrackInfo(info.mVideo, streamID);
+      mVideoTracks.mLastInfo = mVideoTracks.mInfo;
     }
     // 4. For each text track in the initialization segment, run following steps:
     // 5. If active track flag equals true, then run the following steps:
@@ -877,6 +884,9 @@ TrackBuffersManager::OnDemuxerInitDone(nsresult)
 
     // 6. Set first initialization segment received flag to true.
     mFirstInitializationSegmentReceived = true;
+  } else {
+    mAudioTracks.mLastInfo = new SharedTrackInfo(info.mAudio, streamID);
+    mVideoTracks.mLastInfo = new SharedTrackInfo(info.mVideo, streamID);
   }
 
   // TODO CHECK ENCRYPTION
@@ -1318,6 +1328,8 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
   // 16. Add the coded frame with the presentation timestamp, decode timestamp, and frame duration to the track buffer.
   aSample->mTime = presentationTimestamp.ToMicroseconds();
   aSample->mTimecode = decodeTimestamp.ToMicroseconds();
+  aSample->mTrackInfo = trackBuffer.mLastInfo;
+
   if (firstRemovedIndex >= 0) {
     data.InsertElementAt(firstRemovedIndex, aSample);
   } else {

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -216,7 +216,9 @@ private:
     // Byte size of all samples contained in this track buffer.
     uint32_t mSizeBuffer;
     // TrackInfo of the first metadata received.
-    UniquePtr<TrackInfo> mInfo;
+    nsRefPtr<SharedTrackInfo> mInfo;
+    // TrackInfo of the last metadata parsed (updated with each init segment.
+    nsRefPtr<SharedTrackInfo> mLastInfo;
   };
 
   bool ProcessFrame(MediaRawData* aSample, TrackData& aTrackData);

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -21,6 +21,7 @@ namespace mozilla {
 class ContainerParser;
 class MediaLargeByteBuffer;
 class MediaRawData;
+class MediaSourceDemuxer;
 class SourceBuffer;
 class SourceBufferResource;
 
@@ -262,6 +263,7 @@ private:
   // Strong references to external objects.
   nsMainThreadPtrHandle<dom::SourceBuffer> mParent;
   nsMainThreadPtrHandle<MediaSourceDecoder> mParentDecoder;
+  nsRefPtr<MediaSourceDemuxer> mMediaSourceDemuxer;
 
   // Set to true if abort is called.
   Atomic<bool> mAbort;

--- a/dom/media/mediasource/moz.build
+++ b/dom/media/mediasource/moz.build
@@ -8,6 +8,7 @@ MOCHITEST_MANIFESTS += ['test/mochitest.ini']
 EXPORTS += [
     'AsyncEventRunner.h',
     'MediaSourceDecoder.h',
+    'MediaSourceDemuxer.h',
     'MediaSourceReader.h',
     'SourceBufferContentManager.h',
 ]
@@ -22,6 +23,7 @@ UNIFIED_SOURCES += [
     'ContainerParser.cpp',
     'MediaSource.cpp',
     'MediaSourceDecoder.cpp',
+    'MediaSourceDemuxer.cpp',
     'MediaSourceReader.cpp',
     'MediaSourceUtils.cpp',
     'SourceBuffer.cpp',

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -469,11 +469,12 @@ pref("media.mediasource.mp4.enabled", true);
 pref("media.mediasource.webm.enabled", false);
 
 // Enable new MediaSource architecture.
+// NOTE: This is an on-going WIP and should not be enabled yet.
 pref("media.mediasource.format-reader", false);
 
-// Enable new MediaFormatReader architecture for mp4 in MSE
+// Enable the MediaFormatReader architecture for MP4 + MSE.
 pref("media.mediasource.format-reader.mp4", true);
-// Enable new MediaFormatReader architecture for plain mp4.
+// Enable the MediaFormatReader architecture for plain MP4.
 pref("media.format-reader.mp4", true);
 
 #ifdef MOZ_WEBSPEECH

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -468,6 +468,9 @@ pref("media.mediasource.enabled", true);
 pref("media.mediasource.mp4.enabled", true);
 pref("media.mediasource.webm.enabled", false);
 
+// Enable new MediaSource architecture.
+pref("media.mediasource.format-reader", false);
+
 // Enable new MediaFormatReader architecture for mp4 in MSE
 pref("media.mediasource.format-reader.mp4", true);
 // Enable new MediaFormatReader architecture for plain mp4.


### PR DESCRIPTION
Here's another big one! This PR introduces the MediaSourceDemuxer, which (together with the TrackBuffersManager in #1081) makes up the bulk or our new MSE code. In addition to landing that, this PR also makes several changes to our existing MSE support (which in turn will also be used by the new architecture when it is active):

- Adds the MediaSourceDemuxer object (our new MSE!) behind a pref which is disabled by default. This object uses the TrackBuffersManager to a much greater extent than we do currently.
- Adds an IsThreadSafe method because the media source demuxer can't support cloning.
- Allow MediaFormatReader to handle errors when skipping to the next keyframe.
- Don't compute the start time for MSE.
- Force the buffered range to update after reaching EOS.
- Ensure that the decoder doesn't stop decoding if there is still data available.
- Only allow seeking if we have the target data.
- Allow the MediaFormatReader to detect changes in stream content and recreate the decoder as needed.

Note that this is only a base implementation of our new MSE code. There are still many bugs and spec-compliance issues that need researched and fixed before this can start being used in place of our existing implementation. It is still very much a WIP, and should be treated as such.

As with #1081, This mostly needs testing (at this stage) to ensure that our existing implementation has not been broken. With that said, note that flipping the media.mediasource.format-reader pref _will_ cause playback regressions and (in some cases) things may not play at all. So unless you want to see all the colorful ways this doesn't quite work correctly (yet), leave it disabled!

Spent a few hours with it on Linux and appears to be working (though will continue testing). Needs verification on Windows.