### PR TITLE
Remove forward button hiding selectors [suggestion]

### DIFF
--- a/browser/themes/linux/browser.css
+++ b/browser/themes/linux/browser.css
@@ -17,9 +17,6 @@
 %define conditionalForwardWithUrlbar       window:not([chromehidden~=toolbar]) :-moz-any(#nav-bar[currentset*="unified-back-forward-button,urlbar-container"][mode=icons],                #nav-bar:not([currentset])[mode=icons])                 > #unified-back-forward-button
 %define conditionalForwardWithUrlbar_small window:not([chromehidden~=toolbar]) :-moz-any(#nav-bar[currentset*="unified-back-forward-button,urlbar-container"][mode=icons][iconsize=small],#nav-bar:not([currentset])[mode=icons][iconsize=small]) > #unified-back-forward-button
 
-%define conditionalForwardWithUrlbarWidth 32
-%define conditionalForwardWithUrlbarWidth_small 24
-
 #menubar-items {
   -moz-box-orient: vertical; /* for flex hack */
 }
@@ -931,40 +928,6 @@ toolbar[iconsize="small"] #webrtc-status-button {
   -moz-box-orient: horizontal;
   -moz-box-align: stretch;
 }
-/*
-@conditionalForwardWithUrlbar@ + #urlbar-container {
-  -moz-padding-start: @conditionalForwardWithUrlbarWidth@px;
-  -moz-margin-start: -@conditionalForwardWithUrlbarWidth@px;
-  position: relative;
-  pointer-events: none;
-}
-
-@conditionalForwardWithUrlbar_small@ + #urlbar-container {
-  -moz-padding-start: @conditionalForwardWithUrlbarWidth_small@px;
-  -moz-margin-start: -@conditionalForwardWithUrlbarWidth_small@px;
-}
-
-@conditionalForwardWithUrlbar@ + #urlbar-container > #urlbar {
-  pointer-events: all;
-}
-
-@conditionalForwardWithUrlbar@:not([switchingtabs]) + #urlbar-container > #urlbar {
-  transition: margin-left @forwardTransitionLength@ ease-out,
-              margin-right @forwardTransitionLength@ ease-out;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled] + #urlbar-container > #urlbar:-moz-locale-dir(ltr) {
-  margin-left: -@conditionalForwardWithUrlbarWidth@px;
-}
-@conditionalForwardWithUrlbar@[forwarddisabled] + #urlbar-container > #urlbar:-moz-locale-dir(rtl) {
-  margin-right: -@conditionalForwardWithUrlbarWidth@px;
-}
-@conditionalForwardWithUrlbar_small@[forwarddisabled] + #urlbar-container > #urlbar:-moz-locale-dir(ltr) {
-  margin-left: -@conditionalForwardWithUrlbarWidth_small@px;
-}
-@conditionalForwardWithUrlbar_small@[forwarddisabled] + #urlbar-container > #urlbar:-moz-locale-dir(rtl) {
-  margin-right: -@conditionalForwardWithUrlbarWidth_small@px;
-}*/
 
 #urlbar-icons {
   -moz-box-align: center;

--- a/browser/themes/osx/browser.css
+++ b/browser/themes/osx/browser.css
@@ -876,20 +876,6 @@ toolbar[brighttext] #bookmarks-menu-button.bookmark-item {
     clip-path: url("chrome://browser/content/browser.xul#windows-urlbar-back-button-clip-path");
 }
 
-@conditionalForwardWithUrlbar@[forwarddisabled] + #urlbar-container > #urlbar {
-    /*  margin-left: -@conditionalForwardWithUrlbarWidth@px; */
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:hover:not([switchingtabs]) + #urlbar-container > #urlbar {
-    /* delay the hiding of the forward button when hovered to avoid accidental clicks on the url bar */
-    transition-delay: 100s;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:not(:hover) + #urlbar-container > #urlbar {
-    /* when not hovered anymore, trigger a new transition to hide the forward button immediately */
-    /*  margin-left: -@conditionalForwardWithUrlbarWidth@.01px; */
-}
-
 @conditionalForwardWithUrlbar@ + #urlbar-container:-moz-locale-dir(rtl),
 @conditionalForwardWithUrlbar@ + #urlbar-container > #urlbar:-moz-locale-dir(rtl) {
     /* let windows-urlbar-back-button-mask clip the urlbar's right side for RTL */
@@ -991,31 +977,6 @@ html|*.urlbar-input:-moz-lwtheme::-moz-placeholder,
 
 @conditionalForwardWithUrlbar@ + #urlbar-container > #urlbar > #identity-box {
     border-radius: 0;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled] + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box:-moz-locale-dir(ltr) {
-    padding-left: 5px;
-    transition: padding-left;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled] + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box:-moz-locale-dir(rtl) {
-    padding-right: 5px;
-    transition: padding-right;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:hover:not([switchingtabs]) + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box {
-    /* forward button hiding is delayed when hovered */
-    transition-delay: 100s;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:not(:hover) + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box:-moz-locale-dir(ltr) {
-    /* when not hovered anymore, trigger a new non-delayed transition to react to the forward button hiding */
-    padding-left: 5.01px;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:not(:hover) + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box:-moz-locale-dir(rtl) {
-    /* when not hovered anymore, trigger a new non-delayed transition to react to the forward button hiding */
-    padding-right: 5.01px;
 }
 
 #urlbar[pageproxystate="valid"] > #identity-box.verifiedIdentity {

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -1297,20 +1297,6 @@ toolbar[brighttext] #bookmarks-menu-button.bookmark-item {
   clip-path: url("chrome://browser/content/browser.xul#windows-urlbar-back-button-clip-path");
 }
 
-@conditionalForwardWithUrlbar@[forwarddisabled] + #urlbar-container > #urlbar {
-/*  margin-left: -@conditionalForwardWithUrlbarWidth@px; */
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:hover:not([switchingtabs]) + #urlbar-container > #urlbar {
-  /* delay the hiding of the forward button when hovered to avoid accidental clicks on the url bar */
-  transition-delay: 100s;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:not(:hover) + #urlbar-container > #urlbar {
-  /* when not hovered anymore, trigger a new transition to hide the forward button immediately */
-/*  margin-left: -@conditionalForwardWithUrlbarWidth@.01px; */
-}
-
 @conditionalForwardWithUrlbar@ + #urlbar-container:-moz-locale-dir(rtl),
 @conditionalForwardWithUrlbar@ + #urlbar-container > #urlbar:-moz-locale-dir(rtl) {
   /* let windows-urlbar-back-button-mask clip the urlbar's right side for RTL */
@@ -1412,31 +1398,6 @@ html|*.urlbar-input:-moz-lwtheme::-moz-placeholder,
 
 @conditionalForwardWithUrlbar@ + #urlbar-container > #urlbar > #identity-box {
   border-radius: 0;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled] + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box:-moz-locale-dir(ltr) {
-  padding-left: 5px;
-  transition: padding-left;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled] + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box:-moz-locale-dir(rtl) {
-  padding-right: 5px;
-  transition: padding-right;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:hover:not([switchingtabs]) + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box {
-  /* forward button hiding is delayed when hovered */
-  transition-delay: 100s;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:not(:hover) + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box:-moz-locale-dir(ltr) {
-  /* when not hovered anymore, trigger a new non-delayed transition to react to the forward button hiding */
-  padding-left: 5.01px;
-}
-
-@conditionalForwardWithUrlbar@[forwarddisabled]:not(:hover) + #urlbar-container > #urlbar > #notification-popup-box[hidden] + #identity-box:-moz-locale-dir(rtl) {
-  /* when not hovered anymore, trigger a new non-delayed transition to react to the forward button hiding */
-  padding-right: 5.01px;
 }
 
 #urlbar[pageproxystate="valid"] > #identity-box.verifiedIdentity {


### PR DESCRIPTION
The properties for hiding the forward button when inactive/disabled are commented, but some parts were forgotten (with the urlbar) which creates a small gap between the identity bar and the forward button.

It seems reasonable enough to fully remove the selectors for this.

Please add the `verification needed` label. Tested by editing omni.ja.