### PR TITLE
Extensions - loadSubScript - add support for blob

### DIFF
--- a/js/xpconnect/idl/mozIJSSubScriptLoader.idl
+++ b/js/xpconnect/idl/mozIJSSubScriptLoader.idl
@@ -18,7 +18,7 @@ interface mozIJSSubScriptLoader : nsISupports
      * In JS, the signature looks like:
      * rv loadSubScript (url [, obj] [, charset]);
      * @param url the url of the sub-script, it MUST be either a file:,
-     *            resource:, or chrome: url, and MUST be local.
+     *            resource:, blob:, or chrome: url, and MUST be local.
      * @param obj an optional object to evaluate the script onto, it
      *            defaults to the global object of the caller.
      * @param charset optionally specifies the character encoding of
@@ -34,7 +34,7 @@ interface mozIJSSubScriptLoader : nsISupports
      * In JS, the signature looks like:
      * rv = loadSubScript (url, optionsObject)
      * @param url the url of the sub-script, it MUST be either a file:,
-     *            resource:, or chrome: url, and MUST be local.
+     *            resource:, blob:, or chrome: url, and MUST be local.
      * @param optionsObject an object with parameters. Valid parameters are:
      *                      - charset: specifying the character encoding of the file (default: ASCII)
      *                      - target:  an object to evaluate onto (default: global object of the caller)

--- a/js/xpconnect/tests/chrome/test_chrometoSource.xul
+++ b/js/xpconnect/tests/chrome/test_chrometoSource.xul
@@ -62,5 +62,13 @@ Services.scriptloader.loadSubScriptWithOptions(resolvedBase + "utf8_subscript.js
                                                {target: ns, charset: "UTF-8", ignoreCache: true});
 src = ns.f.toSource();
 isnot(src.indexOf("return 42;"), -1, "encoded subscript should have correct source");
+
+ns = {};
+let b = new Blob([
+  "var Exported = 17;"
+]);
+var blobUrl = URL.createObjectURL(b);
+Services.scriptloader.loadSubScript(blobUrl, ns);
+is(ns.Exported, 17, "subscript from a blob URL should work");
   ]]></script>
 </window>


### PR DESCRIPTION
__Steps to reproduce:__

1) Open Scratchpad
2) Menu: "Environment-Browser"
3) Insert the code:
```
Components.utils.import("resource://gre/modules/Services.jsm");

var ns = {};
var b = new Blob([
  "var Exported = 17;"
]);
var blobUrl = URL.createObjectURL(b);
try {
  Services.scriptloader.loadSubScript(blobUrl, ns);
  alert(ns.Exported);
} finally {
  URL.revokeObjectURL(blobUrl);
}
```
4) Run

__Actual results__

Throws an error:
```
Exception: Trying to load a non-local URI.: blob:null/...
```

__Expected results__

alert("17");

---

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1221148

---

You add the label `Enhancement` (?), `Extensions`, `UXP-task`, please.

---

I've created the new build (x32, Windows) and tested.
