### PR TITLE
Fix potential crashes/incorrect MSE behavior

### DIFF
--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -1435,10 +1435,8 @@ TrackBuffersManager::CheckNextInsertionIndex(TrackData& aTrackData,
   }
   for (uint32_t i = 0; i < data.Length(); i++) {
    const nsRefPtr<MediaRawData>& sample = data[i];
-    TimeInterval sampleInterval{
-      TimeUnit::FromMicroseconds(sample->mTime),
-      TimeUnit::FromMicroseconds(sample->GetEndTime())};
-    if (target.Intersects(sampleInterval)) {
+    if (sample->mTime >= target.mStart.ToMicroseconds() ||
+        sample->GetEndTime() > target.mStart.ToMicroseconds()) {
       aTrackData.mNextInsertionIndex = Some(size_t(i));
       return;
     }

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -1201,11 +1201,11 @@ TrackBuffersManager::ResolveProcessing(bool aResolveValue, const char* aName)
 }
 
 void
-TrackBuffersManager::CheckSequenceDiscontinuity()
+TrackBuffersManager::CheckSequenceDiscontinuity(const TimeUnit& aPresentationTime)
 {
   if (mSourceBufferAttributes->GetAppendMode() == SourceBufferAppendMode::Sequence &&
       mGroupStartTimestamp.isSome()) {
-    mTimestampOffset = mGroupStartTimestamp.ref();
+    mTimestampOffset = mGroupStartTimestamp.ref() - aPresentationTime;
     mGroupEndTimestamp = mGroupStartTimestamp.ref();
     mVideoTracks.mNeedRandomAccessPoint = true;
     mAudioTracks.mNeedRandomAccessPoint = true;
@@ -1220,8 +1220,15 @@ TrackBuffersManager::ProcessFrames(TrackBuffer& aSamples, TrackData& aTrackData)
     return;
   }
 
+  // 1. If generate timestamps flag equals true
+  // Let presentation timestamp equal 0.
+  // Otherwise
+  // Let presentation timestamp be a double precision floating point representation of the coded frame's presentation timestamp in seconds.
+  TimeUnit presentationTimestamp = mSourceBufferAttributes->mGenerateTimestamps
+    ? TimeUnit() : TimeUnit::FromMicroseconds(aSamples[0]->mTime);
+
   // 3. If mode equals "sequence" and group start timestamp is set, then run the following steps:
-  CheckSequenceDiscontinuity();
+  CheckSequenceDiscontinuity(presentationTimestamp);
 
   // 5. Let track buffer equal the track buffer that the coded frame will be added to.
   auto& trackBuffer = aTrackData;
@@ -1319,7 +1326,9 @@ TrackBuffersManager::ProcessFrames(TrackBuffer& aSamples, TrackData& aTrackData)
       // Rather that restarting the process for the frame, we run the first
       // steps again instead.
       // 3. If mode equals "sequence" and group start timestamp is set, then run the following steps:
-      CheckSequenceDiscontinuity();
+      TimeUnit presentationTimestamp = mSourceBufferAttributes->mGenerateTimestamps
+        ? TimeUnit() : TimeUnit::FromMicroseconds(sample->mTime);
+      CheckSequenceDiscontinuity(presentationTimestamp);
 
       if (!sample->mKeyframe) {
         continue;

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -1405,19 +1405,19 @@ TrackBuffersManager::ProcessFrames(TrackBuffer& aSamples, TrackData& aTrackData)
   }
 }
 
-void
+bool
 TrackBuffersManager::CheckNextInsertionIndex(TrackData& aTrackData,
                                              const TimeUnit& aSampleTime)
 {
   if (aTrackData.mNextInsertionIndex.isSome()) {
-    return;
+    return true;
   }
 
   TrackBuffer& data = aTrackData.mBuffers.LastElement();
 
   if (data.IsEmpty() || aSampleTime < aTrackData.mBufferedRanges.GetStart()) {
     aTrackData.mNextInsertionIndex = Some(size_t(0));
-    return;
+    return true;
   }
 
   // Find which discontinuity we should insert the frame before.
@@ -1431,17 +1431,20 @@ TrackBuffersManager::CheckNextInsertionIndex(TrackData& aTrackData,
   if (target.IsEmpty()) {
     // No target found, it will be added at the end of the track buffer.
     aTrackData.mNextInsertionIndex = Some(data.Length());
-    return;
+    return true;
   }
+  // We now need to find the first frame of the searched interval.
+  // We will insert our new frames right before.
   for (uint32_t i = 0; i < data.Length(); i++) {
    const nsRefPtr<MediaRawData>& sample = data[i];
     if (sample->mTime >= target.mStart.ToMicroseconds() ||
         sample->GetEndTime() > target.mStart.ToMicroseconds()) {
       aTrackData.mNextInsertionIndex = Some(size_t(i));
-      return;
+      return true;
     }
   }
-  MOZ_CRASH("Insertion Index Not Found");
+  NS_ASSERTION(false, "Insertion Index Not Found");
+  return false;
 }
 
 void
@@ -1485,8 +1488,11 @@ TrackBuffersManager::InsertFrames(TrackBuffer& aSamples,
   }
 
   // 16. Add the coded frame with the presentation timestamp, decode timestamp, and frame duration to the track buffer.
-  CheckNextInsertionIndex(aTrackData,
-                          TimeUnit::FromMicroseconds(aSamples[0]->mTime));
+  if (!CheckNextInsertionIndex(aTrackData,
+                               TimeUnit::FromMicroseconds(aSamples[0]->mTime))) {
+    RejectProcessing(NS_ERROR_FAILURE, __func__);
+    return;
+  }
 
   // Adjust our demuxing index if necessary.
   if (trackBuffer.mNextGetSampleIndex.isSome()) {

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -268,7 +268,7 @@ private:
     }
   };
 
-  void CheckSequenceDiscontinuity();
+  void CheckSequenceDiscontinuity(const TimeUnit& aPresentationTime);
   void ProcessFrames(TrackBuffer& aSamples, TrackData& aTrackData);
   bool CheckNextInsertionIndex(TrackData& aTrackData,
                                const TimeUnit& aSampleTime);

--- a/dom/media/mediasource/TrackBuffersManager.h
+++ b/dom/media/mediasource/TrackBuffersManager.h
@@ -270,7 +270,7 @@ private:
 
   void CheckSequenceDiscontinuity();
   void ProcessFrames(TrackBuffer& aSamples, TrackData& aTrackData);
-  void CheckNextInsertionIndex(TrackData& aTrackData,
+  bool CheckNextInsertionIndex(TrackData& aTrackData,
                                const TimeUnit& aSampleTime);
   void InsertFrames(TrackBuffer& aSamples,
                     const TimeIntervals& aIntervals,


### PR DESCRIPTION
Currently, if Pale Moon is fed a frame with a duration of 0 and a discontinuity is detected later in the same stream, the frames could potentially be inserted in an incorrect order causing the rest of the stream to be undecodable (resulting in a playback stall), and potentially even causing a browser crash. This PR fixes that. This PR also fixes an incorrect calculation of timestampOffset (which was also invalid behavior in our DOM MSE function). With this PR we now calculate correctly and according to spec.

Tested on YouTube, Twitch, and Vimeo.