### PR TITLE
Fixes for new MSE architecture

### DIFF
--- a/dom/media/MediaInfo.h
+++ b/dom/media/MediaInfo.h
@@ -287,6 +287,11 @@ public:
 
 class EncryptionInfo {
 public:
+  EncryptionInfo()
+    : mEncrypted(false)
+  {
+  }
+
   struct InitData {
     template<typename AInitDatas>
     InitData(const nsAString& aType, AInitDatas&& aInitData)
@@ -306,22 +311,26 @@ public:
   // True if the stream has encryption metadata
   bool IsEncrypted() const
   {
-    return !mInitDatas.IsEmpty();
+    return mEncrypted;
   }
 
   template<typename AInitDatas>
   void AddInitData(const nsAString& aType, AInitDatas&& aInitData)
   {
     mInitDatas.AppendElement(InitData(aType, Forward<AInitDatas>(aInitData)));
+    mEncrypted = true;
   }
 
   void AddInitData(const EncryptionInfo& aInfo)
   {
     mInitDatas.AppendElements(aInfo.mInitDatas);
+    mEncrypted = !!mInitDatas.Length();
   }
 
   // One 'InitData' per encrypted buffer.
   InitDatas mInitDatas;
+private:
+  bool mEncrypted;
 };
 
 class MediaInfo {

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -974,10 +974,12 @@ TrackBuffersManager::OnDemuxerInitDone(nsresult)
     mVideoTracks.mLastInfo = new SharedTrackInfo(info.mVideo, streamID);
   }
 
-  // TODO CHECK ENCRYPTION
   UniquePtr<EncryptionInfo> crypto = mInputDemuxer->GetCrypto();
   if (crypto && crypto->IsEncrypted()) {
     info.mCrypto = *crypto;
+    // We clear our crypto init data array, so the MediaFormatReader will
+    // not emit an encrypted event for the same init data again.
+    info.mCrypto.mInitDatas.Clear();
     mEncrypted = true;
   }
 

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -1375,78 +1375,84 @@ TrackBuffersManager::ProcessFrame(MediaRawData* aSample,
   Maybe<uint32_t> firstRemovedIndex;
   TimeInterval removedInterval;
   TrackBuffer& data = trackBuffer.mBuffers.LastElement();
-  if (trackBuffer.mBufferedRanges.ContainsStrict(presentationTimestamp)) {
+  bool removeCodedFrames =
+    trackBuffer.mHighestEndTimestamp.isSome()
+      ? trackBuffer.mHighestEndTimestamp.ref() <= presentationTimestamp
+      : true;
+  if (removeCodedFrames) {
     TimeUnit lowerBound =
       trackBuffer.mHighestEndTimestamp.valueOr(presentationTimestamp);
-    for (uint32_t i = 0; i < data.Length();) {
-      MediaRawData* sample = data[i].get();
-      if (sample->mTime >= lowerBound.ToMicroseconds() &&
-          sample->mTime < frameEndTimestamp.ToMicroseconds()) {
-        if (firstRemovedIndex.isNothing()) {
-          removedInterval =
-            TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
-                         TimeUnit::FromMicroseconds(sample->GetEndTime()));
-          firstRemovedIndex = Some(i);
-        } else {
-          removedInterval = removedInterval.Span(
-            TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
-                         TimeUnit::FromMicroseconds(sample->GetEndTime())));
-        }
-        trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
-        MSE_DEBUGV("Overlapping frame:%u ([%f, %f))",
-                  i,
-                  TimeUnit::FromMicroseconds(sample->mTime).ToSeconds(),
-                  TimeUnit::FromMicroseconds(sample->GetEndTime()).ToSeconds());
-        data.RemoveElementAt(i);
-
-        if (trackBuffer.mNextGetSampleIndex.isSome()) {
-          if (trackBuffer.mNextGetSampleIndex.ref() == i) {
-            MSE_DEBUG("Next sample to be played got evicted");
-           trackBuffer.mNextGetSampleIndex.reset();
-          } else if (trackBuffer.mNextGetSampleIndex.ref() > i) {
-            trackBuffer.mNextGetSampleIndex.ref()--;
+    if (trackBuffer.mBufferedRanges.ContainsStrict(lowerBound)) {
+      for (uint32_t i = 0; i < data.Length();) {
+        MediaRawData* sample = data[i].get();
+        if (sample->mTime >= lowerBound.ToMicroseconds() &&
+            sample->mTime < frameEndTimestamp.ToMicroseconds()) {
+          if (firstRemovedIndex.isNothing()) {
+            removedInterval =
+              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                           TimeUnit::FromMicroseconds(sample->GetEndTime()));
+            firstRemovedIndex = Some(i);
+          } else {
+            removedInterval = removedInterval.Span(
+              TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                           TimeUnit::FromMicroseconds(sample->GetEndTime())));
           }
+          trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
+          MSE_DEBUGV("Overlapping frame:%u ([%f, %f))",
+                    i,
+                    TimeUnit::FromMicroseconds(sample->mTime).ToSeconds(),
+                    TimeUnit::FromMicroseconds(sample->GetEndTime()).ToSeconds());
+          data.RemoveElementAt(i);
+
+          if (trackBuffer.mNextGetSampleIndex.isSome()) {
+            if (trackBuffer.mNextGetSampleIndex.ref() == i) {
+              MSE_DEBUG("Next sample to be played got evicted");
+              trackBuffer.mNextGetSampleIndex.reset();
+            } else if (trackBuffer.mNextGetSampleIndex.ref() > i) {
+              trackBuffer.mNextGetSampleIndex.ref()--;
+            }
+          }
+        } else {
+          i++;
         }
-      } else {
-        i++;
       }
     }
-  }
-  // 15. Remove decoding dependencies of the coded frames removed in the previous step:
-  // Remove all coded frames between the coded frames removed in the previous step and the next random access point after those removed frames.
-  if (firstRemovedIndex.isSome()) {
-    uint32_t start = firstRemovedIndex.ref();
-    uint32_t end = start;
-    for (;end < data.Length(); end++) {
-      MediaRawData* sample = data[end].get();
-      if (sample->mKeyframe) {
-        break;
+    // 15. Remove decoding dependencies of the coded frames removed in the previous step:
+    // Remove all coded frames between the coded frames removed in the previous step and the next random access point after those removed frames.
+    if (firstRemovedIndex.isSome()) {
+      uint32_t start = firstRemovedIndex.ref();
+      uint32_t end = start;
+      for (;end < data.Length(); end++) {
+        MediaRawData* sample = data[end].get();
+        if (sample->mKeyframe) {
+          break;
+        }
+        removedInterval = removedInterval.Span(
+          TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
+                       TimeUnit::FromMicroseconds(sample->GetEndTime())));
+        trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
       }
-      removedInterval = removedInterval.Span(
-        TimeInterval(TimeUnit::FromMicroseconds(sample->mTime),
-                     TimeUnit::FromMicroseconds(sample->GetEndTime())));
-      trackBuffer.mSizeBuffer -= sizeof(*sample) + sample->Size();
-    }
-    data.RemoveElementsAt(start, end - start);
+      data.RemoveElementsAt(start, end - start);
 
-    MSE_DEBUG("Removing undecodable frames from:%u (frames:%u) ([%f, %f))",
-              start, end - start,
-              removedInterval.mStart.ToSeconds(), removedInterval.mEnd.ToSeconds());
+      MSE_DEBUG("Removing undecodable frames from:%u (frames:%u) ([%f, %f))",
+                start, end - start,
+                removedInterval.mStart.ToSeconds(), removedInterval.mEnd.ToSeconds());
 
-    if (trackBuffer.mNextGetSampleIndex.isSome()) {
-      if (trackBuffer.mNextGetSampleIndex.ref() >= start &&
-          trackBuffer.mNextGetSampleIndex.ref() < end) {
-        MSE_DEBUG("Next sample to be played got evicted");
-        trackBuffer.mNextGetSampleIndex.reset();
-      } else if (trackBuffer.mNextGetSampleIndex.ref() >= end) {
-        trackBuffer.mNextGetSampleIndex.ref() -= end - start;
+      if (trackBuffer.mNextGetSampleIndex.isSome()) {
+        if (trackBuffer.mNextGetSampleIndex.ref() >= start &&
+            trackBuffer.mNextGetSampleIndex.ref() < end) {
+          MSE_DEBUG("Next sample to be played got evicted");
+          trackBuffer.mNextGetSampleIndex.reset();
+        } else if (trackBuffer.mNextGetSampleIndex.ref() >= end) {
+          trackBuffer.mNextGetSampleIndex.ref() -= end - start;
+        }
       }
-    }
 
-    // Update our buffered range to exclude the range just removed.
-    trackBuffer.mBufferedRanges -= removedInterval;
-    MOZ_ASSERT(trackBuffer.mNextInsertionIndex.isNothing() ||
-               trackBuffer.mNextInsertionIndex.ref() <= start);
+      // Update our buffered range to exclude the range just removed.
+      trackBuffer.mBufferedRanges -= removedInterval;
+      MOZ_ASSERT(trackBuffer.mNextInsertionIndex.isNothing() ||
+                 trackBuffer.mNextInsertionIndex.ref() <= start);
+    }
   }
 
   // 16. Add the coded frame with the presentation timestamp, decode timestamp, and frame duration to the track buffer.

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -1580,11 +1580,11 @@ TrackBuffersManager::RestoreCachedVariables()
 {
   MOZ_ASSERT(OnTaskQueue());
   if (mTimestampOffset != mLastTimestampOffset) {
+    nsRefPtr<TrackBuffersManager> self = this;
     nsCOMPtr<nsIRunnable> task =
-      NS_NewRunnableMethodWithArg<TimeUnit>(
-        mParent.get(),
-        static_cast<void (dom::SourceBuffer::*)(const TimeUnit&)>(&dom::SourceBuffer::SetTimestampOffset), /* beauty uh? :) */
-        mTimestampOffset);
+      NS_NewRunnableFunction([self] {
+        self->mParent->SetTimestampOffset(self->mTimestampOffset);
+      });
     AbstractThread::MainThread()->Dispatch(task.forget());
   }
 }


### PR DESCRIPTION
Three small MSE fixes that only apply to the new architecture:

- Fix a potential crash by preventing calls to SourceBuffer outside of the main thread.
- Fix an issue where frames could be incorrectly removed in some situations (this fix brings us closer to spec).
- Correctly handle encryption if the MSE stream has multiple init segments.