### PR TITLE
Crash/hang fixes

### DIFF
--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -3226,6 +3226,9 @@ void HTMLMediaElement::FirstFrameLoaded()
 
 void HTMLMediaElement::NetworkError()
 {
+  if (mDecoder) {
+    ShutdownDecoder();
+  }
   Error(nsIDOMMediaError::MEDIA_ERR_NETWORK);
 }
 

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -917,11 +917,11 @@ MediaFormatReader::DrainDecoder(TrackType aTrack)
     return;
   }
   decoder.mNeedDraining = false;
-  if (!decoder.mDecoder) {
-    return;
-  }
+  // mOutputRequest must be set, otherwise NotifyDrainComplete()
+  // may reject the drain if a Flush recently occurred.
   decoder.mOutputRequested = true;
-  if (decoder.mNumSamplesInput == decoder.mNumSamplesOutput) {
+  if (!decoder.mDecoder ||
+      decoder.mNumSamplesInput == decoder.mNumSamplesOutput) {
     // No frames to drain.
     NotifyDrainComplete(aTrack);
     return;

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -631,6 +631,8 @@ void
 MediaFormatReader::NotifyNewOutput(TrackType aTrack, MediaData* aSample)
 {
   MOZ_ASSERT(OnTaskQueue());
+  LOGV("Received new %s sample time:%lld duration:%lld",
+       TrackTypeToStr(aTrack), aSample->mTime, aSample->mDuration);
   auto& decoder = GetDecoderData(aTrack);
   if (!decoder.mOutputRequested) {
     LOG("MediaFormatReader produced output while flushing, discarding.");
@@ -1007,6 +1009,7 @@ MediaFormatReader::Update(TrackType aTrack)
   }
 
   if (!NeedInput(decoder)) {
+    LOGV("No need for additional input");
     return;
   }
 
@@ -1118,8 +1121,9 @@ MediaFormatReader::ResetDecode()
 void
 MediaFormatReader::Output(TrackType aTrack, MediaData* aSample)
 {
-  LOGV("Decoded %s sample time=%lld dur=%lld",
-       TrackTypeToStr(aTrack), aSample->mTime, aSample->mDuration);
+  LOGV("Decoded %s sample time=%lld timecode=%lld kf=%d dur=%lld",
+       TrackTypeToStr(aTrack), aSample->mTime, aSample->mTimecode,
+       aSample->mKeyframe, aSample->mDuration);
 
   if (!aSample) {
     NS_WARNING("MediaFormatReader::Output() passed a null sample");

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -829,7 +829,7 @@ MediaFormatReader::DecodeDemuxedSamples(TrackType aTrack,
             info->GetID());
         decoder.mNeedDraining = true;
         decoder.mNextStreamSourceID = Some(info->GetID());
-        DrainDecoder(aTrack);
+        ScheduleUpdate(aTrack);
         return;
       }
 

--- a/dom/media/fmp4/MP4Demuxer.cpp
+++ b/dom/media/fmp4/MP4Demuxer.cpp
@@ -364,6 +364,7 @@ MP4TrackDemuxer::SkipToNextRandomAccessPoint(media::TimeUnit aTimeThreshold)
 int64_t
 MP4TrackDemuxer::GetEvictionOffset(media::TimeUnit aTime)
 {
+  EnsureUpToDateIndex();
   MonitorAutoLock mon(mMonitor);
   uint64_t offset = mIndex->GetEvictionOffset(aTime.ToMicroseconds());
   return int64_t(offset == std::numeric_limits<uint64_t>::max() ? 0 : offset);

--- a/dom/media/mediasource/MediaSource.cpp
+++ b/dom/media/mediasource/MediaSource.cpp
@@ -88,12 +88,12 @@ IsTypeSupported(const nsAString& aType)
       if ((mimeType.EqualsASCII("video/mp4") ||
            mimeType.EqualsASCII("audio/mp4")) &&
           !Preferences::GetBool("media.mediasource.mp4.enabled", false)) {
-        break;
+        return NS_ERROR_DOM_INVALID_STATE_ERR;
       }
       if ((mimeType.EqualsASCII("video/webm") ||
            mimeType.EqualsASCII("audio/webm")) &&
           !Preferences::GetBool("media.mediasource.webm.enabled", false)) {
-        break;
+        return NS_ERROR_DOM_INVALID_STATE_ERR;
       }
       found = true;
       break;

--- a/dom/media/mediasource/MediaSourceDemuxer.cpp
+++ b/dom/media/mediasource/MediaSourceDemuxer.cpp
@@ -136,15 +136,6 @@ MediaSourceDemuxer::GetCrypto()
 }
 
 void
-MediaSourceDemuxer::NotifyTimeRangesChanged()
-{
-  MOZ_ASSERT(OnTaskQueue());
-  for (uint32_t i = 0; i < mDemuxers.Length(); i++) {
-    mDemuxers[i]->NotifyTimeRangesChanged();
-  }
-}
-
-void
 MediaSourceDemuxer::AttachSourceBuffer(TrackBuffersManager* aSourceBuffer)
 {
   nsCOMPtr<nsIRunnable> task =
@@ -232,13 +223,6 @@ MediaSourceTrackDemuxer::MediaSourceTrackDemuxer(MediaSourceDemuxer* aParent,
   , mType(aType)
   , mMonitor("MediaSourceTrackDemuxer")
 {
-  // Force refresh of our buffered ranges.
-  nsRefPtr<MediaSourceTrackDemuxer> self = this;
-  nsCOMPtr<nsIRunnable> task =
-    NS_NewRunnableFunction([self] () {
-      self->NotifyTimeRangesChanged();
-    });
-  mParent->GetTaskQueue()->Dispatch(task.forget());
 }
 
 UniquePtr<TrackInfo>
@@ -324,7 +308,10 @@ MediaSourceTrackDemuxer::BreakCycles()
 nsRefPtr<MediaSourceTrackDemuxer::SeekPromise>
 MediaSourceTrackDemuxer::DoSeek(media::TimeUnit aTime)
 {
-  if (!mBufferedRanges.Contains(aTime)) {
+  TimeIntervals buffered = mManager->Buffered(mType);
+  buffered.SetFuzz(TimeUnit::FromMicroseconds(EOS_FUZZ_US));
+
+  if (!buffered.Contains(aTime)) {
     // We don't have the data to seek to.
     return SeekPromise::CreateAndReject(DemuxerFailureReason::WAITING_FOR_DATA,
                                         __func__);
@@ -374,17 +361,6 @@ MediaSourceTrackDemuxer::DoSkipToNextRandomAccessPoint(media::TimeUnit aTimeThre
     mManager->IsEnded() ? DemuxerFailureReason::END_OF_STREAM :
                           DemuxerFailureReason::WAITING_FOR_DATA, parsed);
   return SkipAccessPointPromise::CreateAndReject(holder, __func__);
-}
-
-void
-MediaSourceTrackDemuxer::NotifyTimeRangesChanged()
-{
-  if (!mParent) {
-    return;
-  }
-  MOZ_ASSERT(mParent->OnTaskQueue());
-  mBufferedRanges = mManager->Buffered(mType);
-  mBufferedRanges.SetFuzz(TimeUnit::FromMicroseconds(EOS_FUZZ_US));
 }
 
 } // namespace mozilla

--- a/dom/media/mediasource/MediaSourceDemuxer.h
+++ b/dom/media/mediasource/MediaSourceDemuxer.h
@@ -53,7 +53,6 @@ public:
   void AttachSourceBuffer(TrackBuffersManager* aSourceBuffer);
   void DetachSourceBuffer(TrackBuffersManager* aSourceBuffer);
   MediaTaskQueue* GetTaskQueue() { return mTaskQueue; }
-  void NotifyTimeRangesChanged();
 
 private:
   ~MediaSourceDemuxer();
@@ -112,10 +111,6 @@ public:
     return false;
   }
 
-  // Called by TrackBuffersManager to indicate that new frames were added or
-  // removed.
-  void NotifyTimeRangesChanged();
-
 private:
   nsRefPtr<SeekPromise> DoSeek(media::TimeUnit aTime);
   nsRefPtr<SamplesPromise> DoGetSamples(int32_t aNumSamples);
@@ -127,7 +122,6 @@ private:
   nsRefPtr<MediaSourceDemuxer> mParent;
   nsRefPtr<TrackBuffersManager> mManager;
   TrackInfo::TrackType mType;
-  media::TimeIntervals mBufferedRanges;
   // Monitor protecting members below accessed from multiple threads.
   Monitor mMonitor;
   media::TimeUnit mNextRandomAccessPoint;

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -529,9 +529,6 @@ TrackBuffersManager::UpdateBufferedRanges()
 #endif
 
   mOfficialGroupEndTimestamp = mGroupEndTimestamp;
-
-  // Tell our demuxer that data was removed or added.
-  mMediaSourceDemuxer->NotifyTimeRangesChanged();
 }
 
 nsRefPtr<TrackBuffersManager::AppendPromise>


### PR DESCRIPTION
This PR is a collection of crash and hang fixes for our media code (both MSE and regular media). I've been testing these patches on YouTube, Twitch, and Vimeo and have not seen any hangs or cashes (hopefully this resolves our shutdown crash that's been reported). Changes:

- Clear mDecoder in HTMLMediaElement::NetworkError() to prevent it from dispatching a task to a task queue that has already been shut down (potential shutdown hang or crash).
- Change exception code when MediaSource.addSourceBuffer() fails due to user disabling MP4 (Mozilla bug 1160441).
- Remove potentially racey (and unnecessary) code from new MSE.
- Ensure buffered index is up to date for MP4 (Mozilla bug 1180403).
- Fix up and add a bit more logging to the MediaFormatReader.
- Ensure that the MediaFormatReader correctly sets the drainComplete flag on error (fixes potential shutdown hang).

Tag #1033.