### PR TITLE
Places - getLivemark - deprecated warnings

### DIFF
--- a/browser/components/places/content/bookmarkProperties.js
+++ b/browser/components/places/content/bookmarkProperties.js
@@ -253,24 +253,20 @@ var BookmarkPropertiesPanel = {
 
         case "folder":
           this._itemType = BOOKMARK_FOLDER;
-          PlacesUtils.livemarks.getLivemark(
-            { id: this._itemId },
-            (function (aStatus, aLivemark) {
-              if (Components.isSuccessCode(aStatus)) {
-                this._itemType = LIVEMARK_CONTAINER;
-                this._feedURI = aLivemark.feedURI;
-                this._siteURI = aLivemark.siteURI;
-                this._fillEditProperties();
+          PlacesUtils.livemarks.getLivemark({ id: this._itemId })
+            .then(aLivemark => {
+              this._itemType = LIVEMARK_CONTAINER;
+              this._feedURI = aLivemark.feedURI;
+              this._siteURI = aLivemark.siteURI;
+              this._fillEditProperties();
 
-                let acceptButton = document.documentElement.getButton("accept");
-                acceptButton.disabled = !this._inputIsValid();
+              let acceptButton = document.documentElement.getButton("accept");
+              acceptButton.disabled = !this._inputIsValid();
 
-                let newHeight = window.outerHeight +
-                                this._element("descriptionField").boxObject.height;
-                window.resizeTo(window.outerWidth, newHeight);
-              }
-            }).bind(this)
-          );
+              let newHeight = window.outerHeight +
+                              this._element("descriptionField").boxObject.height;
+              window.resizeTo(window.outerWidth, newHeight);
+            }, () => undefined);
 
           break;
       }

--- a/browser/components/places/content/browserPlacesViews.js
+++ b/browser/components/places/content/browserPlacesViews.js
@@ -302,21 +302,17 @@ PlacesViewBase.prototype = {
             element.setAttribute("hostContainer", "true");
         }
         else if (itemId != -1) {
-          PlacesUtils.livemarks.getLivemark(
-            { id: itemId },
-            function (aStatus, aLivemark) {
-              if (Components.isSuccessCode(aStatus)) {
-                element.setAttribute("livemark", "true");
+          PlacesUtils.livemarks.getLivemark({ id: itemId })
+            .then(aLivemark => {
+              element.setAttribute("livemark", "true");
 #ifdef XP_MACOSX
-                // OS X native menubar doesn't track list-style-images since
-                // it doesn't have a frame (bug 733415).  Thus enforce updating.
-                element.setAttribute("image", "");
-                element.removeAttribute("image");
+              // OS X native menubar doesn't track list-style-images since
+              // it doesn't have a frame (bug 733415).  Thus enforce updating.
+              element.setAttribute("image", "");
+              element.removeAttribute("image");
 #endif
-                this.controller.cacheLivemarkInfo(aPlacesNode, aLivemark);
-              }
-            }.bind(this)
-          );
+              this.controller.cacheLivemarkInfo(aPlacesNode, aLivemark);
+            }, () => undefined);
         }
 
         let popup = document.createElement("menupopup");
@@ -489,16 +485,12 @@ PlacesViewBase.prototype = {
 #endif
       }
 
-      PlacesUtils.livemarks.getLivemark(
-        { id: aPlacesNode.itemId },
-        function (aStatus, aLivemark) {
-          if (Components.isSuccessCode(aStatus)) {
-            // Controller will use this to build the meta data for the node.
-            this.controller.cacheLivemarkInfo(aPlacesNode, aLivemark);
-            this.invalidateContainer(aPlacesNode);
-          }
-        }.bind(this)
-      );
+      PlacesUtils.livemarks.getLivemark({ id: aPlacesNode.itemId })
+        .then(aLivemark => {
+          // Controller will use this to build the meta data for the node.
+          this.controller.cacheLivemarkInfo(aPlacesNode, aLivemark);
+          this.invalidateContainer(aPlacesNode);
+        }, () => undefined);
     }
   },
 
@@ -627,26 +619,23 @@ PlacesViewBase.prototype = {
           return;
         }
 
-        PlacesUtils.livemarks.getLivemark({ id: aPlacesNode.itemId },
-          function (aStatus, aLivemark) {
-            if (Components.isSuccessCode(aStatus)) {
-              let shouldInvalidate =
-                !this.controller.hasCachedLivemarkInfo(aPlacesNode);
-              this.controller.cacheLivemarkInfo(aPlacesNode, aLivemark);
-              if (aNewState == Ci.nsINavHistoryContainerResultNode.STATE_OPENED) {
-                aLivemark.registerForUpdates(aPlacesNode, this);
-                // Prioritize the current livemark.
-                aLivemark.reload();
-                PlacesUtils.livemarks.reloadLivemarks();
-                if (shouldInvalidate)
-                  this.invalidateContainer(aPlacesNode);
-              }
-              else {
-                aLivemark.unregisterForUpdates(aPlacesNode);
-              }
+        PlacesUtils.livemarks.getLivemark({ id: aPlacesNode.itemId })
+          .then(aLivemark => {
+            let shouldInvalidate =
+              !this.controller.hasCachedLivemarkInfo(aPlacesNode);
+            this.controller.cacheLivemarkInfo(aPlacesNode, aLivemark);
+            if (aNewState == Ci.nsINavHistoryContainerResultNode.STATE_OPENED) {
+              aLivemark.registerForUpdates(aPlacesNode, this);
+              // Prioritize the current livemark.
+              aLivemark.reload();
+              PlacesUtils.livemarks.reloadLivemarks();
+              if (shouldInvalidate)
+                this.invalidateContainer(aPlacesNode);
             }
-          }.bind(this)
-        );
+            else {
+              aLivemark.unregisterForUpdates(aPlacesNode);
+            }
+          }, () => undefined);
       }
     }
   },
@@ -658,10 +647,10 @@ PlacesViewBase.prototype = {
     if (aPopup._startMarker.nextSibling == aPopup._endMarker)
       this._setLivemarkStatusMenuItem(aPopup, Ci.mozILivemark.STATUS_LOADING);
 
-    PlacesUtils.livemarks.getLivemark({ id: aPopup._placesNode.itemId },
-      function (aStatus, aLivemark) {
+    PlacesUtils.livemarks.getLivemark({ id: aPopup._placesNode.itemId })
+      .then(aLivemark => {
         let placesNode = aPopup._placesNode;
-        if (!Components.isSuccessCode(aStatus) || !placesNode.containerOpen)
+        if (!placesNode.containerOpen)
           return;
 
         if (aLivemark.status != Ci.mozILivemark.STATUS_LOADING)
@@ -678,8 +667,7 @@ PlacesViewBase.prototype = {
           else
             this._getDOMNodeForPlacesNode(child).removeAttribute("visited");
         }
-      }.bind(this)
-    );
+      }, Components.utils.reportError);
   },
 
   invalidateContainer: function PVB_invalidateContainer(aPlacesNode) {
@@ -978,15 +966,11 @@ PlacesToolbar.prototype = {
             button.setAttribute("tagContainer", "true");
         }
         else if (PlacesUtils.nodeIsFolder(aChild)) {
-          PlacesUtils.livemarks.getLivemark(
-            { id: aChild.itemId },
-            function (aStatus, aLivemark) {
-              if (Components.isSuccessCode(aStatus)) {
-                button.setAttribute("livemark", "true");
-                this.controller.cacheLivemarkInfo(aChild, aLivemark);
-              }
-            }.bind(this)
-          );
+          PlacesUtils.livemarks.getLivemark({ id: aChild.itemId })
+            .then(aLivemark => {
+              button.setAttribute("livemark", "true");
+              this.controller.cacheLivemarkInfo(aChild, aLivemark);
+            }, () => undefined);
         }
 
         let popup = document.createElement("menupopup");
@@ -1229,15 +1213,11 @@ PlacesToolbar.prototype = {
       if (aAnno == PlacesUtils.LMANNO_FEEDURI) {
         elt.setAttribute("livemark", true);
 
-        PlacesUtils.livemarks.getLivemark(
-          { id: aPlacesNode.itemId },
-          function (aStatus, aLivemark) {
-            if (Components.isSuccessCode(aStatus)) {
-              this.controller.cacheLivemarkInfo(aPlacesNode, aLivemark);
-              this.invalidateContainer(aPlacesNode);
-            }
-          }.bind(this)
-        );
+        PlacesUtils.livemarks.getLivemark({ id: aPlacesNode.itemId })
+          .then(aLivemark => {
+            this.controller.cacheLivemarkInfo(aPlacesNode, aLivemark);
+            this.invalidateContainer(aPlacesNode);
+          }, Components.utils.reportError);
       }
     }
     else {

--- a/browser/components/places/content/controller.js
+++ b/browser/components/places/content/controller.js
@@ -692,14 +692,10 @@ PlacesController.prototype = {
     var selectedNode = this._view.selectedNode;
     if (selectedNode) {
       let itemId = selectedNode.itemId;
-      PlacesUtils.livemarks.getLivemark(
-        { id: itemId },
-        (function(aStatus, aLivemark) {
-          if (Components.isSuccessCode(aStatus)) {
-            aLivemark.reload(true);
-          }
-        }).bind(this)
-      );
+      PlacesUtils.livemarks.getLivemark({ id: itemId })
+        .then(aLivemark => {
+          aLivemark.reload(true);
+        }, Components.utils.reportError);
     }
   },
 

--- a/browser/components/places/content/editBookmarkOverlay.js
+++ b/browser/components/places/content/editBookmarkOverlay.js
@@ -147,17 +147,13 @@ var gEditItemOverlay = {
       else {
         this._uri = null;
         this._isLivemark = false;
-        PlacesUtils.livemarks.getLivemark(
-          {id: this._itemId },
-          (function (aStatus, aLivemark) {
-            if (Components.isSuccessCode(aStatus)) {
-              this._isLivemark = true;
-              this._initTextField("feedLocationField", aLivemark.feedURI.spec, true);
-              this._initTextField("siteLocationField", aLivemark.siteURI ? aLivemark.siteURI.spec : "", true);
-              this._showHideRows();
-            }
-          }).bind(this)
-        );
+        PlacesUtils.livemarks.getLivemark({id: this._itemId })
+          .then(aLivemark => {
+            this._isLivemark = true;
+            this._initTextField("feedLocationField", aLivemark.feedURI.spec, true);
+            this._initTextField("siteLocationField", aLivemark.siteURI ? aLivemark.siteURI.spec : "", true);
+            this._showHideRows();
+          }, () => undefined);
       }
 
       // folder picker

--- a/browser/components/places/content/treeView.js
+++ b/browser/components/places/content/treeView.js
@@ -796,11 +796,11 @@ PlacesTreeView.prototype = {
   },
 
   _populateLivemarkContainer: function PTV__populateLivemarkContainer(aNode) {
-    PlacesUtils.livemarks.getLivemark({ id: aNode.itemId },
-      function (aStatus, aLivemark) {
+    PlacesUtils.livemarks.getLivemark({ id: aNode.itemId })
+      .then(aLivemark => {
         let placesNode = aNode;
         // Need to check containerOpen since getLivemark is async.
-        if (!Components.isSuccessCode(aStatus) || !placesNode.containerOpen)
+        if (!placesNode.containerOpen)
           return;
 
         let children = aLivemark.getNodesForContainer(placesNode);
@@ -808,7 +808,7 @@ PlacesTreeView.prototype = {
           let child = children[i];
           this.nodeInserted(placesNode, child, i);
         }
-      }.bind(this));
+      }, Components.utils.reportError);
   },
 
   nodeTitleChanged: function PTV_nodeTitleChanged(aNode, aNewTitle) {
@@ -857,18 +857,14 @@ PlacesTreeView.prototype = {
       this._invalidateCellValue(aNode, this.COLUMN_TYPE_DESCRIPTION);
     }
     else if (aAnno == PlacesUtils.LMANNO_FEEDURI) {
-      PlacesUtils.livemarks.getLivemark(
-        { id: aNode.itemId },
-        function (aStatus, aLivemark) {
-          if (Components.isSuccessCode(aStatus)) {
-            this._controller.cacheLivemarkInfo(aNode, aLivemark);
-            let properties = this._cellProperties.get(aNode);
-            this._cellProperties.set(aNode, properties += " livemark");
-            // The livemark attribute is set as a cell property on the title cell.
-            this._invalidateCellValue(aNode, this.COLUMN_TYPE_TITLE);
-          }
-        }.bind(this)
-      );
+      PlacesUtils.livemarks.getLivemark({ id: aNode.itemId })
+        .then(aLivemark => {
+          this._controller.cacheLivemarkInfo(aNode, aLivemark);
+          let properties = this._cellProperties.get(aNode);
+          this._cellProperties.set(aNode, properties += " livemark");
+          // The livemark attribute is set as a cell property on the title cell.
+          this._invalidateCellValue(aNode, this.COLUMN_TYPE_TITLE);
+        }, Components.utils.reportError);
     }
   },
 
@@ -1181,18 +1177,14 @@ PlacesTreeView.prototype = {
             properties += " livemark";
           }
           else {
-            PlacesUtils.livemarks.getLivemark(
-              { id: node.itemId },
-              function (aStatus, aLivemark) {
-                if (Components.isSuccessCode(aStatus)) {
-                  this._controller.cacheLivemarkInfo(node, aLivemark);
-                  let props = this._cellProperties.get(node);
-                  this._cellProperties.set(node, props += " livemark");
-                  // The livemark attribute is set as a cell property on the title cell.
-                  this._invalidateCellValue(node, this.COLUMN_TYPE_TITLE);
-                }
-              }.bind(this)
-            );
+            PlacesUtils.livemarks.getLivemark({ id: node.itemId })
+              .then(aLivemark => {
+                this._controller.cacheLivemarkInfo(node, aLivemark);
+                let props = this._cellProperties.get(node); 
+                this._cellProperties.set(node, props += " livemark");
+                // The livemark attribute is set as a cell property on the title cell.
+                this._invalidateCellValue(node, this.COLUMN_TYPE_TITLE);
+              }, () => undefined);
           }
         }
 


### PR DESCRIPTION
__Steps to reproduce:__

Go to: `about:config`
Setting `devtools.errorconsole.deprecation_warnings` = `true`

## 1)

The Main Menu: Bookmarks (with some livemarks)

Throws an warnings in Browser Console:
```
DEPRECATION WARNING:
Passing a callback to Livermarks methods is deprecated. Please use the returned promise instead.
You may find more details about this deprecation at:
https://developer.mozilla.org/docs/Mozilla/JavaScript_code_modules/Promise.jsm
resource://gre/components/nsLivemarkService.js 371 LS_getLivemark
chrome://browser/content/places/browserPlacesViews.js 614 PVB_containerStateChanged
chrome://browser/content/places/browserPlacesViews.js 77 PlacesViewBase.prototype.result
chrome://browser/content/places/browserPlacesViews.js 51 PlacesViewBase.prototype.place
chrome://browser/content/places/browserPlacesViews.js 13 PlacesViewBase
chrome://browser/content/places/browserPlacesViews.js 1663 PlacesMenu
chrome://browser/content/browser.xul 1 onpopupshowing
Deprecated.jsm:79:0
```
```
DEPRECATION WARNING:
Passing a callback to Livermarks methods is deprecated. Please use the returned promise instead.
You may find more details about this deprecation at:
https://developer.mozilla.org/docs/Mozilla/JavaScript_code_modules/Promise.jsm
resource://gre/components/nsLivemarkService.js 371 LS_getLivemark
chrome://browser/content/places/browserPlacesViews.js 305 PVB__createMenuItemForPlacesNode
chrome://browser/content/places/browserPlacesViews.js 347 PVB__insertNewItemToPopup
chrome://browser/content/places/browserPlacesViews.js 231 PVB__rebuildPopup
chrome://browser/content/places/browserPlacesViews.js 825 PVB__onPopupShowing
chrome://browser/content/places/browserPlacesViews.js 1664 PlacesMenu
chrome://browser/content/browser.xul 1 onpopupshowing
Deprecated.jsm:79:0
```
## 2)

Go to: https://forum.palemoon.org/feed.php?f=1
Press the `Subscribe Now` button.

Throws an warnings in Browser Console:
```
DEPRECATION WARNING:
Passing a callback to Livermarks methods is deprecated. Please use the returned promise instead.
You may find more details about this deprecation at:
https://developer.mozilla.org/docs/Mozilla/JavaScript_code_modules/Promise.jsm
resource://gre/components/nsLivemarkService.js 371 LS_getLivemark
chrome://browser/content/places/editBookmarkOverlay.js 150 EIO_initPanel
chrome://browser/content/places/bookmarkProperties.js 438 BPP__fillAddProperties
chrome://browser/content/places/bookmarkProperties.js 362 BPP_onDialogLoad
chrome://browser/content/places/bookmarkProperties2.xul 1 onload
resource://app/modules/PlacesUIUtils.jsm 393 PUIU_showBookmarkDialog
chrome://browser/content/browser.js 2462 PCH_addLiveBookmark
resource://app/components/FeedConverter.js 427 FRS_addToClientReader
resource://app/components/FeedWriter.js 1285 FW_subscribe/subscribeCallback<
resource://app/components/FeedWriter.js 1310 FW_subscribe
resource://app/components/FeedWriter.js 828 FeedWriter.prototype.handleEvent
Deprecated.jsm:79:0
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=969318

See also:
#1023 

---

I've created the new build (x32, Windows).
