### PR TITLE
[minor fix] about:feeds - throws a warning (deprecated)

### DIFF
--- a/browser/base/content/browser-places.js
+++ b/browser/base/content/browser-places.js
@@ -424,18 +424,15 @@ var PlacesCommandHook = {
    *            A short description of the feed. Optional.
    */
   addLiveBookmark: function PCH_addLiveBookmark(url, feedTitle, feedSubtitle) {
-    var feedURI = makeURI(url);
-    
-    var doc = gBrowser.contentDocument;
-    var title = (arguments.length > 1) ? feedTitle : doc.title;
- 
-    var description;
-    if (arguments.length > 2)
-      description = feedSubtitle;
-    else
-      description = PlacesUIUtils.getDescriptionFromDocument(doc);
+    let toolbarIP = new InsertionPoint(PlacesUtils.toolbarFolderId, -1);
 
-    var toolbarIP = new InsertionPoint(PlacesUtils.toolbarFolderId, -1);
+    let feedURI = makeURI(url);
+    let title = feedTitle || gBrowser.contentTitle;
+    let description = feedSubtitle;
+    if (!description) {
+      description = PlacesUIUtils.getDescriptionFromDocument(gBrowser.contentDocument);
+    }
+
     PlacesUIUtils.showBookmarkDialog({ action: "add"
                                      , type: "livemark"
                                      , feedURI: feedURI


### PR DESCRIPTION
Ad #1200

__Steps to reproduce:__

Go to: `about:feeds`
Press the `Subscribe Now` button.

Throws an error in Browser Console:
```
Error: nsNavHistory::GetPageTitle is deprecated and will be removed in the next version.
<unknown>
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1199239

\+ style clean up (CRLF -> LF)

---

I've created the new build (x32) and tested.
