### PR TITLE
[minor fix] blocklist.xml - fix typo

### DIFF
--- a/browser/app/blocklist.xml
+++ b/browser/app/blocklist.xml
@@ -2481,7 +2481,7 @@ xmlns="http://www.mozilla.org/2006/addons-blocklist">
       </versionRange>
       <prefs></prefs>
     </emItem>
-    <emitem blockID="pm108" id="html5@encoding">
+    <emItem blockID="pm108" id="html5@encoding">
       <versionRange minVersion="0" maxVersion="*" severity="3">
       </versionRange>
       <prefs></prefs>


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/commit/a1318e858b39708715eb93cb7edbf3eb3dabad3c

Sometimes:
Throws an error in Browser Console:
```
XML Parsing Error: mismatched tag. Expected: </emitem>.
Location: moz-nullprincipal:{...}
Line Number 2488, Column 7:
moz-nullprincipal:{...}:2488:7
```
---

You add the label `Uplift Wanted`, please.
(if it seems important to you)
