### PR TITLE
[minor fix] Places - addLivemark (deprecate passing a callback)

### DIFF
--- a/browser/components/distribution.js
+++ b/browser/components/distribution.js
@@ -159,7 +159,7 @@ DistributionCustomizer.prototype = {
                                           , index: index
                                           , feedURI: this._makeURI(items[iid]["feedLink"])
                                           , siteURI: this._makeURI(items[iid]["siteLink"])
-                                          });
+                                          }).then(null, Cu.reportError);
         break;
 
       case "bookmark":


### PR DESCRIPTION
Little preparation for the UXP (potentially).
Tags: #1201, #1203

---

See:
https://hg.mozilla.org/mozilla-central/diff/60c1af78091a/browser/components/distribution.js
(https://bugzilla.mozilla.org/show_bug.cgi?id=969318)

---

I've created the new build (x32, Windows) and tested
(__create a new profil - I don't know if that's enough__).
