### PR TITLE
Restore missing notification icons

### DIFF
--- a/toolkit/themes/linux/global/notification.css
+++ b/toolkit/themes/linux/global/notification.css
@@ -44,15 +44,15 @@ notification[type="critical"] {
 
 /* Default icons for notifications */
 
-.messageImage[type="info"] {
+notification[type="info"] .messageImage {
   list-style-image: url("moz-icon://stock/gtk-dialog-info?size=menu");
 }
 
-.messageImage[type="warning"] {
+notification[type="warning"] .messageImage {
   list-style-image: url("moz-icon://stock/gtk-dialog-warning?size=menu");
 }
 
-.messageImage[type="critical"] {
+notification[type="critical"] .messageImage {
   list-style-image: url("moz-icon://stock/gtk-dialog-error?size=menu");
 }
 

--- a/toolkit/themes/osx/global/notification.css
+++ b/toolkit/themes/osx/global/notification.css
@@ -44,15 +44,15 @@ notification[type="critical"] {
 
 /* Default icons for notifications */
 
-.messageImage[type="info"] {
+notification[type="info"] .messageImage {
   list-style-image: url("chrome://global/skin/notification/info-icon.png");
 }
 
-.messageImage[type="warning"] {
+notification[type="warning"] .messageImage {
   list-style-image: url("chrome://global/skin/notification/warning-icon.png");
 }
 
-.messageImage[type="critical"] {
+notification[type="critical"] .messageImage {
   list-style-image: url("chrome://global/skin/notification/error-icon.png");
 }
 

--- a/toolkit/themes/windows/global/notification.css
+++ b/toolkit/themes/windows/global/notification.css
@@ -34,15 +34,15 @@ notification[type="critical"] {
 
 /* Default icons for notifications */
 
-.messageImage[type="info"] {
+notification[type="info"] .messageImage {
   list-style-image: url("chrome://global/skin/icons/information-16.png");
 }
 
-.messageImage[type="warning"] {
+notification[type="warning"] .messageImage {
   list-style-image: url("chrome://global/skin/icons/warning-16.png");
 }
 
-.messageImage[type="critical"] {
+notification[type="critical"] .messageImage {
   list-style-image: url("chrome://global/skin/icons/error-16.png");
 }
 


### PR DESCRIPTION
This pull request restores the missing notification icons in the notification bar (appears on top of the status bar) by changing the selectors for the notification icons. Tested by editing omni.ja, please add the `verification needed` and `theme/ui` tags.

I have noticed in a lot of themes (including the default theme) that when some events happen such as I was unable to sync for a few days, the icon beside the notification text is missing. I compared the "notification.css" file to one of my themes and found that the selectors for the icons were different.