### PR TITLE
[minor fix, suggestion] Pageinfo - General - the site's security information (regression)

### DIFF
--- a/browser/base/content/pageinfo/security.js
+++ b/browser/base/content/pageinfo/security.js
@@ -302,6 +302,7 @@ function securityOnLoad() {
   setText("security-technical-shortform", hdr);
   setText("security-technical-longform1", msg1);
   setText("security-technical-longform2", msg2); 
+  setText("general-security-privacy", hdr);
 }
 
 function setText(id, value)


### PR DESCRIPTION
![1](https://cloud.githubusercontent.com/assets/2373486/26763619/f907d952-4955-11e7-937b-6d73e7801079.png)

vs.

![2](https://cloud.githubusercontent.com/assets/2373486/26763621/fe92eb14-4955-11e7-9e0c-4acd036ebebb.png)
or
![3](https://cloud.githubusercontent.com/assets/2373486/26763652/90b35dbc-4956-11e7-845c-37b30b120253.png)

See also Pale Moon 26.5.0 (and SeaMonkey).

---

If the proposal is accepted:

__You add the label `Regression`, please.__

__You add the label `UXP-task`, please.__
(or is it not needed for `/browser`?)

---

I've created the new build (x32, Windows) and tested.
