### PR TITLE
[minor fix, suggestion] Search box - browser.urlbar.clickSelectsAll - add an observer

### DIFF
--- a/browser/components/search/content/search.xml
+++ b/browser/components/search/content/search.xml
@@ -722,15 +722,12 @@
           if (aTopic == "nsPref:changed") {
             switch (aData) {
               case "browser.search.suggest.enabled":
-                this._suggestEnabled =
-                  this._prefBranch.getBoolPref(aData);
-                this._suggestMenuItem.setAttribute(
-                  "checked", this._suggestEnabled);
+                this._suggestEnabled = this._prefBranch.getBoolPref(aData);
+                this._suggestMenuItem.setAttribute("checked", this._suggestEnabled);
                 break;
               case "browser.urlbar.clickSelectsAll":
-                this._clickSelectsAll =
-                  this._prefBranch.getBoolPref(aData);
-                  this.setAttribute("clickSelectsAll", this._clickSelectsAll);
+                this._clickSelectsAll = this._prefBranch.getBoolPref(aData);
+                this.setAttribute("clickSelectsAll", this._clickSelectsAll);
                 break;
             }
           }

--- a/browser/components/search/content/search.xml
+++ b/browser/components/search/content/search.xml
@@ -653,6 +653,7 @@
       <field name="_prefBranch"/>
       <field name="_suggestMenuItem"/>
       <field name="_suggestEnabled"/>
+      <field name="_clickSelectsAll"/>
 
       <!--
         This overrides the searchParam property in autocomplete.xml.  We're

--- a/browser/components/search/content/search.xml
+++ b/browser/components/search/content/search.xml
@@ -564,9 +564,10 @@
                             .getService(Components.interfaces.nsIPrefBranch);
         this._suggestEnabled =
             this._prefBranch.getBoolPref("browser.search.suggest.enabled");
+        this._clickSelectsAll =
+            this._prefBranch.getBoolPref("browser.urlbar.clickSelectsAll");
 
-        if (this._prefBranch.getBoolPref("browser.urlbar.clickSelectsAll"))
-          this.setAttribute("clickSelectsAll", true);
+        this.setAttribute("clickSelectsAll", this._clickSelectsAll);
 
         // Add items to context menu and attach controller to handle them
         var textBox = document.getAnonymousElementByAttribute(this,
@@ -632,12 +633,14 @@
         var prefs = Components.classes["@mozilla.org/preferences-service;1"]
                             .getService(Components.interfaces.nsIPrefBranch);
         prefs.addObserver("browser.search.suggest.enabled", this, false);
+        prefs.addObserver("browser.urlbar.clickSelectsAll", this, false);
       ]]></constructor>
 
       <destructor><![CDATA[
           var prefs = Components.classes["@mozilla.org/preferences-service;1"]
                               .getService(Components.interfaces.nsIPrefBranch);
           prefs.removeObserver("browser.search.suggest.enabled", this);
+          prefs.removeObserver("browser.urlbar.clickSelectsAll", this);
 
         // Because XBL and the customize toolbar code interacts poorly,
         // there may not be anything to remove here
@@ -716,9 +719,19 @@
         <parameter name="aData"/>
         <body><![CDATA[
           if (aTopic == "nsPref:changed") {
-            this._suggestEnabled =
-              this._prefBranch.getBoolPref("browser.search.suggest.enabled");
-            this._suggestMenuItem.setAttribute("checked", this._suggestEnabled);
+            switch (aData) {
+              case "browser.search.suggest.enabled":
+                this._suggestEnabled =
+                  this._prefBranch.getBoolPref(aData);
+                this._suggestMenuItem.setAttribute(
+                  "checked", this._suggestEnabled);
+                break;
+              case "browser.urlbar.clickSelectsAll":
+                this._clickSelectsAll =
+                  this._prefBranch.getBoolPref(aData);
+                  this.setAttribute("clickSelectsAll", this._clickSelectsAll);
+                break;
+            }
           }
         ]]></body>
       </method>


### PR DESCRIPTION
Ad https://forum.palemoon.org/viewtopic.php?f=37&t=16091

`about:config` > `browser.urlbar.clickSelectsAll`

For Search box:
It works, but does not take effect until after the browser restarts.

---

I've created the new build (x32, Windows) and tested.
