### PR TITLE
MSE fixes

### DIFF
--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -619,6 +619,27 @@ public:
     return NoIndex;
   }
 
+  // Methods for range-based for loops.
+  typename ContainerType::iterator begin()
+  {
+    return mIntervals.begin();
+  }
+
+  typename ContainerType::const_iterator begin() const
+  {
+    return mIntervals.begin();
+  }
+
+  typename ContainerType::iterator end()
+  {
+    return mIntervals.end();
+  }
+
+  typename ContainerType::const_iterator end() const
+  {
+    return mIntervals.end();
+  }
+
 protected:
   ContainerType mIntervals;
 

--- a/dom/media/mediasource/MediaSource.cpp
+++ b/dom/media/mediasource/MediaSource.cpp
@@ -82,6 +82,10 @@ IsTypeSupported(const nsAString& aType)
   if (NS_FAILED(rv)) {
     return NS_ERROR_DOM_NOT_SUPPORTED_ERR;
   }
+  if (Preferences::GetBool("media.mediasource.format-reader", false) &&
+      !mimeType.EqualsASCII("video/mp4") && !mimeType.EqualsASCII("audio/mp4")) {
+    return NS_ERROR_DOM_NOT_SUPPORTED_ERR;
+  }
   bool found = false;
   for (uint32_t i = 0; gMediaSourceTypes[i]; ++i) {
     if (mimeType.EqualsASCII(gMediaSourceTypes[i])) {

--- a/dom/media/mediasource/MediaSourceDemuxer.cpp
+++ b/dom/media/mediasource/MediaSourceDemuxer.cpp
@@ -232,6 +232,13 @@ MediaSourceTrackDemuxer::MediaSourceTrackDemuxer(MediaSourceDemuxer* aParent,
   , mType(aType)
   , mMonitor("MediaSourceTrackDemuxer")
 {
+  // Force refresh of our buffered ranges.
+  nsRefPtr<MediaSourceTrackDemuxer> self = this;
+  nsCOMPtr<nsIRunnable> task =
+    NS_NewRunnableFunction([self] () {
+      self->NotifyTimeRangesChanged();
+    });
+  mParent->GetTaskQueue()->Dispatch(task.forget());
 }
 
 UniquePtr<TrackInfo>

--- a/dom/media/mediasource/MediaSourceDemuxer.cpp
+++ b/dom/media/mediasource/MediaSourceDemuxer.cpp
@@ -17,6 +17,11 @@ typedef TrackInfo::TrackType TrackType;
 using media::TimeUnit;
 using media::TimeIntervals;
 
+// Gap allowed between frames. Due to inaccuracies in determining buffer end
+// frames (see Mozilla bug 1065207). This value is based on the end of frame
+// default value used in Blink, kDefaultBufferDurationInMs.
+#define EOS_FUZZ_US 125000
+
 MediaSourceDemuxer::MediaSourceDemuxer()
   : mTaskQueue(new MediaTaskQueue(GetMediaThreadPool(),
                                   /* aSupportsTailDispatch = */ true))
@@ -225,7 +230,6 @@ MediaSourceTrackDemuxer::MediaSourceTrackDemuxer(MediaSourceDemuxer* aParent,
   : mParent(aParent)
   , mManager(aManager)
   , mType(aType)
-  , mNextSampleIndex(0)
   , mMonitor("MediaSourceTrackDemuxer")
 {
 }
@@ -259,11 +263,11 @@ MediaSourceTrackDemuxer::Reset()
   nsRefPtr<MediaSourceTrackDemuxer> self = this;
   nsCOMPtr<nsIRunnable> task =
     NS_NewRunnableFunction([self] () {
-      self->mNextSampleTime = TimeUnit();
-      self->mNextSampleIndex = 0;
+      self->mManager->Seek(self->mType, TimeUnit());
       {
         MonitorAutoLock mon(self->mMonitor);
-        self->mNextRandomAccessPoint = self->GetNextRandomAccessPoint();
+        self->mNextRandomAccessPoint =
+          self->mManager->GetNextRandomAccessPoint(self->mType);
       }
     });
   mParent->GetTaskQueue()->Dispatch(task.forget());
@@ -313,47 +317,39 @@ MediaSourceTrackDemuxer::BreakCycles()
 nsRefPtr<MediaSourceTrackDemuxer::SeekPromise>
 MediaSourceTrackDemuxer::DoSeek(media::TimeUnit aTime)
 {
-  if (aTime.ToMicroseconds() && !mManager->Buffered(mType).Contains(aTime)) {
+  if (aTime.ToMicroseconds() && !mBufferedRanges.Contains(aTime)) {
     // We don't have the data to seek to.
     return SeekPromise::CreateAndReject(DemuxerFailureReason::WAITING_FOR_DATA,
                                         __func__);
   }
-  const TrackBuffersManager::TrackBuffer& track =
-    mManager->GetTrackBuffer(mType);
-  TimeUnit lastKeyFrameTime;
-  uint32_t lastKeyFrameIndex = 0;
-  for (uint32_t i = 0; i < track.Length(); i++) {
-    const nsRefPtr<MediaRawData>& sample = track[i];
-    if (sample->mKeyframe) {
-      lastKeyFrameTime = TimeUnit::FromMicroseconds(sample->mTime);
-      lastKeyFrameIndex = i;
-    }
-    if (sample->mTime >= aTime.ToMicroseconds()) {
-      break;
-    }
-  }
-  mNextSampleIndex = lastKeyFrameIndex;
-  mNextSampleTime = lastKeyFrameTime;
+  TimeUnit seekTime = mManager->Seek(mType, aTime);
   {
     MonitorAutoLock mon(mMonitor);
-    mNextRandomAccessPoint = GetNextRandomAccessPoint();
+    mNextRandomAccessPoint = mManager->GetNextRandomAccessPoint(mType);
   }
-  return SeekPromise::CreateAndResolve(mNextSampleTime, __func__);
+  return SeekPromise::CreateAndResolve(seekTime, __func__);
 }
 
 nsRefPtr<MediaSourceTrackDemuxer::SamplesPromise>
 MediaSourceTrackDemuxer::DoGetSamples(int32_t aNumSamples)
 {
-  DemuxerFailureReason failure;
-  nsRefPtr<MediaRawData> sample = GetSample(failure);
+  bool error;
+  nsRefPtr<MediaRawData> sample = mManager->GetSample(mType,
+                                                      TimeUnit::FromMicroseconds(EOS_FUZZ_US),
+                                                      error);
   if (!sample) {
-    return SamplesPromise::CreateAndReject(failure, __func__);
+    if (error) {
+      return SamplesPromise::CreateAndReject(DemuxerFailureReason::DEMUXER_ERROR, __func__);
+    }
+    return SamplesPromise::CreateAndReject(
+      mManager->IsEnded() ? DemuxerFailureReason::END_OF_STREAM :
+                            DemuxerFailureReason::WAITING_FOR_DATA, __func__);
   }
   nsRefPtr<SamplesHolder> samples = new SamplesHolder;
   samples->mSamples.AppendElement(sample);
   if (mNextRandomAccessPoint.ToMicroseconds() <= sample->mTime) {
     MonitorAutoLock mon(mMonitor);
-    mNextRandomAccessPoint = GetNextRandomAccessPoint();
+    mNextRandomAccessPoint = mManager->GetNextRandomAccessPoint(mType);
   }
   return SamplesPromise::CreateAndResolve(samples, __func__);
 }
@@ -361,21 +357,9 @@ MediaSourceTrackDemuxer::DoGetSamples(int32_t aNumSamples)
 nsRefPtr<MediaSourceTrackDemuxer::SkipAccessPointPromise>
 MediaSourceTrackDemuxer::DoSkipToNextRandomAccessPoint(media::TimeUnit aTimeThreadshold)
 {
-  bool found = false;
-  int32_t parsed = 0;
-  const TrackBuffersManager::TrackBuffer& track =
-    mManager->GetTrackBuffer(mType);
-  for (uint32_t i = mNextSampleIndex; i < track.Length(); i++) {
-    const nsRefPtr<MediaRawData>& sample = track[i];
-    if (sample->mKeyframe &&
-        sample->mTime >= aTimeThreadshold.ToMicroseconds()) {
-      mNextSampleTime = TimeUnit::FromMicroseconds(sample->GetEndTime());
-      found = true;
-      break;
-    }
-    parsed++;
-  }
-
+  bool found;
+  uint32_t parsed =
+    mManager->SkipToNextRandomAccessPoint(mType, aTimeThreadshold, found);
   if (found) {
     return SkipAccessPointPromise::CreateAndResolve(parsed, __func__);
   }
@@ -385,70 +369,6 @@ MediaSourceTrackDemuxer::DoSkipToNextRandomAccessPoint(media::TimeUnit aTimeThre
   return SkipAccessPointPromise::CreateAndReject(holder, __func__);
 }
 
-already_AddRefed<MediaRawData>
-MediaSourceTrackDemuxer::GetSample(DemuxerFailureReason& aFailure)
-{
-  const TrackBuffersManager::TrackBuffer& track =
-    mManager->GetTrackBuffer(mType);
-  const TimeIntervals& ranges = mManager->Buffered(mType);
-  if (mNextSampleTime >= ranges.GetEnd()) {
-    if (mManager->IsEnded()) {
-      aFailure = DemuxerFailureReason::END_OF_STREAM;
-    } else {
-      aFailure = DemuxerFailureReason::WAITING_FOR_DATA;
-    }
-    return nullptr;
-  }
-  if (mNextSampleTime == TimeUnit()) {
-    // First demux, get first sample time.
-    mNextSampleTime = ranges.GetStart();
-  }
-  if (!ranges.ContainsWithStrictEnd(mNextSampleTime)) {
-    aFailure = DemuxerFailureReason::WAITING_FOR_DATA;
-    return nullptr;
-  }
-
-  if (mNextSampleIndex) {
-    const nsRefPtr<MediaRawData>& sample = track[mNextSampleIndex];
-    nsRefPtr<MediaRawData> p = sample->Clone();
-    if (!p) {
-      aFailure = DemuxerFailureReason::DEMUXER_ERROR;
-      return nullptr;
-    }
-    mNextSampleTime = TimeUnit::FromMicroseconds(sample->GetEndTime());
-    mNextSampleIndex++;
-    return p.forget();
-  }
-  for (uint32_t i = 0; i < track.Length(); i++) {
-    const nsRefPtr<MediaRawData>& sample = track[i];
-    if (sample->mTime >= mNextSampleTime.ToMicroseconds()) {
-      nsRefPtr<MediaRawData> p = sample->Clone();
-      mNextSampleTime = TimeUnit::FromMicroseconds(sample->GetEndTime());
-      mNextSampleIndex = i+1;
-      if (!p) {
-        // OOM
-        break;
-      }
-      return p.forget();
-    }
-  }
-  aFailure = DemuxerFailureReason::DEMUXER_ERROR;
-  return nullptr;
-}
-
-TimeUnit
-MediaSourceTrackDemuxer::GetNextRandomAccessPoint()
-{
-  const TrackBuffersManager::TrackBuffer& track = mManager->GetTrackBuffer(mType);
-  for (uint32_t i = mNextSampleIndex; i < track.Length(); i++) {
-    const nsRefPtr<MediaRawData>& sample = track[i];
-    if (sample->mKeyframe) {
-      return TimeUnit::FromMicroseconds(sample->mTime);
-    }
-  }
-  return media::TimeUnit::FromInfinity();
-}
-
 void
 MediaSourceTrackDemuxer::NotifyTimeRangesChanged()
 {
@@ -456,7 +376,8 @@ MediaSourceTrackDemuxer::NotifyTimeRangesChanged()
     return;
   }
   MOZ_ASSERT(mParent->OnTaskQueue());
-  mNextSampleIndex = 0;
+  mBufferedRanges = mManager->Buffered(mType);
+  mBufferedRanges.SetFuzz(TimeUnit::FromMicroseconds(EOS_FUZZ_US));
 }
 
 } // namespace mozilla

--- a/dom/media/mediasource/MediaSourceDemuxer.h
+++ b/dom/media/mediasource/MediaSourceDemuxer.h
@@ -127,8 +127,7 @@ private:
   nsRefPtr<MediaSourceDemuxer> mParent;
   nsRefPtr<TrackBuffersManager> mManager;
   TrackInfo::TrackType mType;
-  uint32_t mNextSampleIndex;
-  media::TimeUnit mNextSampleTime;
+  media::TimeIntervals mBufferedRanges;
   // Monitor protecting members below accessed from multiple threads.
   Monitor mMonitor;
   media::TimeUnit mNextRandomAccessPoint;

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -321,7 +321,7 @@ SourceBuffer::SourceBuffer(MediaSource* aMediaSource, const nsACString& aType)
   MOZ_ASSERT(NS_IsMainThread());
   MOZ_ASSERT(aMediaSource);
   mEvictionThreshold = Preferences::GetUint("media.mediasource.eviction_threshold",
-                                            75 * (1 << 20));
+                                            100 * (1 << 20));
   mContentManager =
     SourceBufferContentManager::CreateManager(this,
                                               aMediaSource->GetDecoder(),

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -584,7 +584,7 @@ SourceBuffer::PrepareAppend(const uint8_t* aData, uint32_t aLength, ErrorResult&
   // See if we have enough free space to append our new data.
   // As we can only evict once we have playable data, we must give a chance
   // to the DASH player to provide a complete media segment.
-  if (aLength > mEvictionThreshold ||
+  if (aLength > mEvictionThreshold || evicted == Result::BUFFER_FULL ||
       ((!mIsUsingFormatReader &&
         mContentManager->GetSize() > mEvictionThreshold - aLength) &&
        evicted != Result::CANT_EVICT)) {
@@ -597,7 +597,6 @@ SourceBuffer::PrepareAppend(const uint8_t* aData, uint32_t aLength, ErrorResult&
     aRv.Throw(NS_ERROR_DOM_QUOTA_EXCEEDED_ERR);
     return nullptr;
   }
-  // TODO: Test buffer full flag.
   return data.forget();
 }
 

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -492,6 +492,8 @@ SourceBuffer::AppendDataCompletedWithSuccess(bool aHasActiveTracks)
         mMediaSource->GetDecoder()->NotifyWaitingForResourcesStatusChanged();
       }
     }
+  }
+  if (mActive) {
     // Tell our parent decoder that we have received new data.
     // The information provided do not matter much so long as it is monotonically
     // increasing.

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -446,7 +446,7 @@ SourceBuffer::AppendData(const uint8_t* aData, uint32_t aLength, ErrorResult& aR
 
   StartUpdating();
 
-  MOZ_ASSERT(mAppendMode == SourceBufferAppendMode::Segments,
+  MOZ_ASSERT(mIsUsingFormatReader || mAppendMode == SourceBufferAppendMode::Segments,
              "We don't handle timestampOffset for sequence mode yet");
   nsRefPtr<nsIRunnable> task = new BufferAppendRunnable(this, mUpdateID);
   NS_DispatchToMainThread(task);

--- a/dom/media/mediasource/SourceBuffer.cpp
+++ b/dom/media/mediasource/SourceBuffer.cpp
@@ -583,7 +583,8 @@ SourceBuffer::PrepareAppend(const uint8_t* aData, uint32_t aLength, ErrorResult&
   // As we can only evict once we have playable data, we must give a chance
   // to the DASH player to provide a complete media segment.
   if (aLength > mEvictionThreshold ||
-      ((mContentManager->GetSize() > mEvictionThreshold - aLength) &&
+      ((!mIsUsingFormatReader &&
+        mContentManager->GetSize() > mEvictionThreshold - aLength) &&
        evicted != Result::CANT_EVICT)) {
     aRv.Throw(NS_ERROR_DOM_QUOTA_EXCEEDED_ERR);
     return nullptr;

--- a/dom/media/mediasource/SourceBufferContentManager.h
+++ b/dom/media/mediasource/SourceBufferContentManager.h
@@ -57,6 +57,7 @@ public:
     NO_DATA_EVICTED,
     DATA_EVICTED,
     CANT_EVICT,
+    BUFFER_FULL,
   };
 
   // Evicts data up to aPlaybackTime. aThreshold is used to

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -161,6 +161,10 @@ TrackBuffersManager::EvictData(TimeUnit aPlaybackTime,
   if (toEvict <= 0) {
     return EvictDataResult::NO_DATA_EVICTED;
   }
+  if (toEvict <= 512*1024) {
+    // Don't bother evicting less than 512KB.
+    return EvictDataResult::CANT_EVICT;
+  }
   MSE_DEBUG("Reaching our size limit, schedule eviction of %lld bytes", toEvict);
 
   nsCOMPtr<nsIRunnable> task =

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -339,12 +339,12 @@ TrackBuffersManager::DoEvictData(const TimeUnit& aPlaybackTime,
 {
   MOZ_ASSERT(OnTaskQueue());
 
-  // Remove any data we've already played, up to 5s behind.
-  TimeUnit lowerLimit = aPlaybackTime - TimeUnit::FromSeconds(5);
-  TimeUnit to;
   // Video is what takes the most space, only evict there if we have video.
   const auto& track = HasVideo() ? mVideoTracks : mAudioTracks;
   const auto& buffer = track.mBuffers.LastElement();
+  // Remove any data we've already played, or before the next sample to be
+  // demuxed whichever is lowest.
+  TimeUnit lowerLimit = std::min(track.mNextSampleTime, aPlaybackTime);
   uint32_t lastKeyFrameIndex = 0;
   int64_t toEvict = aSizeToEvict;
   uint32_t partialEvict = 0;
@@ -363,18 +363,29 @@ TrackBuffersManager::DoEvictData(const TimeUnit& aPlaybackTime,
     }
     partialEvict += sizeof(*frame) + frame->Size();
   }
+
+  int64_t finalSize = mSizeSourceBuffer - aSizeToEvict;
+
   if (lastKeyFrameIndex > 0) {
+    MSE_DEBUG("Step1. Evicting %u bytes prior currentTime",
+              aSizeToEvict - toEvict);
     CodedFrameRemoval(
       TimeInterval(TimeUnit::FromMicroseconds(0),
-                   TimeUnit::FromMicroseconds(buffer[lastKeyFrameIndex-1]->mTime)));
+                   TimeUnit::FromMicroseconds(buffer[lastKeyFrameIndex]->mTime - 1)));
   }
-  if (toEvict <= 0) {
+
+  if (mSizeSourceBuffer <= finalSize) {
     return;
   }
 
-  // Still some to remove. Remove data starting from the end, up to 5s ahead
-  // of our playtime.
-  TimeUnit upperLimit = aPlaybackTime + TimeUnit::FromSeconds(5);
+  toEvict = mSizeSourceBuffer - finalSize;
+
+  // Still some to remove. Remove data starting from the end, up to 30s ahead
+  // of the later of the playback time or the next sample to be demuxed.
+  // 30s is a value chosen as it appears to work with YouTube.
+  TimeUnit upperLimit =
+    std::max(aPlaybackTime, track.mNextSampleTime) + TimeUnit::FromSeconds(30);
+  lastKeyFrameIndex = buffer.Length();
   for (int32_t i = buffer.Length() - 1; i >= 0; i--) {
     const auto& frame = buffer[i];
     if (frame->mKeyframe) {
@@ -390,9 +401,11 @@ TrackBuffersManager::DoEvictData(const TimeUnit& aPlaybackTime,
     }
     partialEvict += sizeof(*frame) + frame->Size();
   }
-  if (lastKeyFrameIndex + 1 < buffer.Length()) {
+  if (lastKeyFrameIndex < buffer.Length()) {
+    MSE_DEBUG("Step2. Evicting %u bytes from trailing data",
+              mSizeSourceBuffer - finalSize);
     CodedFrameRemoval(
-      TimeInterval(TimeUnit::FromMicroseconds(buffer[lastKeyFrameIndex+1]->mTime),
+      TimeInterval(TimeUnit::FromMicroseconds(buffer[lastKeyFrameIndex]->GetEndTime() + 1),
                    TimeUnit::FromInfinity()));
   }
 }

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -473,6 +473,12 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
         }
         track->mSizeBuffer -= sizeof(*frame) + frame->Size();
         data.RemoveElementAt(i);
+        MOZ_ASSERT(track->mNextInsertionIndex.isNothing() ||
+                   track->mNextInsertionIndex.ref() != i);
+        if (track->mNextInsertionIndex.isSome() &&
+            track->mNextInsertionIndex.ref() > i) {
+          track->mNextInsertionIndex.ref()--;
+        }
       } else {
         i++;
       }
@@ -493,6 +499,13 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
         track->mSizeBuffer -= sizeof(*sample) + sample->Size();
       }
       data.RemoveElementsAt(start, end - start);
+      MOZ_ASSERT(track->mNextInsertionIndex.isNothing() ||
+                 track->mNextInsertionIndex.ref() <= start ||
+                 track->mNextInsertionIndex.ref() >= end);
+      if (track->mNextInsertionIndex.isSome() &&
+          track->mNextInsertionIndex.ref() >= end) {
+        track->mNextInsertionIndex.ref() -= end - start;
+      }
 
       MSE_DEBUG("Removing undecodable frames from:%u (frames:%d) ([%f, %f))",
                 start, end - start,
@@ -528,10 +541,6 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
 
   // Update our reported total size.
   mSizeSourceBuffer = mVideoTracks.mSizeBuffer + mAudioTracks.mSizeBuffer;
-
-  // Reset our insertion indexes as they are now invalid.
-  mAudioTracks.mNextInsertionIndex.reset();
-  mVideoTracks.mNextInsertionIndex.reset();
 
   // Tell our demuxer that data was removed.
   mMediaSourceDemuxer->NotifyTimeRangesChanged();

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -390,7 +390,7 @@ TrackBuffersManager::DoEvictData(const TimeUnit& aPlaybackTime,
     }
     partialEvict += sizeof(*frame) + frame->Size();
   }
-  if (lastKeyFrameIndex < buffer.Length()) {
+  if (lastKeyFrameIndex + 1 < buffer.Length()) {
     CodedFrameRemoval(
       TimeInterval(TimeUnit::FromMicroseconds(buffer[lastKeyFrameIndex+1]->mTime),
                    TimeUnit::FromInfinity()));
@@ -1438,12 +1438,6 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
     data.InsertElementAt(0, aSample);
     MOZ_ASSERT(aSample->mKeyframe);
     trackBuffer.mNextInsertionIndex = Some(size_t(1));
-  } else if (presentationTimestamp >= trackBuffer.mBufferedRanges.GetEnd()) {
-    data.AppendElement(aSample);
-    MOZ_ASSERT(data.Length() <= 2 ||
-               data[data.Length()-1]->mTrackInfo->GetID() == data[data.Length()-2]->mTrackInfo->GetID() ||
-               data[data.Length()-1]->mKeyframe);
-    trackBuffer.mNextInsertionIndex = Some(data.Length());
   } else {
     // Find which discontinuity we should insert the frame before.
     TimeInterval target;
@@ -1452,6 +1446,15 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
         target = interval;
         break;
       }
+    }
+    if (target.IsEmpty()) {
+      // No existing ranges found after our frame presentation time.
+      // Insert frame at the end of array.
+      data.AppendElement(aSample);
+      MOZ_ASSERT(data.Length() <= 2 ||
+                 data[data.Length()-1]->mTrackInfo->GetID() == data[data.Length()-2]->mTrackInfo->GetID() ||
+                 data[data.Length()-1]->mKeyframe);
+      trackBuffer.mNextInsertionIndex = Some(data.Length());
     }
     for (uint32_t i = 0; i < data.Length(); i++) {
       const nsRefPtr<MediaRawData>& sample = data[i];

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -415,11 +415,11 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
   TimeUnit duration{TimeUnit::FromSeconds(mediaSourceDuration)};
 
   MSE_DEBUG("duration:%.2f", duration.ToSeconds());
-  if (HasAudio()) {
+  if (HasVideo()) {
     MSE_DEBUG("before video ranges=%s",
               DumpTimeRanges(mVideoTracks.mBufferedRanges).get());
   }
-  if (HasVideo()) {
+  if (HasAudio()) {
     MSE_DEBUG("before audio ranges=%s",
               DumpTimeRanges(mAudioTracks.mBufferedRanges).get());
   }
@@ -505,11 +505,11 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
     mAudioBufferedRanges = mAudioTracks.mBufferedRanges;
   }
 
-  if (HasAudio()) {
+  if (HasVideo()) {
     MSE_DEBUG("after video ranges=%s",
               DumpTimeRanges(mVideoTracks.mBufferedRanges).get());
   }
-  if (HasVideo()) {
+  if (HasAudio()) {
     MSE_DEBUG("after audio ranges=%s",
               DumpTimeRanges(mAudioTracks.mBufferedRanges).get());
   }

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -453,7 +453,7 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
     TimeInterval removedInterval;
     Maybe<uint32_t> firstRemovedIndex;
     TrackBuffer& data = track->mBuffers.LastElement();
-    for (uint32_t i = 0; i < data.Length(); i++) {
+    for (uint32_t i = 0; i < data.Length();) {
       const auto& frame = data[i];
       if (frame->mTime >= start.ToMicroseconds() &&
           frame->mTime < removeEndTimestamp.ToMicroseconds()) {
@@ -469,25 +469,33 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
         }
         track->mSizeBuffer -= sizeof(*frame) + frame->Size();
         data.RemoveElementAt(i);
+      } else {
+        i++;
       }
     }
     // 4. Remove decoding dependencies of the coded frames removed in the previous step:
     // Remove all coded frames between the coded frames removed in the previous step and the next random access point after those removed frames.
     if (firstRemovedIndex.isSome()) {
-      for (uint32_t i = firstRemovedIndex.ref(); i < data.Length(); i++) {
-        const auto& frame = data[i];
-        if (frame->mKeyframe) {
+      uint32_t start = firstRemovedIndex.ref();
+      uint32_t end = start;
+      for (;end < data.Length(); end++) {
+        MediaRawData* sample = data[end].get();
+        if (sample->mKeyframe) {
           break;
         }
         removedInterval = removedInterval.Span(
-          TimeInterval(TimeUnit::FromMicroseconds(frame->mTime),
-                       TimeUnit::FromMicroseconds(frame->mTime + frame->mDuration)));
-        track->mSizeBuffer -= sizeof(*frame) + frame->Size();
-        data.RemoveElementAt(i);
+          TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                       TimeUnit::FromMicroseconds(sample->GetEndTime())));
+        track->mSizeBuffer -= sizeof(*sample) + sample->Size();
       }
+      data.RemoveElementsAt(start, end - start);
+
+      MSE_DEBUG("Removing undecodable frames from:%u (frames:%d) ([%f, %f))",
+                start, end - start,
+                removedInterval.mStart.ToSeconds(), removedInterval.mEnd.ToSeconds());
+      track->mBufferedRanges -= removedInterval;
       dataRemoved = true;
     }
-    track->mBufferedRanges -= removedInterval;
 
     // 5. If this object is in activeSourceBuffers, the current playback position
     // is greater than or equal to start and less than the remove end timestamp,

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -297,6 +297,7 @@ TrackBuffersManager::CompleteResetParserState()
     // to discard now.
     track->mQueuedSamples.Clear();
     track->mLongestFrameDuration.reset();
+    track->mNextInsertionIndex.reset();
   }
   // 6. Remove all bytes from the input buffer.
   mIncomingBuffers.Clear();
@@ -450,17 +451,17 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
     // 3. Remove all media data, from this track buffer, that contain starting
     // timestamps greater than or equal to start and less than the remove end timestamp.
     TimeInterval removedInterval;
-    int32_t firstRemovedIndex = -1;
+    Maybe<uint32_t> firstRemovedIndex;
     TrackBuffer& data = track->mBuffers.LastElement();
     for (uint32_t i = 0; i < data.Length(); i++) {
       const auto& frame = data[i];
       if (frame->mTime >= start.ToMicroseconds() &&
           frame->mTime < removeEndTimestamp.ToMicroseconds()) {
-        if (firstRemovedIndex < 0) {
+        if (firstRemovedIndex.isNothing()) {
           removedInterval =
             TimeInterval(TimeUnit::FromMicroseconds(frame->mTime),
                          TimeUnit::FromMicroseconds(frame->mTime + frame->mDuration));
-          firstRemovedIndex = i;
+          firstRemovedIndex = Some(i);
         } else {
           removedInterval = removedInterval.Span(
             TimeInterval(TimeUnit::FromMicroseconds(frame->mTime),
@@ -472,8 +473,8 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
     }
     // 4. Remove decoding dependencies of the coded frames removed in the previous step:
     // Remove all coded frames between the coded frames removed in the previous step and the next random access point after those removed frames.
-    if (firstRemovedIndex >= 0) {
-      for (uint32_t i = firstRemovedIndex; i < data.Length(); i++) {
+    if (firstRemovedIndex.isSome()) {
+      for (uint32_t i = firstRemovedIndex.ref(); i < data.Length(); i++) {
         const auto& frame = data[i];
         if (frame->mKeyframe) {
           break;
@@ -515,6 +516,10 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
 
   // Update our reported total size.
   mSizeSourceBuffer = mVideoTracks.mSizeBuffer + mAudioTracks.mSizeBuffer;
+
+  // Reset our insertion indexes as they are now invalid.
+  mAudioTracks.mNextInsertionIndex.reset();
+  mVideoTracks.mNextInsertionIndex.reset();
 
   // Tell our demuxer that data was removed.
   mMediaSourceDemuxer->NotifyTimeRangesChanged();
@@ -1058,6 +1063,16 @@ TrackBuffersManager::CompleteCodedFrameProcessing()
     }
   }
   mVideoTracks.mQueuedSamples.Clear();
+#if defined(DEBUG)
+  if (HasVideo()) {
+    const auto& track = mVideoTracks.mBuffers.LastElement();
+    MOZ_ASSERT(track.IsEmpty() || track[0]->mKeyframe);
+    for (uint32_t i = 1; i < track.Length(); i++) {
+      MOZ_ASSERT((track[i-1]->mTrackInfo->GetID() == track[i]->mTrackInfo->GetID() && track[i-1]->mTimecode < track[i]->mTimecode) ||
+                 track[i]->mKeyframe);
+    }
+  }
+#endif
 
   for (auto& sample : mAudioTracks.mQueuedSamples) {
     while (true) {
@@ -1067,6 +1082,16 @@ TrackBuffersManager::CompleteCodedFrameProcessing()
     }
   }
   mAudioTracks.mQueuedSamples.Clear();
+#if defined(DEBUG)
+  if (HasAudio()) {
+    const auto& track = mAudioTracks.mBuffers.LastElement();
+    MOZ_ASSERT(track.IsEmpty() || track[0]->mKeyframe);
+    for (uint32_t i = 1; i < track.Length(); i++) {
+      MOZ_ASSERT((track[i-1]->mTrackInfo->GetID() == track[i]->mTrackInfo->GetID() && track[i-1]->mTimecode < track[i]->mTimecode) ||
+                 track[i]->mKeyframe);
+    }
+  }
+#endif
 
   {
     MonitorAutoLock mon(mMonitor);
@@ -1218,9 +1243,11 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
       // 5. Set the need random access point flag on all track buffers to true.
       track->mNeedRandomAccessPoint = true;
 
-      trackBuffer.mLongestFrameDuration.reset();
+      track->mLongestFrameDuration.reset();
+      track->mNextInsertionIndex.reset();
     }
-    MSE_DEBUG("Detected discontinuity. Restarting process");
+
+    MSE_DEBUG("Discontinuity detected. Restarting process");
     // 6. Jump to the Loop Top step above to restart processing of the current coded frame.
     return true;
   }
@@ -1262,70 +1289,70 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
   // skip this step.
 
   // 14. Remove existing coded frames in track buffer:
+  //   a) If highest end timestamp for track buffer is not set:
+  //      Remove all coded frames from track buffer that have a presentation timestamp greater than or equal to presentation timestamp and less than frame end timestamp.
+  //   b) If highest end timestamp for track buffer is set and less than or equal to presentation timestamp:
+  //      Remove all coded frames from track buffer that have a presentation timestamp greater than or equal to highest end timestamp and less than frame end timestamp.
 
   // There is an ambiguity on how to remove frames, which was lodged with:
   // https://www.w3.org/Bugs/Public/show_bug.cgi?id=28710, implementing as per
   // bug description.
-  int firstRemovedIndex = -1;
+  Maybe<uint32_t> firstRemovedIndex;
   TimeInterval removedInterval;
   TrackBuffer& data = trackBuffer.mBuffers.LastElement();
-  if (trackBuffer.mBufferedRanges.Contains(presentationTimestamp)) {
-    if (trackBuffer.mHighestEndTimestamp.isNothing()) {
-      for (uint32_t i = 0; i < data.Length(); i++) {
-        MediaRawData* sample = data[i].get();
-        if (sample->mTime >= presentationTimestamp.ToMicroseconds() &&
-            sample->mTime < frameEndTimestamp.ToMicroseconds()) {
-          if (firstRemovedIndex < 0) {
-            removedInterval =
-              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
-                           TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration));
-            firstRemovedIndex = i;
-          } else {
-            removedInterval = removedInterval.Span(
-              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
-                           TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration)));
-          }
-          trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
-          data.RemoveElementAt(i);
+  if (trackBuffer.mBufferedRanges.ContainsStrict(presentationTimestamp)) {
+    TimeUnit lowerBound =
+      trackBuffer.mHighestEndTimestamp.valueOr(presentationTimestamp);
+    for (uint32_t i = 0; i < data.Length();) {
+      MediaRawData* sample = data[i].get();
+      if (sample->mTime >= lowerBound.ToMicroseconds() &&
+          sample->mTime < frameEndTimestamp.ToMicroseconds()) {
+        if (firstRemovedIndex.isNothing()) {
+          removedInterval =
+            TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                         TimeUnit::FromMicroseconds(sample->GetEndTime()));
+          firstRemovedIndex = Some(i);
+        } else {
+          removedInterval = removedInterval.Span(
+            TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                         TimeUnit::FromMicroseconds(sample->GetEndTime())));
         }
-      }
-    } else if (trackBuffer.mHighestEndTimestamp.ref() <= presentationTimestamp) {
-      for (uint32_t i = 0; i < data.Length(); i++) {
-        MediaRawData* sample = data[i].get();
-        if (sample->mTime >= trackBuffer.mHighestEndTimestamp.ref().ToMicroseconds() &&
-            sample->mTime < frameEndTimestamp.ToMicroseconds()) {
-          if (firstRemovedIndex < 0) {
-            removedInterval =
-              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
-                           TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration));
-            firstRemovedIndex = i;
-          } else {
-            removedInterval = removedInterval.Span(
-              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
-                           TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration)));
-          }
-          trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
-          data.RemoveElementAt(i);
-        }
+        trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
+        MSE_DEBUGV("Overlapping frame:%u ([%f, %f))",
+                  i,
+                  TimeUnit::FromMicroseconds(sample->mTime).ToSeconds(),
+                  TimeUnit::FromMicroseconds(sample->GetEndTime()).ToSeconds());
+        data.RemoveElementAt(i);
+      } else {
+        i++;
       }
     }
   }
   // 15. Remove decoding dependencies of the coded frames removed in the previous step:
   // Remove all coded frames between the coded frames removed in the previous step and the next random access point after those removed frames.
-  if (firstRemovedIndex >= 0) {
-    for (uint32_t i = firstRemovedIndex; i < data.Length(); i++) {
-      MediaRawData* sample = data[i].get();
+  if (firstRemovedIndex.isSome()) {
+    uint32_t start = firstRemovedIndex.ref();
+    uint32_t end = start;
+    for (;end < data.Length(); end++) {
+      MediaRawData* sample = data[end].get();
       if (sample->mKeyframe) {
         break;
       }
       removedInterval = removedInterval.Span(
         TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
-                     TimeUnit::FromMicroseconds(sample->mTime + sample->mDuration)));
-      trackBuffer.mSizeBuffer -= sizeof(*aSample) + sample->Size();
-      data.RemoveElementAt(i);
+                     TimeUnit::FromMicroseconds(sample->GetEndTime())));
+      trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
     }
+    data.RemoveElementsAt(start, end - start);
+
+    MSE_DEBUG("Removing undecodable frames from:%u (frames:%u) ([%f, %f))",
+              start, end - start,
+              removedInterval.mStart.ToSeconds(), removedInterval.mEnd.ToSeconds());
+
     // Update our buffered range to exclude the range just removed.
     trackBuffer.mBufferedRanges -= removedInterval;
+    MOZ_ASSERT(trackBuffer.mNextInsertionIndex.isNothing() ||
+               trackBuffer.mNextInsertionIndex.ref() <= start);
   }
 
   // 16. Add the coded frame with the presentation timestamp, decode timestamp, and frame duration to the track buffer.
@@ -1333,21 +1360,50 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
   aSample->mTimecode = decodeTimestamp.ToMicroseconds();
   aSample->mTrackInfo = trackBuffer.mLastInfo;
 
-  if (firstRemovedIndex >= 0) {
-    data.InsertElementAt(firstRemovedIndex, aSample);
+  if (data.IsEmpty()) {
+    data.AppendElement(aSample);
+    MOZ_ASSERT(aSample->mKeyframe);
+    trackBuffer.mNextInsertionIndex = Some(data.Length());
+  } else if (trackBuffer.mNextInsertionIndex.isSome()) {
+    data.InsertElementAt(trackBuffer.mNextInsertionIndex.ref(), aSample);
+    MOZ_ASSERT(trackBuffer.mNextInsertionIndex.ref() == 0 ||
+               data[trackBuffer.mNextInsertionIndex.ref()]->mTrackInfo->GetID() == data[trackBuffer.mNextInsertionIndex.ref()-1]->mTrackInfo->GetID() ||
+               data[trackBuffer.mNextInsertionIndex.ref()]->mKeyframe);
+    trackBuffer.mNextInsertionIndex.ref()++;
+  } else if (presentationTimestamp < trackBuffer.mBufferedRanges.GetStart()) {
+    data.InsertElementAt(0, aSample);
+    MOZ_ASSERT(aSample->mKeyframe);
+    trackBuffer.mNextInsertionIndex = Some(size_t(1));
+  } else if (presentationTimestamp >= trackBuffer.mBufferedRanges.GetEnd()) {
+    data.AppendElement(aSample);
+    MOZ_ASSERT(data.Length() <= 2 ||
+               data[data.Length()-1]->mTrackInfo->GetID() == data[data.Length()-2]->mTrackInfo->GetID() ||
+               data[data.Length()-1]->mKeyframe);
+    trackBuffer.mNextInsertionIndex = Some(data.Length());
   } else {
-    if (data.IsEmpty() || aSample->mTimecode > data.LastElement()->mTimecode) {
-      data.AppendElement(aSample);
-    } else {
-      // Find where to insert frame.
-      for (uint32_t i = 0; i < data.Length(); i++) {
-        const auto& sample = data[i];
-        if (sample->mTimecode > aSample->mTimecode) {
-          data.InsertElementAt(i, aSample);
-          break;
-        }
+    // Find which discontinuity we should insert the frame before.
+    TimeInterval target;
+    for (const auto& interval : trackBuffer.mBufferedRanges) {
+      if (presentationTimestamp < interval.mStart) {
+        target = interval;
+        break;
       }
     }
+    for (uint32_t i = 0; i < data.Length(); i++) {
+      const nsRefPtr<MediaRawData>& sample = data[i];
+      TimeInterval sampleInterval{
+        TimeUnit::FromMicroseconds(sample->mTime),
+        TimeUnit::FromMicroseconds(sample->GetEndTime())};
+      if (target.Intersects(sampleInterval)) {
+        data.InsertElementAt(i, aSample);
+        MOZ_ASSERT(i != 0 &&
+                   (data[i]->mTrackInfo->GetID() == data[i-1]->mTrackInfo->GetID() ||
+                    data[i]->mKeyframe));
+        trackBuffer.mNextInsertionIndex = Some(size_t(i) + 1);
+        break;
+      }
+    }
+    MOZ_ASSERT(aSample->mKeyframe);
   }
   trackBuffer.mSizeBuffer += sizeof(*aSample) + aSample->Size();
 

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -59,6 +59,10 @@ TrackBuffersManager::TrackBuffersManager(dom::SourceBuffer* aParent, MediaSource
   MOZ_ASSERT(NS_IsMainThread(), "Must be instantiated on the main thread");
 }
 
+TrackBuffersManager::~TrackBuffersManager()
+{
+}
+
 bool
 TrackBuffersManager::AppendData(MediaLargeByteBuffer* aData,
                                 TimeUnit aTimestampOffset)
@@ -479,6 +483,15 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
             track->mNextInsertionIndex.ref() > i) {
           track->mNextInsertionIndex.ref()--;
         }
+
+        if (track->mNextGetSampleIndex.isSome()) {
+          if (track->mNextGetSampleIndex.ref() == i) {
+            MSE_DEBUG("Next sample to be played got evicted");
+            track->mNextGetSampleIndex.reset();
+         } else if (track->mNextGetSampleIndex.ref() > i) {
+            track->mNextGetSampleIndex.ref()--;
+          }
+        }
       } else {
         i++;
       }
@@ -507,6 +520,16 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
           track->mNextInsertionIndex.isSome() &&
           track->mNextInsertionIndex.ref() >= end) {
         track->mNextInsertionIndex.ref() -= end - start;
+      }
+
+      if (track->mNextGetSampleIndex.isSome()) {
+        if (track->mNextGetSampleIndex.ref() >= start &&
+            track->mNextGetSampleIndex.ref() < end) {
+          MSE_DEBUG("Next sample to be played got evicted");
+          track->mNextGetSampleIndex.reset();
+        } else if (track->mNextGetSampleIndex.ref() >= end) {
+          track->mNextGetSampleIndex.ref() -= end - start;
+        }
       }
 
       MSE_DEBUG("Removing undecodable frames from:%u (frames:%d) ([%f, %f))",
@@ -1193,7 +1216,6 @@ bool
 TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
                                   TrackData& aTrackData)
 {
-  TrackData* tracks[] = { &mVideoTracks, &mAudioTracks };
   TimeUnit presentationTimestamp;
   TimeUnit decodeTimestamp;
 
@@ -1259,7 +1281,7 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
       // Set group start timestamp equal to the group end timestamp.
       mGroupStartTimestamp = Some(mGroupEndTimestamp);
     }
-    for (auto& track : tracks) {
+    for (auto& track : GetTracksList()) {
       // 2. Unset the last decode timestamp on all track buffers.
       // 3. Unset the last frame duration on all track buffers.
       // 4. Unset the highest end timestamp on all track buffers.
@@ -1343,6 +1365,15 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
                   TimeUnit::FromMicroseconds(sample->mTime).ToSeconds(),
                   TimeUnit::FromMicroseconds(sample->GetEndTime()).ToSeconds());
         data.RemoveElementAt(i);
+
+        if (trackBuffer.mNextGetSampleIndex.isSome()) {
++          if (trackBuffer.mNextGetSampleIndex.ref() == i) {
++            MSE_DEBUG("Next sample to be played got evicted");
++            trackBuffer.mNextGetSampleIndex.reset();
++          } else if (trackBuffer.mNextGetSampleIndex.ref() > i) {
++            trackBuffer.mNextGetSampleIndex.ref()--;
++          }
++        }
       } else {
         i++;
       }
@@ -1368,6 +1399,16 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
     MSE_DEBUG("Removing undecodable frames from:%u (frames:%u) ([%f, %f))",
               start, end - start,
               removedInterval.mStart.ToSeconds(), removedInterval.mEnd.ToSeconds());
+
+    if (trackBuffer.mNextGetSampleIndex.isSome()) {
+      if (trackBuffer.mNextGetSampleIndex.ref() >= start &&
+          trackBuffer.mNextGetSampleIndex.ref() < end) {
+        MSE_DEBUG("Next sample to be played got evicted");
+        trackBuffer.mNextGetSampleIndex.reset();
+      } else if (trackBuffer.mNextGetSampleIndex.ref() >= end) {
+        trackBuffer.mNextGetSampleIndex.ref() -= end - start;
+      }
+    }
 
     // Update our buffered range to exclude the range just removed.
     trackBuffer.mBufferedRanges -= removedInterval;
@@ -1549,10 +1590,6 @@ TrackBuffersManager::RestartGroupStartTimestamp()
   mGroupStartTimestamp = Some(mGroupEndTimestamp);
 }
 
-TrackBuffersManager::~TrackBuffersManager()
-{
-}
-
 MediaInfo
 TrackBuffersManager::GetMetadata()
 {
@@ -1572,6 +1609,183 @@ TrackBuffersManager::GetTrackBuffer(TrackInfo::TrackType aTrack)
 {
   MOZ_ASSERT(OnTaskQueue());
   return GetTracksData(aTrack).mBuffers.LastElement();
+}
+
+TimeUnit
+TrackBuffersManager::Seek(TrackInfo::TrackType aTrack,
+                          const TimeUnit& aTime)
+{
+  MOZ_ASSERT(OnTaskQueue());
+  auto& trackBuffer = GetTracksData(aTrack);
+  const TrackBuffersManager::TrackBuffer& track = GetTrackBuffer(aTrack);
+  TimeUnit lastKeyFrameTime;
+  TimeUnit lastKeyFrameTimecode;
+  uint32_t lastKeyFrameIndex = 0;
+  for (uint32_t i = 0; i < track.Length(); i++) {
+    const nsRefPtr<MediaRawData>& sample = track[i];
+    TimeUnit sampleTime = TimeUnit::FromMicroseconds(sample->mTime);
+    if (sampleTime > aTime) {
+      break;
+    }
+    if (sample->mKeyframe) {
+      lastKeyFrameTimecode = TimeUnit::FromMicroseconds(sample->mTimecode);
+      lastKeyFrameTime = sampleTime;
+      lastKeyFrameIndex = i;
+    }
+    if (sampleTime == aTime) {
+      break;
+    }
+  }
+  trackBuffer.mNextGetSampleIndex = Some(lastKeyFrameIndex);
+  trackBuffer.mNextSampleTimecode = lastKeyFrameTimecode;
+  trackBuffer.mNextSampleTime = lastKeyFrameTime;
+
+  return lastKeyFrameTime;
+}
+
+uint32_t
+TrackBuffersManager::SkipToNextRandomAccessPoint(TrackInfo::TrackType aTrack,
+                                                 const TimeUnit& aTimeThreadshold,
+                                                 bool& aFound)
+{
+  MOZ_ASSERT(OnTaskQueue());
+  uint32_t parsed = 0;
+  auto& trackData = GetTracksData(aTrack);
+  const TrackBuffer& track = GetTrackBuffer(aTrack);
+
+  uint32_t nextSampleIndex = trackData.mNextGetSampleIndex.valueOr(0);
+  for (uint32_t i = nextSampleIndex; i < track.Length(); i++) {
+    const nsRefPtr<MediaRawData>& sample = track[i];
+    if (sample->mKeyframe &&
+        sample->mTime >= aTimeThreadshold.ToMicroseconds()) {
+      trackData.mNextSampleTimecode =
+        TimeUnit::FromMicroseconds(sample->mTimecode);
+      trackData.mNextSampleTime =
+        TimeUnit::FromMicroseconds(sample->mTime);
+      trackData.mNextGetSampleIndex = Some(i);
+      aFound = true;
+      break;
+    }
+    parsed++;
+  }
+
+  return parsed;
+}
+
+already_AddRefed<MediaRawData>
+TrackBuffersManager::GetSample(TrackInfo::TrackType aTrack,
+                               const TimeUnit& aFuzz,
+                               bool& aError)
+{
+  MOZ_ASSERT(OnTaskQueue());
+  auto& trackData = GetTracksData(aTrack);
+  const TrackBuffer& track = GetTrackBuffer(aTrack);
+
+  aError = false;
+
+  if (!track.Length() ||
+      (trackData.mNextGetSampleIndex.isSome() &&
+       trackData.mNextGetSampleIndex.ref() >= track.Length())) {
+    return nullptr;
+  }
+  if (trackData.mNextGetSampleIndex.isNothing() &&
+      trackData.mNextSampleTimecode == TimeUnit()) {
+    // First demux, get first sample.
+    trackData.mNextGetSampleIndex = Some(0u);
+  }
+
+  if (trackData.mNextGetSampleIndex.isSome()) {
+    const nsRefPtr<MediaRawData>& sample =
+      track[trackData.mNextGetSampleIndex.ref()];
+    if (trackData.mNextGetSampleIndex.ref() &&
+        sample->mTimecode > (trackData.mNextSampleTimecode + aFuzz).ToMicroseconds()) {
+      // Gap is too big. End of Stream or Waiting for Data.
+      return nullptr;
+    }
+
+    nsRefPtr<MediaRawData> p = sample->Clone();
+    if (!p) {
+      aError = true;
+      return nullptr;
+    }
+    trackData.mNextGetSampleIndex.ref()++;
+    // Estimate decode timestamp of the next sample.
+    trackData.mNextSampleTimecode =
+      TimeUnit::FromMicroseconds(sample->mTimecode + sample->mDuration);
+    trackData.mNextSampleTime =
+      TimeUnit::FromMicroseconds(sample->GetEndTime());
+    return p.forget();
+  }
+
+  // Our previous index has been overwritten, attempt to find the new one.
+  for (uint32_t i = 0; i < track.Length(); i++) {
+    const nsRefPtr<MediaRawData>& sample = track[i];
+    TimeInterval sampleInterval{
+      TimeUnit::FromMicroseconds(sample->mTimecode),
+      TimeUnit::FromMicroseconds(sample->mTimecode + sample->mDuration),
+      aFuzz};
+
+    if (sampleInterval.ContainsWithStrictEnd(trackData.mNextSampleTimecode)) {
+      nsRefPtr<MediaRawData> p = sample->Clone();
+      if (!p) {
+        // OOM
+        aError = true;
+        return nullptr;
+      }
+      trackData.mNextGetSampleIndex = Some(i+1);
+      trackData.mNextSampleTimecode = sampleInterval.mEnd;
+      trackData.mNextSampleTime =
+        TimeUnit::FromMicroseconds(sample->GetEndTime());
+      return p.forget();
+    }
+  }
+
+  // We couldn't find our sample by decode timestamp. Attempt to find it using
+  // presentation timestamp. There will likely be small jerkiness.
+    for (uint32_t i = 0; i < track.Length(); i++) {
+    const nsRefPtr<MediaRawData>& sample = track[i];
+    TimeInterval sampleInterval{
+      TimeUnit::FromMicroseconds(sample->mTime),
+      TimeUnit::FromMicroseconds(sample->GetEndTime()),
+      aFuzz};
+
+    if (sampleInterval.ContainsWithStrictEnd(trackData.mNextSampleTimecode)) {
+      nsRefPtr<MediaRawData> p = sample->Clone();
+      if (!p) {
+        // OOM
+        aError = true;
+        return nullptr;
+      }
+      trackData.mNextGetSampleIndex = Some(i+1);
+      // Estimate decode timestamp of the next sample.
+      trackData.mNextSampleTimecode = sampleInterval.mEnd;
+      trackData.mNextSampleTime =
+        TimeUnit::FromMicroseconds(sample->GetEndTime());
+      return p.forget();
+    }
+  }
+
+  MSE_DEBUG("Couldn't find sample (pts:%lld dts:%lld)",
+             trackData.mNextSampleTime.ToMicroseconds(),
+            trackData.mNextSampleTimecode.ToMicroseconds());
+  return nullptr;
+}
+
+TimeUnit
+TrackBuffersManager::GetNextRandomAccessPoint(TrackInfo::TrackType aTrack)
+{
+  auto& trackData = GetTracksData(aTrack);
+  MOZ_ASSERT(trackData.mNextGetSampleIndex.isSome());
+  const TrackBuffersManager::TrackBuffer& track = GetTrackBuffer(aTrack);
+
+  uint32_t i = trackData.mNextGetSampleIndex.ref();
+  for (; i < track.Length(); i++) {
+    const nsRefPtr<MediaRawData>& sample = track[i];
+    if (sample->mKeyframe) {
+      return TimeUnit::FromMicroseconds(sample->mTime);
+    }
+  }
+  return media::TimeUnit::FromInfinity();
 }
 
 }

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -328,6 +328,9 @@ TrackBuffersManager::CompleteResetParserState()
 
   // 7. Set append state to WAITING_FOR_SEGMENT.
   SetAppendState(AppendState::WAITING_FOR_SEGMENT);
+
+  // Reject our promise immediately.
+  mAppendPromise.RejectIfExists(NS_ERROR_ABORT, __func__);
 }
 
 void

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -287,21 +287,16 @@ TrackBuffersManager::CompleteResetParserState()
   MOZ_ASSERT(!mAppendRunning);
   MSE_DEBUG("");
 
-  for (auto track : GetTracksList()) {
+  for (auto& track : GetTracksList()) {
     // 2. Unset the last decode timestamp on all track buffers.
-    track->mLastDecodeTimestamp.reset();
     // 3. Unset the last frame duration on all track buffers.
-    track->mLastFrameDuration.reset();
     // 4. Unset the highest end timestamp on all track buffers.
-    track->mHighestEndTimestamp.reset();
     // 5. Set the need random access point flag on all track buffers to true.
-    track->mNeedRandomAccessPoint = true;
+    track->ResetAppendState();
 
     // if we have been aborted, we may have pending frames that we are going
     // to discard now.
     track->mQueuedSamples.Clear();
-    track->mLongestFrameDuration.reset();
-    track->mNextInsertionIndex.reset();
   }
   // 6. Remove all bytes from the input buffer.
   mIncomingBuffers.Clear();
@@ -452,6 +447,9 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
         }
       }
     }
+
+    bool removeCurrentCodedFrameGroup = false;
+
     // 3. Remove all media data, from this track buffer, that contain starting
     // timestamps greater than or equal to start and less than the remove end timestamp.
     TimeInterval removedInterval;
@@ -473,9 +471,11 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
         }
         track->mSizeBuffer -= sizeof(*frame) + frame->Size();
         data.RemoveElementAt(i);
-        MOZ_ASSERT(track->mNextInsertionIndex.isNothing() ||
-                   track->mNextInsertionIndex.ref() != i);
-        if (track->mNextInsertionIndex.isSome() &&
+        removeCurrentCodedFrameGroup |=
+          track->mNextInsertionIndex.isSome() &&
+          track->mNextInsertionIndex.ref() == i;
+        if (!removeCurrentCodedFrameGroup &&
+            track->mNextInsertionIndex.isSome() &&
             track->mNextInsertionIndex.ref() > i) {
           track->mNextInsertionIndex.ref()--;
         }
@@ -499,10 +499,12 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
         track->mSizeBuffer -= sizeof(*sample) + sample->Size();
       }
       data.RemoveElementsAt(start, end - start);
-      MOZ_ASSERT(track->mNextInsertionIndex.isNothing() ||
-                 track->mNextInsertionIndex.ref() <= start ||
-                 track->mNextInsertionIndex.ref() >= end);
-      if (track->mNextInsertionIndex.isSome() &&
+      removeCurrentCodedFrameGroup |=
+        track->mNextInsertionIndex.isSome() &&
+        track->mNextInsertionIndex.ref() >= start &&
+        track->mNextInsertionIndex.ref() < end;
+      if (!removeCurrentCodedFrameGroup &&
+          track->mNextInsertionIndex.isSome() &&
           track->mNextInsertionIndex.ref() >= end) {
         track->mNextInsertionIndex.ref() -= end - start;
       }
@@ -512,6 +514,9 @@ TrackBuffersManager::CodedFrameRemoval(TimeInterval aInterval)
                 removedInterval.mStart.ToSeconds(), removedInterval.mEnd.ToSeconds());
       track->mBufferedRanges -= removedInterval;
       dataRemoved = true;
+      if (removeCurrentCodedFrameGroup) {
+        track->ResetAppendState();
+      }
     }
 
     // 5. If this object is in activeSourceBuffers, the current playback position
@@ -1256,16 +1261,10 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
     }
     for (auto& track : tracks) {
       // 2. Unset the last decode timestamp on all track buffers.
-      track->mLastDecodeTimestamp.reset();
       // 3. Unset the last frame duration on all track buffers.
-      track->mLastFrameDuration.reset();
       // 4. Unset the highest end timestamp on all track buffers.
-      track->mHighestEndTimestamp.reset();
       // 5. Set the need random access point flag on all track buffers to true.
-      track->mNeedRandomAccessPoint = true;
-
-      track->mLongestFrameDuration.reset();
-      track->mNextInsertionIndex.reset();
+      track->ResetAppendState();
     }
 
     MSE_DEBUG("Discontinuity detected. Restarting process");

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -1367,13 +1367,13 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
         data.RemoveElementAt(i);
 
         if (trackBuffer.mNextGetSampleIndex.isSome()) {
-+          if (trackBuffer.mNextGetSampleIndex.ref() == i) {
-+            MSE_DEBUG("Next sample to be played got evicted");
-+            trackBuffer.mNextGetSampleIndex.reset();
-+          } else if (trackBuffer.mNextGetSampleIndex.ref() > i) {
-+            trackBuffer.mNextGetSampleIndex.ref()--;
-+          }
-+        }
+          if (trackBuffer.mNextGetSampleIndex.ref() == i) {
+            MSE_DEBUG("Next sample to be played got evicted");
+           trackBuffer.mNextGetSampleIndex.reset();
+          } else if (trackBuffer.mNextGetSampleIndex.ref() > i) {
+            trackBuffer.mNextGetSampleIndex.ref()--;
+          }
+        }
       } else {
         i++;
       }

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -739,8 +739,9 @@ TrackBuffersManager::CreateDemuxerforMIMEType()
   }
   mInputDemuxer = nullptr;
   if (mType.LowerCaseEqualsLiteral("video/webm") || mType.LowerCaseEqualsLiteral("audio/webm")) {
-    MOZ_ASSERT(false, "Waiting on WebMDemuxer");
+    NS_WARNING("Waiting on WebMDemuxer");
   // mInputDemuxer = new WebMDemuxer(mCurrentInputBuffer);
+    return;
   }
 
 #ifdef MOZ_FMP4
@@ -749,7 +750,8 @@ TrackBuffersManager::CreateDemuxerforMIMEType()
     return;
   }
 #endif
-  MOZ_ASSERT(false, "Not supported (yet)");
+  NS_WARNING("Not supported (yet)");
+  return;
 }
 
 void
@@ -776,7 +778,8 @@ TrackBuffersManager::InitializationSegmentReceived()
   }
   CreateDemuxerforMIMEType();
   if (!mInputDemuxer) {
-    MOZ_ASSERT(false, "TODO type not supported");
+    NS_WARNING("TODO type not supported");
+    RejectAppend(NS_ERROR_DOM_NOT_SUPPORTED_ERR, __func__);
     return;
   }
   mDemuxerInitRequest.Begin(mInputDemuxer->Init()

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -305,6 +305,8 @@ private:
 
   // Global size of this source buffer content.
   Atomic<int64_t> mSizeSourceBuffer;
+  uint32_t mEvictionThreshold;
+  Atomic<bool> mEvictionOccurred;
 
   // Monitor to protect following objects accessed across multiple threads.
   mutable Monitor mMonitor;

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -223,6 +223,17 @@ private:
     nsRefPtr<SharedTrackInfo> mInfo;
     // TrackInfo of the last metadata parsed (updated with each init segment.
     nsRefPtr<SharedTrackInfo> mLastInfo;
+
+    void ResetAppendState()
+    {
+      mLastDecodeTimestamp.reset();
+      mLastFrameDuration.reset();
+      mHighestEndTimestamp.reset();
+      mNeedRandomAccessPoint = true;
+
+      mLongestFrameDuration.reset();
+      mNextInsertionIndex.reset();
+    }
   };
 
   bool ProcessFrame(MediaRawData* aSample, TrackData& aTrackData);

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -8,6 +8,7 @@
 #define MOZILLA_TRACKBUFFERSMANAGER_H_
 
 #include "SourceBufferContentManager.h"
+#include "MediaDataDemuxer.h"
 #include "MediaSourceDecoder.h"
 #include "mozilla/Atomics.h"
 #include "mozilla/Maybe.h"
@@ -78,6 +79,14 @@ public:
   {
     return mEnded;
   }
+  TimeUnit Seek(TrackInfo::TrackType aTrack, const TimeUnit& aTime);
+  uint32_t SkipToNextRandomAccessPoint(TrackInfo::TrackType aTrack,
+                                       const TimeUnit& aTimeThreadshold,
+                                       bool& aFound);
+  already_AddRefed<MediaRawData> GetSample(TrackInfo::TrackType aTrack,
+                                           const TimeUnit& aFuzz,
+                                           bool& aError);
+  TimeUnit GetNextRandomAccessPoint(TrackInfo::TrackType aTrack);
 
 #if defined(DEBUG)
   void Dump(const char* aPath) override;
@@ -223,6 +232,13 @@ private:
     nsRefPtr<SharedTrackInfo> mInfo;
     // TrackInfo of the last metadata parsed (updated with each init segment.
     nsRefPtr<SharedTrackInfo> mLastInfo;
+
+    // If set, position of the next sample to be retrieved by GetSample().
+    Maybe<uint32_t> mNextGetSampleIndex;
+    // Approximation of the next sample's decode timestamp.
+    TimeUnit mNextSampleTimecode;
+    // Approximation of the next sample's presentation timestamp.
+    TimeUnit mNextSampleTime;
 
     void ResetAppendState()
     {

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -206,6 +206,10 @@ private:
     bool mNeedRandomAccessPoint;
     nsRefPtr<MediaTrackDemuxer> mDemuxer;
     MediaPromiseRequestHolder<MediaTrackDemuxer::SamplesPromise> mDemuxRequest;
+    // If set, position where the next contiguous frame will be inserted.
+    // If a discontinuity is detected, it will be unset and recalculated upon
+    // the next insertion.
+    Maybe<size_t> mNextInsertionIndex;
     // Samples just demuxed, but not yet parsed.
     TrackBuffer mQueuedSamples;
     // We only manage a single track of each type at this time.


### PR DESCRIPTION
And here are several more MSE fixes on the road to completing #1033. First, these changes affect both our current MSE implementation as well as our new architecture:

- Ensure that the MediaFormatReader is notified when new data is received (so it can fetch new samples from the media stream).
- Be slightly less aggressive about evicting data and increase the eviction threshold to 100MB (fixes playback stalls in some situations).
- If eviction fails for some reason, throw an error.

And these changes only apply to our new code (i.e. only when the media.mediasource.format-reader pref is set to true):

- Fix an issue where new data would be inserted at the wrong position (in some circumstances) when appending data to the source buffer.
- Fix an issue where calling sourcebuffer.remove() could leave the trackbuffers in an invalid and unplayable state.
- Update the insertion index on the fly (preventing the entire stream from being reparsed).
- Various fixes related to frames being handled incorrectly.
- Various fixes related to buffered/cached data.
- At this stage, only MP4 is supported. Throw an error instead of asserting if other formats (such as WebM) are passed to the TrackBuffersManager.

I've done light testing (have been unable to test as thoroughly as usual due to intermittent lack of internet service again), and everything appears to be working as intended. I did not see any regressions with either our old or new code.

While our new code still has issues (most notable being a playback hang when changing resolutions requiring a page refresh), this PR does appear to fix the visible video distortion when on YouTube.