### PR TITLE
[minor fix] JS - URL - add toJSON support

### DIFF
--- a/dom/base/URL.h
+++ b/dom/base/URL.h
@@ -122,6 +122,12 @@ public:
     GetHref(aRetval, aRv);
   }
 
+  void
+  ToJSON(nsString& aResult, ErrorResult& aRv) const
+  {
+    GetHref(aResult, aRv);
+  }
+
   // URLSearchParamsObserver
   void URLSearchParamsUpdated(URLSearchParams* aSearchParams) override;
 

--- a/dom/base/test/test_url.html
+++ b/dom/base/test/test_url.html
@@ -335,5 +335,11 @@
     a.href = url;
     ok(a.origin, 'http://mochi.test:8888', "The 'a' element has the correct origin");
   </script>
+
+  <script>
+    var u = new URL('http://www.example.org');
+    ok(u.toJSON(), 'http://www.example.org', "URL.toJSON()");
+    is(JSON.stringify(u), "\"http://www.example.org/\"", "JSON.stringify(u) works");
+  </script>
 </body>
 </html>

--- a/dom/webidl/URL.webidl
+++ b/dom/webidl/URL.webidl
@@ -17,6 +17,8 @@
  Constructor(DOMString url, optional DOMString base = "about:blank"),
  Exposed=(Window,Worker)]
 interface URL {
+  [Throws]
+  USVString toJSON();
 };
 URL implements URLUtils;
 URL implements URLUtilsSearchParams;

--- a/dom/workers/URL.h
+++ b/dom/workers/URL.h
@@ -116,6 +116,12 @@ public:
     GetHref(aRetval, aRv);
   }
 
+  void
+  ToJSON(nsString& aResult, ErrorResult& aRv) const
+  {
+    GetHref(aResult, aRv);
+  }
+
   // IURLSearchParamsObserver
   void URLSearchParamsUpdated(URLSearchParams* aSearchParams) override;
 


### PR DESCRIPTION
__Steps to reproduce__

1) Open Scratchpad

2) Menu: "Environment-Browser"

3) Insert the code:

``` javascript
var u = new URL("http://www.example.org");
var o = {"key": u};
console.log(JSON.stringify(o), u.toJSON(), JSON.stringify(u));
```

4) Run

5) Expected results (in Browser Console):

```
"{"key":"http://www.example.org/"}"
"http://www.example.org/"
""http://www.example.org/""
```

---

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1337702

---

I've created the new build (x32, Windows) and tested.
