### PR TITLE
Remove cycle between TrackBuffersManager and MediaSourceDemuxer

### DIFF
--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -59,7 +59,6 @@ TrackBuffersManager::TrackBuffersManager(dom::SourceBufferAttributes* aAttribute
   , mTaskQueue(aParentDecoder->GetDemuxer()->GetTaskQueue())
   , mSourceBufferAttributes(aAttributes)
   , mParentDecoder(new nsMainThreadPtrHolder<MediaSourceDecoder>(aParentDecoder, false /* strict */))
-  , mMediaSourceDemuxer(mParentDecoder->GetDemuxer())
   , mAbort(false)
   , mEvictionThreshold(Preferences::GetUint("media.mediasource.eviction_threshold",
                                             100 * (1 << 20)))

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -326,7 +326,6 @@ private:
   // Strong references to external objects.
   nsRefPtr<dom::SourceBufferAttributes> mSourceBufferAttributes;
   nsMainThreadPtrHandle<MediaSourceDecoder> mParentDecoder;
-  nsRefPtr<MediaSourceDemuxer> mMediaSourceDemuxer;
 
   // Set to true if abort is called.
   Atomic<bool> mAbort;


### PR DESCRIPTION
This fixes a potential never-ending cycle between TrackBuffersManage and the MediaSourceDemuxer that prevents the appropriate destructor from being called. This particularly happens when multiple streams have been played in a single session. I believe this is the cause of the shutdown hang we've seen with the new MSE code.

I've tested using my normal steps to reproduce the shutdown hang and so far have not experienced it.