### PR TITLE
Updates to NesteggPacketHolder/WebM

### DIFF
--- a/dom/media/webm/IntelWebMVideoDecoder.cpp
+++ b/dom/media/webm/IntelWebMVideoDecoder.cpp
@@ -156,7 +156,7 @@ IntelWebMVideoDecoder::Init(unsigned int aWidth, unsigned int aHeight)
 bool
 IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
 {
-  nsAutoRef<NesteggPacketHolder> holder(mReader->NextPacket(WebMReader::VIDEO));
+  nsRefPtr<NesteggPacketHolder> holder(mReader->NextPacket(WebMReader::VIDEO));
   if (!holder) {
     return false;
   }
@@ -185,13 +185,13 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
   // end of the resource, use the file's duration as the end time of this
   // video frame.
   uint64_t next_tstamp = 0;
-  nsAutoRef<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
+  nsRefPtr<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
   if (next_holder) {
     r = nestegg_packet_tstamp(next_holder->mPacket, &next_tstamp);
     if (r == -1) {
       return false;
     }
-    mReader->PushVideoPacket(next_holder.disown());
+    mReader->PushVideoPacket(next_holder.forget());
   } else {
     next_tstamp = tstamp;
     next_tstamp += tstamp - mReader->GetLastVideoFrameTime();

--- a/dom/media/webm/IntelWebMVideoDecoder.cpp
+++ b/dom/media/webm/IntelWebMVideoDecoder.cpp
@@ -161,7 +161,7 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
     return false;
   }
 
-  nestegg_packet* packet = holder->mPacket;
+  nestegg_packet* packet = holder->Packet();
   unsigned int track = 0;
   int r = nestegg_packet_track(packet, &track);
   if (r == -1) {
@@ -187,7 +187,7 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
   uint64_t next_tstamp = 0;
   nsRefPtr<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
   if (next_holder) {
-    r = nestegg_packet_tstamp(next_holder->mPacket, &next_tstamp);
+    r = nestegg_packet_tstamp(next_holder->Packet(), &next_tstamp);
     if (r == -1) {
       return false;
     }

--- a/dom/media/webm/IntelWebMVideoDecoder.cpp
+++ b/dom/media/webm/IntelWebMVideoDecoder.cpp
@@ -174,23 +174,16 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
     return false;
   }
 
-  uint64_t tstamp = 0;
-  r = nestegg_packet_tstamp(packet, &tstamp);
-  if (r == -1) {
-    return false;
-  }
+  int64_t tstamp = holder->Timestamp();
 
   // The end time of this frame is the start time of the next frame.  Fetch
   // the timestamp of the next packet for this track.  If we've reached the
   // end of the resource, use the file's duration as the end time of this
   // video frame.
-  uint64_t next_tstamp = 0;
+  int64_t next_tstamp = 0;
   nsRefPtr<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
   if (next_holder) {
-    r = nestegg_packet_tstamp(next_holder->Packet(), &next_tstamp);
-    if (r == -1) {
-      return false;
-    }
+    next_tstamp = holder->Timestamp();
     mReader->PushVideoPacket(next_holder.forget());
   } else {
     next_tstamp = tstamp;
@@ -198,7 +191,6 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
   }
   mReader->SetLastVideoFrameTime(tstamp);
 
-  int64_t tstamp_usecs = tstamp / NS_PER_USEC;
   for (uint32_t i = 0; i < count; ++i) {
     unsigned char* data;
     size_t length;
@@ -218,8 +210,8 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
 
     MOZ_ASSERT(mPlatform && mMediaDataDecoder);
 
-    aSample = new VP8Sample(tstamp_usecs,
-                            (next_tstamp/NS_PER_USEC) - tstamp_usecs,
+    aSample = new VP8Sample(tstamp,
+                            next_tstamp - tstamp,
                             0,
                             data,
                             length,

--- a/dom/media/webm/IntelWebMVideoDecoder.cpp
+++ b/dom/media/webm/IntelWebMVideoDecoder.cpp
@@ -174,6 +174,11 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
     return false;
   }
 
+  if (count > 1) {
+    NS_WARNING("Packet contains more than one video frame");
+    return false;
+  }
+
   int64_t tstamp = holder->Timestamp();
 
   // The end time of this frame is the start time of the next frame.  Fetch
@@ -191,34 +196,32 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
   }
   mReader->SetLastVideoFrameTime(tstamp);
 
-  for (uint32_t i = 0; i < count; ++i) {
-    unsigned char* data;
-    size_t length;
-    r = nestegg_packet_data(packet, i, &data, &length);
-    if (r == -1) {
-      return false;
-    }
+  unsigned char* data;
+  size_t length;
+  r = nestegg_packet_data(packet, 0, &data, &length);
+  if (r == -1) {
+    return false;
+  }
 
-    vpx_codec_stream_info_t si;
-    memset(&si, 0, sizeof(si));
-    si.sz = sizeof(si);
-    if (mReader->GetVideoCodec() == NESTEGG_CODEC_VP8) {
-      vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), data, length, &si);
-    } else if (mReader->GetVideoCodec() == NESTEGG_CODEC_VP9) {
-      vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
-    }
+  vpx_codec_stream_info_t si;
+  memset(&si, 0, sizeof(si));
+  si.sz = sizeof(si);
+  if (mReader->GetVideoCodec() == NESTEGG_CODEC_VP8) {
+    vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), data, length, &si);
+  } else if (mReader->GetVideoCodec() == NESTEGG_CODEC_VP9) {
+    vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
+  }
 
-    MOZ_ASSERT(mPlatform && mMediaDataDecoder);
+  MOZ_ASSERT(mPlatform && mMediaDataDecoder);
 
-    aSample = new VP8Sample(tstamp,
-                            next_tstamp - tstamp,
-                            0,
-                            data,
-                            length,
-                            si.is_kf);
-    if (!aSample->Data()) {
-      return false;
-    }
+  aSample = new VP8Sample(tstamp,
+                          next_tstamp - tstamp,
+                          0,
+                          data,
+                          length,
+                          si.is_kf);
+  if (!aSample->Data()) {
+    return false;
   }
 
   return true;

--- a/dom/media/webm/SoftwareWebMVideoDecoder.cpp
+++ b/dom/media/webm/SoftwareWebMVideoDecoder.cpp
@@ -102,7 +102,7 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
     return false;
   }
 
-  nestegg_packet* packet = holder->mPacket;
+  nestegg_packet* packet = holder->Packet();
   unsigned int track = 0;
   int r = nestegg_packet_track(packet, &track);
   if (r == -1) {
@@ -128,7 +128,7 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
   uint64_t next_tstamp = 0;
   nsRefPtr<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
   if (next_holder) {
-    r = nestegg_packet_tstamp(next_holder->mPacket, &next_tstamp);
+    r = nestegg_packet_tstamp(next_holder->Packet(), &next_tstamp);
     if (r == -1) {
       return false;
     }
@@ -224,7 +224,7 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
       VideoInfo videoInfo = mReader->GetMediaInfo().mVideo;
       nsRefPtr<VideoData> v = VideoData::Create(videoInfo,
                                                 mReader->GetDecoder()->GetImageContainer(),
-                                                holder->mOffset,
+                                                holder->Offset(),
                                                 tstamp_usecs,
                                                 (next_tstamp / NS_PER_USEC) - tstamp_usecs,
                                                 b,

--- a/dom/media/webm/SoftwareWebMVideoDecoder.cpp
+++ b/dom/media/webm/SoftwareWebMVideoDecoder.cpp
@@ -115,6 +115,11 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
     return false;
   }
 
+  if (count > 1) {
+    NS_WARNING("Packet contains more than one video frame");
+    return false;
+  }
+
   int64_t tstamp = holder->Timestamp();
 
   // The end time of this frame is the start time of the next frame.  Fetch
@@ -132,106 +137,104 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
   }
   mReader->SetLastVideoFrameTime(tstamp);
 
-  for (uint32_t i = 0; i < count; ++i) {
-    unsigned char* data;
-    size_t length;
-    r = nestegg_packet_data(packet, i, &data, &length);
-    if (r == -1) {
+  unsigned char* data;
+  size_t length;
+  r = nestegg_packet_data(packet, 0, &data, &length);
+  if (r == -1) {
+    return false;
+  }
+
+  vpx_codec_stream_info_t si;
+  memset(&si, 0, sizeof(si));
+  si.sz = sizeof(si);
+  if (mReader->GetVideoCodec() == NESTEGG_CODEC_VP8) {
+    vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), data, length, &si);
+  } else if (mReader->GetVideoCodec() == NESTEGG_CODEC_VP9) {
+    vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
+  }
+  if (aKeyframeSkip && (!si.is_kf || tstamp < aTimeThreshold)) {
+    // Skipping to next keyframe...
+    a.mParsed++;
+    a.mDropped++;
+    return true;
+  }
+
+  if (aKeyframeSkip && si.is_kf) {
+    aKeyframeSkip = false;
+  }
+
+  if (vpx_codec_decode(&mVPX, data, length, nullptr, 0)) {
+    return false;
+  }
+
+  // If the timestamp of the video frame is less than
+  // the time threshold required then it is not added
+  // to the video queue and won't be displayed.
+  if (tstamp < aTimeThreshold) {
+    a.mParsed++;
+    a.mDropped++;
+    return true;
+  }
+
+   vpx_codec_iter_t  iter = nullptr;
+  vpx_image_t      *img;
+
+  while ((img = vpx_codec_get_frame(&mVPX, &iter))) {
+    NS_ASSERTION(img->fmt == VPX_IMG_FMT_I420, "WebM image format not I420");
+
+    // Chroma shifts are rounded down as per the decoding examples in the SDK
+    VideoData::YCbCrBuffer b;
+    b.mPlanes[0].mData = img->planes[0];
+    b.mPlanes[0].mStride = img->stride[0];
+    b.mPlanes[0].mHeight = img->d_h;
+    b.mPlanes[0].mWidth = img->d_w;
+    b.mPlanes[0].mOffset = b.mPlanes[0].mSkip = 0;
+
+    b.mPlanes[1].mData = img->planes[1];
+    b.mPlanes[1].mStride = img->stride[1];
+    b.mPlanes[1].mHeight = (img->d_h + 1) >> img->y_chroma_shift;
+    b.mPlanes[1].mWidth = (img->d_w + 1) >> img->x_chroma_shift;
+    b.mPlanes[1].mOffset = b.mPlanes[1].mSkip = 0;
+
+    b.mPlanes[2].mData = img->planes[2];
+    b.mPlanes[2].mStride = img->stride[2];
+    b.mPlanes[2].mHeight = (img->d_h + 1) >> img->y_chroma_shift;
+    b.mPlanes[2].mWidth = (img->d_w + 1) >> img->x_chroma_shift;
+    b.mPlanes[2].mOffset = b.mPlanes[2].mSkip = 0;
+
+    nsIntRect pictureRect = mReader->GetPicture();
+    IntRect picture = ToIntRect(pictureRect);
+    nsIntSize initFrame = mReader->GetInitialFrame();
+    if (img->d_w != static_cast<uint32_t>(initFrame.width) ||
+        img->d_h != static_cast<uint32_t>(initFrame.height)) {
+      // Frame size is different from what the container reports. This is
+      // legal in WebM, and we will preserve the ratio of the crop rectangle
+      // as it was reported relative to the picture size reported by the
+      // container.
+      picture.x = (pictureRect.x * img->d_w) / initFrame.width;
+      picture.y = (pictureRect.y * img->d_h) / initFrame.height;
+      picture.width = (img->d_w * pictureRect.width) / initFrame.width;
+      picture.height = (img->d_h * pictureRect.height) / initFrame.height;
+    }
+
+    VideoInfo videoInfo = mReader->GetMediaInfo().mVideo;
+    nsRefPtr<VideoData> v = VideoData::Create(videoInfo,
+                                              mReader->GetDecoder()->GetImageContainer(),
+                                              holder->Offset(),
+                                              tstamp,
+                                              next_tstamp - tstamp,
+                                              b,
+                                              si.is_kf,
+                                              -1,
+                                              picture);
+    if (!v) {
       return false;
     }
-
-    vpx_codec_stream_info_t si;
-    memset(&si, 0, sizeof(si));
-    si.sz = sizeof(si);
-    if (mReader->GetVideoCodec() == NESTEGG_CODEC_VP8) {
-      vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), data, length, &si);
-    } else if (mReader->GetVideoCodec() == NESTEGG_CODEC_VP9) {
-      vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
-    }
-    if (aKeyframeSkip && (!si.is_kf || tstamp < aTimeThreshold)) {
-      // Skipping to next keyframe...
-      a.mParsed++; // Assume 1 frame per chunk.
-      a.mDropped++;
-      continue;
-    }
-
-    if (aKeyframeSkip && si.is_kf) {
-      aKeyframeSkip = false;
-    }
-
-    if (vpx_codec_decode(&mVPX, data, length, nullptr, 0)) {
-      return false;
-    }
-
-    // If the timestamp of the video frame is less than
-    // the time threshold required then it is not added
-    // to the video queue and won't be displayed.
-    if (tstamp < aTimeThreshold) {
-      a.mParsed++; // Assume 1 frame per chunk.
-      a.mDropped++;
-      continue;
-    }
-
-    vpx_codec_iter_t  iter = nullptr;
-    vpx_image_t      *img;
-
-    while ((img = vpx_codec_get_frame(&mVPX, &iter))) {
-      NS_ASSERTION(img->fmt == VPX_IMG_FMT_I420, "WebM image format not I420");
-
-      // Chroma shifts are rounded down as per the decoding examples in the SDK
-      VideoData::YCbCrBuffer b;
-      b.mPlanes[0].mData = img->planes[0];
-      b.mPlanes[0].mStride = img->stride[0];
-      b.mPlanes[0].mHeight = img->d_h;
-      b.mPlanes[0].mWidth = img->d_w;
-      b.mPlanes[0].mOffset = b.mPlanes[0].mSkip = 0;
-
-      b.mPlanes[1].mData = img->planes[1];
-      b.mPlanes[1].mStride = img->stride[1];
-      b.mPlanes[1].mHeight = (img->d_h + 1) >> img->y_chroma_shift;
-      b.mPlanes[1].mWidth = (img->d_w + 1) >> img->x_chroma_shift;
-      b.mPlanes[1].mOffset = b.mPlanes[1].mSkip = 0;
-
-      b.mPlanes[2].mData = img->planes[2];
-      b.mPlanes[2].mStride = img->stride[2];
-      b.mPlanes[2].mHeight = (img->d_h + 1) >> img->y_chroma_shift;
-      b.mPlanes[2].mWidth = (img->d_w + 1) >> img->x_chroma_shift;
-      b.mPlanes[2].mOffset = b.mPlanes[2].mSkip = 0;
-
-      nsIntRect pictureRect = mReader->GetPicture();
-      IntRect picture = ToIntRect(pictureRect);
-      nsIntSize initFrame = mReader->GetInitialFrame();
-      if (img->d_w != static_cast<uint32_t>(initFrame.width) ||
-          img->d_h != static_cast<uint32_t>(initFrame.height)) {
-        // Frame size is different from what the container reports. This is
-        // legal in WebM, and we will preserve the ratio of the crop rectangle
-        // as it was reported relative to the picture size reported by the
-        // container.
-        picture.x = (pictureRect.x * img->d_w) / initFrame.width;
-        picture.y = (pictureRect.y * img->d_h) / initFrame.height;
-        picture.width = (img->d_w * pictureRect.width) / initFrame.width;
-        picture.height = (img->d_h * pictureRect.height) / initFrame.height;
-      }
-
-      VideoInfo videoInfo = mReader->GetMediaInfo().mVideo;
-      nsRefPtr<VideoData> v = VideoData::Create(videoInfo,
-                                                mReader->GetDecoder()->GetImageContainer(),
-                                                holder->Offset(),
-                                                tstamp,
-                                                next_tstamp - tstamp,
-                                                b,
-                                                si.is_kf,
-                                                -1,
-                                                picture);
-      if (!v) {
-        return false;
-      }
-      a.mParsed++;
-      a.mDecoded++;
-      NS_ASSERTION(a.mDecoded <= a.mParsed,
-        "Expect only 1 frame per chunk per packet in WebM...");
-      mReader->VideoQueue().Push(v);
-    }
+    a.mParsed++;
+    a.mDecoded++;
+    NS_ASSERTION(a.mDecoded <= a.mParsed,
+                 "Expect only 1 frame per chunk per packet in WebM...");
+    mReader->VideoQueue().Push(v);
   }
 
   return true;

--- a/dom/media/webm/SoftwareWebMVideoDecoder.cpp
+++ b/dom/media/webm/SoftwareWebMVideoDecoder.cpp
@@ -115,23 +115,16 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
     return false;
   }
 
-  uint64_t tstamp = 0;
-  r = nestegg_packet_tstamp(packet, &tstamp);
-  if (r == -1) {
-    return false;
-  }
+  int64_t tstamp = holder->Timestamp();
 
   // The end time of this frame is the start time of the next frame.  Fetch
   // the timestamp of the next packet for this track.  If we've reached the
   // end of the resource, use the file's duration as the end time of this
   // video frame.
-  uint64_t next_tstamp = 0;
+  int64_t next_tstamp = 0;
   nsRefPtr<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
   if (next_holder) {
-    r = nestegg_packet_tstamp(next_holder->Packet(), &next_tstamp);
-    if (r == -1) {
-      return false;
-    }
+    next_tstamp = next_holder->Timestamp();
     mReader->PushVideoPacket(next_holder.forget());
   } else {
     next_tstamp = tstamp;
@@ -139,7 +132,6 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
   }
   mReader->SetLastVideoFrameTime(tstamp);
 
-  int64_t tstamp_usecs = tstamp / NS_PER_USEC;
   for (uint32_t i = 0; i < count; ++i) {
     unsigned char* data;
     size_t length;
@@ -156,7 +148,7 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
     } else if (mReader->GetVideoCodec() == NESTEGG_CODEC_VP9) {
       vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
     }
-    if (aKeyframeSkip && (!si.is_kf || tstamp_usecs < aTimeThreshold)) {
+    if (aKeyframeSkip && (!si.is_kf || tstamp < aTimeThreshold)) {
       // Skipping to next keyframe...
       a.mParsed++; // Assume 1 frame per chunk.
       a.mDropped++;
@@ -174,7 +166,7 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
     // If the timestamp of the video frame is less than
     // the time threshold required then it is not added
     // to the video queue and won't be displayed.
-    if (tstamp_usecs < aTimeThreshold) {
+    if (tstamp < aTimeThreshold) {
       a.mParsed++; // Assume 1 frame per chunk.
       a.mDropped++;
       continue;
@@ -225,8 +217,8 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
       nsRefPtr<VideoData> v = VideoData::Create(videoInfo,
                                                 mReader->GetDecoder()->GetImageContainer(),
                                                 holder->Offset(),
-                                                tstamp_usecs,
-                                                (next_tstamp / NS_PER_USEC) - tstamp_usecs,
+                                                tstamp,
+                                                next_tstamp - tstamp,
                                                 b,
                                                 si.is_kf,
                                                 -1,

--- a/dom/media/webm/SoftwareWebMVideoDecoder.cpp
+++ b/dom/media/webm/SoftwareWebMVideoDecoder.cpp
@@ -97,7 +97,7 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
   // stats counters using the AutoNotifyDecoded stack-based class.
   AbstractMediaDecoder::AutoNotifyDecoded a(mReader->GetDecoder());
 
-  nsAutoRef<NesteggPacketHolder> holder(mReader->NextPacket(WebMReader::VIDEO));
+  nsRefPtr<NesteggPacketHolder> holder(mReader->NextPacket(WebMReader::VIDEO));
   if (!holder) {
     return false;
   }
@@ -126,13 +126,13 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
   // end of the resource, use the file's duration as the end time of this
   // video frame.
   uint64_t next_tstamp = 0;
-  nsAutoRef<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
+  nsRefPtr<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
   if (next_holder) {
     r = nestegg_packet_tstamp(next_holder->mPacket, &next_tstamp);
     if (r == -1) {
       return false;
     }
-    mReader->PushVideoPacket(next_holder.disown());
+    mReader->PushVideoPacket(next_holder.forget());
   } else {
     next_tstamp = tstamp;
     next_tstamp += tstamp - mReader->GetLastVideoFrameTime();

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -922,9 +922,46 @@ WebMReader::DemuxPacket()
     return nullptr;
   }
 
+  // Figure out if this is a keyframe.
+  //
+  // Doing this at packet-granularity is kind of the wrong level of
+  // abstraction, but timestamps are on the packet, so the only time
+  // we have multiple video frames in a packet is when we have "alternate
+  // reference frames", which are a compression detail and never displayed.
+  // So for our purposes, we can just take the union of the is_kf values for
+  // all the frames in the packet.
+  bool isKeyframe = false;
+  if (track == mAudioTrack) {
+    isKeyframe = true;
+  } else if (track == mVideoTrack) {
+    unsigned int count = 0;
+    r = nestegg_packet_count(packet, &count);
+    if (r == -1) {
+      return nullptr;
+    }
+
+    for (unsigned i = 0; i < count; ++i) {
+      unsigned char* data;
+      size_t length;
+      r = nestegg_packet_data(packet, i, &data, &length);
+      if (r == -1) {
+        return nullptr;
+      }
+      vpx_codec_stream_info_t si;
+      memset(&si, 0, sizeof(si));
+      si.sz = sizeof(si);
+      if (mVideoCodec == NESTEGG_CODEC_VP8) {
+        vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), data, length, &si);
+      } else if (mVideoCodec == NESTEGG_CODEC_VP9) {
+        vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
+      }
+      isKeyframe = isKeyframe || si.is_kf;
+    }
+  }
+
   int64_t offset = mDecoder->GetResource()->Tell();
   nsRefPtr<NesteggPacketHolder> holder = new NesteggPacketHolder();
-  if (!holder->Init(packet, offset, track)) {
+  if (!holder->Init(packet, offset, track, isKeyframe)) {
     return nullptr;
   }
 
@@ -984,34 +1021,12 @@ int64_t WebMReader::GetNextKeyframeTime(int64_t aTimeThreshold)
     if (!holder) {
       break;
     }
-    unsigned int count = 0;
-    int r = nestegg_packet_count(holder->Packet(), &count);
-    if (r == -1) {
-      break;
+
+    if (holder->IsKeyframe()) {
+      foundKeyframe = true;
+      keyframeTime = holder->Timestamp();
     }
-    int64_t tstamp = holder->Timestamp();
-    for (uint32_t i = 0; i < count; ++i) {
-      unsigned char* data;
-      size_t length;
-      r = nestegg_packet_data(holder->Packet(), i, &data, &length);
-      if (r == -1) {
-        foundKeyframe = true;
-        break;
-      }
-      vpx_codec_stream_info_t si;
-      memset(&si, 0, sizeof(si));
-      si.sz = sizeof(si);
-      if (mVideoCodec == NESTEGG_CODEC_VP8) {
-        vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), data, length, &si);
-      } else if (mVideoCodec == NESTEGG_CODEC_VP9) {
-        vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
-      }
-      if (si.is_kf) {
-        foundKeyframe = true;
-        keyframeTime = tstamp;
-        break;
-      }
-    }
+
     skipPacketQueue.PushFront(holder.forget());
   }
 

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -923,40 +923,26 @@ WebMReader::DemuxPacket()
   }
 
   // Figure out if this is a keyframe.
-  //
-  // Doing this at packet-granularity is kind of the wrong level of
-  // abstraction, but timestamps are on the packet, so the only time
-  // we have multiple video frames in a packet is when we have "alternate
-  // reference frames", which are a compression detail and never displayed.
-  // So for our purposes, we can just take the union of the is_kf values for
-  // all the frames in the packet.
   bool isKeyframe = false;
   if (track == mAudioTrack) {
     isKeyframe = true;
   } else if (track == mVideoTrack) {
-    unsigned int count = 0;
-    r = nestegg_packet_count(packet, &count);
+    unsigned char* data;
+    size_t length;
+    r = nestegg_packet_data(packet, 0, &data, &length);
     if (r == -1) {
       return nullptr;
     }
 
-    for (unsigned i = 0; i < count; ++i) {
-      unsigned char* data;
-      size_t length;
-      r = nestegg_packet_data(packet, i, &data, &length);
-      if (r == -1) {
-        return nullptr;
-      }
-      vpx_codec_stream_info_t si;
-      memset(&si, 0, sizeof(si));
-      si.sz = sizeof(si);
-      if (mVideoCodec == NESTEGG_CODEC_VP8) {
-        vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), data, length, &si);
-      } else if (mVideoCodec == NESTEGG_CODEC_VP9) {
-        vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
-      }
-      isKeyframe = isKeyframe || si.is_kf;
+    vpx_codec_stream_info_t si;
+    memset(&si, 0, sizeof(si));
+    si.sz = sizeof(si);
+    if (mVideoCodec == NESTEGG_CODEC_VP8) {
+      vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), data, length, &si);
+    } else if (mVideoCodec == NESTEGG_CODEC_VP9) {
+      vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
     }
+    isKeyframe = si.is_kf;
   }
 
   int64_t offset = mDecoder->GetResource()->Tell();

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -884,42 +884,48 @@ already_AddRefed<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackTyp
   // Value of other track
   uint32_t otherTrack = aTrackType == VIDEO ? mAudioTrack : mVideoTrack;
 
-  nsRefPtr<NesteggPacketHolder> holder;
-
   if (packets.GetSize() > 0) {
-    holder = packets.PopFront();
-  } else {
-    // Keep reading packets until we find a packet
-    // for the track we want.
-    do {
-      nestegg_packet* packet;
-      int r = nestegg_read_packet(mContext, &packet);
-      if (r <= 0) {
-        return nullptr;
-      }
-      int64_t offset = mDecoder->GetResource()->Tell();
-      holder = new NesteggPacketHolder();
-      if (!holder->Init(packet, offset)) {
-        return nullptr;
-      }
+    return packets.PopFront();
+  }
 
-      unsigned int track = 0;
-      r = nestegg_packet_track(packet, &track);
-      if (r == -1) {
-        return already_AddRefed<NesteggPacketHolder>();
-      }
+  do {
+    nsRefPtr<NesteggPacketHolder> holder = DemuxPacket();
+    if (!holder) {
+      return nullptr;
+    }
 
-      if (hasOtherType && otherTrack == track) {
-        // Save the packet for when we want these packets
-        otherPackets.Push(holder.forget());
-        continue;
-      }
+    if (hasOtherType && otherTrack == holder->Track()) {
+      // Save the packet for when we want these packets
+      otherPackets.Push(holder.forget());
+      continue;
+    }
 
-      // The packet is for the track we want to play
-      if (hasType && ourTrack == track) {
-        break;
-      }
-    } while (true);
+    // The packet is for the track we want to play
+    if (hasType && ourTrack == holder->Track()) {
+      return holder.forget();
+    }
+  } while (true);
+}
+
+already_AddRefed<NesteggPacketHolder>
+WebMReader::DemuxPacket()
+{
+  nestegg_packet* packet;
+  int r = nestegg_read_packet(mContext, &packet);
+  if (r <= 0) {
+    return nullptr;
+  }
+
+  unsigned int track = 0;
+  r = nestegg_packet_track(packet, &track);
+  if (r == -1) {
+    return nullptr;
+  }
+
+  int64_t offset = mDecoder->GetResource()->Tell();
+  nsRefPtr<NesteggPacketHolder> holder = new NesteggPacketHolder();
+  if (!holder->Init(packet, offset, track)) {
+    return nullptr;
   }
 
   return holder.forget();

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -591,23 +591,17 @@ bool WebMReader::DecodeAudioPacket(NesteggPacketHolder* aHolder)
     return false;
   }
 
-  uint64_t tstamp = 0;
-  r = nestegg_packet_tstamp(aHolder->Packet(), &tstamp);
-  if (r == -1) {
-    return false;
-  }
-
-  uint64_t tstamp_usecs = tstamp / NS_PER_USEC;
+  int64_t tstamp = aHolder->Timestamp();
   if (mAudioStartUsec == -1) {
     // This is the first audio chunk. Assume the start time of our decode
     // is the start of this chunk.
-    mAudioStartUsec = tstamp_usecs;
+    mAudioStartUsec = tstamp;
   }
   // If there's a gap between the start of this audio chunk and the end of
   // the previous audio chunk, we need to increment the packet count so that
   // the vorbis decode doesn't use data from before the gap to help decode
   // from after the gap.
-  CheckedInt64 tstamp_frames = UsecsToFrames(tstamp_usecs, mInfo.mAudio.mRate);
+  CheckedInt64 tstamp_frames = UsecsToFrames(tstamp, mInfo.mAudio.mRate);
   CheckedInt64 decoded_frames = UsecsToFrames(mAudioStartUsec,
                                               mInfo.mAudio.mRate);
   if (!tstamp_frames.isValid() || !decoded_frames.isValid()) {
@@ -628,7 +622,7 @@ bool WebMReader::DecodeAudioPacket(NesteggPacketHolder* aHolder)
                        gap_frames));
 #endif
     mPacketCount++;
-    mAudioStartUsec = tstamp_usecs;
+    mAudioStartUsec = tstamp;
     mAudioFrames = 0;
   }
 
@@ -641,11 +635,11 @@ bool WebMReader::DecodeAudioPacket(NesteggPacketHolder* aHolder)
       return false;
     }
     if (mAudioCodec == NESTEGG_CODEC_VORBIS) {
-      if (!DecodeVorbis(data, length, aHolder->Offset(), tstamp_usecs, &total_frames)) {
+      if (!DecodeVorbis(data, length, aHolder->Offset(), tstamp, &total_frames)) {
         return false;
       }
     } else if (mAudioCodec == NESTEGG_CODEC_OPUS) {
-      if (!DecodeOpus(data, length, aHolder->Offset(), tstamp_usecs, aHolder->Packet())) {
+      if (!DecodeOpus(data, length, aHolder->Offset(), tstamp, aHolder->Packet())) {
         return false;
       }
     }
@@ -952,13 +946,8 @@ bool WebMReader::FilterPacketByTime(int64_t aEndTime, WebMPacketQueue& aOutput)
     if (!holder) {
       break;
     }
-    uint64_t tstamp = 0;
-    int r = nestegg_packet_tstamp(holder->Packet(), &tstamp);
-    if (r == -1) {
-      break;
-    }
-    uint64_t tstamp_usecs = tstamp / NS_PER_USEC;
-    if (tstamp_usecs >= (uint64_t)aEndTime) {
+    int64_t tstamp = holder->Timestamp();
+    if (tstamp >= aEndTime) {
       PushVideoPacket(holder.forget());
       return true;
     } else {
@@ -994,13 +983,7 @@ int64_t WebMReader::GetNextKeyframeTime(int64_t aTimeThreshold)
     if (r == -1) {
       break;
     }
-    uint64_t tstamp = 0;
-    r = nestegg_packet_tstamp(holder->Packet(), &tstamp);
-    if (r == -1) {
-      break;
-    }
-    uint64_t tstamp_usecs = tstamp / NS_PER_USEC;
-
+    int64_t tstamp = holder->Timestamp();
     for (uint32_t i = 0; i < count; ++i) {
       unsigned char* data;
       size_t length;
@@ -1019,7 +1002,7 @@ int64_t WebMReader::GetNextKeyframeTime(int64_t aTimeThreshold)
       }
       if (si.is_kf) {
         foundKeyframe = true;
-        keyframeTime = tstamp_usecs;
+        keyframeTime = tstamp;
         break;
       }
     }
@@ -1192,12 +1175,12 @@ nsIntSize WebMReader::GetInitialFrame()
   return mInitialFrame;
 }
 
-uint64_t WebMReader::GetLastVideoFrameTime()
+int64_t WebMReader::GetLastVideoFrameTime()
 {
   return mLastVideoFrameTime;
 }
 
-void WebMReader::SetLastVideoFrameTime(uint64_t aFrameTime)
+void WebMReader::SetLastVideoFrameTime(int64_t aFrameTime)
 {
   mLastVideoFrameTime = aFrameTime;
 }

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -865,7 +865,7 @@ bool WebMReader::DecodeOpus(const unsigned char* aData, size_t aLength,
   return true;
 }
 
-nsReturnRef<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackType)
+already_AddRefed<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackType)
 {
   // The packet queue that packets will be pushed on if they
   // are not the type we are interested in.
@@ -890,10 +890,10 @@ nsReturnRef<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackType)
   // Value of other track
   uint32_t otherTrack = aTrackType == VIDEO ? mAudioTrack : mVideoTrack;
 
-  nsAutoRef<NesteggPacketHolder> holder;
+  nsRefPtr<NesteggPacketHolder> holder;
 
   if (packets.GetSize() > 0) {
-    holder.own(packets.PopFront());
+    holder = packets.PopFront();
   } else {
     // Keep reading packets until we find a packet
     // for the track we want.
@@ -901,20 +901,20 @@ nsReturnRef<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackType)
       nestegg_packet* packet;
       int r = nestegg_read_packet(mContext, &packet);
       if (r <= 0) {
-        return nsReturnRef<NesteggPacketHolder>();
+        return nullptr;
       }
       int64_t offset = mDecoder->GetResource()->Tell();
-      holder.own(new NesteggPacketHolder(packet, offset));
+      holder = new NesteggPacketHolder(packet, offset);
 
       unsigned int track = 0;
       r = nestegg_packet_track(packet, &track);
       if (r == -1) {
-        return nsReturnRef<NesteggPacketHolder>();
+        return already_AddRefed<NesteggPacketHolder>();
       }
 
       if (hasOtherType && otherTrack == track) {
         // Save the packet for when we want these packets
-        otherPackets.Push(holder.disown());
+        otherPackets.Push(holder.forget());
         continue;
       }
 
@@ -925,14 +925,14 @@ nsReturnRef<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackType)
     } while (true);
   }
 
-  return holder.out();
+  return holder.forget();
 }
 
 bool WebMReader::DecodeAudioData()
 {
   MOZ_ASSERT(OnTaskQueue());
 
-  nsAutoRef<NesteggPacketHolder> holder(NextPacket(AUDIO));
+  nsRefPtr<NesteggPacketHolder> holder(NextPacket(AUDIO));
   if (!holder) {
     return false;
   }
@@ -945,7 +945,7 @@ bool WebMReader::FilterPacketByTime(int64_t aEndTime, WebMPacketQueue& aOutput)
   // Push the video frames to the aOutput which's timestamp is less
   // than aEndTime.
   while (true) {
-    nsAutoRef<NesteggPacketHolder> holder(NextPacket(VIDEO));
+    nsRefPtr<NesteggPacketHolder> holder(NextPacket(VIDEO));
     if (!holder) {
       break;
     }
@@ -956,10 +956,10 @@ bool WebMReader::FilterPacketByTime(int64_t aEndTime, WebMPacketQueue& aOutput)
     }
     uint64_t tstamp_usecs = tstamp / NS_PER_USEC;
     if (tstamp_usecs >= (uint64_t)aEndTime) {
-      PushVideoPacket(holder.disown());
+      PushVideoPacket(holder.forget());
       return true;
     } else {
-      aOutput.PushFront(holder.disown());
+      aOutput.PushFront(holder.forget());
     }
   }
 
@@ -982,7 +982,7 @@ int64_t WebMReader::GetNextKeyframeTime(int64_t aTimeThreshold)
   bool foundKeyframe = false;
   int64_t keyframeTime = -1;
   while (!foundKeyframe) {
-    nsAutoRef<NesteggPacketHolder> holder(NextPacket(VIDEO));
+    nsRefPtr<NesteggPacketHolder> holder(NextPacket(VIDEO));
     if (!holder) {
       break;
     }
@@ -1020,7 +1020,7 @@ int64_t WebMReader::GetNextKeyframeTime(int64_t aTimeThreshold)
         break;
       }
     }
-    skipPacketQueue.PushFront(holder.disown());
+    skipPacketQueue.PushFront(holder.forget());
   }
 
   uint32_t size = skipPacketQueue.GetSize();
@@ -1045,9 +1045,9 @@ bool WebMReader::DecodeVideoFrame(bool &aKeyframeSkip, int64_t aTimeThreshold)
   return mVideoDecoder->DecodeVideoFrame(aKeyframeSkip, aTimeThreshold);
 }
 
-void WebMReader::PushVideoPacket(NesteggPacketHolder* aItem)
+void WebMReader::PushVideoPacket(already_AddRefed<NesteggPacketHolder> aItem)
 {
-    mVideoPackets.PushFront(aItem);
+    mVideoPackets.PushFront(Move(aItem));
 }
 
 nsRefPtr<MediaDecoderReader::SeekPromise>

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -580,19 +580,19 @@ bool WebMReader::InitOpusDecoder()
   return r == OPUS_OK;
 }
 
-bool WebMReader::DecodeAudioPacket(nestegg_packet* aPacket, int64_t aOffset)
+bool WebMReader::DecodeAudioPacket(NesteggPacketHolder* aHolder)
 {
   MOZ_ASSERT(OnTaskQueue());
 
   int r = 0;
   unsigned int count = 0;
-  r = nestegg_packet_count(aPacket, &count);
+  r = nestegg_packet_count(aHolder->Packet(), &count);
   if (r == -1) {
     return false;
   }
 
   uint64_t tstamp = 0;
-  r = nestegg_packet_tstamp(aPacket, &tstamp);
+  r = nestegg_packet_tstamp(aHolder->Packet(), &tstamp);
   if (r == -1) {
     return false;
   }
@@ -636,16 +636,16 @@ bool WebMReader::DecodeAudioPacket(nestegg_packet* aPacket, int64_t aOffset)
   for (uint32_t i = 0; i < count; ++i) {
     unsigned char* data;
     size_t length;
-    r = nestegg_packet_data(aPacket, i, &data, &length);
+    r = nestegg_packet_data(aHolder->Packet(), i, &data, &length);
     if (r == -1) {
       return false;
     }
     if (mAudioCodec == NESTEGG_CODEC_VORBIS) {
-      if (!DecodeVorbis(data, length, aOffset, tstamp_usecs, &total_frames)) {
+      if (!DecodeVorbis(data, length, aHolder->Offset(), tstamp_usecs, &total_frames)) {
         return false;
       }
     } else if (mAudioCodec == NESTEGG_CODEC_OPUS) {
-      if (!DecodeOpus(data, length, aOffset, tstamp_usecs, aPacket)) {
+      if (!DecodeOpus(data, length, aHolder->Offset(), tstamp_usecs, aHolder->Packet())) {
         return false;
       }
     }
@@ -904,7 +904,10 @@ already_AddRefed<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackTyp
         return nullptr;
       }
       int64_t offset = mDecoder->GetResource()->Tell();
-      holder = new NesteggPacketHolder(packet, offset);
+      holder = new NesteggPacketHolder();
+      if (!holder->Init(packet, offset)) {
+        return nullptr;
+      }
 
       unsigned int track = 0;
       r = nestegg_packet_track(packet, &track);
@@ -937,7 +940,7 @@ bool WebMReader::DecodeAudioData()
     return false;
   }
 
-  return DecodeAudioPacket(holder->mPacket, holder->mOffset);
+  return DecodeAudioPacket(holder);
 }
 
 bool WebMReader::FilterPacketByTime(int64_t aEndTime, WebMPacketQueue& aOutput)
@@ -950,7 +953,7 @@ bool WebMReader::FilterPacketByTime(int64_t aEndTime, WebMPacketQueue& aOutput)
       break;
     }
     uint64_t tstamp = 0;
-    int r = nestegg_packet_tstamp(holder->mPacket, &tstamp);
+    int r = nestegg_packet_tstamp(holder->Packet(), &tstamp);
     if (r == -1) {
       break;
     }
@@ -987,12 +990,12 @@ int64_t WebMReader::GetNextKeyframeTime(int64_t aTimeThreshold)
       break;
     }
     unsigned int count = 0;
-    int r = nestegg_packet_count(holder->mPacket, &count);
+    int r = nestegg_packet_count(holder->Packet(), &count);
     if (r == -1) {
       break;
     }
     uint64_t tstamp = 0;
-    r = nestegg_packet_tstamp(holder->mPacket, &tstamp);
+    r = nestegg_packet_tstamp(holder->Packet(), &tstamp);
     if (r == -1) {
       break;
     }
@@ -1001,7 +1004,7 @@ int64_t WebMReader::GetNextKeyframeTime(int64_t aTimeThreshold)
     for (uint32_t i = 0; i < count; ++i) {
       unsigned char* data;
       size_t length;
-      r = nestegg_packet_data(holder->mPacket, i, &data, &length);
+      r = nestegg_packet_data(holder->Packet(), i, &data, &length);
       if (r == -1) {
         foundKeyframe = true;
         break;

--- a/dom/media/webm/WebMReader.h
+++ b/dom/media/webm/WebMReader.h
@@ -25,6 +25,10 @@
 
 #include "OpusParser.h"
 
+namespace mozilla {
+static const unsigned NS_PER_USEC = 1000;
+static const double NS_PER_S = 1e9;
+
 // Holds a nestegg_packet, and its file offset. This is needed so we
 // know the offset in the file we've played up to, in order to calculate
 // whether it's likely we can play through to the end without needing
@@ -32,27 +36,51 @@
 class NesteggPacketHolder {
 public:
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(NesteggPacketHolder)
-  NesteggPacketHolder(nestegg_packet* aPacket, int64_t aOffset)
-    : mPacket(aPacket), mOffset(aOffset) {}
+  NesteggPacketHolder() : mPacket(nullptr), mOffset(-1), mTimestamp(-1) {}
+
+  bool Init(nestegg_packet* aPacket, int64_t aOffset)
+  {
+    uint64_t timestamp_ns;
+    if (nestegg_packet_tstamp(aPacket, &timestamp_ns) == -1) {
+      return false;
+    }
+
+    // We store the timestamp as signed microseconds so that it's easily
+    // comparable to other timestamps we have in the system.
+    mTimestamp = timestamp_ns / 1000;
+    mPacket = aPacket;
+    mOffset = aOffset;
+
+    return true;
+  }
+
+  nestegg_packet* Packet() { MOZ_ASSERT(IsInitialized()); return mPacket; }
+  int64_t Offset() { MOZ_ASSERT(IsInitialized()); return mOffset; }
+  int64_t Timestamp() { MOZ_ASSERT(IsInitialized()); return mTimestamp; }
+
+private:
+  ~NesteggPacketHolder()
+  {
+    nestegg_free_packet(mPacket);
+  }
+
+  bool IsInitialized() { return mOffset >= 0; }
 
   nestegg_packet* mPacket;
+
   // Offset in bytes. This is the offset of the end of the Block
   // which contains the packet.
   int64_t mOffset;
-private:
-  ~NesteggPacketHolder() {
-    nestegg_free_packet(mPacket);
-  }
+
+  // Packet presentation timestamp in microseconds.
+  int64_t mTimestamp;
 
   // Copy constructor and assignment operator not implemented. Don't use them!
   NesteggPacketHolder(const NesteggPacketHolder &aOther);
   NesteggPacketHolder& operator= (NesteggPacketHolder const& aOther);
 };
 
-namespace mozilla {
 class WebMBufferedState;
-static const unsigned NS_PER_USEC = 1000;
-static const double NS_PER_S = 1e9;
 
 // Queue for holding nestegg packets.
 class WebMPacketQueue {
@@ -174,7 +202,7 @@ protected:
   // or an un-recoverable read error has occured. The reader's monitor
   // must be held during this call. The caller is responsible for freeing
   // aPacket.
-  bool DecodeAudioPacket(nestegg_packet* aPacket, int64_t aOffset);
+  bool DecodeAudioPacket(NesteggPacketHolder* aHolder);
   bool DecodeVorbis(const unsigned char* aData, size_t aLength,
                     int64_t aOffset, uint64_t aTstampUsecs,
                     int32_t* aTotalFrames);

--- a/dom/media/webm/WebMReader.h
+++ b/dom/media/webm/WebMReader.h
@@ -187,8 +187,8 @@ public:
   int GetVideoCodec();
   nsIntRect GetPicture();
   nsIntSize GetInitialFrame();
-  uint64_t GetLastVideoFrameTime();
-  void SetLastVideoFrameTime(uint64_t aFrameTime);
+  int64_t GetLastVideoFrameTime();
+  void SetLastVideoFrameTime(int64_t aFrameTime);
   layers::LayersBackend GetLayersBackendType() { return mLayersBackendType; }
   FlushableMediaTaskQueue* GetVideoTaskQueue() { return mVideoTaskQueue; }
 
@@ -268,7 +268,7 @@ private:
 
   // Calculate the frame duration from the last decodeable frame using the
   // previous frame's timestamp.  In NS.
-  uint64_t mLastVideoFrameTime;
+  int64_t mLastVideoFrameTime;
 
   // Parser state and computed offset-time mappings.  Shared by multiple
   // readers when decoder has been cloned.  Main thread only.

--- a/dom/media/webm/WebMReader.h
+++ b/dom/media/webm/WebMReader.h
@@ -36,9 +36,9 @@ static const double NS_PER_S = 1e9;
 class NesteggPacketHolder {
 public:
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(NesteggPacketHolder)
-  NesteggPacketHolder() : mPacket(nullptr), mOffset(-1), mTimestamp(-1) {}
+  NesteggPacketHolder() : mPacket(nullptr), mOffset(-1), mTimestamp(-1), mIsKeyframe(false) {}
 
-  bool Init(nestegg_packet* aPacket, int64_t aOffset, unsigned aTrack)
+  bool Init(nestegg_packet* aPacket, int64_t aOffset, unsigned aTrack, bool aIsKeyframe)
   {
     uint64_t timestamp_ns;
     if (nestegg_packet_tstamp(aPacket, &timestamp_ns) == -1) {
@@ -51,6 +51,7 @@ public:
     mPacket = aPacket;
     mOffset = aOffset;
     mTrack = aTrack;
+    mIsKeyframe = aIsKeyframe;
 
     return true;
   }
@@ -59,6 +60,7 @@ public:
   int64_t Offset() { MOZ_ASSERT(IsInitialized()); return mOffset; }
   int64_t Timestamp() { MOZ_ASSERT(IsInitialized()); return mTimestamp; }
   unsigned Track() { MOZ_ASSERT(IsInitialized()); return mTrack; }
+  bool IsKeyframe() { MOZ_ASSERT(IsInitialized()); return mIsKeyframe; }
 
 private:
   ~NesteggPacketHolder()
@@ -79,6 +81,9 @@ private:
 
   // Track ID.
   unsigned mTrack;
+
+  // Does this packet contain a keyframe?
+  bool mIsKeyframe;
 
   // Copy constructor and assignment operator not implemented. Don't use them!
   NesteggPacketHolder(const NesteggPacketHolder &aOther);

--- a/dom/media/webm/WebMReader.h
+++ b/dom/media/webm/WebMReader.h
@@ -8,7 +8,6 @@
 
 #include <stdint.h>
 
-#include "nsDeque.h"
 #include "MediaDecoderReader.h"
 #include "nsAutoRef.h"
 #include "nestegg/nestegg.h"
@@ -32,30 +31,22 @@
 // to stop to buffer, given the current download rate.
 class NesteggPacketHolder {
 public:
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(NesteggPacketHolder)
   NesteggPacketHolder(nestegg_packet* aPacket, int64_t aOffset)
-    : mPacket(aPacket), mOffset(aOffset)
-  {
-    MOZ_COUNT_CTOR(NesteggPacketHolder);
-  }
-  ~NesteggPacketHolder() {
-    MOZ_COUNT_DTOR(NesteggPacketHolder);
-    nestegg_free_packet(mPacket);
-  }
+    : mPacket(aPacket), mOffset(aOffset) {}
+
   nestegg_packet* mPacket;
   // Offset in bytes. This is the offset of the end of the Block
   // which contains the packet.
   int64_t mOffset;
 private:
+  ~NesteggPacketHolder() {
+    nestegg_free_packet(mPacket);
+  }
+
   // Copy constructor and assignment operator not implemented. Don't use them!
   NesteggPacketHolder(const NesteggPacketHolder &aOther);
   NesteggPacketHolder& operator= (NesteggPacketHolder const& aOther);
-};
-
-template <>
-class nsAutoRefTraits<NesteggPacketHolder> : public nsPointerRefTraits<NesteggPacketHolder>
-{
-public:
-  static void Release(NesteggPacketHolder* aHolder) { delete aHolder; }
 };
 
 namespace mozilla {
@@ -63,50 +54,35 @@ class WebMBufferedState;
 static const unsigned NS_PER_USEC = 1000;
 static const double NS_PER_S = 1e9;
 
-// Thread and type safe wrapper around nsDeque.
-class PacketQueueDeallocator : public nsDequeFunctor {
-  virtual void* operator() (void* aObject) {
-    delete static_cast<NesteggPacketHolder*>(aObject);
-    return nullptr;
-  }
-};
-
-// Typesafe queue for holding nestegg packets. It has
-// ownership of the items in the queue and will free them
-// when destroyed.
-class WebMPacketQueue : private nsDeque {
+// Queue for holding nestegg packets.
+class WebMPacketQueue {
  public:
-   WebMPacketQueue()
-     : nsDeque(new PacketQueueDeallocator())
-   {}
-
-  ~WebMPacketQueue() {
-    Reset();
+   int32_t GetSize() {
+    return mQueue.size();
   }
 
-  inline int32_t GetSize() {
-    return nsDeque::GetSize();
+  void Push(already_AddRefed<NesteggPacketHolder> aItem) {
+    mQueue.push_back(Move(aItem));
   }
 
-  inline void Push(NesteggPacketHolder* aItem) {
-    NS_ASSERTION(aItem, "NULL pushed to WebMPacketQueue");
-    nsDeque::Push(aItem);
+  void PushFront(already_AddRefed<NesteggPacketHolder> aItem) {
+    mQueue.push_front(Move(aItem));
   }
 
-  inline void PushFront(NesteggPacketHolder* aItem) {
-    NS_ASSERTION(aItem, "NULL pushed to WebMPacketQueue");
-    nsDeque::PushFront(aItem);
-  }
-
-  inline NesteggPacketHolder* PopFront() {
-    return static_cast<NesteggPacketHolder*>(nsDeque::PopFront());
+  already_AddRefed<NesteggPacketHolder> PopFront() {
+    nsRefPtr<NesteggPacketHolder> result = mQueue.front().forget();
+    mQueue.pop_front();
+    return result.forget();
   }
 
   void Reset() {
-    while (GetSize() > 0) {
-      delete PopFront();
+    while (!mQueue.empty()) {
+      mQueue.pop_front();
     }
   }
+
+private:
+  std::deque<nsRefPtr<NesteggPacketHolder>> mQueue;
 };
 
 class WebMReader;
@@ -175,10 +151,10 @@ public:
   // Read a packet from the nestegg file. Returns nullptr if all packets for
   // the particular track have been read. Pass VIDEO or AUDIO to indicate the
   // type of the packet we want to read.
-  nsReturnRef<NesteggPacketHolder> NextPacket(TrackType aTrackType);
+  already_AddRefed<NesteggPacketHolder> NextPacket(TrackType aTrackType);
 
   // Pushes a packet to the front of the video packet queue.
-  virtual void PushVideoPacket(NesteggPacketHolder* aItem);
+  virtual void PushVideoPacket(already_AddRefed<NesteggPacketHolder> aItem);
 
   int GetVideoCodec();
   nsIntRect GetPicture();
@@ -245,7 +221,7 @@ private:
   uint64_t mSeekPreroll; // Nanoseconds to discard after seeking.
 
   // Queue of video and audio packets that have been read but not decoded. These
-  // must only be accessed from the state machine thread.
+  // must only be accessed from the decode thread.
   WebMPacketQueue mVideoPackets;
   WebMPacketQueue mAudioPackets;
 


### PR DESCRIPTION
Continuing the prep work for re-writing our WebM code (#1119):

- refcount NesteggPacketHolder (makes the code a bit more robust).
- Move away from using nsDeque (brings WebM decoders more in line with the rest of the media code).
- Use NesteggPacketHolder  to improve the keyframe logic for WebM.
- Remove some buggy multiple-frame-per-packet handling code that is not necessary.

Compiled and tested on quirksmode and YouTube. Works as intended.