### PR TITLE
Build fixes for Linux/m68k

### DIFF
--- a/ipc/chromium/src/build/build_config.h
+++ b/ipc/chromium/src/build/build_config.h
@@ -81,6 +81,9 @@
 #elif defined(__ppc__) || defined(__powerpc__)
 #define ARCH_CPU_PPC 1
 #define ARCH_CPU_32_BITS 1
+#elif defined(__m68k__)
+#define ARCH_CPU_M68K 1
+#define ARCH_CPU_32_BITS 1
 #elif defined(__sparc64__)
 #define ARCH_CPU_SPARC 1
 #define ARCH_CPU_64_BITS 1

--- a/media/webrtc/trunk/build/build_config.h
+++ b/media/webrtc/trunk/build/build_config.h
@@ -129,6 +129,11 @@
 #define ARCH_CPU_PPC 1
 #define ARCH_CPU_32_BITS 1
 #define ARCH_CPU_BIG_ENDIAN 1
+#elif defined(__m68k__)
+#define ARCH_CPU_M68K_FAMILY 1
+#define ARCH_CPU_M68K 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_BIG_ENDIAN 1
 #elif defined(__sparc64__)
 #define ARCH_CPU_SPARC_FAMILY 1
 #define ARCH_CPU_SPARC 1

--- a/mfbt/tests/TestPair.cpp
+++ b/mfbt/tests/TestPair.cpp
@@ -29,14 +29,19 @@ using mozilla::Pair;
   static_assert(sizeof(name##_2) == (size), \
                 "Pair<" #T2 ", " #T1 "> has an unexpected size");
 
+static constexpr size_t sizemax(size_t a, size_t b)
+{
+  return (a > b) ? a : b;
+}
+
 INSTANTIATE(int, int, prim1, 2 * sizeof(int));
-INSTANTIATE(int, long, prim2, 2 * sizeof(long));
+INSTANTIATE(int, long, prim2, sizeof(long) + sizemax(sizeof(int), alignof(long)));
 
 struct EmptyClass { explicit EmptyClass(int) {} };
 struct NonEmpty { char mC; explicit NonEmpty(int) {} };
 
 INSTANTIATE(int, EmptyClass, both1, sizeof(int));
-INSTANTIATE(int, NonEmpty, both2, 2 * sizeof(int));
+INSTANTIATE(int, NonEmpty, both2, sizeof(int) + alignof(int));
 INSTANTIATE(EmptyClass, NonEmpty, both3, 1);
 
 struct A { char dummy; explicit A(int) {} };

--- a/mfbt/tests/TestPoisonArea.cpp
+++ b/mfbt/tests/TestPoisonArea.cpp
@@ -133,6 +133,9 @@
 #elif defined _ARCH_PPC || defined _ARCH_PWR || defined _ARCH_PWR2
 #define RETURN_INSTR 0x4E800020 /* blr */
 
+#elif defined __m68k__
+#define RETURN_INSTR 0x4E754E75 /* rts; rts */
+
 #elif defined __sparc || defined __sparcv9
 #define RETURN_INSTR 0x81c3e008 /* retl */
 

--- a/xpcom/reflect/xptcall/md/unix/xptcinvoke_linux_m68k.cpp
+++ b/xpcom/reflect/xptcall/md/unix/xptcinvoke_linux_m68k.cpp
@@ -100,7 +100,8 @@ EXPORT_XPCOM_API(nsresult)
 NS_InvokeByIndex(nsISupports* that, uint32_t methodIndex,
                    uint32_t paramCount, nsXPTCVariant* params)
 {
-    uint32_t result, n;
+    nsresult result;
+    uint32_t n;
 
     n = invoke_count_words(paramCount, params) * 4;
 

--- a/xpcom/reflect/xptcall/md/unix/xptcstubs_linux_m68k.cpp
+++ b/xpcom/reflect/xptcall/md/unix/xptcstubs_linux_m68k.cpp
@@ -63,7 +63,7 @@ extern "C" {
             case nsXPTType::T_U64    : dp->val.u64 = *((uint64_t*)ap); ap++; break;
             case nsXPTType::T_FLOAT  : dp->val.f   = *((float*)   ap);       break;
             case nsXPTType::T_DOUBLE : dp->val.d   = *((double*)  ap); ap++; break;
-            case nsXPTType::T_BOOL   : dp->val.b   = *((uint32_t* ap);       break;
+            case nsXPTType::T_BOOL   : dp->val.b   = *((uint32_t*)ap);       break;
             case nsXPTType::T_CHAR   : dp->val.c   = *(((char*)   ap) + 3);  break;
             case nsXPTType::T_WCHAR  : dp->val.wc  = *((wchar_t*) ap);       break;
             default:


### PR DESCRIPTION
Hi!

This pull request contains a couple of patches necessary to fix the build of PaleMoon on Linux/m68k.

Those patches are based on my patch set for Firefox upstream [1], I just backported them to the PaleMoon codebase.

All of these patches have already been acknowledged by Mozilla upstream [2]. However, they haven't been merged yet because Mozilla upstream does not agree with my approach to enforce alignment of some structs as required for Linux/m68k. I haven't included these alignment fixes in this pull request yet anyway.

I have more fixes for other patches lined up which I am happy to contribute to PaleMoon as well!

Thanks for consideration! 

Adrian

> [1] https://github.com/glaubitz/gecko-dev/commits/m68k
> [2] https://bugzilla.mozilla.org/show_bug.cgi?id=1325771