### PR TITLE
[minor fix] HTML - select - changing the value of a select to a value that matches none of the options

### DIFF
--- a/dom/html/HTMLSelectElement.cpp
+++ b/dom/html/HTMLSelectElement.cpp
@@ -1201,9 +1201,11 @@ HTMLSelectElement::SetValue(const nsAString& aValue)
     option->GetValue(optionVal);
     if (optionVal.Equals(aValue)) {
       SetSelectedIndexInternal(int32_t(i), true);
-      break;
+      return NS_OK;
     }
   }
+  // No matching option was found.
+  SetSelectedIndexInternal(-1, true);
   return NS_OK;
 }
 

--- a/dom/html/test/mochitest.ini
+++ b/dom/html/test/mochitest.ini
@@ -588,3 +588,4 @@ support-files = file_bug871161-1.html file_bug871161-2.html
 [test_window_open_close.html]
 skip-if = buildapp == 'b2g' # bug 1129014
 [test_img_complete.html]
+[test_bug1203668.html]

--- a/dom/html/test/test_bug1203668.html
+++ b/dom/html/test/test_bug1203668.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML>
+<html>
+<!--
+https://bugzilla.mozilla.org/show_bug.cgi?id=1203668
+-->
+<head>
+  <title>Test for Bug 1203668</title>
+  <script type="application/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>
+  <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css"/>
+</head>
+<body>
+<a target="_blank" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1203668">Mozilla Bug 1203668</a>
+<p id="display"></p>
+<div id="content">
+  <select class="select" multiple>
+    <option value="foo" selected>foo</option>
+    <option value="bar" selected>bar</option>
+  </select>
+  <select class="select" multiple>
+    <option value="foo">foo</option>
+    <option value="bar" selected>bar</option>
+  </select>
+  <select class="select" multiple>
+    <option value="foo">foo</option>
+    <option value="bar">bar</option>
+  </select>
+  <select class="select" size=1>
+    <option value="foo">foo</option>
+    <option value="bar" selected>bar</option>
+  </select>
+  <select class="select" size=1>
+    <option value="foo">foo</option>
+    <option value="bar">bar</option>
+  </select>
+</div>
+<pre id="test">
+<script type="application/javascript">
+
+/** Test for Bug 1203668 **/
+
+SimpleTest.waitForExplicitFinish();
+
+function runTest()
+{
+  var selects = document.querySelectorAll('.select');
+  for (i=0; i < selects.length; i++) {
+    var select = selects[i];
+    select.value = "bogus"
+    is(select.selectedIndex, -1, "no option is selected");
+    is(select.children[0].selected, false, "first option is not selected");
+    is(select.children[1].selected, false, "second option is not selected");
+  }
+
+  SimpleTest.finish();
+}
+
+SimpleTest.waitForFocus(runTest);
+
+</script>
+</pre>
+</body>
+</html>


### PR DESCRIPTION
__Steps to reproduce__

Go to: http://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_select_value
Change this line:
`document.getElementById("mySelect").value = "banana";`
with this one:
`document.getElementById("mySelect").value = "bananas";`

Actual results:
The selected value still the first value. 

Expected results:
This option should be blank.

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1203668

---

I've created the new build (x32, Windows) and tested.
