### PR TITLE
CSS - non-floated block formatting context only checks top edge for overlap (follow up)

### DIFF
--- a/layout/generic/crashtests/1222783.xhtml
+++ b/layout/generic/crashtests/1222783.xhtml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<title>Test, bug 1222783</title>
+<body>
+
+
+<div id="container" style="width: 400px">
+  <div id="float1" style="float: left; height: 50px; width: 50px"></div>
+  <div id="float2" style="float: left; clear: left; height: 50px; width: 200px"></div>
+
+  <frameset cols="50%,50%">
+    <frame></frame>
+    <frame></frame>
+  </frameset>
+</div>
+
+</body>
+</html>

--- a/layout/generic/crashtests/crashtests.list
+++ b/layout/generic/crashtests/crashtests.list
@@ -576,3 +576,4 @@ load 1039454-1.html
 load 1042489.html
 load 1054010-1.html
 load 1058954-1.html
+load 1222783.xhtml

--- a/layout/generic/nsBlockFrame.cpp
+++ b/layout/generic/nsBlockFrame.cpp
@@ -906,21 +906,45 @@ nsBlockFrame::GetPrefWidthTightBounds(nsRenderingContext* aRenderingContext,
   return NS_OK;
 }
 
+/**
+ * Return whether aNewAvailableSpace is smaller *on either side*
+ * (inline-start or inline-end) than aOldAvailableSpace, so that we know
+ * if we need to redo layout on an line, replaced block, or block
+ * formatting context, because its height (which we used to compute
+ * aNewAvailableSpace) caused it to intersect additional floats.
+ */
 static bool
 AvailableSpaceShrunk(WritingMode aWM,
                      const LogicalRect& aOldAvailableSpace,
-                     const LogicalRect& aNewAvailableSpace)
+                     const LogicalRect& aNewAvailableSpace,
+                     bool aCanGrow /* debug-only */)
+
 {
   if (aNewAvailableSpace.ISize(aWM) == 0) {
     // Positions are not significant if the inline size is zero.
     return aOldAvailableSpace.ISize(aWM) != 0;
   }
-  NS_ASSERTION(aOldAvailableSpace.IStart(aWM) <=
-               aNewAvailableSpace.IStart(aWM) &&
-               aOldAvailableSpace.IEnd(aWM) >=
-               aNewAvailableSpace.IEnd(aWM),
-               "available space should never grow");
-  return aOldAvailableSpace.ISize(aWM) != aNewAvailableSpace.ISize(aWM);
+  if (aCanGrow) {
+    NS_ASSERTION(aNewAvailableSpace.IStart(aWM) <=
+                   aOldAvailableSpace.IStart(aWM) ||
+                 aNewAvailableSpace.IEnd(aWM) <= aOldAvailableSpace.IEnd(aWM),
+                 "available space should not shrink on the start side and "
+                 "grow on the end side");
+    NS_ASSERTION(aNewAvailableSpace.IStart(aWM) >=
+                   aOldAvailableSpace.IStart(aWM) ||
+                 aNewAvailableSpace.IEnd(aWM) >= aOldAvailableSpace.IEnd(aWM),
+                 "available space should not grow on the start side and "
+                 "shrink on the end side");
+  } else {
+    NS_ASSERTION(aOldAvailableSpace.IStart(aWM) <=
+                 aNewAvailableSpace.IStart(aWM) &&
+                 aOldAvailableSpace.IEnd(aWM) >=
+                 aNewAvailableSpace.IEnd(aWM),
+                 "available space should never grow");
+  }
+  // Have we shrunk on either side?
+  return aNewAvailableSpace.IStart(aWM) > aOldAvailableSpace.IStart(aWM) ||
+         aNewAvailableSpace.IEnd(aWM) < aOldAvailableSpace.IEnd(aWM);
 }
 
 static LogicalSize
@@ -3388,8 +3412,18 @@ nsBlockFrame::ReflowBlockFrame(nsBlockReflowState& aState,
       // Restore the height to the position of the next band.
       floatAvailableSpace.mRect.BSize(wm) =
         oldFloatAvailableSpaceRect.BSize(wm);
+      // Determine whether the available space shrunk on either side,
+      // because (the first time round) we now know the block's height,
+      // and it may intersect additional floats, or (on later
+      // iterations) because narrowing the width relative to the
+      // previous time may cause the block to become taller.  Note that
+      // since we're reflowing the block, narrowing the width might also
+      // make it shorter, so we must pass aCanGrow as true.
       if (!AvailableSpaceShrunk(wm, oldFloatAvailableSpaceRect,
-                                floatAvailableSpace.mRect)) {
+                                floatAvailableSpace.mRect, true)) {
+        // The size and position we chose before are fine (i.e., they
+        // don't cause intersecting with floats that requires a change
+        // in size or position), so we're done.
         break;
       }
 
@@ -4430,8 +4464,11 @@ nsBlockFrame::PlaceLine(nsBlockReflowState& aState,
   aFloatAvailableSpace.BSize(wm) = oldFloatAvailableSpace.BSize(wm);
   // If the available space between the floats is smaller now that we
   // know the height, return false (and cause another pass with
-  // LINE_REFLOW_REDO_MORE_FLOATS).
-  if (AvailableSpaceShrunk(wm, oldFloatAvailableSpace, aFloatAvailableSpace)) {
+  // LINE_REFLOW_REDO_MORE_FLOATS).  We ensure aAvailableSpaceHeight
+  // never decreases, which means that we can't reduce the set of floats
+  // we intersect, which means that the available space cannot grow.
+  if (AvailableSpaceShrunk(wm, oldFloatAvailableSpace, aFloatAvailableSpace,
+                           false)) {
     return false;
   }
 

--- a/layout/generic/nsFrameSetFrame.cpp
+++ b/layout/generic/nsFrameSetFrame.cpp
@@ -872,7 +872,14 @@ nsHTMLFramesetFrame::Reflow(nsPresContext*           aPresContext,
   nscoord height = (aDesiredSize.Height() <= aReflowState.AvailableHeight())
     ? aDesiredSize.Height() : aReflowState.AvailableHeight();
 
-  bool firstTime = (GetStateBits() & NS_FRAME_FIRST_REFLOW) != 0;
+  // We might be reflowed more than once with NS_FRAME_FIRST_REFLOW;
+  // that's allowed.  (Though it will only happen for misuse of frameset
+  // that includes it within other content.)  So measure firstTime by
+  // what we care about, which is whether we've processed the data we
+  // process below if firstTime is true.
+  MOZ_ASSERT(!mChildFrameborder == !mChildBorderColors);
+  bool firstTime = !!mChildFrameborder;
+
   if (firstTime) {
     Preferences::RegisterCallback(FrameResizePrefCallback,
                                   kFrameResizePref, this);

--- a/layout/reftests/floats/1236745-1-ref.html
+++ b/layout/reftests/floats/1236745-1-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<title>Reftest, bug 1236745</title>
+<style>
+
+div.contain {
+  border: medium solid blue;
+  width: 100px;
+  height: 200px;
+}
+
+.float1 {
+  float: left;
+  background: yellow;
+  width: 10px;
+  height: 60px;
+}
+
+.float2 {
+  float: left; clear: left;
+  background: aqua;
+  width: 50px;
+  height: 50px;
+}
+
+.bfc {
+  float: right;
+  background: #00137f;
+  width: 50px;
+  height: 50px;
+}
+
+</style>
+
+
+<div class="contain">
+  <div class="float1"></div>
+  <div class="bfc"></div>
+  <div class="float2"></div>
+</div>

--- a/layout/reftests/floats/1236745-1.html
+++ b/layout/reftests/floats/1236745-1.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<title>Reftest, bug 1236745</title>
+<style>
+
+div.contain {
+  border: medium solid blue;
+  width: 100px;
+  height: 200px;
+}
+
+.float1 {
+  float: left;
+  background: yellow;
+  width: 10px;
+  height: 60px;
+}
+
+.float2 {
+  float: left; clear: left;
+  background: aqua;
+  width: 50px;
+  height: 50px;
+}
+
+.bfc {
+  overflow: hidden;
+  background: fuchsia;
+  /*
+   * Will be 90px wide (and thus 90px high) if placed based on only its
+   * top or based on a 50px height, but 50px wide (and thus 50px high)
+   * if placed based on a 90px height.
+   */
+}
+
+img {
+  width: 100%;
+  display: block;
+}
+
+</style>
+
+
+<div class="contain">
+  <div class="float1"></div>
+  <div class="float2"></div>
+  <div class="bfc">
+    <img src="../bugs/solidblue.png"> <!-- 16x16 blue image -->
+  </div>
+</div>

--- a/layout/reftests/floats/reftest.list
+++ b/layout/reftests/floats/reftest.list
@@ -19,6 +19,7 @@ fails == 345369-2.html 345369-2-ref.html
 == 546048-1.html 546048-1-ref.html
 == 775350-1.html 775350-1-ref.html
 == 1114329.html 1114329-ref.html
+== 1236745-1.html 1236745-1-ref.html
 == float-in-rtl-1a.html float-in-rtl-1-ref.html
 == float-in-rtl-1b.html float-in-rtl-1-ref.html
 == float-in-rtl-1c.html float-in-rtl-1-ref.html


### PR DESCRIPTION
Ad #1133 (follow up)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1222783

An example [__a warning - crash after #1133!__]
https://hg.mozilla.org/mozilla-central/raw-file/76753a9a19fd/layout/generic/crashtests/1222783.xhtml

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1236745

An example [__a warning - crash after #1133!__]
https://hg.mozilla.org/mozilla-central/raw-file/65e84ada79e4/layout/reftests/floats/1236745-1.html

---

I've created the new build (x32, Windows) and tested.
