### PR TITLE
More media-related crash/hang fixes

### DIFF
--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -1205,6 +1205,7 @@ nsresult HTMLMediaElement::LoadResource()
       // TODO: Handle failure: run "If the media data cannot be fetched at
       // all, due to network errors, causing the user agent to give up
       // trying to fetch the resource" section of resource fetch algorithm.
+      decoder->Shutdown();
       return NS_ERROR_FAILURE;
     }
     mMediaSource = source.forget();

--- a/dom/media/Intervals.h
+++ b/dom/media/Intervals.h
@@ -419,8 +419,8 @@ public:
     }
     T firstEnd = std::max(mIntervals[0].mStart, aInterval.mStart);
     T secondStart = std::min(mIntervals.LastElement().mEnd, aInterval.mEnd);
-    ElemType startInterval(mIntervals[0].mStart, firstEnd, aInterval.mFuzz);
-    ElemType endInterval(secondStart, mIntervals.LastElement().mEnd, aInterval.mFuzz);
+    ElemType startInterval(mIntervals[0].mStart, firstEnd);
+    ElemType endInterval(secondStart, mIntervals.LastElement().mEnd);
     SelfType intervals(Move(startInterval));
     intervals += Move(endInterval);
     return Intersection(intervals);

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -763,12 +763,11 @@ void MediaDecoder::SetMinimizePrerollUntilPlaybackStarts()
 nsresult MediaDecoder::ScheduleStateMachineThread()
 {
   MOZ_ASSERT(NS_IsMainThread());
-  NS_ASSERTION(mDecoderStateMachine,
-               "Must have state machine to start state machine thread");
-  NS_ENSURE_STATE(mDecoderStateMachine);
-
   if (mShuttingDown)
     return NS_OK;
+
+  MOZ_ASSERT(mDecoderStateMachine);
+  NS_ENSURE_STATE(mDecoderStateMachine);
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
   mDecoderStateMachine->ScheduleStateMachine();
   return NS_OK;

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -970,18 +970,20 @@ MediaFormatReader::Update(TrackType aTrack)
     needOutput = true;
     if (!decoder.mOutput.IsEmpty()) {
       // We have a decoded sample ready to be returned.
-      nsRefPtr<MediaData> output = decoder.mOutput[0];
-      decoder.mOutput.RemoveElementAt(0);
-      decoder.mSizeOfQueue -= 1;
-      if (decoder.mTimeThreshold.isNothing() ||
-          media::TimeUnit::FromMicroseconds(output->mTime) >= decoder.mTimeThreshold.ref()) {
-        ReturnOutput(output, aTrack);
-        decoder.mTimeThreshold.reset();
-      } else {
-        LOGV("Internal Seeking: Dropping frame time:%f wanted:%f (kf:%d)",
-             media::TimeUnit::FromMicroseconds(output->mTime).ToSeconds(),
-             decoder.mTimeThreshold.ref().ToSeconds(),
-             output->mKeyframe);
+      while (decoder.mOutput.Length()) {
+        nsRefPtr<MediaData> output = decoder.mOutput[0];
+        decoder.mOutput.RemoveElementAt(0);
+        decoder.mSizeOfQueue -= 1;
+        if (decoder.mTimeThreshold.isNothing() ||
+            media::TimeUnit::FromMicroseconds(output->mTime) >= decoder.mTimeThreshold.ref()) {
+          ReturnOutput(output, aTrack);
+          decoder.mTimeThreshold.reset();
+        } else {
+          LOGV("Internal Seeking: Dropping frame time:%f wanted:%f (kf:%d)",
+               media::TimeUnit::FromMicroseconds(output->mTime).ToSeconds(),
+               decoder.mTimeThreshold.ref().ToSeconds(),
+               output->mKeyframe);
+        }
       }
     } else if (decoder.mDrainComplete) {
       decoder.mDrainComplete = false;

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -898,7 +898,11 @@ MediaFormatReader::DecodeDemuxedSamples(TrackType aTrack,
     if (aTrack == TrackInfo::kVideoTrack) {
       aA.mParsed++;
     }
-    decoder.mDecoder->Input(sample);
+    if (NS_FAILED(decoder.mDecoder->Input(sample))) {
+      LOG("Unable to pass frame to decoder");
+      NotifyError(aTrack);
+      return;
+    }
     decoder.mQueuedSamples.RemoveElementAt(0);
     samplesPending = true;
   }

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -974,20 +974,18 @@ MediaFormatReader::Update(TrackType aTrack)
     needOutput = true;
     if (!decoder.mOutput.IsEmpty()) {
       // We have a decoded sample ready to be returned.
-      while (decoder.mOutput.Length()) {
-        nsRefPtr<MediaData> output = decoder.mOutput[0];
-        decoder.mOutput.RemoveElementAt(0);
-        decoder.mSizeOfQueue -= 1;
-        if (decoder.mTimeThreshold.isNothing() ||
-            media::TimeUnit::FromMicroseconds(output->mTime) >= decoder.mTimeThreshold.ref()) {
-          ReturnOutput(output, aTrack);
-          decoder.mTimeThreshold.reset();
-        } else {
-          LOGV("Internal Seeking: Dropping frame time:%f wanted:%f (kf:%d)",
-               media::TimeUnit::FromMicroseconds(output->mTime).ToSeconds(),
-               decoder.mTimeThreshold.ref().ToSeconds(),
-               output->mKeyframe);
-        }
+      nsRefPtr<MediaData> output = decoder.mOutput[0];
+      decoder.mOutput.RemoveElementAt(0);
+      decoder.mSizeOfQueue -= 1;
+      if (decoder.mTimeThreshold.isNothing() ||
+          media::TimeUnit::FromMicroseconds(output->mTime) >= decoder.mTimeThreshold.ref()) {
+        ReturnOutput(output, aTrack);
+        decoder.mTimeThreshold.reset();
+      } else {
+        LOGV("Internal Seeking: Dropping frame time:%f wanted:%f (kf:%d)",
+             media::TimeUnit::FromMicroseconds(output->mTime).ToSeconds(),
+             decoder.mTimeThreshold.ref().ToSeconds(),
+             output->mKeyframe);
       }
     } else if (decoder.mDrainComplete) {
       decoder.mDrainComplete = false;

--- a/dom/media/gtest/TestIntervalSet.cpp
+++ b/dom/media/gtest/TestIntervalSet.cpp
@@ -777,4 +777,46 @@ TEST(IntervalSet, Substraction)
   EXPECT_EQ(1u, i0.Length());
   EXPECT_EQ(5, i0[0].mStart);
   EXPECT_EQ(8, i0[0].mEnd);
+
+  i0 = IntIntervals();
+  i0 += IntInterval(0, 10);
+  IntIntervals i2;
+  i2 += IntInterval(4, 6);
+  i0 -= i2;
+  EXPECT_EQ(2u, i0.Length());
+  EXPECT_EQ(0, i0[0].mStart);
+  EXPECT_EQ(4, i0[0].mEnd);
+  EXPECT_EQ(6, i0[1].mStart);
+  EXPECT_EQ(10, i0[1].mEnd);
+
+  i0 = IntIntervals();
+  i0 += IntInterval(0, 1);
+  i0 += IntInterval(3, 10);
+  EXPECT_EQ(2u, i0.Length());
+  // This fuzz should collapse i0 into [0,10).
+  i0.SetFuzz(1);
+  EXPECT_EQ(1u, i0.Length());
+  EXPECT_EQ(1, i0[0].mFuzz);
+  i2 = IntInterval(4, 6);
+  i0 -= i2;
+  EXPECT_EQ(2u, i0.Length());
+  EXPECT_EQ(0, i0[0].mStart);
+  EXPECT_EQ(4, i0[0].mEnd);
+  EXPECT_EQ(6, i0[1].mStart);
+  EXPECT_EQ(10, i0[1].mEnd);
+  EXPECT_EQ(1, i0[0].mFuzz);
+  EXPECT_EQ(1, i0[1].mFuzz);
+
+  i0 = IntIntervals();
+  i0 += IntInterval(0, 10);
+  // [4,6) with fuzz 1 used to fail because the complementary interval set
+  // [0,4)+[6,10) would collapse into [0,10).
+  i2 = IntInterval(4, 6);
+  i2.SetFuzz(1);
+  i0 -= i2;
+  EXPECT_EQ(2u, i0.Length());
+  EXPECT_EQ(0, i0[0].mStart);
+  EXPECT_EQ(4, i0[0].mEnd);
+  EXPECT_EQ(6, i0[1].mStart);
+  EXPECT_EQ(10, i0[1].mEnd);
 }

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -916,6 +916,13 @@ TrackBuffersManager::OnDemuxerInitDone(nsresult)
     // 6. Set first initialization segment received flag to true.
     mFirstInitializationSegmentReceived = true;
   } else {
+    // Check that audio configuration hasn't changed as this is something
+    // we do not support yet (Mozilla bug 1185827).
+    if (mAudioTracks.mNumTracks &&
+        (info.mAudio.mChannels != mAudioTracks.mInfo->GetAsAudioInfo()->mChannels ||
+         info.mAudio.mRate != mAudioTracks.mInfo->GetAsAudioInfo()->mRate)) {
+      RejectAppend(NS_ERROR_FAILURE, __func__);
+    }
     mAudioTracks.mLastInfo = new SharedTrackInfo(info.mAudio, streamID);
     mVideoTracks.mLastInfo = new SharedTrackInfo(info.mVideo, streamID);
   }

--- a/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
@@ -1673,6 +1673,11 @@ status_t MPEG4Extractor::parseChunk(off64_t *offset, int depth) {
 
         case FOURCC('a', 'v', 'c', 'C'):
         {
+            if (chunk_data_size < 7) {
+              ALOGE("short avcC chunk (%d bytes)", chunk_data_size);
+              return ERROR_MALFORMED;
+            }
+
             sp<ABuffer> buffer = new ABuffer(chunk_data_size);
 
             if (mDataSource->readAt(


### PR DESCRIPTION
#A few more crash/hang fixes related to our media and new MSE code:

- Shutdown decoder in HTMLMediaElement a bit earlier (crash fix).
- Reject MP4 streams with short avc chunks (fixes a crash if a invalid or malicious file is played).
- Error out when an audio format configuration change is detected in MSE streams (instead of crashing).
- Small crash fix in Intervals code.
- Make MediaFormatReader actually check the value of MediaDataDecoder::Input instead of assuming it is always NS_OK.

Tested on YouTube, Vimeo and Twitch and works as intended. Also have a testcase:

http://www.musepen.com/blog/adobe-muse-hover-rolling-push-widget/  -- This URL will crash a current trunk build. With these patches, the page loads correctly.