### PR TITLE
[minor fix] DevTools - Network - arrows convention for ascending/descending order

### DIFF
--- a/toolkit/themes/linux/global/jar.mn
+++ b/toolkit/themes/linux/global/jar.mn
@@ -100,6 +100,7 @@ toolkit.jar:
 * skin/classic/global/devtools/profiler.css          (devtools/profiler.css)
 * skin/classic/global/devtools/performance.css       (devtools/performance.css)
 * skin/classic/global/devtools/timeline.css          (devtools/timeline.css)
++  skin/classic/global/devtools/sort-arrows.svg       (../../shared/devtools/images/sort-arrows.svg)
 +  skin/classic/global/devtools/timeline-filter.svg   (../../shared/devtools/images/timeline-filter.svg)
 * skin/classic/global/devtools/scratchpad.css        (devtools/scratchpad.css)
 * skin/classic/global/devtools/shadereditor.css      (devtools/shadereditor.css)

--- a/toolkit/themes/osx/global/jar.mn
+++ b/toolkit/themes/osx/global/jar.mn
@@ -150,6 +150,7 @@ toolkit.jar:
 * skin/classic/global/devtools/profiler.css                (devtools/profiler.css)
 * skin/classic/global/devtools/performance.css             (devtools/performance.css)
 * skin/classic/global/devtools/timeline.css                (devtools/timeline.css)
+  skin/classic/global/devtools/sort-arrows.svg             (../../shared/devtools/images/sort-arrows.svg)
   skin/classic/global/devtools/timeline-filter.svg         (../../shared/devtools/images/timeline-filter.svg)
 * skin/classic/global/devtools/scratchpad.css              (devtools/scratchpad.css)
 * skin/classic/global/devtools/shadereditor.css            (devtools/shadereditor.css)

--- a/toolkit/themes/shared/devtools/images/sort-arrows.svg
+++ b/toolkit/themes/shared/devtools/images/sort-arrows.svg
@@ -1,0 +1,12 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="7" height="4" fill="#edf0f1" fill-opacity="0.8">
+  <style>
+    polygon:not(:target) {
+      display: none;
+    }
+  </style>
+  <polygon points="0,4 3.5,0 7,4" id="ascending"/>
+  <polygon points="0,0 3.5,4 7,0" id="descending"/>
+</svg>

--- a/toolkit/themes/shared/devtools/netmonitor.inc.css
+++ b/toolkit/themes/shared/devtools/netmonitor.inc.css
@@ -97,17 +97,30 @@
   background: rgba(0,0,0,0.15);
 }
 
-.requests-menu-header-button:not(:active)[sorted=ascending] {
-  background-image: radial-gradient(farthest-side at center top, hsla(200,100%,70%,.7), hsla(200,100%,70%,0.3));
-  background-size: 100% 1px;
-  background-repeat: no-repeat;
+.requests-menu-header-button[sorted] {
+  background-position: right 6px center !important;
 }
 
-.requests-menu-header-button:not(:active)[sorted=descending] {
-  background-image: radial-gradient(farthest-side at center bottom, hsla(200,100%,70%,.7), hsla(200,100%,70%,0.3));
-  background-size: 100% 1px;
-  background-repeat: no-repeat;
-  background-position: bottom;
+.requests-menu-header-button[sorted]:-moz-locale-dir(rtl) {
+  background-position: left 6px center !important;
+}
+
+.requests-menu-status[sorted] {
+  background-position: right 1px top 1px !important;
+}
+
+.requests-menu-status[sorted]:-moz-locale-dir(rtl) {
+  background-position: left 1px top 1px !important;
+}
+
+.requests-menu-header-button[sorted=ascending] {
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#ascending") !important;
+  background-repeat: no-repeat !important;
+}
+ 
+.requests-menu-header-button[sorted=descending] {
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#descending") !important;
+  background-repeat: no-repeat !important;
 }
 
 /* Network requests table: specific column dimensions */

--- a/toolkit/themes/shared/devtools/netmonitor.inc.css
+++ b/toolkit/themes/shared/devtools/netmonitor.inc.css
@@ -86,41 +86,41 @@
 }
 
 .requests-menu-header-button:hover {
-  background: rgba(0,0,0,0.10);
+  background-color: rgba(0,0,0,0.10);
 }
 
 .requests-menu-header-button:hover:active {
-  background: rgba(0,0,0,0.25);
+  background-color: rgba(0,0,0,0.25);
 }
 
 .requests-menu-header-button:not(:active)[sorted] {
-  background: rgba(0,0,0,0.15);
+  background-color: rgba(0,0,0,0.15);
 }
 
 .requests-menu-header-button[sorted] {
-  background-position: right 6px center !important;
+  background-position: right 6px center;
 }
 
 .requests-menu-header-button[sorted]:-moz-locale-dir(rtl) {
-  background-position: left 6px center !important;
+  background-position: left 6px center;
 }
 
 .requests-menu-status[sorted] {
-  background-position: right 1px top 1px !important;
+  background-position: right 1px top 1px;
 }
 
 .requests-menu-status[sorted]:-moz-locale-dir(rtl) {
-  background-position: left 1px top 1px !important;
+  background-position: left 1px top 1px;
 }
 
 .requests-menu-header-button[sorted=ascending] {
-  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#ascending") !important;
-  background-repeat: no-repeat !important;
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#ascending");
+  background-repeat: no-repeat;
 }
  
 .requests-menu-header-button[sorted=descending] {
-  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#descending") !important;
-  background-repeat: no-repeat !important;
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#descending");
+  background-repeat: no-repeat;
 }
 
 /* Network requests table: specific column dimensions */

--- a/toolkit/themes/shared/devtools/widgets.inc.css
+++ b/toolkit/themes/shared/devtools/widgets.inc.css
@@ -1210,19 +1210,22 @@
   background-image: linear-gradient(rgba(0,0,0,0.15), rgba(0,0,0,0.15));
 }
 
-.table-widget-column-header:not(:active)[sorted=ascending] {
-  background-image: radial-gradient(farthest-side at center top, hsla(200,100%,70%,.7), hsla(200,100%,70%,0.3)),
-                    linear-gradient(rgba(0,0,0,0.15), rgba(0,0,0,0.15));
-  background-size: 100% 1px, auto;
-  background-repeat: no-repeat, repeat;
+.table-widget-column-header[sorted] {
+  background-position: right 6px center !important;
 }
 
-.table-widget-column-header:not(:active)[sorted=descending] {
-  background-image: radial-gradient(farthest-side at center bottom, hsla(200,100%,70%,.7), hsla(200,100%,70%,0.3)),
-                    linear-gradient(rgba(0,0,0,0.15), rgba(0,0,0,0.15));
-  background-size: 100% 1px, auto;
-  background-repeat: no-repeat, repeat;
-  background-position: bottom;
+.table-widget-column-header[sorted]:-moz-locale-dir(rtl) {
+  background-position: left 6px center !important;
+}
+
+.table-widget-column-header[sorted=ascending] {
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#descending") !important;
+  background-repeat: no-repeat !important;
+}
+
+.table-widget-column-header[sorted=descending] {
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#ascending") !important;
+  background-repeat: no-repeat !important;
 }
 
 /* Cells */

--- a/toolkit/themes/shared/devtools/widgets.inc.css
+++ b/toolkit/themes/shared/devtools/widgets.inc.css
@@ -1211,21 +1211,21 @@
 }
 
 .table-widget-column-header[sorted] {
-  background-position: right 6px center !important;
+  background-position: right 6px center;
 }
 
 .table-widget-column-header[sorted]:-moz-locale-dir(rtl) {
-  background-position: left 6px center !important;
+  background-position: left 6px center;
 }
 
 .table-widget-column-header[sorted=ascending] {
-  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#descending") !important;
-  background-repeat: no-repeat !important;
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#descending");
+  background-repeat: no-repeat;
 }
 
 .table-widget-column-header[sorted=descending] {
-  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#ascending") !important;
-  background-repeat: no-repeat !important;
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#ascending");
+  background-repeat: no-repeat;
 }
 
 /* Cells */

--- a/toolkit/themes/windows/global/jar.mn
+++ b/toolkit/themes/windows/global/jar.mn
@@ -153,6 +153,7 @@ toolkit.jar:
 *       skin/classic/global/devtools/profiler.css                  (devtools/profiler.css)
 *       skin/classic/global/devtools/performance.css               (devtools/performance.css)
 *       skin/classic/global/devtools/timeline.css                  (devtools/timeline.css)
+        skin/classic/global/devtools/sort-arrows.svg               (../../shared/devtools/images/sort-arrows.svg)
         skin/classic/global/devtools/timeline-filter.svg           (../../shared/devtools/images/timeline-filter.svg)
 *       skin/classic/global/devtools/scratchpad.css                (devtools/scratchpad.css)
 *       skin/classic/global/devtools/shadereditor.css              (devtools/shadereditor.css)


### PR DESCRIPTION
An example:
![1](https://user-images.githubusercontent.com/2373486/26896831-89fa0a08-4bc6-11e7-8f3e-4deb4ff78140.png)

---

You add the label `Devtools`, please.
You add the label `Theme changes`, please.

---

I've created the new build (x32, Windows) and tested.
