### PR TITLE
DevTools - gcli commands - cookie (+ help)

### DIFF
--- a/toolkit/devtools/gcli/source/lib/gcli/commands/commands.js
+++ b/toolkit/devtools/gcli/source/lib/gcli/commands/commands.js
@@ -298,10 +298,10 @@ Parameter.prototype.toJson = function() {
   };
 
   // Values do not need to be serializable, so we don't try. For the client
-  // side (which doesn't do any executing) we don't actually care what the
-  // default value is, just that it exists
+  // side (which doesn't do any executing) we only care whether default value is
+  // undefined, null, or something else.
   if (this.paramSpec.defaultValue !== undefined) {
-    json.defaultValue = {};
+    json.defaultValue = (this.paramSpec.defaultValue === null) ? null : {};
   }
   if (this.paramSpec.description != null) {
     json.description = this.paramSpec.description;

--- a/toolkit/devtools/gcli/source/lib/gcli/commands/help.js
+++ b/toolkit/devtools/gcli/source/lib/gcli/commands/help.js
@@ -65,7 +65,7 @@ function getHelpManData(commandData, context) {
       }
       else {
         // We need defaultText to work the text version of defaultValue
-        input = l10n.lookupFormat('helpManOptional');
+        input = l10n.lookup('helpManOptional');
         /*
         var val = param.type.stringify(param.defaultValue);
         input = Promise.resolve(val).then(function(defaultValue) {


### PR DESCRIPTION
## 1) gcli commands - cookie

Removing invalid attributes, adding a valid attributes.

\+ style clean up
(a performance - `XPCOMUtils.defineLazyGetter`; remove unused code - `let cookies = [];`)

An example:
`cookie list` - `Attributes`

## 2) gcli commands - fix the help

An example:
`help cookie set`

Throws an error in Browser Console:
```
"Failed to format" "helpManOptional"
TypeError: swaps is undefined
Stack trace:
exports.lookupFormat@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/gcli/util/l10n.js:83:5
getHelpManData/<.getTypeDescription@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/gcli/commands/help.js:68:17
l10n.js:86
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1045273

---

You add the label `Devtools`, please.
You add the label `UXP-task`, please.
(Firefox - I will create an issue for that - ad 1))

---

I've created the new build (x32, Windows).
