### PR TITLE
DevTools - Inspector - tooltip get element width/height wrong when browser zoomed (follow up)

### DIFF
--- a/toolkit/devtools/layoutview/test/browser_layoutview.js
+++ b/toolkit/devtools/layoutview/test/browser_layoutview.js
@@ -9,8 +9,8 @@
 
 // Expected values:
 let res1 = [
-      {selector: "#element-size",              value: "160" + "\u00D7" + "160"},
-      {selector: ".size > span",               value: "100" + "\u00D7" + "100"},
+      {selector: "#element-size",              value: "160" + "\u00D7" + "160.117"},
+      {selector: ".size > span",               value: "100" + "\u00D7" + "100.117"},
       {selector: ".margin.top > span",         value: 30},
       {selector: ".margin.left > span",        value: "auto"},
       {selector: ".margin.bottom > span",      value: 30},
@@ -43,7 +43,7 @@ let res2 = [
 ];
 
 add_task(function*() {
-  let style = "div { position: absolute; top: 42px; left: 42px; height: 100px; width: 100px; border: 10px solid black; padding: 20px; margin: 30px auto;}";
+  let style = "div { position: absolute; top: 42px; left: 42px; height: 100.111px; width: 100px; border: 10px solid black; padding: 20px; margin: 30px auto;}";
   let html = "<style>" + style + "</style><div></div>"
 
   yield addTab("data:text/html," + encodeURIComponent(html));

--- a/toolkit/devtools/layoutview/view.js
+++ b/toolkit/devtools/layoutview/view.js
@@ -422,7 +422,7 @@ LayoutView.prototype = {
           // might be missing.
           continue;
         }
-        let parsedValue = parseInt(layout[property]);
+        let parsedValue = parseFloat(layout[property]);
         if (Number.isNaN(parsedValue)) {
           // Not a number. We use the raw string.
           // Useful for "position" for example.
@@ -451,9 +451,10 @@ LayoutView.prototype = {
 
       width -= this.map.borderLeft.value + this.map.borderRight.value +
                this.map.paddingLeft.value + this.map.paddingRight.value;
-
+      width = parseFloat(width.toPrecision(6));
       height -= this.map.borderTop.value + this.map.borderBottom.value +
                 this.map.paddingTop.value + this.map.paddingBottom.value;
+      height = parseFloat(height.toPrecision(6));
 
       let newValue = width + "\u00D7" + height;
       if (this.sizeLabel.textContent != newValue) {

--- a/toolkit/devtools/server/actors/styles.js
+++ b/toolkit/devtools/server/actors/styles.js
@@ -747,8 +747,8 @@ var PageStyleActor = protocol.ActorClass({
     // the size of the element.
 
     let clientRect = node.rawNode.getBoundingClientRect();
-    layout.width = Math.ceil(clientRect.width);
-    layout.height = Math.ceil(clientRect.height);
+    layout.width = parseFloat(clientRect.width.toPrecision(6));
+    layout.height = parseFloat(clientRect.height.toPrecision(6));
 
     // We compute and update the values of margins & co.
     let style = CssLogic.getComputedStyle(node.rawNode);
@@ -776,7 +776,7 @@ var PageStyleActor = protocol.ActorClass({
 
     for (let i in this.map) {
       let property = this.map[i].property;
-      this.map[i].value = parseInt(style.getPropertyValue(property));
+      this.map[i].value = parseFloat(style.getPropertyValue(property));
     }
 
 


### PR DESCRIPTION
Ad #1160 (follow up)
(tag #1157)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1113761

---

I've created the new build (x32, Windows) and tested.
