### PR TITLE
[minor fix] about:feeds - throws an errors

### DIFF
--- a/browser/components/feeds/FeedWriter.js
+++ b/browser/components/feeds/FeedWriter.js
@@ -637,14 +637,20 @@ FeedWriter.prototype = {
         Cc["@mozilla.org/browser/feeds/result-service;1"].
         getService(Ci.nsIFeedResultService);
 
+    var result = null;
     try {
-      var result = 
+      result = 
         feedService.getFeedResult(this._getOriginalURI(this._window));
     }
     catch (e) {
-      LOG("Subscribe Preview: feed not available?!");
+      // Ignore.
     }
-    
+
+    if (!result) {
+      LOG("Subscribe Preview: feed not available?!");
+      return null;
+    }
+
     if (result.bozo) {
       LOG("Subscribe Preview: feed result is bozo?!");
     }


### PR DESCRIPTION

Ad #1200

__Steps to reproduce:__

Go to: `about:feeds`

Throws an errors in Browser Console:
```
TypeError: result is null
FeedWriter.js:644:0

NS_ERROR_UNEXPECTED:
subscribe.js:17:0
```

---

I've created the new build (x64) and tested.
