### PR TITLE
[minor fix] JS - make window.pageYOffset/pageXOffset/scrollX/scrollY double

### DIFF
--- a/docshell/test/file_bug1151421.html
+++ b/docshell/test/file_bug1151421.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<style>
+body, html {
+    height: 100%;
+}
+.spacer {
+    height: 80%;
+}
+</style>
+</head>
+<body onload='(parent || opener).childLoad()'>
+
+<div class="spacer"></div>
+<div id="content">content</div>
+<div class="spacer"></div>
+
+</body>
+</html>

--- a/docshell/test/mochitest.ini
+++ b/docshell/test/mochitest.ini
@@ -32,6 +32,7 @@ support-files =
   file_bug680257.html
   file_bug703855.html
   file_bug728939.html
+  file_bug1151421.html
   file_pushState_after_document_open.html
   historyframes.html
 

--- a/docshell/test/test_bug1151421.html
+++ b/docshell/test/test_bug1151421.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML>
+<html>
+<!--
+https://bugzilla.mozilla.org/show_bug.cgi?id=1151421
+-->
+<head>
+  <title>Test for Bug 1151421</title>
+  <script type="application/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>
+  <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css"/>
+</head>
+<body>
+<a target="_blank" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1151421">Mozilla Bug 1151421</a>
+
+<script type="application/javascript">
+
+/** Test for Bug 1151421 **/
+SimpleTest.waitForExplicitFinish();
+
+function childLoad() {
+  // Spin the event loop so we leave the onload handler.
+  SimpleTest.executeSoon(childLoad2);
+}
+
+function childLoad2() {
+  let cw = iframe.contentWindow;
+  let content = cw.document.getElementById("content");
+
+  // Create a function to calculate an invariant.
+  let topPlusOffset = function()
+  {
+    return Math.round(content.getBoundingClientRect().top + cw.pageYOffset);
+  }
+
+  let initialTPO = topPlusOffset();
+
+  // Scroll the iframe to various positions, and check the TPO.
+  // Scrolling down to the bottom will adjust the page offset by a fractional amount.
+  let positions = [-100, 0.17, 0, 1.5, 10.41, 1e6, 12.1];
+
+  // Run some tests with scrollTo() and ensure we have the same invariant after scrolling.
+  positions.forEach(function(pos) {
+    cw.scrollTo(0, pos);
+    is(topPlusOffset(), initialTPO, "Top plus offset should remain invariant across scrolling.");
+  });
+
+  positions.reverse().forEach(function(pos) {
+    cw.scrollTo(0, pos);
+    is(topPlusOffset(), initialTPO, "(reverse) Top plus offset should remain invariant across scrolling.");
+  });
+
+  SimpleTest.finish();
+}
+
+</script>
+
+<!-- When the iframe loads, it calls childLoad(). -->
+<br>
+<iframe height='100px' id='iframe' src='file_bug1151421.html'></iframe>
+
+</body>
+</html>

--- a/docshell/test/test_bug590573.html
+++ b/docshell/test/test_bug590573.html
@@ -136,21 +136,21 @@ function pageLoad()
     popup.scroll(0, 100);
 
     popup.history.pushState('', '', '?pushed');
-    is(popup.scrollY, 100, "test 2");
+    is(Math.round(popup.scrollY), 100, "test 2");
     popup.scroll(0, 200); // set state-2's position to 200
 
     popup.history.back();
-    is(popup.scrollY, 100, "test 3");
+    is(Math.round(popup.scrollY), 100, "test 3");
     popup.scroll(0, 150); // set original page's position to 150
 
     popup.history.forward();
-    is(popup.scrollY, 200, "test 4");
+    is(Math.round(popup.scrollY), 200, "test 4");
 
     popup.history.back();
-    is(popup.scrollY, 150, "test 5");
+    is(Math.round(popup.scrollY), 150, "test 5");
 
     popup.history.forward();
-    is(popup.scrollY, 200, "test 6");
+    is(Math.round(popup.scrollY), 200, "test 6");
 
     // At this point, the history looks like:
     //   PATH                         POSITION
@@ -195,18 +195,18 @@ function pageLoad()
     if (popup.scrollY >= 199 && popup.scrollY <= 200) {
       is(1, 1, "test 8");
     } else {
-      is(1, 0, "test 8, got " + popup.scrollY + " for popup.scrollY instead of 199|200");
+      is(1, 0, "test 8, got " + Math.round(popup.scrollY) + " for popup.scrollY instead of 199|200");
     }
 
     popup.history.back();
-    is(popup.scrollY, 150, "test 9");
+    is(Math.round(popup.scrollY), 150, "test 9");
     popup.history.forward();
 
     // Bug 821821, on android 4.0.4 on panda we get 199 instead of 200
     if (popup.scrollY >= 199 && popup.scrollY <= 200) {
       is(1, 1, "test 10");
     } else {
-      is(1, 0, "test 10, got " + popup.scrollY + " for popup.scrollY instead of 199|200");
+      is(1, 0, "test 10, got " + Math.round(popup.scrollY) + " for popup.scrollY instead of 199|200");
     }
 
     // Spin one last time...

--- a/docshell/test/test_bug653741.html
+++ b/docshell/test/test_bug653741.html
@@ -27,7 +27,7 @@ function childLoad2() {
   
   // Save the Y offset.  For sanity's sake, make sure it's not 0, because we
   // should be at the bottom of the page!
-  let origYOffset = cw.pageYOffset;
+  let origYOffset = Math.round(cw.pageYOffset);
   ok(origYOffset != 0, 'Original Y offset is not 0.');
 
   // Scroll the iframe to the top, then navigate to #bottom again.
@@ -37,7 +37,7 @@ function childLoad2() {
   // bottom again.
   cw.location = cw.location + '';
 
-  is(cw.pageYOffset, origYOffset, 'Correct offset after reloading page.');
+  is(Math.round(cw.pageYOffset), origYOffset, 'Correct offset after reloading page.');
   SimpleTest.finish();
 }
 

--- a/docshell/test/test_bug662170.html
+++ b/docshell/test/test_bug662170.html
@@ -32,7 +32,7 @@ function childLoad2() {
   cw.scrollTo(0, 300);
 
   // Did we actually scroll somewhere?
-  isnot(cw.pageYOffset, 0, 'Y offset should be non-zero after scrolling.');
+  isnot(Math.round(cw.pageYOffset), 0, 'Y offset should be non-zero after scrolling.');
 
   // Now load file_bug662170.html#, which should take us to the top of the
   // page.

--- a/dom/base/nsGlobalWindow.cpp
+++ b/dom/base/nsGlobalWindow.cpp
@@ -5736,7 +5736,7 @@ nsGlobalWindow::GetScrollMaxY(int32_t* aScrollMaxY)
   return rv.ErrorCode();
 }
 
-CSSIntPoint
+CSSPoint
 nsGlobalWindow::GetScrollXY(bool aDoFlush)
 {
   MOZ_ASSERT(IsOuterWindow());
@@ -5760,10 +5760,10 @@ nsGlobalWindow::GetScrollXY(bool aDoFlush)
     return GetScrollXY(true);
   }
 
-  return sf->GetScrollPositionCSSPixels();
+  return CSSPoint::FromAppUnits(scrollPos);
 }
 
-int32_t
+double
 nsGlobalWindow::GetScrollX(ErrorResult& aError)
 {
   FORWARD_TO_OUTER_OR_THROW(GetScrollX, (aError), aError, 0);
@@ -5779,7 +5779,7 @@ nsGlobalWindow::GetScrollX(int32_t* aScrollX)
   return rv.ErrorCode();
 }
 
-int32_t
+double
 nsGlobalWindow::GetScrollY(ErrorResult& aError)
 {
   FORWARD_TO_OUTER_OR_THROW(GetScrollY, (aError), aError, 0);

--- a/dom/base/nsGlobalWindow.h
+++ b/dom/base/nsGlobalWindow.h
@@ -955,13 +955,13 @@ public:
   void SetInnerWidth(int32_t aInnerWidth, mozilla::ErrorResult& aError);
   int32_t GetInnerHeight(mozilla::ErrorResult& aError);
   void SetInnerHeight(int32_t aInnerHeight, mozilla::ErrorResult& aError);
-  int32_t GetScrollX(mozilla::ErrorResult& aError);
-  int32_t GetPageXOffset(mozilla::ErrorResult& aError)
+  double GetScrollX(mozilla::ErrorResult& aError);
+  double GetPageXOffset(mozilla::ErrorResult& aError)
   {
     return GetScrollX(aError);
   }
-  int32_t GetScrollY(mozilla::ErrorResult& aError);
-  int32_t GetPageYOffset(mozilla::ErrorResult& aError)
+  double GetScrollY(mozilla::ErrorResult& aError);
+  double GetPageYOffset(mozilla::ErrorResult& aError)
   {
     return GetScrollY(aError);
   }
@@ -1313,7 +1313,7 @@ public:
   // If aDoFlush is true, we'll flush our own layout; otherwise we'll try to
   // just flush our parent and only flush ourselves if we think we need to.
   // Outer windows only.
-  mozilla::CSSIntPoint GetScrollXY(bool aDoFlush);
+  mozilla::CSSPoint GetScrollXY(bool aDoFlush);
 
   void GetScrollMaxXY(int32_t* aScrollMaxX, int32_t* aScrollMaxY,
                       mozilla::ErrorResult& aError);

--- a/dom/base/test/test_viewport_scroll.html
+++ b/dom/base/test/test_viewport_scroll.html
@@ -28,10 +28,10 @@ function subtest(winProp, elemProp, win, correctElement, elemToSet, otherElem1, 
   win.scrollTo(50, 50);
   elemToSet[elemProp] = 100;
   if (elemToSet == correctElement) {
-    is(win[winProp], 100, "Setting " + elemToSet.name + "." + elemProp + " should scroll");
+    is(Math.round(win[winProp]), 100, "Setting " + elemToSet.name + "." + elemProp + " should scroll");
     is(elemToSet[elemProp], 100, "Reading back " + elemToSet.name + "." + elemProp + " after scrolling");
   } else {
-    is(win[winProp], 50, "Setting " + elemToSet.name + "." + elemProp + " should not scroll");
+    is(Math.round(win[winProp]), 50, "Setting " + elemToSet.name + "." + elemProp + " should not scroll");
     is(elemToSet[elemProp], 0, "Reading back " + elemToSet.name + "." + elemProp + " after not scrolling");
   }
   if (otherElem1 == correctElement) {

--- a/dom/browser-element/mochitest/browserElement_ScrollEvent.js
+++ b/dom/browser-element/mochitest/browserElement_ScrollEvent.js
@@ -16,8 +16,8 @@ function runTest() {
   iframe.addEventListener("mozbrowserscroll", function(e) {
     ok(true, "got mozbrowserscroll event.");
     ok(e.detail, "event.detail is not null.");
-    ok(e.detail.top === 4000, "top position is correct.");
-    ok(e.detail.left === 4000, "left position is correct.");
+    ok(Math.round(e.detail.top) == 4000, "top position is correct.");
+    ok(Math.round(e.detail.left) == 4000, "left position is correct.");
     SimpleTest.finish();
   });
 

--- a/dom/tests/mochitest/general/test_domWindowUtils_scrollXY.html
+++ b/dom/tests/mochitest/general/test_domWindowUtils_scrollXY.html
@@ -31,13 +31,13 @@
       function checkGetScrollXYState(flush, vals, testName) {
         let scrollX = {}, scrollY = {};
         domWindowUtils.getScrollXY(flush, scrollX, scrollY);
-        is(scrollX.value, vals[0], "getScrollXY x for test: " + testName);
-        is(scrollY.value, vals[1], "getScrollXY y for test: " + testName);
+        is(Math.round(scrollX.value), vals[0], "getScrollXY x for test: " + testName);
+        is(Math.round(scrollY.value), vals[1], "getScrollXY y for test: " + testName);
       }
 
       function checkWindowScrollState(vals, testName) {
-        is(cwindow.scrollX, vals[0], "scrollX for test: " + testName);
-        is(cwindow.scrollY, vals[1], "scrollY for test: " + testName);
+        is(Math.round(cwindow.scrollX), vals[0], "scrollX for test: " + testName);
+        is(Math.round(cwindow.scrollY), vals[1], "scrollY for test: " + testName);
       }
 
       // Check initial state (0, 0)
@@ -67,8 +67,8 @@
       let scrollX = {}, scrollY = {};
       domWindowUtils.getScrollXY(false, scrollX, scrollY);
 
-      is(scrollX.value, 0, "scrollX is zero for display:none iframe");
-      is(scrollY.value, 0, "scrollY is zero for display:none iframe");
+      is(Math.round(scrollX.value), 0, "scrollX is zero for display:none iframe");
+      is(Math.round(scrollY.value), 0, "scrollY is zero for display:none iframe");
     }
 
     SimpleTest.waitForExplicitFinish();

--- a/dom/webidl/Window.webidl
+++ b/dom/webidl/Window.webidl
@@ -190,10 +190,10 @@ partial interface Window {
   void scrollTo(optional ScrollToOptions options);
   void scrollBy(unrestricted double x, unrestricted double y);
   void scrollBy(optional ScrollToOptions options);
-  [Replaceable, Throws] readonly attribute long scrollX;
-  [Throws] readonly attribute long pageXOffset;
-  [Replaceable, Throws] readonly attribute long scrollY;
-  [Throws] readonly attribute long pageYOffset;
+  [Replaceable, Throws] readonly attribute double scrollX;
+  [Throws] readonly attribute double pageXOffset;
+  [Replaceable, Throws] readonly attribute double scrollY;
+  [Throws] readonly attribute double pageYOffset;
 
   // client
   //[Throws] readonly attribute double screenX;

--- a/layout/forms/test/test_bug562447.html
+++ b/layout/forms/test/test_bug562447.html
@@ -23,7 +23,7 @@ addLoadEvent(function() {
 
   setTimeout(function() {
     // Make sure that we're scrolled by 5000px
-    is(window.pageYOffset, 5000, "Make sure we're scrolled correctly");
+    is(Math.round(window.pageYOffset), 5000, "Make sure we're scrolled correctly");
 
     // Scroll back up, and mess with the input box along the way
     var input = document.getElementById("WhyDoYouFocusMe");
@@ -38,14 +38,14 @@ addLoadEvent(function() {
       window.scrollTo(0, 5000);
 
       setTimeout(function() {
-        is(window.pageYOffset, 5000, "Sanity check");
+        is(Math.round(window.pageYOffset), 5000, "Sanity check");
 
         window.scrollTo(0, 0);
         input.focus();
         input.blur();
 
         setTimeout(function() {
-          isnot(window.pageYOffset, 0, "This time we shouldn't be scrolled up");
+          isnot(Math.round(window.pageYOffset), 0, "This time we shouldn't be scrolled up");
 
           SimpleTest.finish();
         }, 0);

--- a/layout/forms/test/test_bug564115.html
+++ b/layout/forms/test/test_bug564115.html
@@ -30,12 +30,12 @@ addLoadEvent(function() {
       win.scrollTo(0, 5000);
 
       setTimeout(function() {
-        is(win.pageYOffset, 5000, "Page should be scrolled correctly");
+        is(Math.round(win.pageYOffset), 5000, "Page should be scrolled correctly");
 
         // Refocus the window
         SimpleTest.waitForFocus(function() {
           SimpleTest.waitForFocus(function() {
-            is(win.pageYOffset, 5000,
+            is(Math.round(win.pageYOffset), 5000,
                "The page's scroll offset should not have been changed");
 
             win.close();


### PR DESCRIPTION
An example:
http://jsfiddle.net/janpaepke/okeg4a7n/
- When scrolling up and down, while looking at the console, the values aren't constant.

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1151421

---

I've created the new build (x32, Windows) and tested.
