### PR TITLE
[minor fix] Some sites - throws an errors (aTab is null)

### DIFF
--- a/browser/base/content/tabbrowser.xml
+++ b/browser/base/content/tabbrowser.xml
@@ -3160,6 +3160,10 @@
             return;
 
           var tab = this._getTabForContentWindow(contentWin);
+          if (!tab) {
+            return;
+          }
+
           var titleChanged = this.setTabTitle(tab);
           if (titleChanged && !tab.selected && !tab.hasAttribute("busy"))
             tab.setAttribute("titlechanged", "true");


### PR DESCRIPTION
Some sites - throws an errors in Browser Console:
```
TypeError: aTab is null
tabbrowser.xml:2291:10
```

See:
https://hg.mozilla.org/mozilla-central/rev/103ffeaa554d

See also:
#745 

__I can give some example later today... Do you need it, please?__

---

I've created the new build (x64) and tested.
