### PR TITLE
Small fixes to libnestegg (for WebM)

### DIFF
--- a/dom/media/DecoderTraits.cpp
+++ b/dom/media/DecoderTraits.cpp
@@ -187,8 +187,8 @@ static char const *const gWebMCodecs[7] = {
   nullptr
 };
 
-static bool
-IsWebMType(const nsACString& aType)
+/* static */ bool
+DecoderTraits::IsWebMType(const nsACString& aType)
 {
   if (!MediaDecoder::IsWebMEnabled()) {
     return false;
@@ -589,7 +589,7 @@ if (IsMP3SupportedType(aType)) {
   }
 #endif
 #ifdef MOZ_WEBM
-  if (IsWebMType(aType)) {
+  if (DecoderTraits::IsWebMType(aType)) {
     decoder = new WebMDecoder();
     return decoder.forget();
   }

--- a/dom/media/DecoderTraits.h
+++ b/dom/media/DecoderTraits.h
@@ -61,6 +61,8 @@ public:
   // Returns true if we should not start decoder until we receive
   // OnConnected signal. (currently RTSP only)
   static bool DecoderWaitsForOnConnected(const nsACString& aType);
+
+  static bool IsWebMType(const nsACString& aType);
 };
 
 }

--- a/dom/media/mediasource/MediaSourceReader.cpp
+++ b/dom/media/mediasource/MediaSourceReader.cpp
@@ -23,6 +23,10 @@
 #include "MP4Reader.h"
 #endif
 
+#ifdef MOZ_WEBM
+#include "WebMReader.h"
+#endif
+
 #ifdef PR_LOGGING
 extern PRLogModuleInfo* GetMediaSourceLog();
 
@@ -677,7 +681,14 @@ CreateReaderForType(const nsACString& aType, AbstractMediaDecoder* aDecoder)
     return reader;
   }
 #endif
-  return DecoderTraits::CreateReader(aType, aDecoder);
+
+#ifdef MOZ_WEBM
+  if (DecoderTraits::IsWebMType(aType)) {
+    return new WebMReader(aDecoder);
+  }
+#endif
+
+  return nullptr;
 }
 
 already_AddRefed<SourceBufferDecoder>

--- a/media/libnestegg/include/nestegg.h
+++ b/media/libnestegg/include/nestegg.h
@@ -7,6 +7,7 @@
 #if !defined(NESTEGG_671cac2a_365d_ed69_d7a3_4491d3538d79)
 #define NESTEGG_671cac2a_365d_ed69_d7a3_4491d3538d79
 
+#include <limits.h>
 #include <nestegg/nestegg-stdint.h>
 
 #if defined(__cplusplus)
@@ -62,13 +63,15 @@ extern "C" {
 /** @file
     The <tt>libnestegg</tt> C API. */
 
-#define NESTEGG_TRACK_VIDEO 0 /**< Track is of type video. */
-#define NESTEGG_TRACK_AUDIO 1 /**< Track is of type audio. */
+#define NESTEGG_TRACK_VIDEO   0       /**< Track is of type video. */
+#define NESTEGG_TRACK_AUDIO   1       /**< Track is of type audio. */
+#define NESTEGG_TRACK_UNKNOWN INT_MAX /**< Track is of type unknown. */
 
-#define NESTEGG_CODEC_VP8    0 /**< Track uses Google On2 VP8 codec. */
-#define NESTEGG_CODEC_VORBIS 1 /**< Track uses Xiph Vorbis codec. */
-#define NESTEGG_CODEC_VP9    2 /**< Track uses Google On2 VP9 codec. */
-#define NESTEGG_CODEC_OPUS   3 /**< Track uses Xiph Opus codec. */
+#define NESTEGG_CODEC_VP8     0       /**< Track uses Google On2 VP8 codec. */
+#define NESTEGG_CODEC_VORBIS  1       /**< Track uses Xiph Vorbis codec. */
+#define NESTEGG_CODEC_VP9     2       /**< Track uses Google On2 VP9 codec. */
+#define NESTEGG_CODEC_OPUS    3       /**< Track uses Xiph Opus codec. */
+#define NESTEGG_CODEC_UNKNOWN INT_MAX /**< Track uses unknown codec. */
 
 #define NESTEGG_VIDEO_MONO              0 /**< Track is mono video. */
 #define NESTEGG_VIDEO_STEREO_LEFT_RIGHT 1 /**< Track is side-by-side stereo video.  Left first. */
@@ -222,16 +225,20 @@ int nestegg_track_seek(nestegg * context, unsigned int track, uint64_t tstamp);
 /** Query the type specified by @a track.
     @param context Stream context initialized by #nestegg_init.
     @param track   Zero based track number.
-    @retval #NESTEGG_TRACK_VIDEO Track type is video.
-    @retval #NESTEGG_TRACK_AUDIO Track type is audio.
+    @retval #NESTEGG_TRACK_VIDEO   Track type is video.
+    @retval #NESTEGG_TRACK_AUDIO   Track type is audio.
+    @retval #NESTEGG_TRACK_UNKNOWN Track type is unknown.
     @retval -1 Error. */
 int nestegg_track_type(nestegg * context, unsigned int track);
 
 /** Query the codec ID specified by @a track.
     @param context Stream context initialized by #nestegg_init.
     @param track   Zero based track number.
-    @retval #NESTEGG_CODEC_VP8    Track codec is VP8.
-    @retval #NESTEGG_CODEC_VORBIS Track codec is Vorbis.
+    @retval #NESTEGG_CODEC_VP8     Track codec is VP8.
+    @retval #NESTEGG_CODEC_VP9     Track codec is VP9.
+    @retval #NESTEGG_CODEC_VORBIS  Track codec is Vorbis.
+    @retval #NESTEGG_CODEC_OPUS    Track codec is Opus.
+    @retval #NESTEGG_CODEC_UNKNOWN Track codec is unknown.
     @retval -1 Error. */
 int nestegg_track_codec_id(nestegg * context, unsigned int track);
 

--- a/media/libnestegg/src/nestegg.c
+++ b/media/libnestegg/src/nestegg.c
@@ -2168,7 +2168,7 @@ nestegg_track_type(nestegg * ctx, unsigned int track)
   if (type & TRACK_TYPE_AUDIO)
     return NESTEGG_TRACK_AUDIO;
 
-  return -1;
+  return NESTEGG_TRACK_UNKNOWN;
 }
 
 int
@@ -2196,7 +2196,7 @@ nestegg_track_codec_id(nestegg * ctx, unsigned int track)
   if (strcmp(codec_id, TRACK_ID_OPUS) == 0)
     return NESTEGG_CODEC_OPUS;
 
-  return -1;
+  return NESTEGG_CODEC_UNKNOWN;
 }
 
 int

--- a/media/libnestegg/src/nestegg.c
+++ b/media/libnestegg/src/nestegg.c
@@ -2205,6 +2205,7 @@ nestegg_track_codec_data_count(nestegg * ctx, unsigned int track,
 {
   struct track_entry * entry;
   struct ebml_binary codec_private;
+  int codec_id;
   unsigned char * p;
 
   *count = 0;
@@ -2213,7 +2214,14 @@ nestegg_track_codec_data_count(nestegg * ctx, unsigned int track,
   if (!entry)
     return -1;
 
-  if (nestegg_track_codec_id(ctx, track) != NESTEGG_CODEC_VORBIS)
+  codec_id = nestegg_track_codec_id(ctx, track);
+
+  if (codec_id == NESTEGG_CODEC_OPUS) {
+    *count = 1;
+    return 0;
+  }
+
+  if (codec_id != NESTEGG_CODEC_VORBIS)
     return -1;
 
   if (ne_get_binary(entry->codec_private, &codec_private) != 0)


### PR DESCRIPTION
The PR contains 3 small updates in preparation for updating our WebM code:

- Explicitly instantiate the WebMReader in MediaSourceReader.
- Cherry-pick fix from upstream libnestegg for opus handling.
- Cherry-pick fix from upstream libnestegg to distinguish unknown track types from actual errors (for better spec compliance).

Lightly tested with MSE + WebM on YouTube and quirksmode WebM tests.