### PR TITLE
CSS - Add support "q" absolute length units

### DIFF
--- a/dom/mathml/nsMathMLElement.cpp
+++ b/dom/mathml/nsMathMLElement.cpp
@@ -474,6 +474,7 @@ nsMathMLElement::ParseNumericValue(const nsString& aString,
   else if (unit.EqualsLiteral("mm")) cssUnit = eCSSUnit_Millimeter;
   else if (unit.EqualsLiteral("pt")) cssUnit = eCSSUnit_Point;
   else if (unit.EqualsLiteral("pc")) cssUnit = eCSSUnit_Pica;
+  else if (unit.EqualsLiteral("q")) cssUnit = eCSSUnit_Quarter;
   else { // unexpected unit
     if (!(aFlags & PARSE_SUPPRESS_WARNINGS)) {
       ReportLengthParseError(aString, aDocument);

--- a/layout/style/nsCSSParser.cpp
+++ b/layout/style/nsCSSParser.cpp
@@ -6703,6 +6703,7 @@ const UnitInfo UnitData[] = {
   { STR_WITH_LEN("vmin"), eCSSUnit_ViewportMin, VARIANT_LENGTH },
   { STR_WITH_LEN("vmax"), eCSSUnit_ViewportMax, VARIANT_LENGTH },
   { STR_WITH_LEN("pc"), eCSSUnit_Pica, VARIANT_LENGTH },
+  { STR_WITH_LEN("q"), eCSSUnit_Quarter, VARIANT_LENGTH },
   { STR_WITH_LEN("deg"), eCSSUnit_Degree, VARIANT_ANGLE },
   { STR_WITH_LEN("grad"), eCSSUnit_Grad, VARIANT_ANGLE },
   { STR_WITH_LEN("rad"), eCSSUnit_Radian, VARIANT_ANGLE },

--- a/layout/style/nsCSSValue.cpp
+++ b/layout/style/nsCSSValue.cpp
@@ -331,6 +331,7 @@ nscoord nsCSSValue::GetPixelLength() const
   case eCSSUnit_Inch: scaleFactor = 96.0; break;
   case eCSSUnit_Millimeter: scaleFactor = 96/25.4; break;
   case eCSSUnit_Centimeter: scaleFactor = 96/2.54; break;
+  case eCSSUnit_Quarter: scaleFactor = 96/101.6; break;
   default:
     NS_ERROR("should never get here");
     return 0;
@@ -1674,6 +1675,7 @@ nsCSSValue::AppendToString(nsCSSProperty aProperty, nsAString& aResult,
     case eCSSUnit_Centimeter:   aResult.AppendLiteral("cm");   break;
     case eCSSUnit_Point:        aResult.AppendLiteral("pt");   break;
     case eCSSUnit_Pica:         aResult.AppendLiteral("pc");   break;
+    case eCSSUnit_Quarter:      aResult.AppendLiteral("q");    break;
 
     case eCSSUnit_ViewportWidth:  aResult.AppendLiteral("vw");   break;
     case eCSSUnit_ViewportHeight: aResult.AppendLiteral("vh");   break;
@@ -1856,6 +1858,7 @@ nsCSSValue::SizeOfExcludingThis(mozilla::MallocSizeOf aMallocSizeOf) const
     case eCSSUnit_Centimeter:
     case eCSSUnit_Pica:
     case eCSSUnit_Pixel:
+    case eCSSUnit_Quarter:
     case eCSSUnit_Degree:
     case eCSSUnit_Grad:
     case eCSSUnit_Turn:

--- a/layout/style/nsCSSValue.h
+++ b/layout/style/nsCSSValue.h
@@ -347,7 +347,8 @@ enum nsCSSUnit {
   eCSSUnit_Millimeter   = 902,    // (float) 96/25.4 CSS pixels
   eCSSUnit_Centimeter   = 903,    // (float) 96/2.54 CSS pixels
   eCSSUnit_Pica         = 904,    // (float) 12 points == 16 CSS pixls
-  eCSSUnit_Pixel        = 905,    // (float) CSS pixel unit
+  eCSSUnit_Quarter      = 905,    // (float) 96/101.6 CSS pixels
+  eCSSUnit_Pixel        = 906,    // (float) CSS pixel unit
 
   // Angular units
   eCSSUnit_Degree       = 1000,    // (float) 360 per circle

--- a/layout/style/test/test_pixel_lengths.html
+++ b/layout/style/test/test_pixel_lengths.html
@@ -13,6 +13,7 @@
 <div id="mm" style="width:25.4mm; height:25.4mm; background:orange;">mm</div>
 <div id="cm" style="width:2.54cm; height:2.54cm; background:purple;">cm</div>
 <div id="in" style="width:1in; height:1in; background:magenta;">in</div>
+<div id="q" style="width:101.6q; height:101.6q; background:blue;">q</div>
 
 <div id="mozmm" style="width:25.4mozmm; height:25.4mozmm; background:cyan;">mozmm</div>
 
@@ -37,6 +38,7 @@ function checkPixelRelativeUnits() {
   check("mm", 96);
   check("cm", 96);
   check("in", 96);
+  check("q", 96);
 }
 
 checkPixelRelativeUnits();

--- a/testing/web-platform/meta/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute.html.ini
+++ b/testing/web-platform/meta/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute.html.ini
@@ -1,9 +1,6 @@
 [parse-a-sizes-attribute.html]
   type: testharness
   disabled: investigating intermittent failures in bug 1134120
-  [<img srcset="data:,a 50w, data:,b 51w" sizes="1q"> ref sizes="1px" (standards mode)]
-    expected: FAIL
-
   [<img srcset="data:,a 50w, data:,b 51w" sizes="(),1px"> ref sizes="1px" (standards mode)]
     expected: FAIL
 
@@ -107,9 +104,6 @@
     expected: FAIL
 
   [<img srcset="data:,a 50w, data:,b 51w" sizes="(min-width:0) 0.1%"> ref sizes="100vw" (standards mode)]
-    expected: FAIL
-
-  [<img srcset="data:,a 50w, data:,b 51w" sizes="1q"> ref sizes="1px" (quirks mode)]
     expected: FAIL
 
   [<img srcset="data:,a 50w, data:,b 51w" sizes="(),1px"> ref sizes="1px" (quirks mode)]
@@ -217,9 +211,6 @@
   [<img srcset="data:,a 50w, data:,b 51w" sizes="(min-width:0) 0.1%"> ref sizes="100vw" (quirks mode)]
     expected: FAIL
 
-  [<img srcset="data:,a 50w, data:,b 51w" sizes="1q"> ref sizes="1px" (display:none)]
-    expected: FAIL
-
   [<img srcset="data:,a 50w, data:,b 51w" sizes="(),1px"> ref sizes="1px" (display:none)]
     expected: FAIL
 
@@ -323,9 +314,6 @@
     expected: FAIL
 
   [<img srcset="data:,a 50w, data:,b 51w" sizes="(min-width:0) 0.1%"> ref sizes="100vw" (display:none)]
-    expected: FAIL
-
-  [<img srcset="data:,a 50w, data:,b 51w" sizes="1q"> ref sizes="1px" (width:1000px)]
     expected: FAIL
 
   [<img srcset="data:,a 50w, data:,b 51w" sizes="(),1px"> ref sizes="1px" (width:1000px)]


### PR DESCRIPTION
Ad #1126 

An example:
```
<!DOCTYPE html>
<html>
<head>
<meta http-equiv="content-type" content="text/html; charset=utf-8">
<style type="text/css">
h3 { letter-spacing: 10Q }
</style>
<title>H3 - letter-spacing</title>
</head>
<body>
<h3>H3 - letter-spacing</h3>
</body>
</html>
```

![1](https://cloud.githubusercontent.com/assets/2373486/26639847/37255058-4626-11e7-94b0-741e85f120b9.png)
vs.
![2](https://cloud.githubusercontent.com/assets/2373486/26639856/3c8d84de-4626-11e7-95a4-2cffc4c18689.png)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1274526

---

You add the label `Standards Compliance`, please.

---

I've created the new build (x32, Windows) and tested.
