### PR TITLE
Re-introduce Clang support

### DIFF
--- a/js/xpconnect/src/xpcprivate.h
+++ b/js/xpconnect/src/xpcprivate.h
@@ -199,6 +199,10 @@ extern const char XPC_SCRIPT_ERROR_CONTRACTID[];
 extern const char XPC_ID_CONTRACTID[];
 extern const char XPC_XPCONNECT_CONTRACTID[];
 
+// Duplicate WeakMapPtr declaration, this help mark WeakMapPtr symbols in
+// xpconnect as "visible" so as not to break libxul linking
+template class JS_PUBLIC_API(JS::WeakMapPtr)<JSObject*, JSObject*>;
+
 /***************************************************************************/
 // Useful macros...
 

--- a/js/xpconnect/src/xpcprivate.h
+++ b/js/xpconnect/src/xpcprivate.h
@@ -199,9 +199,11 @@ extern const char XPC_SCRIPT_ERROR_CONTRACTID[];
 extern const char XPC_ID_CONTRACTID[];
 extern const char XPC_XPCONNECT_CONTRACTID[];
 
+#if defined(__clang__)
 // Duplicate WeakMapPtr declaration, this help mark WeakMapPtr symbols in
 // xpconnect as "visible" so as not to break libxul linking
 template class JS_PUBLIC_API(JS::WeakMapPtr)<JSObject*, JSObject*>;
+#endif
 
 /***************************************************************************/
 // Useful macros...

--- a/memory/mozalloc/throw_gcc.h
+++ b/memory/mozalloc/throw_gcc.h
@@ -22,14 +22,14 @@
 // libc++ 4.0.0 and higher use C++11 [[noreturn]] attributes for the functions
 // below, and since clang does not allow mixing __attribute__((noreturn)) and
 // [[noreturn]], we have to explicitly use the latter here.  See bug 1329520.
-#if defined(__clang__)
-#  if __has_feature(cxx_attributes) && \
-      defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 4000
-#    define MOZ_THROW_NORETURN [[noreturn]]
-#  endif
+#if __has_feature(cxx_attributes) && \
+    defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 4000
+#  define MOZ_THROW_NORETURN [[noreturn]]
+#  define MOZ_THROW_EXPORT MOZALLOC_EXPORT
 #endif
 #ifndef MOZ_THROW_NORETURN
 #  define MOZ_THROW_NORETURN MOZ_NORETURN
+#  define MOZ_THROW_EXPORT
 #endif
 
 namespace std {
@@ -38,91 +38,91 @@ namespace std {
 // doing this after careful review because we want to define our own
 // exception throwing semantics.  Don't try this at home!
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_bad_exception(void)
 {
     mozalloc_abort("fatal: STL threw bad_exception");
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_bad_alloc(void)
 {
     mozalloc_abort("fatal: STL threw bad_alloc");
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_bad_cast(void)
 {
     mozalloc_abort("fatal: STL threw bad_cast");
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_bad_typeid(void)
 {
     mozalloc_abort("fatal: STL threw bad_typeid");
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_logic_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_domain_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_invalid_argument(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_length_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_out_of_range(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_runtime_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_range_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_overflow_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_underflow_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_ios_failure(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZ_THROW_EXPORT MOZ_ALWAYS_INLINE void
 __throw_system_error(int err)
 {
     char error[128];

--- a/memory/mozalloc/throw_gcc.h
+++ b/memory/mozalloc/throw_gcc.h
@@ -22,10 +22,12 @@
 // libc++ 4.0.0 and higher use C++11 [[noreturn]] attributes for the functions
 // below, and since clang does not allow mixing __attribute__((noreturn)) and
 // [[noreturn]], we have to explicitly use the latter here.  See bug 1329520.
-#if __has_feature(cxx_attributes) && \
-    defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 4000
-#  define MOZ_THROW_NORETURN [[noreturn]]
-#  define MOZ_THROW_EXPORT MOZALLOC_EXPORT
+#if defined(__clang__)
+#  if __has_feature(cxx_attributes) && \
+      defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 4000
+#    define MOZ_THROW_NORETURN [[noreturn]]
+#    define MOZ_THROW_EXPORT MOZALLOC_EXPORT
+#  endif
 #endif
 #ifndef MOZ_THROW_NORETURN
 #  define MOZ_THROW_NORETURN MOZ_NORETURN

--- a/memory/mozalloc/throw_gcc.h
+++ b/memory/mozalloc/throw_gcc.h
@@ -19,97 +19,110 @@
 
 #include "mozilla/mozalloc_abort.h"
 
+// libc++ 4.0.0 and higher use C++11 [[noreturn]] attributes for the functions
+// below, and since clang does not allow mixing __attribute__((noreturn)) and
+// [[noreturn]], we have to explicitly use the latter here.  See bug 1329520.
+#if defined(__clang__)
+#  if __has_feature(cxx_attributes) && \
+      defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 4000
+#    define MOZ_THROW_NORETURN [[noreturn]]
+#  endif
+#endif
+#ifndef MOZ_THROW_NORETURN
+#  define MOZ_THROW_NORETURN MOZ_NORETURN
+#endif
+
 namespace std {
 
 // NB: user code is not supposed to touch the std:: namespace.  We're
 // doing this after careful review because we want to define our own
 // exception throwing semantics.  Don't try this at home!
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_bad_exception(void)
 {
     mozalloc_abort("fatal: STL threw bad_exception");
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_bad_alloc(void)
 {
     mozalloc_abort("fatal: STL threw bad_alloc");
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_bad_cast(void)
 {
     mozalloc_abort("fatal: STL threw bad_cast");
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_bad_typeid(void)
 {
     mozalloc_abort("fatal: STL threw bad_typeid");
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_logic_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_domain_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_invalid_argument(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_length_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_out_of_range(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_runtime_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_range_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_overflow_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_underflow_error(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_ios_failure(const char* msg)
 {
     mozalloc_abort(msg);
 }
 
-MOZ_NORETURN MOZ_ALWAYS_INLINE void
+MOZ_THROW_NORETURN MOZALLOC_EXPORT MOZ_ALWAYS_INLINE void
 __throw_system_error(int err)
 {
     char error[128];

--- a/xpcom/glue/nsTArray.h
+++ b/xpcom/glue/nsTArray.h
@@ -1812,7 +1812,7 @@ public:
   nsTArray() {}
   explicit nsTArray(size_type aCapacity) : base_type(aCapacity) {}
   explicit nsTArray(const nsTArray& aOther) : base_type(aOther) {}
-  explicit nsTArray(nsTArray&& aOther) : base_type(mozilla::Move(aOther)) {}
+  MOZ_IMPLICIT nsTArray(nsTArray&& aOther) : base_type(mozilla::Move(aOther)) {}
 
   template<class Allocator>
   explicit nsTArray(const nsTArray_Impl<E, Allocator>& aOther)

--- a/xpcom/glue/nsTArray.h
+++ b/xpcom/glue/nsTArray.h
@@ -1812,7 +1812,11 @@ public:
   nsTArray() {}
   explicit nsTArray(size_type aCapacity) : base_type(aCapacity) {}
   explicit nsTArray(const nsTArray& aOther) : base_type(aOther) {}
+#if defined(__clang__)
   MOZ_IMPLICIT nsTArray(nsTArray&& aOther) : base_type(mozilla::Move(aOther)) {}
+#else
+  explicit nsTArray(nsTArray&& aOther) : base_type(mozilla::Move(aOther)) {}
+#endif
 
   template<class Allocator>
   explicit nsTArray(const nsTArray_Impl<E, Allocator>& aOther)

--- a/xpcom/tests/TestTArray.cpp
+++ b/xpcom/tests/TestTArray.cpp
@@ -289,6 +289,16 @@ class Moveable {
 /* static */ uint32_t Countable::sCount = 0;
 /* static */ uint32_t Moveable::sCount = 0;
 
+static nsTArray<int> returns_by_value() {
+  nsTArray<int> result;
+  return result;
+}
+
+static bool test_return_by_value() {
+  nsTArray<int> result = returns_by_value();
+  return true;
+}
+
 static bool test_move_array() {
   nsTArray<Countable> countableArray;
   uint32_t i;
@@ -1171,6 +1181,7 @@ static const struct Test {
   DECL_TEST(test_char_array),
   DECL_TEST(test_uint32_array),
   DECL_TEST(test_object_array),
+  DECL_TEST(test_return_by_value),
   DECL_TEST(test_move_array),
   DECL_TEST(test_string_array),
   DECL_TEST(test_comptr_array),


### PR DESCRIPTION
Changes since #1180:

- Fixed build with `--enable-shared-js`
- Properly `#ifdef`-ed clang bits

Bugs: [1156538](https://bugzil.la/1156538), [1259537](https://bugzil.la/1259537), [1329520](https://bugzil.la/1329520)

Build status:
- [x] Clang 5.0.0
- [x] GCC 4 - 6
- [x] MSVC