### PR TITLE
Revert "Supports building with Clang and Libc++"

### DIFF
--- a/memory/mozalloc/throw_gcc.h
+++ b/memory/mozalloc/throw_gcc.h
@@ -19,110 +19,97 @@
 
 #include "mozilla/mozalloc_abort.h"
 
-// libc++ 4.0.0 and higher use C++11 [[noreturn]] attributes for the functions
-// below, and since clang does not allow mixing __attribute__((noreturn)) and
-// [[noreturn]], we have to explicitly use the latter here.  See bug 1329520.
-#if defined(__clang__)
-#  if __has_feature(cxx_attributes) && \
-      defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 4000
-#    define MOZ_THROW_NORETURN [[noreturn]]
-#  endif
-#endif
-#ifndef MOZ_THROW_NORETURN
-#  define MOZ_THROW_NORETURN MOZ_NORETURN
-#endif
-
 namespace std {
 
 // NB: user code is not supposed to touch the std:: namespace.  We're
 // doing this after careful review because we want to define our own
 // exception throwing semantics.  Don't try this at home!
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_bad_exception(void)
 {
     mozalloc_abort("fatal: STL threw bad_exception");
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_bad_alloc(void)
 {
     mozalloc_abort("fatal: STL threw bad_alloc");
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_bad_cast(void)
 {
     mozalloc_abort("fatal: STL threw bad_cast");
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_bad_typeid(void)
 {
     mozalloc_abort("fatal: STL threw bad_typeid");
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_logic_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_domain_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_invalid_argument(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_length_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_out_of_range(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_runtime_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_range_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_overflow_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_underflow_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_ios_failure(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_NORETURN MOZ_ALWAYS_INLINE void
 __throw_system_error(int err)
 {
     char error[128];

--- a/xpcom/glue/nsTArray.h
+++ b/xpcom/glue/nsTArray.h
@@ -1812,7 +1812,7 @@ public:
   nsTArray() {}
   explicit nsTArray(size_type aCapacity) : base_type(aCapacity) {}
   explicit nsTArray(const nsTArray& aOther) : base_type(aOther) {}
-  MOZ_IMPLICIT nsTArray(nsTArray&& aOther) : base_type(mozilla::Move(aOther)) {}
+  explicit nsTArray(nsTArray&& aOther) : base_type(mozilla::Move(aOther)) {}
 
   template<class Allocator>
   explicit nsTArray(const nsTArray_Impl<E, Allocator>& aOther)

--- a/xpcom/tests/TestTArray.cpp
+++ b/xpcom/tests/TestTArray.cpp
@@ -289,16 +289,6 @@ class Moveable {
 /* static */ uint32_t Countable::sCount = 0;
 /* static */ uint32_t Moveable::sCount = 0;
 
-static nsTArray<int> returns_by_value() {
-  nsTArray<int> result;
-  return result;
-}
-
-static bool test_return_by_value() {
-  nsTArray<int> result = returns_by_value();
-  return true;
-}
-
 static bool test_move_array() {
   nsTArray<Countable> countableArray;
   uint32_t i;
@@ -1181,7 +1171,6 @@ static const struct Test {
   DECL_TEST(test_char_array),
   DECL_TEST(test_uint32_array),
   DECL_TEST(test_object_array),
-  DECL_TEST(test_return_by_value),
   DECL_TEST(test_move_array),
   DECL_TEST(test_string_array),
   DECL_TEST(test_comptr_array),


### PR DESCRIPTION
Reverts MoonchildProductions/Pale-Moon#1180

This breaks too many stable builds and needs to be reworked into conditional changes selected via preprocessor.