### PR TITLE
Fix seeking when video has only 1 video frame

### DIFF
--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -2428,16 +2428,7 @@ MediaDecoderStateMachine::SeekCompleted()
     newCurrentTime = mAudioStartTime = seekTime;
   } else if (HasAudio()) {
     AudioData* audio = AudioQueue().PeekFront();
-    // Though we adjust the newCurrentTime in audio-based, and supplemented
-    // by video. For better UX, should NOT bind the slide position to
-    // the first audio data timestamp directly.
-    // While seeking to a position where there's only either audio or video, or
-    // seeking to a position lies before audio or video, we need to check if
-    // seekTime is bounded in suitable duration. See Bug 1112438.
-    int64_t videoStart = video ? video->mTime : seekTime;
-    int64_t audioStart = audio ? audio->mTime : seekTime;
-    newCurrentTime = mAudioStartTime =
-        std::min(std::min(audioStart, videoStart), seekTime);
+    newCurrentTime = mAudioStartTime = audio ? audio->mTime : seekTime;
   } else {
     newCurrentTime = video ? video->mTime : seekTime;
   }


### PR DESCRIPTION
This reverts a change we inherited from Mozilla that works around seeking issues in Firefox OS, but had effects on desktop as well if the video stream only contains one video frame (seeking would not work). Since we don't care about FFOS, this PR reverts that change and fixes the issue for desktop. Note that this does not yet fix the Vimeo seek issue.

Tested on several major video sites and works as intended. Below is also a testcase (borrowed from someone at Mozilla):

https://people.mozilla.org/~jyavenard/tests/1frame.html