### PR TITLE
Places - livemarks - menulist.xml (MutationObserver)

### DIFF
--- a/toolkit/content/tests/chrome/test_bug360220.xul
+++ b/toolkit/content/tests/chrome/test_bug360220.xul
@@ -28,15 +28,33 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=360220
 <script class="testbody" type="application/javascript">
 <![CDATA[
 
+SimpleTest.waitForExplicitFinish();
+
 /** Test for Bug 360220 **/
 
 var menulist = document.getElementById("menulist");
 var secondItem = document.getElementById("secondItem");
 menulist.selectedItem = secondItem;
 
-ok(menulist.label == "bar", "second item was not selected");
+is(menulist.label, "bar", "second item was not selected");
+
+let mutObserver = new MutationObserver(() => {
+  is(menulist.label, "new label", "menulist label was not updated to the label of its selected item");
+  done();
+});
+mutObserver.observe(menulist, { attributeFilter: ['label'] });
 secondItem.label = "new label";
-ok(menulist.label == "new label", "menulist label was not updated to the label of its selected item");
+
+let failureTimeout = setTimeout(function() {
+  ok(false, "menulist label should have updated");
+  done();
+}, 2000);
+
+function done() {
+  mutObserver.disconnect();
+  clearTimeout(failureTimeout);
+  SimpleTest.finish();
+}
 ]]>
 </script>
 

--- a/toolkit/content/tests/chrome/test_menulist.xul
+++ b/toolkit/content/tests/chrome/test_menulist.xul
@@ -84,13 +84,6 @@ SimpleTest.waitForExplicitFinish();
 function testtag_menulists()
 {
   testtag_menulist_UI_start($("menulist"), false);
-  testtag_menulist_UI_start($("menulist-editable"), true);
-
-  // bug 566154, the menulist width should account for vertical scrollbar
-  ok(document.getElementById("menulist-size").getBoundingClientRect().width >= 210,
-     "menulist popup width includes scrollbar width");
-
-  $("menulist").open = true;
 }
 
 function testtag_menulist_UI_start(element, editable)
@@ -104,11 +97,25 @@ function testtag_menulist_UI_start(element, editable)
 
   // test the interfaces that menulist implements
   test_nsIDOMXULMenuListElement(element, testprefix, editable);
+}
 
+function testtag_menulist_UI_finish(element, editable)
+{
   element.value = "";
 
   test_nsIDOMXULSelectControlElement(element, "menuitem",
                                      editable ? "editable" : null);
+
+  if (!editable) {
+    testtag_menulist_UI_start($("menulist-editable"), true);
+  }
+  else {
+    // bug 566154, the menulist width should account for vertical scrollbar
+    ok(document.getElementById("menulist-size").getBoundingClientRect().width >= 210,
+       "menulist popup width includes scrollbar width");
+
+    $("menulist").open = true;
+  }
 }
 
 function test_nsIDOMXULMenuListElement(element, testprefix, editable)
@@ -152,6 +159,7 @@ function test_nsIDOMXULMenuListElement(element, testprefix, editable)
     element.selectedIndex = 1;
     is(element.image, "", testprefix + " image set to selected");
     is(element.description, "", testprefix + " description set to selected");
+    test_nsIDOMXULMenuListElement_finish(element, testprefix, editable);
   }
   else {
     element.selectedIndex = 1;
@@ -165,27 +173,66 @@ function test_nsIDOMXULMenuListElement(element, testprefix, editable)
     is(element.description, "This is the third description", testprefix + " description set to selected again");
 
     // check that changing the properties of the selected item changes the menulist's properties
-    thirditem.label = "Item Number Three";
-    is(element.label, "Item Number Three", testprefix + " label modified");
-    thirditem.value = "item-three";
-    is(element.value, "item-three", testprefix + " value modified");
-    thirditem.image = "smile.png";
-    is(element.image, "smile.png", testprefix + " image modified");
-    thirditem.setAttribute("description", "Changed description");
-    is(element.description, "Changed description", testprefix + " description modified");
-    seconditem.label = "Changed Label 2";
-    is(element.label, "Item Number Three", testprefix + " label of another item modified");
+    let properties = [{attr: "label", value: "Item Number Three"},
+                      {attr: "value", value: "item-three"},
+                      {attr: "image", value: "smile.png"},
+                      {attr: "description", value: "Changed description"}];
+    test_nsIDOMXULMenuListElement_properties(element, testprefix, editable, thirditem, properties);
+  }
+}
 
-    element.selectedIndex = 0;
-    is(element.image, "", testprefix + " image set to selected with no image");
-    is(element.description, "", testprefix + " description set to selected with no description");
+function test_nsIDOMXULMenuListElement_properties(element, testprefix, editable, thirditem, properties)
+{
+  let {attr, value} = properties.shift();
+  let last = (properties.length == 0);
+
+  let mutObserver = new MutationObserver(() => {
+    is(element.getAttribute(attr), value, `${testprefix} ${attr} modified`);
+    done();
+  });
+  mutObserver.observe(element, { attributeFilter: [attr] });
+
+  let failureTimeout = setTimeout(() => {
+    ok(false, `${testprefix} ${attr} should have updated`);
+    done();
+  }, 2000);
+
+  function done()
+  {
+    clearTimeout(failureTimeout);
+    mutObserver.disconnect();
+    if (!last) {
+      test_nsIDOMXULMenuListElement_properties(element, testprefix, editable, thirditem, properties);
+    }
+    else {
+      test_nsIDOMXULMenuListElement_unselected(element, testprefix, editable, thirditem);
+    }
   }
 
+  thirditem.setAttribute(attr, value)
+}
+
+function test_nsIDOMXULMenuListElement_unselected(element, testprefix, editable, thirditem)
+{
+  let seconditem = thirditem.previousElementSibling;
+  seconditem.label = "Changed Label 2";
+  is(element.label, "Item Number Three", testprefix + " label of another item modified");
+
+  element.selectedIndex = 0;
+  is(element.image, "", testprefix + " image set to selected with no image");
+  is(element.description, "", testprefix + " description set to selected with no description");
+  test_nsIDOMXULMenuListElement_finish(element, testprefix, editable);
+}
+
+function test_nsIDOMXULMenuListElement_finish(element, testprefix, editable)
+{
   // check the removeAllItems method
   element.appendItem("An Item", "anitem");
   element.appendItem("Another Item", "anotheritem");
   element.removeAllItems();
   is(element.itemCount, 0, testprefix + " removeAllItems");
+
+  testtag_menulist_UI_finish(element, editable);
 }
 
 function test_menulist_open(element, scroller)

--- a/toolkit/content/widgets/menulist.xml
+++ b/toolkit/content/widgets/menulist.xml
@@ -66,10 +66,11 @@
       </handler>
     </handlers>
 
-    <implementation implements="nsIDOMXULMenuListElement, nsIDOMEventListener">
+    <implementation implements="nsIDOMXULMenuListElement">
       <constructor>
         this.mInputField = null;
         this.mSelectedInternal = null;
+        this.mAttributeObserver = null;
         this.menuBoxObject = this.boxObject;
         this.setInitialSelection();
       </constructor>
@@ -211,39 +212,29 @@
 
             if (oldval) {
               oldval.removeAttribute('selected');
-              if (document instanceof Components.interfaces.nsIDOMXULDocument) {
-                document.removeBroadcastListenerFor(oldval, this, "value");
-                document.removeBroadcastListenerFor(oldval, this, "label");
-                document.removeBroadcastListenerFor(oldval, this, "image");
-                document.removeBroadcastListenerFor(oldval, this, "description");
-              }
-              else
-                oldval.removeEventListener("DOMAttrModified", this, false);
+              this.mAttributeObserver.disconnect();
             }
 
             this.mSelectedInternal = val;
+            let attributeFilter = ["value", "label", "image", "description"];
             if (val) {
               val.setAttribute('selected', 'true');
-              this.setAttribute('value', val.getAttribute('value'));
-              this.setAttribute('image', val.getAttribute('image'));
-              this.setAttribute('label', val.getAttribute('label'));
-              this.setAttribute('description', val.getAttribute('description'));
-              // DOMAttrModified listeners slow down setAttribute calls within
-              // the document, see bug 395496
-              if (document instanceof Components.interfaces.nsIDOMXULDocument) {
-                document.addBroadcastListenerFor(val, this, "value");
-                document.addBroadcastListenerFor(val, this, "label");
-                document.addBroadcastListenerFor(val, this, "image");
-                document.addBroadcastListenerFor(val, this, "description");
+              for (let attr of attributeFilter) {
+                if (val.hasAttribute(attr)) {
+                  this.setAttribute(attr, val.getAttribute(attr));
+                }
+                else {
+                  this.removeAttribute(attr);
+                }
               }
-              else
-                val.addEventListener("DOMAttrModified", this, false);
+
+              this.mAttributeObserver = new MutationObserver(this.handleMutation.bind(this));
+              this.mAttributeObserver.observe(val, { attributeFilter });
             }
             else {
-              this.removeAttribute('value');
-              this.removeAttribute('image');
-              this.removeAttribute('label');
-              this.removeAttribute('description');
+              for (let attr of attributeFilter) {
+                this.removeAttribute(attr);
+              }
             }
 
             var event = document.createEvent("Events");
@@ -259,19 +250,26 @@
         </setter>
       </property>
 
-      <method name="handleEvent">
-        <parameter name="aEvent"/>
+      <method name="handleMutation">
+        <parameter name="aRecords"/>
         <body>
           <![CDATA[
-            if (aEvent.type == "DOMAttrModified" &&
-                aEvent.target == this.mSelectedInternal) {
-              var attrName = aEvent.attrName;
-              switch (attrName) {
-                case "value":
-                case "label":
-                case "image":
-                case "description":
-                  this.setAttribute(attrName, aEvent.newValue);
+            for (let record of aRecords) {
+              let t = record.target;
+              if (t == this.mSelectedInternal) {
+                let attrName = record.attributeName;
+                switch (attrName) {
+                  case "value":
+                  case "label":
+                  case "image":
+                  case "description":
+                    if (t.hasAttribute(attrName)) {
+                      this.setAttribute(attrName, t.getAttribute(attrName));
+                    }
+                    else {
+                      this.removeAttribute(attrName);
+                    }
+                }
               }
             }
           ]]>
@@ -384,15 +382,8 @@
 
       <destructor>
         <![CDATA[
-          if (this.mSelectedInternal) {
-            if (document instanceof Components.interfaces.nsIDOMXULDocument) {
-              document.removeBroadcastListenerFor(this.mSelectedInternal, this, "value");
-              document.removeBroadcastListenerFor(this.mSelectedInternal, this, "label");
-              document.removeBroadcastListenerFor(this.mSelectedInternal, this, "image");
-              document.removeBroadcastListenerFor(this.mSelectedInternal, this, "description");
-            }
-            else
-              this.mSelectedInternal.removeEventListener("DOMAttrModified", this, false);
+          if (this.mAttributeObserver) {
+            this.mAttributeObserver.disconnect();
           }
         ]]>
       </destructor>

--- a/toolkit/content/widgets/menulist.xml
+++ b/toolkit/content/widgets/menulist.xml
@@ -131,7 +131,6 @@
                                    onget="return this.getAttribute('description');"/>
       <property name="editable"  onset="this.setAttribute('editable',val); return val;"
                                  onget="return this.getAttribute('editable') == 'true';"/>
-
       <property name="open" onset="this.menuBoxObject.openMenu(val);
                                    return val;"
                             onget="return this.hasAttribute('open');"/>
@@ -241,7 +240,7 @@
             event.initEvent("select", true, true);
             this.dispatchEvent(event);
 
-            var event = document.createEvent("Events");
+            event = document.createEvent("Events");
             event.initEvent("ValueChange", true, true);
             this.dispatchEvent(event);
 
@@ -438,7 +437,7 @@
             if (val)
               val.setAttribute('selected', 'true');
 
-            //Do NOT change the "value", which is owned by inputField
+            // Do NOT change the "value", which is owned by inputField
             return val;
           ]]>
         </body>
@@ -506,7 +505,7 @@
             event.initEvent("select", true, true);
             this.dispatchEvent(event);
 
-            var event = document.createEvent("Events");
+            event = document.createEvent("Events");
             event.initEvent("ValueChange", true, true);
             this.dispatchEvent(event);
 
@@ -541,7 +540,7 @@
     <handlers>
       <handler event="focus" phase="capturing">
         <![CDATA[
-          this.setAttribute('focused','true');
+          this.setAttribute('focused', 'true');
         ]]>
       </handler>
 

--- a/toolkit/content/widgets/menulist.xml
+++ b/toolkit/content/widgets/menulist.xml
@@ -129,8 +129,23 @@
       <property name="label" readonly="true" onget="return this.getAttribute('label');"/>
       <property name="description" onset="this.setAttribute('description',val); return val;"
                                    onget="return this.getAttribute('description');"/>
-      <property name="editable"  onset="this.setAttribute('editable',val); return val;"
-                                 onget="return this.getAttribute('editable') == 'true';"/>
+
+      <property name="editable" onget="return this.getAttribute('editable') == 'true';">
+        <setter>
+          <![CDATA[
+            if (!val && this.editable) {
+              // If we were focused and transition from editable to not editable,
+              // focus the parent menulist so that the focus does not get stuck.
+              if (this.inputField == document.activeElement)
+                window.setTimeout(() => this.focus(), 0);
+            }
+
+            this.setAttribute("editable", val);
+            return val;
+          ]]>
+        </setter>
+      </property>
+
       <property name="open" onset="this.menuBoxObject.openMenu(val);
                                    return val;"
                             onget="return this.hasAttribute('open');"/>


### PR DESCRIPTION
Ad #1200 

__Steps to reproduce:__

Go to: https://forum.palemoon.org/feed.php?f=1

Throws a warning in Browser Console:
```
Use of Mutation Events is deprecated. Use MutationObserver instead.
menulist.xml:240:0
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1059146

\+ Style clean up:
https://hg.mozilla.org/mozilla-central/diff/62c5218b7325/toolkit/content/widgets/menulist.xml
https://hg.mozilla.org/mozilla-central/diff/345ff6c8b0a2/toolkit/content/widgets/menulist.xml
https://hg.mozilla.org/mozilla-central/diff/23b49f827838/toolkit/content/widgets/menulist.xml
(I can revert back)

A suggestion (editable menulist loosing editable attribute gets focus stuck):
https://bugzilla.mozilla.org/show_bug.cgi?id=1142224
(I have no example - I can revert back)

---

I've created the new build (x32, Windows) and tested.
