### PR TITLE
Media fixes

### DIFF
--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -157,6 +157,11 @@ public:
       (aOther.mStart - aOther.mFuzz < mEnd + mFuzz);
   }
 
+  bool IntersectsStrict(const SelfType& aOther) const
+  {
+    return mStart < aOther.mEnd && aOther.mStart < mEnd;
+  }
+
   // Same as Intersects, but including the boundaries.
   bool Touches(const SelfType& aOther) const
   {
@@ -298,14 +303,18 @@ public:
   SelfType& operator= (const ElemType& aInterval)
   {
     mIntervals.Clear();
-    mIntervals.AppendElement(aInterval);
+    if (!aInterval.IsEmpty()) {
+      mIntervals.AppendElement(aInterval);
+    }
     return *this;
   }
 
   SelfType& operator= (ElemType&& aInterval)
   {
     mIntervals.Clear();
-    mIntervals.AppendElement(Move(aInterval));
+    if (!aInterval.IsEmpty()) {
+      mIntervals.AppendElement(Move(aInterval));
+    }
     return *this;
   }
 
@@ -445,7 +454,7 @@ public:
     const ContainerType& other = aOther.mIntervals;
     IndexType i = 0, j = 0;
     for (; i < mIntervals.Length() && j < other.Length();) {
-      if (mIntervals[i].Intersects(other[j])) {
+      if (mIntervals[i].IntersectsStrict(other[j])) {
         intersection.AppendElement(mIntervals[i].Intersection(other[j]));
       }
       if (mIntervals[i].mEnd < other[j].mEnd) {

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -668,7 +668,7 @@ MediaFormatReader::NotifyError(TrackType aTrack)
 {
   MOZ_ASSERT(OnTaskQueue());
   auto& decoder = GetDecoderData(aTrack);
-  decoder.mError = true
+  decoder.mError = true;
   decoder.mNeedDraining = true;
   ScheduleUpdate(aTrack);
 }

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -468,7 +468,7 @@ MediaFormatReader::ShouldSkip(bool aSkipToNextKeyframe, media::TimeUnit aTimeThr
   if (NS_FAILED(rv)) {
     return aSkipToNextKeyframe;
   }
-  return nextKeyframe < aTimeThreshold;
+  return nextKeyframe < aTimeThreshold && nextKeyframe.ToMicroseconds() >= 0;
 }
 
 nsRefPtr<MediaDecoderReader::VideoDataPromise>

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -819,6 +819,17 @@ MediaFormatReader::DecodeDemuxedSamples(TrackType aTrack,
         return;
       }
 
+      if (decoder.mNextStreamSourceID.isNothing() ||
+          decoder.mNextStreamSourceID.ref() != info->GetID()) {
+        LOG("%s stream id has changed from:%d to:%d, draining decoder.",
+            TrackTypeToStr(aTrack), decoder.mLastStreamSourceID,
+            info->GetID());
+        decoder.mNeedDraining = true;
+        decoder.mNextStreamSourceID = Some(info->GetID());
+        DrainDecoder(aTrack);
+        return;
+      }
+
       LOG("%s stream id has changed from:%d to:%d, recreating decoder.",
           TrackTypeToStr(aTrack), decoder.mLastStreamSourceID,
           info->GetID());

--- a/dom/media/MediaFormatReader.h
+++ b/dom/media/MediaFormatReader.h
@@ -210,6 +210,7 @@ private:
       , mInputExhausted(false)
       , mError(false)
       , mNeedDraining(false)
+      , mDraining(false)
       , mDrainComplete(false)
       , mNumSamplesInput(0)
       , mNumSamplesOutput(0)
@@ -258,6 +259,7 @@ private:
     bool mInputExhausted;
     bool mError;
     bool mNeedDraining;
+    bool mDraining;
     bool mDrainComplete;
     // If set, all decoded samples prior mTimeThreshold will be dropped.
     // Used for internal seeking when a change of stream is detected.
@@ -293,6 +295,7 @@ private:
       mOutputRequested = false;
       mInputExhausted = false;
       mNeedDraining = false;
+      mDraining = false;
       mDrainComplete = false;
       mTimeThreshold.reset();
       mOutput.Clear();

--- a/dom/media/MediaFormatReader.h
+++ b/dom/media/MediaFormatReader.h
@@ -298,12 +298,14 @@ private:
       mOutput.Clear();
       mNumSamplesInput = 0;
       mNumSamplesOutput = 0;
+      mNextStreamSourceID.reset();
     }
 
     // Used by the MDSM for logging purposes.
     Atomic<size_t> mSizeOfQueue;
     // Sample format monitoring.
     uint32_t mLastStreamSourceID;
+    Maybe<uint32_t> mNextStreamSourceID;
     // Monitor that protects all non-threadsafe state; the primitives
     // that follow.
     Monitor mMonitor;

--- a/dom/media/MediaFormatReader.h
+++ b/dom/media/MediaFormatReader.h
@@ -132,6 +132,8 @@ private:
   // Decode any pending already demuxed samples.
   void DecodeDemuxedSamples(TrackType aTrack,
                             AbstractMediaDecoder::AutoNotifyDecoded& aA);
+  // Drain the current decoder.
+  void DrainDecoder(TrackType aTrack);
   void NotifyNewOutput(TrackType aTrack, MediaData* aSample);
   void NotifyInputExhausted(TrackType aTrack);
   void NotifyDrainComplete(TrackType aTrack);
@@ -201,13 +203,13 @@ private:
       , mDecodeAhead(aDecodeAhead)
       , mUpdateScheduled(false)
       , mDemuxEOS(false)
-      , mDemuxEOSServiced(false)
       , mWaitingForData(false)
       , mReceivedNewData(false)
       , mDiscontinuity(true)
       , mOutputRequested(false)
       , mInputExhausted(false)
       , mError(false)
+      , mNeedDraining(false)
       , mDrainComplete(false)
       , mNumSamplesInput(0)
       , mNumSamplesOutput(0)
@@ -233,7 +235,6 @@ private:
     uint32_t mDecodeAhead;
     bool mUpdateScheduled;
     bool mDemuxEOS;
-    bool mDemuxEOSServiced;
     bool mWaitingForData;
     bool mReceivedNewData;
     bool mDiscontinuity;
@@ -256,6 +257,7 @@ private:
     bool mOutputRequested;
     bool mInputExhausted;
     bool mError;
+    bool mNeedDraining;
     bool mDrainComplete;
     // If set, all decoded samples prior mTimeThreshold will be dropped.
     // Used for internal seeking when a change of stream is detected.
@@ -284,13 +286,13 @@ private:
     {
       MOZ_ASSERT(mOwner->OnTaskQueue());
       mDemuxEOS = false;
-      mDemuxEOSServiced = false;
       mWaitingForData = false;
       mReceivedNewData = false;
       mDiscontinuity = true;
       mQueuedSamples.Clear();
       mOutputRequested = false;
       mInputExhausted = false;
+      mNeedDraining = false;
       mDrainComplete = false;
       mTimeThreshold.reset();
       mOutput.Clear();

--- a/dom/media/fmp4/MP4Reader.cpp
+++ b/dom/media/fmp4/MP4Reader.cpp
@@ -548,7 +548,7 @@ MP4Reader::ShouldSkip(bool aSkipToNextKeyframe, int64_t aTimeThreshold)
       (nextKeyframe = GetNextKeyframeTime()) == -1) {
     return aSkipToNextKeyframe;
   }
-  return nextKeyframe < aTimeThreshold;
+  return nextKeyframe < aTimeThreshold && nextKeyframe >= 0;
 }
 
 nsRefPtr<MediaDecoderReader::VideoDataPromise>

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -1229,13 +1229,16 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
   TimeUnit frameEndTimestamp = presentationTimestamp + frameDuration;
 
   // 8. If presentation timestamp is less than appendWindowStart, then set the need random access point flag to true, drop the coded frame, and jump to the top of the loop to start processing the next coded frame.
-  if (presentationTimestamp.ToSeconds() < mParent->mAppendWindowStart) {
-    trackBuffer.mNeedRandomAccessPoint = true;
-    return false;
-  }
-
   // 9. If frame end timestamp is greater than appendWindowEnd, then set the need random access point flag to true, drop the coded frame, and jump to the top of the loop to start processing the next coded frame.
-  if (frameEndTimestamp.ToSeconds() > mParent->mAppendWindowEnd) {
+  // We apply a fuzz search += mLongestFrameDuration to get around videos where
+  // the start time is negative but close to 0.
+  TimeInterval targetWindow{
+    TimeInterval(TimeUnit::FromSeconds(mParent->mAppendWindowStart),
+                 TimeUnit::FromSeconds(mParent->mAppendWindowEnd),
+                 trackBuffer.mLongestFrameDuration.valueOr(frameDuration))};
+  TimeInterval frameInterval{presentationTimestamp, frameEndTimestamp};
+
+  if (!targetWindow.Contains(frameInterval)) {
     trackBuffer.mNeedRandomAccessPoint = true;
     return false;
   }

--- a/dom/media/mediasource/test/test_BufferingWait.html
+++ b/dom/media/mediasource/test/test_BufferingWait.html
@@ -41,14 +41,18 @@ runWithMSE(function(ms, v) {
       /* Note - Missing |46712, 67833 - 46712| segment here corresponding to (0.8, 1.2] */
       /* Note - Missing |67833, 88966 - 67833| segment here corresponding to (1.2, 1.6]  */
       loadSegment.bind(null, sb, new Uint8Array(arrayBuffer, 88966))).then(function() {
-        var promise = waitUntilTime(0.27);
+        // Some decoders (Windows in particular) may keep up to 25 frames queued
+        // before returning a sample. 0.7 is 1.62s - 25 * 0.03333
+        var promise = waitUntilTime(0.7);
         info("Playing video. It should play for a bit, then fire 'waiting'");
         v.play();
         return promise;
       }).then(function() {
         window.firstStop = Date.now();
         loadSegment(sb, new Uint8Array(arrayBuffer, 46712, 67833 - 46712));
-        return waitUntilTime(0.66);
+        // Some decoders (Windows in particular) may keep up to 25 frames queued
+        // before returning a sample. 1.5 is 2.41s - 25 * 0.03333
+        return waitUntilTime(1.5);
       }).then(function() {
         var waitDuration = (Date.now() - window.firstStop) / 1000;
         ok(waitDuration < 15, "Should not spend an inordinate amount of time buffering: " + waitDuration);

--- a/media/libstagefright/binding/MoofParser.cpp
+++ b/media/libstagefright/binding/MoofParser.cpp
@@ -46,7 +46,7 @@ MoofParser::RebuildFragmentedIndex(BoxContext& aContext)
   bool foundMdat = false;
 
   for (Box box(&aContext, mOffset); box.IsAvailable(); box = box.Next()) {
-    if (box.IsType("moov")) {
+    if (box.IsType("moov") && mInitRange.IsNull()) {
       mInitRange = MediaByteRange(0, box.Range().mEnd);
       ParseMoov(box);
     } else if (box.IsType("moof")) {


### PR DESCRIPTION
This PR fixes several small issues with the MediaFormatReader not correctly draining its decoder or not draining it at the correct time (which could potentially lead to stalls, dropped frames, or a/v desync in some cases). Additionally, this PR fixes an issue when we try to play a video with negative start times and also fixes a couple assertion failures.

While these fixes are mostly for our new MSE (#1033), our current code should benefit from these fixes as well. Tested and appears to be working on Linux.