### PR TITLE
DevTools - Inspector - throws an errors

### DIFF
--- a/toolkit/devtools/inspector/test/browser.ini
+++ b/toolkit/devtools/inspector/test/browser.ini
@@ -19,6 +19,7 @@ support-files =
   doc_inspector_remove-iframe-during-load.html
   doc_inspector_search.html
   doc_inspector_search-suggestions.html
+  doc_inspector_search-svg.html
   doc_inspector_select-last-selected-01.html
   doc_inspector_select-last-selected-02.html
   head.js
@@ -74,6 +75,7 @@ skip-if = e10s # Test synthesize scrolling events in content. Also, see bug 1035
 [browser_inspector_search-01.js]
 [browser_inspector_search-02.js]
 [browser_inspector_search-03.js]
+[browser_inspector_search-04.js]
 [browser_inspector_select-docshell.js]
 [browser_inspector_select-last-selected.js]
 [browser_inspector_search-navigation.js]

--- a/toolkit/devtools/inspector/test/browser_inspector_search-04.js
+++ b/toolkit/devtools/inspector/test/browser_inspector_search-04.js
@@ -1,0 +1,49 @@
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+"use strict";
+
+// Test that searching for classes on SVG elements does work (see bug 1219920).
+
+const TEST_URL = TEST_URL_ROOT + "doc_inspector_search-svg.html";
+
+// An array of (key, suggestions) pairs where key is a key to press and
+// suggestions is an array of suggestions that should be shown in the popup.
+const TEST_DATA = [{
+  key: "c",
+  suggestions: ["circle", ".class1", ".class2"]
+}, {
+  key: "VK_BACK_SPACE",
+  suggestions: []
+}, {
+  key: ".",
+  suggestions: [".class1", ".class2"]
+}];
+
+add_task(function* () {
+  let {inspector} = yield openInspectorForURL(TEST_URL);
+  let {searchBox} = inspector;
+  let popup = inspector.searchSuggestions.searchPopup;
+
+  yield focusSearchBoxUsingShortcut(inspector.panelWin);
+
+  for (let {key, suggestions} of TEST_DATA) {
+    info("Pressing " + key + " to get " + suggestions);
+
+    let command = once(searchBox, "command");
+    EventUtils.synthesizeKey(key, {}, inspector.panelWin);
+    yield command;
+
+    info("Waiting for search query to complete and getting the suggestions");
+    yield inspector.searchSuggestions._lastQuery;
+    let actualSuggestions = popup.getItems().reverse();
+
+    is(popup.isOpen ? actualSuggestions.length : 0, suggestions.length,
+       "There are expected number of suggestions.");
+
+    for (let i = 0; i < suggestions.length; i++) {
+      is(actualSuggestions[i].label, suggestions[i],
+         "The suggestion at " + i + "th index is correct.");
+    }
+  }
+});

--- a/toolkit/devtools/inspector/test/doc_inspector_search-svg.html
+++ b/toolkit/devtools/inspector/test/doc_inspector_search-svg.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Inspector SVG Search Box Test</title>
+</head>
+<body>
+  <div class="class1"></div>
+  <svg>
+    <circle cx="0" cy="0" r="50" class="class2" />
+  </svg>
+</body>
+</html>

--- a/toolkit/devtools/markupview/markup-view.js
+++ b/toolkit/devtools/markupview/markup-view.js
@@ -14,6 +14,7 @@ const COLLAPSE_ATTRIBUTE_LENGTH = 120;
 const COLLAPSE_DATA_URL_REGEX = /^data.+base64/;
 const COLLAPSE_DATA_URL_LENGTH = 60;
 const NEW_SELECTION_HIGHLIGHTER_TIMER = 1000;
+const AUTOCOMPLETE_POPUP_PANEL_ID = "markupview_autoCompletePopup";
 
 const {UndoStack} = require("devtools/shared/undo");
 const {editableField, InplaceEditor} = require("devtools/shared/inplace-editor");
@@ -77,7 +78,10 @@ function MarkupView(aInspector, aFrame, aControllerWindow) {
   // Creating the popup to be used to show CSS suggestions.
   let options = {
     autoSelect: true,
-    theme: "auto"
+    theme: "auto",
+    // panelId option prevents the markupView autocomplete popup from
+    // sharing XUL elements with other views, such as ruleView (see Bug 1191093)
+    panelId: AUTOCOMPLETE_POPUP_PANEL_ID
   };
   this.popup = new AutocompletePopup(this.doc.defaultView.parent.document, options);
 

--- a/toolkit/devtools/server/actors/inspector.js
+++ b/toolkit/devtools/server/actors/inspector.js
@@ -1816,7 +1816,7 @@ var WalkerActor = protocol.ActorClass({
           nodes = this.rootDoc.querySelectorAll(query);
         }
         for (let node of nodes) {
-          for (let className of node.className.split(" ")) {
+          for (let className of node.classList) {
             sugs.classes.set(className, (sugs.classes.get(className)|0) + 1);
           }
         }
@@ -1871,7 +1871,7 @@ var WalkerActor = protocol.ActorClass({
           node.id && result.push(["#" + node.id, 1]);
           let tag = node.tagName.toLowerCase();
           sugs.tags.set(tag, (sugs.tags.get(tag)|0) + 1);
-          for (let className of node.className.split(" ")) {
+          for (let className of node.classList) {
             sugs.classes.set(className, (sugs.classes.get(className)|0) + 1);
           }
         }

--- a/toolkit/devtools/server/actors/styles.js
+++ b/toolkit/devtools/server/actors/styles.js
@@ -842,18 +842,20 @@ var PageStyleActor = protocol.ActorClass({
     let style = this.styleElement;
     let sheet = style.sheet;
     let rawNode = node.rawNode;
+    let cssRules = sheet.cssRules;
+    let classes = [...rawNode.classList];
 
     let selector;
     if (rawNode.id) {
-      selector = "#" + rawNode.id;
-    } else if (rawNode.className) {
-      selector = "." + rawNode.className.split(" ")[0];
+      selector = "#" + CSS.escape(rawNode.id);
+    } else if (classes.length > 0) {
+      selector = "." + classes.map(c => CSS.escape(c)).join(".");
     } else {
       selector = rawNode.tagName.toLowerCase();
     }
 
-    let index = sheet.insertRule(selector + " {}", sheet.cssRules.length);
-    let ruleActor = this._styleRef(sheet.cssRules[index]);
+    let index = sheet.insertRule(selector + " {}", cssRules.length);
+    let ruleActor = this._styleRef(cssRules[index]);
     return this.getAppliedProps(node, [{ rule: ruleActor }],
       { matchedSelectors: true });
   }, {

--- a/toolkit/devtools/styleinspector/rule-view.js
+++ b/toolkit/devtools/styleinspector/rule-view.js
@@ -1552,6 +1552,10 @@ CssRuleView.prototype = {
       return promise.resolve(undefined);
     }
 
+    if (this.popup.isOpen) {
+      this.popup.hidePopup();
+    }
+
     this.clear();
 
     this._viewedElement = aElement;

--- a/toolkit/devtools/styleinspector/test/browser.ini
+++ b/toolkit/devtools/styleinspector/test/browser.ini
@@ -61,6 +61,7 @@ support-files =
 [browser_ruleview_completion-existing-property_02.js]
 [browser_ruleview_completion-new-property_01.js]
 [browser_ruleview_completion-new-property_02.js]
+[browser_ruleview_completion-popup-hidden-after-navigation.js]
 [browser_ruleview_content_01.js]
 [browser_ruleview_content_02.js]
 skip-if = e10s # Bug 1039528: "inspect element" contextual-menu doesn't work with e10s

--- a/toolkit/devtools/styleinspector/test/browser_ruleview_add-rule_01.js
+++ b/toolkit/devtools/styleinspector/test/browser_ruleview_add-rule_01.js
@@ -16,14 +16,22 @@ let PAGE_CONTENT = [
   '<div id="testid" class="testclass">Styled Node</div>',
   '<span class="testclass2">This is a span</span>',
   '<span class="class1 class2">Multiple classes</span>',
-  '<p>Empty<p>'
+  '<p>Empty<p>',
+  '<h1 class="asd@@@@a!!!!:::@asd">Invalid characters in class</h1>',
+  '<h2 id="asd@@@a!!2a">Invalid characters in id</h2>',
+  '<svg viewBox="0 0 10 10">',
+  '  <circle cx="5" cy="5" r="5" fill="blue"></circle>',
+  '</svg>'
 ].join("\n");
 
 const TEST_DATA = [
   { node: "#testid", expected: "#testid" },
   { node: ".testclass2", expected: ".testclass2" },
   { node: ".class1.class2", expected: ".class1" },
-  { node: "p", expected: "p" }
+  { node: "p", expected: "p" },
+  { node: "h1", expected: ".asd\\@\\@\\@\\@a\\!\\!\\!\\!\\:\\:\\:\\@asd" },
+  { node: "h2", expected: "#asd\\@\\@\\@a\\!\\!2a" },
+  { node: "circle", expected: "circle" }
 ];
 
 add_task(function*() {

--- a/toolkit/devtools/styleinspector/test/browser_ruleview_completion-existing-property_01.js
+++ b/toolkit/devtools/styleinspector/test/browser_ruleview_completion-existing-property_01.js
@@ -57,6 +57,15 @@ add_task(function*() {
   yield addTab(TEST_URL);
   let {toolbox, inspector, view} = yield openRuleView();
 
+  info("Test autocompletion after 1st page load");
+  yield runAutocompletionTest(toolbox, inspector, view);
+
+  info("Test autocompletion after page navigation");
+  yield reloadPage(inspector);
+  yield runAutocompletionTest(toolbox, inspector, view);
+});
+
+function* runAutocompletionTest(toolbox, inspector, view) {
   info("Selecting the test node");
   yield selectNode("h1", inspector);
 
@@ -65,10 +74,10 @@ add_task(function*() {
   let editor = yield focusEditableField(propertyName);
 
   info("Starting to test for css property completion");
-  for (let i = 0; i < testData.length; i ++) {
+  for (let i = 0; i < testData.length; i++) {
     yield testCompletion(testData[i], editor, view);
   }
-});
+}
 
 function* testCompletion([key, completion, index, total], editor, view) {
   info("Pressing key " + key);

--- a/toolkit/devtools/styleinspector/test/browser_ruleview_completion-existing-property_02.js
+++ b/toolkit/devtools/styleinspector/test/browser_ruleview_completion-existing-property_02.js
@@ -42,7 +42,16 @@ let TEST_URL = "data:text/html;charset=utf-8,<h1 style='color: red'>Filename: " 
 add_task(function*() {
   yield addTab(TEST_URL);
   let {toolbox, inspector, view} = yield openRuleView();
+ 
+  info("Test autocompletion after 1st page load");
+  yield runAutocompletionTest(toolbox, inspector, view);
 
+  info("Test autocompletion after page navigation");
+  yield reloadPage(inspector);
+  yield runAutocompletionTest(toolbox, inspector, view);
+});
+
+function* runAutocompletionTest(toolbox, inspector, view) {
   info("Selecting the test node");
   yield selectNode("h1", inspector);
 
@@ -51,13 +60,13 @@ add_task(function*() {
   let editor = yield focusEditableField(value);
 
   info("Starting to test for css property completion");
-  for (let i = 0; i < testData.length; i ++) {
+  for (let i = 0; i < testData.length; i++) {
     // Re-define the editor at each iteration, because the focus may have moved
     // from property to value and back
     editor = inplaceEditor(view.doc.activeElement);
     yield testCompletion(testData[i], editor, view);
   }
-});
+}
 
 function* testCompletion([key, modifiers, completion, index, total], editor, view) {
   info("Pressing key " + key);

--- a/toolkit/devtools/styleinspector/test/browser_ruleview_completion-new-property_01.js
+++ b/toolkit/devtools/styleinspector/test/browser_ruleview_completion-new-property_01.js
@@ -44,6 +44,15 @@ add_task(function*() {
   yield addTab(TEST_URL);
   let {toolbox, inspector, view} = yield openRuleView();
 
+  info("Test autocompletion after 1st page load");
+  yield runAutocompletionTest(toolbox, inspector, view);
+
+  info("Test autocompletion after page navigation");
+  yield reloadPage(inspector);
+  yield runAutocompletionTest(toolbox, inspector, view);
+});
+
+function* runAutocompletionTest(toolbox, inspector, view) {
   info("Selecting the test node");
   yield selectNode("h1", inspector);
 
@@ -52,10 +61,10 @@ add_task(function*() {
   let editor = yield focusEditableField(brace);
 
   info("Starting to test for css property completion");
-  for (let i = 0; i < testData.length; i ++) {
+  for (let i = 0; i < testData.length; i++) {
     yield testCompletion(testData[i], editor, view);
   }
-});
+}
 
 function* testCompletion([key, completion, index, total], editor, view) {
   info("Pressing key " + key);

--- a/toolkit/devtools/styleinspector/test/browser_ruleview_completion-new-property_02.js
+++ b/toolkit/devtools/styleinspector/test/browser_ruleview_completion-new-property_02.js
@@ -46,6 +46,15 @@ add_task(function*() {
   yield addTab(TEST_URL);
   let {toolbox, inspector, view} = yield openRuleView();
 
+  info("Test autocompletion after 1st page load");
+  yield runAutocompletionTest(toolbox, inspector, view);
+
+  info("Test autocompletion after page navigation");
+  yield reloadPage(inspector);
+  yield runAutocompletionTest(toolbox, inspector, view);
+});
+
+function* runAutocompletionTest(toolbox, inspector, view) {
   info("Selecting the test node");
   yield selectNode("h1", inspector);
 
@@ -54,13 +63,13 @@ add_task(function*() {
   let editor = yield focusEditableField(brace);
 
   info("Starting to test for css property completion");
-  for (let i = 0; i < testData.length; i ++) {
+  for (let i = 0; i < testData.length; i++) {
     // Re-define the editor at each iteration, because the focus may have moved
     // from property to value and back
     editor = inplaceEditor(view.doc.activeElement);
     yield testCompletion(testData[i], editor, view);
   }
-});
+}
 
 function* testCompletion([key, modifiers, completion, index, total], editor, view) {
   info("Pressing key " + key);

--- a/toolkit/devtools/styleinspector/test/browser_ruleview_completion-popup-hidden-after-navigation.js
+++ b/toolkit/devtools/styleinspector/test/browser_ruleview_completion-popup-hidden-after-navigation.js
@@ -1,0 +1,38 @@
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* Any copyright is dedicated to the Public Domain.
+ http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Test that the ruleview autocomplete popup is hidden after page navigation
+
+let TEST_URL = "data:text/html;charset=utf-8,<h1 style='font: 24px serif'></h1>";
+
+add_task(function*() {
+  yield addTab(TEST_URL);
+  let {inspector, view} = yield openRuleView();
+
+  info("Test autocompletion popup is hidden after page navigation");
+
+  info("Selecting the test node");
+  yield selectNode("h1", inspector);
+
+  info("Focusing the css property editable field");
+  let propertyName = view.styleDocument.querySelectorAll(".ruleview-propertyname")[0];
+  let editor = yield focusEditableField(view, propertyName);
+
+  info("Pressing key VK_DOWN");
+  let onSuggest = once(editor.input, "keypress");
+  EventUtils.synthesizeKey("VK_DOWN", {}, view.styleWindow);
+
+  info("Waiting for autocomplete popup to be displayed");
+  yield onSuggest;
+  yield wait(1);
+
+  ok(view.popup && view.popup.isOpen, "Popup should be opened");
+
+  info("Reloading the page");
+  yield reloadPage(inspector);
+
+  ok(!(view.popup && view.popup.isOpen), "Popup should be closed");
+});

--- a/toolkit/devtools/styleinspector/test/browser_ruleview_user-property-reset.js
+++ b/toolkit/devtools/styleinspector/test/browser_ruleview_user-property-reset.js
@@ -82,9 +82,3 @@ function* assertRuleAndMarkupViewWidth(id, value, ruleView, inspector) {
   let attr = yield getContainerStyleAttrValue(id, inspector);
   is(attr.textContent.replace(/\s/g, ""), "width:" + value + ";", "Markup-view style attribute width is " + value);
 }
-
-function reloadPage(inspector) {
-  let onNewRoot = inspector.once("new-root");
-  content.location.reload();
-  return onNewRoot.then(inspector.markup._waitForChildren);
-}

--- a/toolkit/devtools/styleinspector/test/head.js
+++ b/toolkit/devtools/styleinspector/test/head.js
@@ -912,3 +912,16 @@ function waitForStyleEditor(toolbox, href) {
 
   return def.promise;
 }
+
+/**
+ * Reload the current page and wait for the inspector to be initialized after
+ * the navigation
+ * @param {InspectorPanel} inspector
+ *        The instance of InspectorPanel currently loaded in the toolbox
+ * @return a promise that resolves after page reload and inspector initialization
+ */
+function reloadPage(inspector) {
+  let onNewRoot = inspector.once("new-root");
+  content.location.reload();
+  return onNewRoot.then(inspector.markup._waitForChildren);
+}


### PR DESCRIPTION
__Steps to reproduce__

Go to:
`data:text/html;charset=utf-8,%0A%3Chtml%3E%3Chead%3E%3Cmeta charset%3D"utf-8"%3E%0A%0A%3Cstyle%3E%0Asvg %7B%0A  width%3A 200px%3B%0A  height%3A 200px%3B%0A  background-color%3A green%3B%0A%7D%0A%3C%2Fstyle%3E%0A%3C%2Fhead%3E%0A%3Cbody%3E%0A%3Csvg viewBox%3D"0 0 10 10"%3E%0A  %3CclipPath%3E%0A    %3Crect x%3D"0" y%3D"0" width%3D"10" height%3D"5"%3E%3C%2Frect%3E%0A  %3C%2FclipPath%3E%0A  %3Ccircle cx%3D"5" cy%3D"5" r%3D"5" fill%3D"blue" clip-path%3D"url(%23clip)"%3E%3C%2Fcircle%3E%0A%3C%2Fsvg%3E%0A%0A%3C%2Fbody%3E%3Cstyle type%3D"text%2Fcss"%3E%3C%2Fstyle%3E%3C%2Fhtml%3E%0A`

Right-click on the blue circle, and chose `Inspect`
In the rule view, right-click and chose `Add new rule`

---

Throws an errors in Browser Console:
```
TypeError: node.className.split is not a function
Stack trace:
WalkerActor<.getSuggestionsForQuery<@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/server/actors/inspector.js:1819:33
actorProto/</handler@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/server/protocol.js:1004:19
DSC_onPacket@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/server/main.js:1450:15
LocalDebuggerTransport.prototype.send/<@resource://gre/modules/devtools/dbg-client.jsm
-> resource://gre/modules/devtools/transport/transport.js:561:11
makeInfallible/<@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/DevToolsUtils.js:82:14
makeInfallible/<@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/DevToolsUtils.js:82:14
protocol.js:900

Protocol error (unknownError): TypeError: node.className.split is not a function
Promise-backend.js:870:0
```

and (after fixing the above problem):
```
TypeError: this._panel.hidePopup is not a function
autocomplete-popup.js:156:4

TypeError: this._list.ensureIndexIsVisible is not a function
autocomplete-popup.js:300:4
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1040199
https://bugzilla.mozilla.org/show_bug.cgi?id=1191093
https://bugzilla.mozilla.org/show_bug.cgi?id=1219920
https://bugzilla.mozilla.org/show_bug.cgi?id=1272208

---

__You add the label `Devtools`, please.__

---

I've created the new build (x32, Windows) and tested.
