### PR TITLE
[minor fix] CSS - user-select: none

### DIFF
--- a/dom/base/nsRange.cpp
+++ b/dom/base/nsRange.cpp
@@ -3167,7 +3167,18 @@ nsRange::ExcludeNonSelectableNodes(nsTArray<nsRefPtr<nsRange>>* aOutRanges)
           }
 
           // Create a new range for the remainder.
-          rv = CreateRange(node, 0, endParent, endOffset,
+          nsINode* startParent = node;
+          int32_t startOffset = 0;
+          // Don't start *inside* a node with independent selection though
+          // (e.g. <input>).
+          if (content && content->HasIndependentSelection()) {
+            nsINode* parent = startParent->GetParent();
+            if (parent) {
+              startOffset = parent->IndexOf(startParent);
+              startParent = parent;
+            }
+          }
+          rv = CreateRange(startParent, startOffset, endParent, endOffset,
                            getter_AddRefs(newRange));
           if (NS_FAILED(rv) || newRange->Collapsed()) {
             newRange = nullptr;

--- a/dom/base/test/test_user_select.html
+++ b/dom/base/test/test_user_select.html
@@ -34,6 +34,9 @@ a { position:absolute; bottom: 0; right:0; }
 <div id="testB"><n><s>aaaa</s>aaa</n>bbbbbbbbccccccc</div>
 <div id="testC">aaaaaaabbbbbbbb<n>cc<s>c</s>cccc</n></div>
 <div id="testE">aaa<s id="testEc1">aaaa<a class="text">bbbb</a>dd<a>cccc</a>ddddddd</s>eeee</div>
+<div id="testF" style="white-space:pre">aaaa
+<div class="non-selectable">x</div><input>
+bbbbbbb</div>
 
 <iframe id="testD" src="data:text/html,<body>aaaa<span style='-moz-user-select:none'>bbbb</span>cccc"></iframe>
 
@@ -256,6 +259,17 @@ function test()
   checkRangeText('aaaaaabbbbbbbb', 0);
   checkText('aaaaaabbbbbbbb', e);
   checkRanges([[0,1,-1,1]], e);
+  doneTest(e);
+
+  clear();
+  e = document.getElementById('testF');
+  synthesizeMouse(e, 1, 1, {});
+  synthesizeMouse(e, 30, 90, { shiftKey: true });
+  synthesizeMouse(e, 50, 90, { shiftKey: true });
+  synthesizeMouse(e, 70, 90, { shiftKey: true });
+  checkText("aaaa bbb", e);
+  checkRanges([[0,0,-1,1],[-1,2,3,4]], e);
+
   doneTest(e);
 
   // ======================================================


### PR DESCRIPTION
An example:
https://bugzilla.mozilla.org/attachment.cgi?id=8823010

__Steps to reproduce:__

Copy string "str" to clipboard (Ctrl-C).
Open attached example.
Click in input, press Ctrl+V.
Press Ctrl+A on the whole page.

__Actual results__
`full`: this word is selected

__Expected results__
`full`: this word is omitted

---

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1327902

---

I've created the new build (x32, Windows) and tested.
