### PR TITLE
Canvas - CanvasRenderingContext2D.drawImage can throw 0x80040111 (NS_ERROR_NOT_AVAILABLE)

### DIFF
--- a/dom/canvas/CanvasRenderingContext2D.cpp
+++ b/dom/canvas/CanvasRenderingContext2D.cpp
@@ -4410,8 +4410,11 @@ CanvasRenderingContext2D::DrawImage(const HTMLImageOrCanvasOrVideoElement& image
       res = nsLayoutUtils::SurfaceFromElement(element, sfeFlags, mTarget);
 
     if (!res.mSourceSurface && !res.mDrawInfo.mImgContainer) {
-      // Spec says to silently do nothing if the element is still loading.
-      if (!res.mIsStillLoading) {
+      // The spec says to silently do nothing in the following cases:
+      //   - The element is still loading.
+      //   - The image is bad, but it's not in the broken state (i.e., we could
+      //     decode the headers and get the size).
+      if (!res.mIsStillLoading && !res.mHasSize) {
         error.Throw(NS_ERROR_NOT_AVAILABLE);
       }
       return;

--- a/layout/base/nsLayoutUtils.h
+++ b/layout/base/nsLayoutUtils.h
@@ -2027,6 +2027,8 @@ public:
     /* Whether the element was still loading.  Some consumers need to handle
        this case specially. */
     bool mIsStillLoading;
+    /* Whether the element has a valid size. */
+    bool mHasSize;
     /* Whether the element used CORS when loading. */
     bool mCORSUsed;
     /* Whether the returned image contains premultiplied pixel data */

--- a/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.emptysrc.html.ini
+++ b/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.emptysrc.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.incomplete.emptysrc.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.incomplete.emptysrc]
-    expected: FAIL
-

--- a/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.nosrc.html.ini
+++ b/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.nosrc.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.incomplete.nosrc.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.incomplete.nosrc]
-    expected: FAIL
-

--- a/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.removedsrc.html.ini
+++ b/testing/web-platform/meta/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.removedsrc.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.incomplete.removedsrc.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.incomplete.removedsrc]
-    expected: FAIL
-


### PR DESCRIPTION
__Steps to reproduce (an example)__
https://bugzilla.mozilla.org/attachment.cgi?id=549180

Actual Results:
```
[Exception... "Component is not available" nsresult: "
0x80040111 (NS_ERROR_NOT_AVAILABLE)" location: "
JS frame :: https://bug405761.bmoattachments.org/attachment.cgi?id=549180
:: window.onload :: line 7" data: no]
```

Expected Results:
```
success
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1297211
https://bugzilla.mozilla.org/show_bug.cgi?id=1162282

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1328005
(I will check it continuously)

---

I've created the new build (x32, Windows) and tested.
