### PR TITLE
Enable new MediaSource architecture by default

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -469,8 +469,7 @@ pref("media.mediasource.mp4.enabled", true);
 pref("media.mediasource.webm.enabled", false);
 
 // Enable new MediaSource architecture.
-// NOTE: This is an on-going WIP and should not be enabled yet.
-pref("media.mediasource.format-reader", false);
+pref("media.mediasource.format-reader", true);
 
 // Enable the MediaFormatReader architecture for MP4 + MSE.
 pref("media.mediasource.format-reader.mp4", true);


### PR DESCRIPTION
They're called unstable builds for a reason, right?

Now that Vimeo plays correctly and resolution can be changed on YouTube without causing playback stalls (#1122) I feel much more comfortable with enabling this for testing purposes. Per #1119 this will disable MSE + WebM; but again, they're called unstable for a reason.

For those who have been following this, once #1122 and this PR make it to unstable, please provide feedback on any playback issues so they can be addressed before release.

Tag #1033.