### PR TITLE
Do not apply add-on compatibility update in strict mode.

### DIFF
--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -6504,6 +6504,9 @@ AddonInternal.prototype = {
   },
 
   applyCompatibilityUpdate: function AddonInternal_applyCompatibilityUpdate(aUpdate, aSyncCompatibility) {
+    if (this.strictCompatibility) {
+      return;
+    }
     this.targetApplications.forEach(function(aTargetApp) {
       aUpdate.targetApplications.forEach(function(aUpdateTarget) {
         if (aTargetApp.id == aUpdateTarget.id && (aSyncCompatibility ||


### PR DESCRIPTION
Do not allow to override add-on's `minVersion` & `maxVersion` from the update server data in the strict compatibility mode (i.e. when `addon.type` is not in `{extension, dictionary}` or `extensions.strictCompatibility == true`).

See also [issue at phoebus](https://github.com/Pale-Moon-Addons-Team/phoebus/issues/57#issuecomment-313670445).
