### PR TITLE
HTML - anchor - without href attribute inside label does not activate associated form element

### DIFF
--- a/dom/html/HTMLAnchorElement.cpp
+++ b/dom/html/HTMLAnchorElement.cpp
@@ -43,6 +43,13 @@ HTMLAnchorElement::~HTMLAnchorElement()
 {
 }
 
+bool
+HTMLAnchorElement::IsInteractiveHTMLContent(bool aIgnoreTabindex) const
+{
+  return HasAttr(kNameSpaceID_None, nsGkAtoms::href) ||
+         nsGenericHTMLElement::IsInteractiveHTMLContent(aIgnoreTabindex);
+}
+
 NS_INTERFACE_TABLE_HEAD_CYCLE_COLLECTION_INHERITED(HTMLAnchorElement)
   NS_INTERFACE_TABLE_INHERITED(HTMLAnchorElement,
                                nsIDOMHTMLAnchorElement,

--- a/dom/html/HTMLAnchorElement.h
+++ b/dom/html/HTMLAnchorElement.h
@@ -43,10 +43,7 @@ public:
   virtual bool Draggable() const override;
 
   // Element
-  virtual bool IsInteractiveHTMLContent(bool aIgnoreTabindex) const override
-  {
-    return true;
-  }
+  virtual bool IsInteractiveHTMLContent(bool aIgnoreTabindex) const override;
 
   // nsIDOMHTMLAnchorElement
   NS_DECL_NSIDOMHTMLANCHORELEMENT

--- a/dom/html/test/forms/test_interactive_content_in_label.html
+++ b/dom/html/test/forms/test_interactive_content_in_label.html
@@ -33,12 +33,13 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=229925
     <textarea id="yes13" cols="1" rows="1"></textarea>
     <video id="yes14" controls></video>
 
-    <audio id="no1"></audio>
-    <img id="no2" src="data:image/png,">
-    <input id="no3" type="hidden">
-    <object id="no4">object</object>
-    <video id="no5"></video>
-    <span id="no6" tabindex="1">tabindex</span>
+    <a id="no1">a</a>
+    <audio id="no2"></audio>
+    <img id="no3" src="data:image/png,">
+    <input id="no4" type="hidden">
+    <object id="no5">object</object>
+    <video id="no6"></video>
+    <span id="no7" tabindex="1">tabindex</span>
   </label>
 </form>
 <script class="testbody" type="text/javascript">
@@ -72,6 +73,7 @@ var no_nodes = [
   document.getElementById("no4"),
   document.getElementById("no5"),
   document.getElementById("no6"),
+  document.getElementById("no7"),
 ];
 
 var target_clicked = false;


### PR DESCRIPTION
An example:
```
<label for="a">
<a>Click Here</a>
</label>
<input id="a" type="checkbox">

```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1175523

---

I've created the new build (x32, Windows) and tested.
