### PR TITLE
JS - A Blob URL object's origin property should not be "null"

### DIFF
--- a/dom/base/nsContentUtils.cpp
+++ b/dom/base/nsContentUtils.cpp
@@ -5862,6 +5862,26 @@ nsContentUtils::GetUTFOrigin(nsIURI* aURI, nsString& aOrigin)
       if (uri && uri != aURI) {
         return GetUTFOrigin(uri, aOrigin);
       }
+    } else {
+      // We are probably dealing with an unknown blob URL.
+      bool isBlobURL = false;
+      nsresult rv = aURI->SchemeIs(BLOBURI_SCHEME, &isBlobURL);
+      NS_ENSURE_SUCCESS(rv, rv);
+
+      if (isBlobURL) {
+        nsAutoCString path;
+        rv = aURI->GetPath(path);
+        NS_ENSURE_SUCCESS(rv, rv);
+
+        nsCOMPtr<nsIURI> uri;
+        nsresult rv = NS_NewURI(getter_AddRefs(uri), path);
+        if (NS_FAILED(rv)) {
+          aOrigin.AssignLiteral("null");
+          return NS_OK;
+        }
+
+        return GetUTFOrigin(uri, aOrigin);
+      }
     }
   }
 

--- a/dom/base/test/mochitest.ini
+++ b/dom/base/test/mochitest.ini
@@ -783,3 +783,4 @@ skip-if = buildapp == 'mulet' || buildapp == 'b2g'
 skip-if = buildapp == 'mulet' || buildapp == 'b2g'
 [test_getAttribute_after_createAttribute.html]
 [test_script_loader_crossorigin_data_url.html]
+[test_unknown_url_origin.html]

--- a/dom/base/test/test_unknown_url_origin.html
+++ b/dom/base/test/test_unknown_url_origin.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Test for unknwon URL.origin</title>
+  <script type="application/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>
+  <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css"/>
+</head>
+<body>
+  <script type="application/javascript">
+
+  is ((new URL("blob:http://foo.com/bar")).origin, "http://foo.com");
+  is ((new URL("blob:blob:http://foo.com/bar")).origin, "http://foo.com");
+
+  </script>
+</body>
+</html>


### PR DESCRIPTION
__Steps to reproduce__

1) Open Scratchpad

2) Menu: "Environment-Browser"

3) Insert the code:

``` javascript
alert(new URL("blob:http://foo.com/bar").origin);
```

4) Run

Actual results:
null

Expected results:
http://foo.com/bar
(see https://url.spec.whatwg.org/#origin)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1270451

---

I've created the new build (x32, Windows) and tested.
