### PR TITLE
GitHub - Total freeze when dragging selected text; Mouse cursor only shows part of the dragged selection

### DIFF
--- a/layout/base/nsPresShell.cpp
+++ b/layout/base/nsPresShell.cpp
@@ -5286,7 +5286,7 @@ PresShell::PaintRangePaintInfo(nsTArray<nsAutoPtr<RangePaintInfo> >* aItems,
     gfxPoint rootOffset =
       nsLayoutUtils::PointToGfxPoint(rangeInfo->mRootOffset,
                                      pc->AppUnitsPerDevPixel());
-    ctx->SetMatrix(initialTM.Translate(rootOffset));
+    ctx->SetMatrix(gfxMatrix(initialTM).Translate(rootOffset));
     aArea.MoveBy(-rangeInfo->mRootOffset.x, -rangeInfo->mRootOffset.y);
     nsRegion visible(aArea);
     nsRefPtr<LayerManager> layerManager =


### PR DESCRIPTION
You must first implement (temporarily):
[nsSelection.cpp#L3611](https://github.com/MoonchildProductions/Pale-Moon/blob/27.3.0_Release/layout/generic/nsSelection.cpp#L3611)
`// #if 0`
[nsSelection.cpp#L3641](https://github.com/MoonchildProductions/Pale-Moon/blob/27.3.0_Release/layout/generic/nsSelection.cpp#L3641)
`// #endif`

## 1)
__GitHub - Total freeze when dragging selected text__

Confirmed.

__Steps to reproduce:__

1. View source code on GitHub
2. Select some code
3. Drag it

__Actual results__
Cursor state switches, Firefox freezes completely.

__Expected results__
No freeze (just a short freeze).

---

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1258476
(see also [nsSelection.cpp#L3609](https://github.com/MoonchildProductions/Pale-Moon/blob/27.3.0_Release/layout/generic/nsSelection.cpp#L3609))

## 2)
__Mouse cursor only shows part of the dragged selection__

An example:
https://bugzilla.mozilla.org/attachment.cgi?id=8742129
https://bugzilla.mozilla.org/attachment.cgi?id=8742131

---

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1265249

---

I've created the new build (x32, Windows) and tested.
