### PR TITLE
Use tail dispatch to notify the mirror of new value

### DIFF
--- a/dom/media/StateMirroring.h
+++ b/dom/media/StateMirroring.h
@@ -138,7 +138,7 @@ private:
       MOZ_ASSERT(OwnerThread()->IsCurrentThreadIn());
       MOZ_ASSERT(!mMirrors.Contains(aMirror));
       mMirrors.AppendElement(aMirror);
-      aMirror->OwnerThread()->Dispatch(MakeNotifier(aMirror), AbstractThread::DontAssertDispatchSuccess);
+      aMirror->OwnerThread()->DispatchStateChange(MakeNotifier(aMirror));
     }
 
     void RemoveMirror(AbstractMirror<T>* aMirror) override


### PR DESCRIPTION
A one-liner that ensures tasks are run in the proper order (preventing playback stalls or potential crashes in some cases).

Tested on YouTube, Vimeo and Twitch.