### PR TITLE
[minor fix] HTML - input - dynamic maxlength didn't work

### DIFF
--- a/dom/html/nsTextEditorState.cpp
+++ b/dom/html/nsTextEditorState.cpp
@@ -1338,19 +1338,16 @@ nsTextEditorState::PrepareEditor(const nsAString *aValue)
     }
   }
 
-  if (shouldInitializeEditor) {
-    // Initialize the plaintext editor
-    nsCOMPtr<nsIPlaintextEditor> textEditor(do_QueryInterface(newEditor));
-    if (textEditor) {
+  // Initialize the plaintext editor
+  nsCOMPtr<nsIPlaintextEditor> textEditor = do_QueryInterface(newEditor);
+  if (textEditor) {
+    if (shouldInitializeEditor) {
       // Set up wrapping
       textEditor->SetWrapColumn(GetWrapCols());
-
-      // Set max text field length
-      int32_t maxLength;
-      if (GetMaxLength(&maxLength)) { 
-        textEditor->SetMaxTextLength(maxLength);
-      }
     }
+
+    // Set max text field length
+    textEditor->SetMaxTextLength(GetMaxLength());
   }
 
   nsCOMPtr<nsIContent> content = do_QueryInterface(mTextCtrlElement);
@@ -1788,22 +1785,22 @@ be called if @placeholder is the empty string when trimmed from line breaks");
   return NS_OK;
 }
 
-bool
-nsTextEditorState::GetMaxLength(int32_t* aMaxLength)
+int32_t
+nsTextEditorState::GetMaxLength()
 {
   nsCOMPtr<nsIContent> content = do_QueryInterface(mTextCtrlElement);
   nsGenericHTMLElement* element =
     nsGenericHTMLElement::FromContentOrNull(content);
-  NS_ENSURE_TRUE(element, false);
+  if (NS_WARN_IF(!element)) {
+    return -1;
+  }
 
   const nsAttrValue* attr = element->GetParsedAttr(nsGkAtoms::maxlength);
   if (attr && attr->Type() == nsAttrValue::eInteger) {
-    *aMaxLength = attr->GetIntegerValue();
-
-    return true;
+    return attr->GetIntegerValue();
   }
 
-  return false;
+  return -1;
 }
 
 void

--- a/dom/html/nsTextEditorState.h
+++ b/dom/html/nsTextEditorState.h
@@ -194,7 +194,7 @@ public:
    * @param aMaxLength the value of the max length attr
    * @returns false if attr not defined
    */
-  bool GetMaxLength(int32_t* aMaxLength);
+  int32_t GetMaxLength();
 
   void ClearValueCache() { mCachedValue.Truncate(); }
 

--- a/editor/libeditor/tests/mochitest.ini
+++ b/editor/libeditor/tests/mochitest.ini
@@ -156,3 +156,4 @@ skip-if = toolkit == 'android'
 [test_bug1068979.html]
 [test_bug1109465.html]
 [test_bug1162952.html]
+[test_bug1352799.html]

--- a/editor/libeditor/tests/test_bug1352799.html
+++ b/editor/libeditor/tests/test_bug1352799.html
@@ -1,0 +1,98 @@
+<!DOCTYPE HTML>
+<html>
+<!--
+https://bugzilla.mozilla.org/show_bug.cgi?id=1352799
+-->
+<head>
+  <title>Test for Bug 1352799</title>
+  <script type="application/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="application/javascript" src="/tests/SimpleTest/EventUtils.js"></script>
+  <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css"/>
+</head>
+<body>
+<a target="_blank" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1352799">Mozilla Bug 1352799</a>
+<p id="display"></p>
+<div id="content">
+<div id="input-container" style="display: none;">
+<input id="input" maxlength="1">
+</div>
+</div>
+<pre id="test">
+<script type="application/javascript">
+
+/** Test for Bug 1352799 **/
+SimpleTest.waitForExplicitFinish();
+SimpleTest.waitForFocus(() => {
+  var input = document.getElementById("input");
+
+  var inputcontainer = document.getElementById('input-container');
+  input.setAttribute('maxlength', 2);
+  inputcontainer.style.display = 'block';
+
+  input.focus();
+
+  synthesizeKey('1', {});
+  synthesizeKey('2', {});
+  synthesizeKey('3', {});
+
+  is(input.value, '12', 'value should be 12 with maxlength = 2');
+
+  input.value = '';
+  inputcontainer.style.display = 'none';
+
+  window.setTimeout(() => {
+    input.setAttribute('maxlength', 4);
+    inputcontainer.style.display = 'block';
+
+    input.focus();
+
+    synthesizeKey('4', {});
+    synthesizeKey('5', {});
+    synthesizeKey('6', {});
+    synthesizeKey('7', {});
+    synthesizeKey('8', {});
+
+    is(input.value, '4567', 'value should be 4567 with maxlength = 4');
+
+    inputcontainer.style.display = 'none';
+
+    window.setTimeout(() => {
+      input.setAttribute('maxlength', 2);
+      inputcontainer.style.display = 'block';
+
+      input.focus();
+
+      synthesizeKey('1', {});
+      synthesizeKey('2', {});
+
+      todo_is(input.value, '45', 'value should be 45 with maxlength = 2');
+
+      input.value = '';
+      inputcontainer.style.display = 'none';
+
+      window.setTimeout(() => {
+        input.removeAttribute('maxlength');
+        inputcontainer.style.display = 'block';
+
+        input.focus();
+
+        synthesizeKey('1', {});
+        synthesizeKey('2', {});
+        synthesizeKey('3', {});
+        synthesizeKey('4', {});
+        synthesizeKey('5', {});
+        synthesizeKey('6', {});
+        synthesizeKey('7', {});
+        synthesizeKey('8', {});
+
+        is(input.value, '12345678', 'value should be 12345678 without maxlength');
+
+        SimpleTest.finish();
+      }, 0);
+    }, 0);
+  }, 0);
+});
+</script>
+</pre>
+</body>
+</html>


### PR DESCRIPTION
An example:
https://jsfiddle.net/n44cbhgd/2/

__Steps to reproduce:__
- click b1
- input: "12" into the textbox
- click b2
- click b3
- input something into the textbox, it should be 4 char max but we can't input more than 2

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1352799

---

I've created the new build (x32, Windows) and tested.
