### PR TITLE
Change print_to_filename

### DIFF
--- a/widget/gtk/nsDeviceContextSpecG.cpp
+++ b/widget/gtk/nsDeviceContextSpecG.cpp
@@ -482,9 +482,9 @@ NS_IMETHODIMP nsPrinterEnumeratorGTK::InitPrintSettingsFromPrinter(const char16_
       path = PR_GetEnv("HOME");
   
     if (path)
-      filename = nsPrintfCString("%s/palemoon.pdf", path);
+      filename = nsPrintfCString("%s/goanna.pdf", path);
     else
-      filename.AssignLiteral("palemoon.pdf");
+      filename.AssignLiteral("goanna.pdf");
   }  
   DO_PR_DEBUG_LOG(("Setting default filename to '%s'\n", filename.get()));
   aPrintSettings->SetToFileName(NS_ConvertUTF8toUTF16(filename).get());

--- a/widget/gtk/nsDeviceContextSpecG.cpp
+++ b/widget/gtk/nsDeviceContextSpecG.cpp
@@ -482,9 +482,9 @@ NS_IMETHODIMP nsPrinterEnumeratorGTK::InitPrintSettingsFromPrinter(const char16_
       path = PR_GetEnv("HOME");
   
     if (path)
-      filename = nsPrintfCString("%s/mozilla.pdf", path);
+      filename = nsPrintfCString("%s/palemoon.pdf", path);
     else
-      filename.AssignLiteral("mozilla.pdf");
+      filename.AssignLiteral("palemoon.pdf");
   }  
   DO_PR_DEBUG_LOG(("Setting default filename to '%s'\n", filename.get()));
   aPrintSettings->SetToFileName(NS_ConvertUTF8toUTF16(filename).get());


### PR DESCRIPTION
When printing to file on Linux systems, filename is filled with "mozilla.pdf".
This PR changes it to "palemoon.pdf"