### PR TITLE
Crash in ClientLayerManager::GetBackendName with Imagus 0.9.8.50+

### DIFF
--- a/gfx/layers/client/ClientLayerManager.cpp
+++ b/gfx/layers/client/ClientLayerManager.cpp
@@ -750,6 +750,7 @@ void
 ClientLayerManager::GetBackendName(nsAString& aName)
 {
   switch (mForwarder->GetCompositorBackendType()) {
+    case LayersBackend::LAYERS_NONE: aName.AssignLiteral("None"); return;
     case LayersBackend::LAYERS_BASIC: aName.AssignLiteral("Basic"); return;
     case LayersBackend::LAYERS_OPENGL: aName.AssignLiteral("OpenGL"); return;
     case LayersBackend::LAYERS_D3D9: aName.AssignLiteral("Direct3D 9"); return;

--- a/gfx/tests/browser/browser.ini
+++ b/gfx/tests/browser/browser.ini
@@ -1,0 +1,4 @@
+[DEFAULT]
+support-files =
+
+[browser_windowless_troubleshoot_crash.js]

--- a/gfx/tests/browser/browser_windowless_troubleshoot_crash.js
+++ b/gfx/tests/browser/browser_windowless_troubleshoot_crash.js
@@ -1,0 +1,43 @@
+let { Services } = Cu.import("resource://gre/modules/Services.jsm", {});
+
+add_task(function* test_windowlessBrowserTroubleshootCrash() {
+  let webNav = Services.appShell.createWindowlessBrowser(false);
+
+  let onLoaded = new Promise((resolve, reject) => {
+    let docShell = webNav.QueryInterface(Ci.nsIInterfaceRequestor)
+                         .getInterface(Ci.nsIDocShell);
+    let listener = {
+      observe(contentWindow, topic, data) {
+        let observedDocShell = contentWindow.QueryInterface(Ci.nsIInterfaceRequestor)
+                                            .getInterface(Ci.nsIWebNavigation)
+                                            .QueryInterface(Ci.nsIDocShellTreeItem)
+                                            .sameTypeRootTreeItem
+                                            .QueryInterface(Ci.nsIDocShell);
+          if (docShell === observedDocShell) {
+            Services.obs.removeObserver(listener, "content-document-global-created", false);
+            resolve();
+          }
+        }
+    }
+    Services.obs.addObserver(listener, "content-document-global-created", false);
+  });
+  webNav.loadURI("about:blank", 0, null, null, null);
+
+  yield onLoaded;
+
+  let winUtils = webNav.document.defaultView.
+                        QueryInterface(Ci.nsIInterfaceRequestor).
+                        getInterface(Ci.nsIDOMWindowUtils);
+  is(winUtils.layerManagerType, "None", "windowless browser's layerManagerType should be 'None'");
+
+  ok(true, "not crashed");
+
+  var Troubleshoot = Cu.import("resource://gre/modules/Troubleshoot.jsm", {}).Troubleshoot;
+  var data = yield new Promise((resolve, reject) => {
+    Troubleshoot.snapshot((data) => {
+      resolve(data);
+    });
+  });
+
+  ok(data.graphics.windowLayerManagerType !== "None", "windowless browser window should not set windowLayerManagerType to 'None'");
+});

--- a/gfx/tests/moz.build
+++ b/gfx/tests/moz.build
@@ -6,3 +6,4 @@
 
 XPCSHELL_TESTS_MANIFESTS += ['unit/xpcshell.ini']
 MOCHITEST_MANIFESTS += ['mochitest/mochitest.ini']
+BROWSER_CHROME_MANIFESTS += ['browser/browser.ini']

--- a/toolkit/modules/Troubleshoot.jsm
+++ b/toolkit/modules/Troubleshoot.jsm
@@ -311,11 +311,15 @@ let dataProviders = {
     data.numAcceleratedWindows = 0;
     let winEnumer = Services.ww.getWindowEnumerator();
     while (winEnumer.hasMoreElements()) {
-      data.numTotalWindows++;
       let winUtils = winEnumer.getNext().
                      QueryInterface(Ci.nsIInterfaceRequestor).
                      getInterface(Ci.nsIDOMWindowUtils);
       try {
+        // NOTE: windowless browser's windows should not be reported in the graphics troubleshoot report
+        if (winUtils.layerManagerType == "None") {
+          continue;
+        }
+        data.numTotalWindows++;
         data.windowLayerManagerType = winUtils.layerManagerType;
         data.windowLayerManagerRemote = winUtils.layerManagerRemote;
       }


### PR DESCRIPTION
Ad #1120 

The problematic function is:
`appShell.createWindowlessBrowser.loadURI()` (in `bootstrap.js`)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1218364

---

I've created the new build (x32, Windows) and tested.
