### PR TITLE
DevTools - Inspector - tooltip get element width/height wrong when browser zoomed

### DIFF
--- a/toolkit/devtools/inspector/test/browser.ini
+++ b/toolkit/devtools/inspector/test/browser.ini
@@ -54,6 +54,7 @@ skip-if = e10s # GCLI isn't e10s compatible. See bug 1128988.
 [browser_inspector_highlighter-zoom.js]
 [browser_inspector_iframe-navigation.js]
 [browser_inspector_infobar_01.js]
+[browser_inspector_infobar_02.js]
 [browser_inspector_initialization.js]
 [browser_inspector_inspect-object-element.js]
 [browser_inspector_invalidate.js]

--- a/toolkit/devtools/inspector/test/browser_inspector_infobar_02.js
+++ b/toolkit/devtools/inspector/test/browser_inspector_infobar_02.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// Check the position and text content of the highlighter nodeinfo bar under page zoom.
+
+const TEST_URI = URL_ROOT + "doc_inspector_infobar_01.html";
+
+add_task(function* () {
+  let {inspector, testActor} = yield openInspectorForURL(TEST_URI);
+  let testData = {
+    selector: "#top",
+    dims: "500" + " \u00D7 " + "100"
+  };
+
+  yield testInfobar(testData, inspector, testActor);
+  info("Change zoom page to level 2.");
+  yield testActor.zoomPageTo(2);
+  info("Testing again the infobar after zoom.");
+  yield testInfobar(testData, inspector, testActor);
+});
+
+function* testInfobar(test, inspector, testActor) {
+  info(`Testing ${test.selector}`);
+
+  yield selectAndHighlightNode(test.selector, inspector);
+
+  // Ensure the node is the correct one.
+  let id = yield testActor.getHighlighterNodeTextContent(
+    "box-model-infobar-id");
+  is(id, test.selector, `Node ${test.selector} selected.`);
+
+  let dims = yield testActor.getHighlighterNodeTextContent(
+    "box-model-infobar-dimensions");
+  is(dims, test.dims, "Node's infobar displays the right dimensions.");
+}

--- a/toolkit/devtools/server/actors/highlighter.js
+++ b/toolkit/devtools/server/actors/highlighter.js
@@ -1369,8 +1369,14 @@ BoxModelHighlighter.prototype = Heritage.extend(AutoRefreshHighlighter.prototype
       pseudos += ":" + pseudo;
     }
 
-    let rect = this._getOuterQuad("border").bounds;
-    let dim = Math.ceil(rect.width) + " \u00D7 " + Math.ceil(rect.height);
+    // We want to display the original `width` and `height`, instead of the ones affected
+    // by any zoom. Since the infobar can be displayed also for text nodes, we can't
+    // access the computed style for that, and this is why we recalculate them here.
+    let zoom = LayoutHelpers.getCurrentZoom(node);
+    let { width, height } = this._getOuterQuad("border").bounds;
+    let dim = parseFloat((width / zoom).toPrecision(6)) +
+              " \u00D7 " +
+              parseFloat((height / zoom).toPrecision(6));
 
     let elementId = this.ID_CLASS_PREFIX + "nodeinfobar-";
     this.markup.setTextContentForElement(elementId + "tagname", tagName);


### PR DESCRIPTION
Ad #1157 

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1341580

---

I've created the new build (x32, Windows) and tested.
