### PR TITLE
Move Vorbis and Opus decoding out of WebMReader

### DIFF
--- a/dom/media/webm/AudioDecoder.cpp
+++ b/dom/media/webm/AudioDecoder.cpp
@@ -1,0 +1,472 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "WebMReader.h"
+
+#ifdef MOZ_TREMOR
+#include "tremor/ivorbiscodec.h"
+#else
+#include "vorbis/codec.h"
+#endif
+
+#include "OpusParser.h"
+
+#include "VorbisUtils.h"
+#include "OggReader.h"
+
+#undef LOG
+
+#ifdef PR_LOGGING
+#include "prprf.h"
+#define LOG(type, msg) PR_LOG(gMediaDecoderLog, type, msg)
+#else
+#define LOG(type, msg)
+#endif
+
+namespace mozilla {
+
+extern PRLogModuleInfo* gMediaDecoderLog;
+
+ogg_packet InitOggPacket(const unsigned char* aData, size_t aLength,
+                         bool aBOS, bool aEOS,
+                         int64_t aGranulepos, int64_t aPacketNo)
+{
+  ogg_packet packet;
+  packet.packet = const_cast<unsigned char*>(aData);
+  packet.bytes = aLength;
+  packet.b_o_s = aBOS;
+  packet.e_o_s = aEOS;
+  packet.granulepos = aGranulepos;
+  packet.packetno = aPacketNo;
+  return packet;
+}
+
+class VorbisDecoder : public WebMAudioDecoder
+{
+public:
+  nsresult Init();
+  void Shutdown();
+  nsresult ResetDecode();
+  nsresult DecodeHeader(const unsigned char* aData, size_t aLength);
+  nsresult FinishInit(AudioInfo& aInfo);
+  bool Decode(const unsigned char* aData, size_t aLength,
+              int64_t aOffset, uint64_t aTstampUsecs,
+              int64_t aDiscardPadding, int32_t* aTotalFrames);
+  explicit VorbisDecoder(WebMReader* aReader);
+  ~VorbisDecoder();
+private:
+  nsRefPtr<WebMReader> mReader;
+
+  // Vorbis decoder state
+  vorbis_info mVorbisInfo;
+  vorbis_comment mVorbisComment;
+  vorbis_dsp_state mVorbisDsp;
+  vorbis_block mVorbisBlock;
+  int64_t mPacketCount;
+};
+
+VorbisDecoder::VorbisDecoder(WebMReader* aReader)
+  : mReader(aReader)
+  , mPacketCount(0)
+{
+  // Zero these member vars to avoid crashes in Vorbis clear functions when
+  // destructor is called before |Init|.
+  PodZero(&mVorbisBlock);
+  PodZero(&mVorbisDsp);
+  PodZero(&mVorbisInfo);
+  PodZero(&mVorbisComment);
+}
+
+VorbisDecoder::~VorbisDecoder()
+{
+  vorbis_block_clear(&mVorbisBlock);
+  vorbis_dsp_clear(&mVorbisDsp);
+  vorbis_info_clear(&mVorbisInfo);
+  vorbis_comment_clear(&mVorbisComment);
+}
+
+void
+VorbisDecoder::Shutdown()
+{
+  mReader = nullptr;
+}
+
+nsresult
+VorbisDecoder::Init()
+{
+  vorbis_info_init(&mVorbisInfo);
+  vorbis_comment_init(&mVorbisComment);
+  PodZero(&mVorbisDsp);
+  PodZero(&mVorbisBlock);
+  return NS_OK;
+}
+
+nsresult
+VorbisDecoder::ResetDecode()
+{
+  // Ignore failed results from vorbis_synthesis_restart. They
+  // aren't fatal and it fails when ResetDecode is called at a
+  // time when no vorbis data has been read.
+  vorbis_synthesis_restart(&mVorbisDsp);
+  return NS_OK;
+}
+
+nsresult
+VorbisDecoder::DecodeHeader(const unsigned char* aData, size_t aLength)
+{
+  bool bos = mPacketCount == 0;
+  ogg_packet pkt = InitOggPacket(aData, aLength, bos, false, 0, mPacketCount++);
+  MOZ_ASSERT(mPacketCount <= 3);
+
+  int r = vorbis_synthesis_headerin(&mVorbisInfo,
+                                    &mVorbisComment,
+                                    &pkt);
+  return r == 0 ? NS_OK : NS_ERROR_FAILURE;
+}
+
+nsresult
+VorbisDecoder::FinishInit(AudioInfo& aInfo)
+{
+  MOZ_ASSERT(mPacketCount == 3);
+
+  int r = vorbis_synthesis_init(&mVorbisDsp, &mVorbisInfo);
+  if (r) {
+    return NS_ERROR_FAILURE;
+  }
+
+  r = vorbis_block_init(&mVorbisDsp, &mVorbisBlock);
+  if (r) {
+    return NS_ERROR_FAILURE;
+  }
+
+  aInfo.mRate = mVorbisDsp.vi->rate;
+  aInfo.mChannels = mVorbisDsp.vi->channels;
+
+  return NS_OK;
+}
+
+bool
+VorbisDecoder::Decode(const unsigned char* aData, size_t aLength,
+                      int64_t aOffset, uint64_t aTstampUsecs,
+                      int64_t aDiscardPadding, int32_t* aTotalFrames)
+{
+  MOZ_ASSERT(mPacketCount >= 3);
+  ogg_packet pkt = InitOggPacket(aData, aLength, false, false, -1, mPacketCount++);
+  bool first_packet = mPacketCount == 4;
+
+  if (vorbis_synthesis(&mVorbisBlock, &pkt)) {
+    return false;
+  }
+
+  if (vorbis_synthesis_blockin(&mVorbisDsp,
+                               &mVorbisBlock)) {
+    return false;
+  }
+
+  VorbisPCMValue** pcm = 0;
+  int32_t frames = vorbis_synthesis_pcmout(&mVorbisDsp, &pcm);
+  // If the first packet of audio in the media produces no data, we
+  // still need to produce an AudioData for it so that the correct media
+  // start time is calculated.  Otherwise we'd end up with a media start
+  // time derived from the timecode of the first packet that produced
+  // data.
+  if (frames == 0 && first_packet) {
+    mReader->AudioQueue().Push(new AudioData(aOffset, aTstampUsecs, 0, 0, nullptr,
+                                             mVorbisDsp.vi->channels,
+                                             mVorbisDsp.vi->rate));
+  }
+  while (frames > 0) {
+    uint32_t channels = mVorbisDsp.vi->channels;
+    nsAutoArrayPtr<AudioDataValue> buffer(new AudioDataValue[frames*channels]);
+    for (uint32_t j = 0; j < channels; ++j) {
+      VorbisPCMValue* channel = pcm[j];
+      for (uint32_t i = 0; i < uint32_t(frames); ++i) {
+        buffer[i*channels + j] = MOZ_CONVERT_VORBIS_SAMPLE(channel[i]);
+      }
+    }
+
+    CheckedInt64 duration = FramesToUsecs(frames, mVorbisDsp.vi->rate);
+    if (!duration.isValid()) {
+      NS_WARNING("Int overflow converting WebM audio duration");
+      return false;
+    }
+    CheckedInt64 total_duration = FramesToUsecs(*aTotalFrames,
+                                                mVorbisDsp.vi->rate);
+    if (!total_duration.isValid()) {
+      NS_WARNING("Int overflow converting WebM audio total_duration");
+      return false;
+    }
+
+    CheckedInt64 time = total_duration + aTstampUsecs;
+    if (!time.isValid()) {
+      NS_WARNING("Int overflow adding total_duration and aTstampUsecs");
+      return false;
+    };
+
+    *aTotalFrames += frames;
+    mReader->AudioQueue().Push(new AudioData(aOffset,
+                                             time.value(),
+                                             duration.value(),
+                                             frames,
+                                             buffer.forget(),
+                                             mVorbisDsp.vi->channels,
+                                             mVorbisDsp.vi->rate));
+    if (vorbis_synthesis_read(&mVorbisDsp, frames)) {
+      return false;
+    }
+
+    frames = vorbis_synthesis_pcmout(&mVorbisDsp, &pcm);
+  }
+
+  return true;
+}
+
+// ------------------------------------------------------------------------
+
+class OpusDecoder : public WebMAudioDecoder
+{
+public:
+  nsresult Init();
+  void Shutdown();
+  nsresult ResetDecode();
+  nsresult DecodeHeader(const unsigned char* aData, size_t aLength);
+  nsresult FinishInit(AudioInfo& aInfo);
+  bool Decode(const unsigned char* aData, size_t aLength,
+              int64_t aOffset, uint64_t aTstampUsecs,
+              int64_t aDiscardPadding, int32_t* aTotalFrames);
+  explicit OpusDecoder(WebMReader* aReader);
+  ~OpusDecoder();
+private:
+  nsRefPtr<WebMReader> mReader;
+
+  // Opus decoder state
+  nsAutoPtr<OpusParser> mOpusParser;
+  OpusMSDecoder* mOpusDecoder;
+  uint16_t mSkip;        // Samples left to trim before playback.
+  bool mDecodedHeader;
+
+  // Opus padding should only be discarded on the final packet.  Once this
+  // is set to true, if the reader attempts to decode any further packets it
+  // will raise an error so we can indicate that the file is invalid.
+  bool mPaddingDiscarded;
+};
+
+OpusDecoder::OpusDecoder(WebMReader* aReader)
+  : mReader(aReader)
+  , mOpusDecoder(nullptr)
+  , mSkip(0)
+  , mDecodedHeader(false)
+  , mPaddingDiscarded(false)
+{
+}
+
+OpusDecoder::~OpusDecoder()
+{
+  if (mOpusDecoder) {
+    opus_multistream_decoder_destroy(mOpusDecoder);
+    mOpusDecoder = nullptr;
+  }
+}
+
+void
+OpusDecoder::Shutdown()
+{
+  mReader = nullptr;
+}
+
+nsresult
+OpusDecoder::Init()
+{
+  return NS_OK;
+}
+
+nsresult
+OpusDecoder::ResetDecode()
+{
+  if (mOpusDecoder) {
+    // Reset the decoder.
+    opus_multistream_decoder_ctl(mOpusDecoder, OPUS_RESET_STATE);
+    mSkip = mOpusParser->mPreSkip;
+    mPaddingDiscarded = false;
+  }
+  return NS_OK;
+}
+
+nsresult
+OpusDecoder::DecodeHeader(const unsigned char* aData, size_t aLength)
+{
+  MOZ_ASSERT(!mOpusParser);
+  MOZ_ASSERT(!mOpusDecoder);
+  MOZ_ASSERT(!mDecodedHeader);
+  mDecodedHeader = true;
+
+  mOpusParser = new OpusParser;
+  if (!mOpusParser->DecodeHeader(const_cast<unsigned char*>(aData), aLength)) {
+    return NS_ERROR_FAILURE;
+  }
+
+  return NS_OK;
+}
+
+nsresult
+OpusDecoder::FinishInit(AudioInfo& aInfo)
+{
+  MOZ_ASSERT(mDecodedHeader);
+
+  int r;
+  mOpusDecoder = opus_multistream_decoder_create(mOpusParser->mRate,
+                                                 mOpusParser->mChannels,
+                                                 mOpusParser->mStreams,
+                                                 mOpusParser->mCoupledStreams,
+                                                 mOpusParser->mMappingTable,
+                                                 &r);
+  mSkip = mOpusParser->mPreSkip;
+  mPaddingDiscarded = false;
+
+  if (int64_t(mReader->GetCodecDelay()) != FramesToUsecs(mOpusParser->mPreSkip,
+                                                         mOpusParser->mRate).value()) {
+    LOG(PR_LOG_WARNING,
+        ("Invalid Opus header: CodecDelay and pre-skip do not match!"));
+    return NS_ERROR_FAILURE;
+  }
+
+  aInfo.mRate = mOpusParser->mRate;
+  aInfo.mChannels = mOpusParser->mChannels;
+
+  return r == OPUS_OK ? NS_OK : NS_ERROR_FAILURE;
+}
+
+bool
+OpusDecoder::Decode(const unsigned char* aData, size_t aLength,
+                    int64_t aOffset, uint64_t aTstampUsecs,
+                    int64_t aDiscardPadding, int32_t* aTotalFrames)
+{
+  uint32_t channels = mOpusParser->mChannels;
+  // No channel mapping for more than 8 channels.
+  if (channels > 8) {
+    return false;
+  }
+
+  if (mPaddingDiscarded) {
+    // Discard padding should be used only on the final packet, so
+    // decoding after a padding discard is invalid.
+    LOG(PR_LOG_DEBUG, ("Opus error, discard padding on interstitial packet"));
+    return false;
+  }
+
+  // Maximum value is 63*2880, so there's no chance of overflow.
+  int32_t frames_number = opus_packet_get_nb_frames(aData, aLength);
+  if (frames_number <= 0) {
+    return false; // Invalid packet header.
+  }
+
+  int32_t samples =
+    opus_packet_get_samples_per_frame(aData, opus_int32(mOpusParser->mRate));
+
+  // A valid Opus packet must be between 2.5 and 120 ms long (48kHz).
+  int32_t frames = frames_number*samples;
+  if (frames < 120 || frames > 5760)
+    return false;
+
+  nsAutoArrayPtr<AudioDataValue> buffer(new AudioDataValue[frames * channels]);
+
+  // Decode to the appropriate sample type.
+#ifdef MOZ_SAMPLE_TYPE_FLOAT32
+  int ret = opus_multistream_decode_float(mOpusDecoder,
+                                          aData, aLength,
+                                          buffer, frames, false);
+#else
+  int ret = opus_multistream_decode(mOpusDecoder,
+                                    aData, aLength,
+                                    buffer, frames, false);
+#endif
+  if (ret < 0)
+    return false;
+  NS_ASSERTION(ret == frames, "Opus decoded too few audio samples");
+  CheckedInt64 startTime = aTstampUsecs;
+
+  // Trim the initial frames while the decoder is settling.
+  if (mSkip > 0) {
+    int32_t skipFrames = std::min<int32_t>(mSkip, frames);
+    int32_t keepFrames = frames - skipFrames;
+    LOG(PR_LOG_DEBUG, ("Opus decoder skipping %d of %d frames",
+                       skipFrames, frames));
+    PodMove(buffer.get(),
+            buffer.get() + skipFrames * channels,
+            keepFrames * channels);
+    startTime = startTime + FramesToUsecs(skipFrames, mOpusParser->mRate);
+    frames = keepFrames;
+    mSkip -= skipFrames;
+  }
+
+  if (aDiscardPadding < 0) {
+    // Negative discard padding is invalid.
+    LOG(PR_LOG_DEBUG, ("Opus error, negative discard padding"));
+    return false;
+  }
+  if (aDiscardPadding > 0) {
+    CheckedInt64 discardFrames = UsecsToFrames(aDiscardPadding / NS_PER_USEC,
+                                               mOpusParser->mRate);
+    if (!discardFrames.isValid()) {
+      NS_WARNING("Int overflow in DiscardPadding");
+      return false;
+    }
+    if (discardFrames.value() > frames) {
+      // Discarding more than the entire packet is invalid.
+      LOG(PR_LOG_DEBUG, ("Opus error, discard padding larger than packet"));
+      return false;
+    }
+    LOG(PR_LOG_DEBUG, ("Opus decoder discarding %d of %d frames",
+                       int32_t(discardFrames.value()), frames));
+    // Padding discard is only supposed to happen on the final packet.
+    // Record the discard so we can return an error if another packet is
+    // decoded.
+    mPaddingDiscarded = true;
+    int32_t keepFrames = frames - discardFrames.value();
+    frames = keepFrames;
+  }
+
+  // Apply the header gain if one was specified.
+#ifdef MOZ_SAMPLE_TYPE_FLOAT32
+  if (mOpusParser->mGain != 1.0f) {
+    float gain = mOpusParser->mGain;
+    int samples = frames * channels;
+    for (int i = 0; i < samples; i++) {
+      buffer[i] *= gain;
+    }
+  }
+#else
+  if (mOpusParser->mGain_Q16 != 65536) {
+    int64_t gain_Q16 = mOpusParser->mGain_Q16;
+    int samples = frames * channels;
+    for (int i = 0; i < samples; i++) {
+      int32_t val = static_cast<int32_t>((gain_Q16*buffer[i] + 32768)>>16);
+      buffer[i] = static_cast<AudioDataValue>(MOZ_CLIP_TO_15(val));
+    }
+  }
+#endif
+
+  CheckedInt64 duration = FramesToUsecs(frames, mOpusParser->mRate);
+  if (!duration.isValid()) {
+    NS_WARNING("Int overflow converting WebM audio duration");
+    return false;
+  }
+  CheckedInt64 time = startTime - mReader->GetCodecDelay();
+  if (!time.isValid()) {
+    NS_WARNING("Int overflow shifting tstamp by codec delay");
+    return false;
+  };
+  mReader->AudioQueue().Push(new AudioData(aOffset,
+                                           time.value(),
+                                           duration.value(),
+                                           frames,
+                                           buffer.forget(),
+                                           mOpusParser->mChannels,
+                                           mOpusParser->mRate));
+  return true;
+}
+
+} // namespace mozilla

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -10,7 +10,6 @@
 #include "SoftwareWebMVideoDecoder.h"
 #include "WebMReader.h"
 #include "WebMBufferedParser.h"
-#include "VorbisUtils.h"
 #include "gfx2DGlue.h"
 #include "Layers.h"
 #include "mozilla/Preferences.h"
@@ -21,8 +20,6 @@
 #define VPX_DONT_DEFINE_STDINT_TYPES
 #include "vpx/vp8dx.h"
 #include "vpx/vpx_decoder.h"
-
-#include "OggReader.h"
 
 // IntelWebMVideoDecoder uses the WMF backend, which is Windows Vista+ only.
 #if defined(MOZ_PDM_VPX)
@@ -146,20 +143,6 @@ static void webm_log(nestegg * context,
 #endif
 }
 
-ogg_packet InitOggPacket(const unsigned char* aData, size_t aLength,
-                         bool aBOS, bool aEOS,
-                         int64_t aGranulepos, int64_t aPacketNo)
-{
-  ogg_packet packet;
-  packet.packet = const_cast<unsigned char*>(aData);
-  packet.bytes = aLength;
-  packet.b_o_s = aBOS;
-  packet.e_o_s = aEOS;
-  packet.granulepos = aGranulepos;
-  packet.packetno = aPacketNo;
-  return packet;
-}
-
 #if defined(MOZ_PDM_VPX)
 static bool sIsIntelDecoderEnabled = false;
 #endif
@@ -167,21 +150,17 @@ static bool sIsIntelDecoderEnabled = false;
 WebMReader::WebMReader(AbstractMediaDecoder* aDecoder)
   : MediaDecoderReader(aDecoder)
   , mContext(nullptr)
-  , mPacketCount(0)
-  , mOpusDecoder(nullptr)
-  , mSkip(0)
-  , mSeekPreroll(0)
   , mVideoTrack(0)
   , mAudioTrack(0)
   , mAudioStartUsec(-1)
   , mAudioFrames(0)
+  , mSeekPreroll(0)
   , mLastVideoFrameTime(0)
   , mAudioCodec(-1)
   , mVideoCodec(-1)
   , mLayersBackendType(layers::LayersBackend::LAYERS_NONE)
   , mHasVideo(false)
   , mHasAudio(false)
-  , mPaddingDiscarded(false)
 {
   MOZ_COUNT_CTOR(WebMReader);
 #ifdef PR_LOGGING
@@ -189,12 +168,6 @@ WebMReader::WebMReader(AbstractMediaDecoder* aDecoder)
     gNesteggLog = PR_NewLogModule("Nestegg");
   }
 #endif
-  // Zero these member vars to avoid crashes in VP8 destroy and Vorbis clear
-  // functions when destructor is called before |Init|.
-  memset(&mVorbisBlock, 0, sizeof(vorbis_block));
-  memset(&mVorbisDsp, 0, sizeof(vorbis_dsp_state));
-  memset(&mVorbisInfo, 0, sizeof(vorbis_info));
-  memset(&mVorbisComment, 0, sizeof(vorbis_comment));
 
 #if defined(MOZ_PDM_VPX)
   sIsIntelDecoderEnabled = Preferences::GetBool("media.webm.intel_decoder.enabled", false);
@@ -206,14 +179,7 @@ WebMReader::~WebMReader()
   Cleanup();
   mVideoPackets.Reset();
   mAudioPackets.Reset();
-  vorbis_block_clear(&mVorbisBlock);
-  vorbis_dsp_clear(&mVorbisDsp);
-  vorbis_info_clear(&mVorbisInfo);
-  vorbis_comment_clear(&mVorbisComment);
-  if (mOpusDecoder) {
-    opus_multistream_decoder_destroy(mOpusDecoder);
-    mOpusDecoder = nullptr;
-  }
+  MOZ_ASSERT(!mAudioDecoder);
   MOZ_ASSERT(!mVideoDecoder);
   MOZ_COUNT_DTOR(WebMReader);
 }
@@ -227,6 +193,10 @@ WebMReader::Shutdown()
     mVideoTaskQueue->AwaitShutdownAndIdle();
   }
 #endif
+  if (mAudioDecoder) {
+    mAudioDecoder->Shutdown();
+    mAudioDecoder = nullptr;
+  }
 
   if (mVideoDecoder) {
     mVideoDecoder->Shutdown();
@@ -238,11 +208,6 @@ WebMReader::Shutdown()
 
 nsresult WebMReader::Init(MediaDecoderReader* aCloneDonor)
 {
-  vorbis_info_init(&mVorbisInfo);
-  vorbis_comment_init(&mVorbisComment);
-  memset(&mVorbisDsp, 0, sizeof(vorbis_dsp_state));
-  memset(&mVorbisBlock, 0, sizeof(vorbis_block));
-
 #if defined(MOZ_PDM_VPX)
   if (sIsIntelDecoderEnabled) {
     PlatformDecoderModule::Init();
@@ -298,18 +263,8 @@ nsresult WebMReader::ResetDecode()
     res = NS_ERROR_FAILURE;
   }
 
-  if (mAudioCodec == NESTEGG_CODEC_VORBIS) {
-    // Ignore failed results from vorbis_synthesis_restart. They
-    // aren't fatal and it fails when ResetDecode is called at a
-    // time when no vorbis data has been read.
-    vorbis_synthesis_restart(&mVorbisDsp);
-  } else if (mAudioCodec == NESTEGG_CODEC_OPUS) {
-    if (mOpusDecoder) {
-      // Reset the decoder.
-      opus_multistream_decoder_ctl(mOpusDecoder, OPUS_RESET_STATE);
-      mSkip = mOpusParser->mPreSkip;
-      mPaddingDiscarded = false;
-    }
+  if (mAudioDecoder) {
+    mAudioDecoder->ResetDecode();
   }
 
   mVideoPackets.Reset();
@@ -465,84 +420,43 @@ nsresult WebMReader::ReadMetadata(MediaInfo* aInfo,
       mHasAudio = true;
       mAudioCodec = nestegg_track_codec_id(mContext, track);
       mCodecDelay = params.codec_delay / NS_PER_USEC;
+      mSeekPreroll = params.seek_preroll;
 
       if (mAudioCodec == NESTEGG_CODEC_VORBIS) {
-        // Get the Vorbis header data
-        unsigned int nheaders = 0;
-        r = nestegg_track_codec_data_count(mContext, track, &nheaders);
-        if (r == -1 || nheaders != 3) {
-          Cleanup();
-          return NS_ERROR_FAILURE;
-        }
-
-        for (uint32_t header = 0; header < nheaders; ++header) {
-          unsigned char* data = 0;
-          size_t length = 0;
-
-          r = nestegg_track_codec_data(mContext, track, header, &data, &length);
-          if (r == -1) {
-            Cleanup();
-            return NS_ERROR_FAILURE;
-          }
-          ogg_packet opacket = InitOggPacket(data, length, header == 0, false,
-                                             0, mPacketCount++);
-
-          r = vorbis_synthesis_headerin(&mVorbisInfo,
-                                        &mVorbisComment,
-                                        &opacket);
-          if (r != 0) {
-            Cleanup();
-            return NS_ERROR_FAILURE;
-          }
-        }
-
-        r = vorbis_synthesis_init(&mVorbisDsp, &mVorbisInfo);
-        if (r != 0) {
-          Cleanup();
-          return NS_ERROR_FAILURE;
-        }
-
-        r = vorbis_block_init(&mVorbisDsp, &mVorbisBlock);
-        if (r != 0) {
-          Cleanup();
-          return NS_ERROR_FAILURE;
-        }
-
-        mInfo.mAudio.mRate = mVorbisDsp.vi->rate;
-        mInfo.mAudio.mChannels = mVorbisDsp.vi->channels;
+        mAudioDecoder = new VorbisDecoder(this);
       } else if (mAudioCodec == NESTEGG_CODEC_OPUS) {
+        mAudioDecoder = new OpusDecoder(this);
+      } else {
+        Cleanup();
+        return NS_ERROR_FAILURE;
+      }
+      if (NS_FAILED(mAudioDecoder->Init())) {
+        Cleanup();
+        return NS_ERROR_FAILURE;
+      }
+
+      unsigned int nheaders = 0;
+      r = nestegg_track_codec_data_count(mContext, track, &nheaders);
+      if (r == -1) {
+        Cleanup();
+        return NS_ERROR_FAILURE;
+      }
+
+      for (uint32_t header = 0; header < nheaders; ++header) {
         unsigned char* data = 0;
         size_t length = 0;
-        r = nestegg_track_codec_data(mContext, track, 0, &data, &length);
+        r = nestegg_track_codec_data(mContext, track, header, &data, &length);
         if (r == -1) {
           Cleanup();
           return NS_ERROR_FAILURE;
         }
 
-        mOpusParser = new OpusParser;
-        if (!mOpusParser->DecodeHeader(data, length)) {
+        if (NS_FAILED(mAudioDecoder->DecodeHeader(data, length))) {
           Cleanup();
           return NS_ERROR_FAILURE;
         }
-
-        if (!InitOpusDecoder()) {
-          Cleanup();
-          return NS_ERROR_FAILURE;
-        }
-
-        if (int64_t(mCodecDelay) != FramesToUsecs(mOpusParser->mPreSkip,
-                                                  mOpusParser->mRate).value()) {
-          LOG(PR_LOG_WARNING,
-              ("Invalid Opus header: CodecDelay and pre-skip do not match!"));
-          Cleanup();
-          return NS_ERROR_FAILURE;
-        }
-
-        mInfo.mAudio.mRate = mOpusParser->mRate;
-
-        mInfo.mAudio.mChannels = mOpusParser->mChannels;
-        mSeekPreroll = params.seek_preroll;
-      } else {
+      }
+      if (NS_FAILED(mAudioDecoder->FinishInit(mInfo.mAudio))) {
         Cleanup();
         return NS_ERROR_FAILURE;
       }
@@ -560,24 +474,6 @@ bool
 WebMReader::IsMediaSeekable()
 {
   return mContext && nestegg_has_cues(mContext);
-}
-
-bool WebMReader::InitOpusDecoder()
-{
-  int r;
-
-  NS_ASSERTION(mOpusDecoder == nullptr, "leaking OpusDecoder");
-
-  mOpusDecoder = opus_multistream_decoder_create(mOpusParser->mRate,
-                                                 mOpusParser->mChannels,
-                                                 mOpusParser->mStreams,
-                                                 mOpusParser->mCoupledStreams,
-                                                 mOpusParser->mMappingTable,
-                                                 &r);
-  mSkip = mOpusParser->mPreSkip;
-  mPaddingDiscarded = false;
-
-  return r == OPUS_OK;
 }
 
 bool WebMReader::DecodeAudioPacket(NesteggPacketHolder* aHolder)
@@ -621,7 +517,6 @@ bool WebMReader::DecodeAudioPacket(NesteggPacketHolder* aHolder)
                        usecs.isValid() ? usecs.value() : -1,
                        gap_frames));
 #endif
-    mPacketCount++;
     mAudioStartUsec = tstamp;
     mAudioFrames = 0;
   }
@@ -634,227 +529,16 @@ bool WebMReader::DecodeAudioPacket(NesteggPacketHolder* aHolder)
     if (r == -1) {
       return false;
     }
-    if (mAudioCodec == NESTEGG_CODEC_VORBIS) {
-      if (!DecodeVorbis(data, length, aHolder->Offset(), tstamp, &total_frames)) {
-        return false;
-      }
-    } else if (mAudioCodec == NESTEGG_CODEC_OPUS) {
-      if (!DecodeOpus(data, length, aHolder->Offset(), tstamp, aHolder->Packet())) {
-        return false;
-      }
-    }
-  }
+    int64_t discardPadding = 0;
+    (void) nestegg_packet_discard_padding(aHolder->Packet(), &discardPadding);
 
-  return true;
-}
-
-bool WebMReader::DecodeVorbis(const unsigned char* aData, size_t aLength,
-                              int64_t aOffset, uint64_t aTstampUsecs,
-                              int32_t* aTotalFrames)
-{
-  ogg_packet opacket = InitOggPacket(aData, aLength, false, false, -1,
-                                     mPacketCount++);
-
-  if (vorbis_synthesis(&mVorbisBlock, &opacket) != 0) {
-    return false;
-  }
-
-  if (vorbis_synthesis_blockin(&mVorbisDsp,
-                               &mVorbisBlock) != 0) {
-    return false;
-  }
-
-  VorbisPCMValue** pcm = 0;
-  int32_t frames = vorbis_synthesis_pcmout(&mVorbisDsp, &pcm);
-  // If the first packet of audio in the media produces no data, we
-  // still need to produce an AudioData for it so that the correct media
-  // start time is calculated.  Otherwise we'd end up with a media start
-  // time derived from the timecode of the first packet that produced
-  // data.
-  if (frames == 0 && mAudioFrames == 0) {
-    AudioQueue().Push(new AudioData(aOffset, aTstampUsecs, 0, 0, nullptr,
-                                    mInfo.mAudio.mChannels,
-                                    mInfo.mAudio.mRate));
-  }
-  while (frames > 0) {
-    uint32_t channels = mInfo.mAudio.mChannels;
-    nsAutoArrayPtr<AudioDataValue> buffer(new AudioDataValue[frames*channels]);
-    for (uint32_t j = 0; j < channels; ++j) {
-      VorbisPCMValue* channel = pcm[j];
-      for (uint32_t i = 0; i < uint32_t(frames); ++i) {
-        buffer[i*channels + j] = MOZ_CONVERT_VORBIS_SAMPLE(channel[i]);
-      }
-    }
-
-    CheckedInt64 duration = FramesToUsecs(frames, mInfo.mAudio.mRate);
-    if (!duration.isValid()) {
-      NS_WARNING("Int overflow converting WebM audio duration");
-      return false;
-    }
-    CheckedInt64 total_duration = FramesToUsecs(*aTotalFrames,
-                                                mInfo.mAudio.mRate);
-    if (!total_duration.isValid()) {
-      NS_WARNING("Int overflow converting WebM audio total_duration");
-      return false;
-    }
-
-    CheckedInt64 time = total_duration + aTstampUsecs;
-    if (!time.isValid()) {
-      NS_WARNING("Int overflow adding total_duration and aTstampUsecs");
-      return false;
-    };
-
-    *aTotalFrames += frames;
-    AudioQueue().Push(new AudioData(aOffset,
-                                    time.value(),
-                                    duration.value(),
-                                    frames,
-                                    buffer.forget(),
-                                    mInfo.mAudio.mChannels,
-                                    mInfo.mAudio.mRate));
-    mAudioFrames += frames;
-    if (vorbis_synthesis_read(&mVorbisDsp, frames) != 0) {
-      return false;
-    }
-
-    frames = vorbis_synthesis_pcmout(&mVorbisDsp, &pcm);
-  }
-
-  return true;
-}
-
-bool WebMReader::DecodeOpus(const unsigned char* aData, size_t aLength,
-                            int64_t aOffset, uint64_t aTstampUsecs,
-                            nestegg_packet* aPacket)
-{
-  uint32_t channels = mOpusParser->mChannels;
-  // No channel mapping for more than 8 channels.
-  if (channels > 8) {
-    return false;
-  }
-
-  if (mPaddingDiscarded) {
-    // Discard padding should be used only on the final packet, so
-    // decoding after a padding discard is invalid.
-    LOG(PR_LOG_DEBUG, ("Opus error, discard padding on interstitial packet"));
-    mHitAudioDecodeError = true;
-    return false;
-  }
-
-  // Maximum value is 63*2880, so there's no chance of overflow.
-  int32_t frames_number = opus_packet_get_nb_frames(aData, aLength);
-  if (frames_number <= 0) {
-    return false; // Invalid packet header.
-  }
-
-  int32_t samples =
-    opus_packet_get_samples_per_frame(aData, opus_int32(mInfo.mAudio.mRate));
-
-  // A valid Opus packet must be between 2.5 and 120 ms long (48kHz).
-  int32_t frames = frames_number*samples;
-  if (frames < 120 || frames > 5760)
-    return false;
-
-  nsAutoArrayPtr<AudioDataValue> buffer(new AudioDataValue[frames * channels]);
-
-  // Decode to the appropriate sample type.
-#ifdef MOZ_SAMPLE_TYPE_FLOAT32
-  int ret = opus_multistream_decode_float(mOpusDecoder,
-                                          aData, aLength,
-                                          buffer, frames, false);
-#else
-  int ret = opus_multistream_decode(mOpusDecoder,
-                                    aData, aLength,
-                                    buffer, frames, false);
-#endif
-  if (ret < 0)
-    return false;
-  NS_ASSERTION(ret == frames, "Opus decoded too few audio samples");
-  CheckedInt64 startTime = aTstampUsecs;
-
-  // Trim the initial frames while the decoder is settling.
-  if (mSkip > 0) {
-    int32_t skipFrames = std::min<int32_t>(mSkip, frames);
-    int32_t keepFrames = frames - skipFrames;
-    LOG(PR_LOG_DEBUG, ("Opus decoder skipping %d of %d frames",
-                       skipFrames, frames));
-    PodMove(buffer.get(),
-            buffer.get() + skipFrames * channels,
-            keepFrames * channels);
-    startTime = startTime + FramesToUsecs(skipFrames, mInfo.mAudio.mRate);
-    frames = keepFrames;
-    mSkip -= skipFrames;
-  }
-
-  int64_t discardPadding = 0;
-  (void) nestegg_packet_discard_padding(aPacket, &discardPadding);
-  if (discardPadding < 0) {
-    // Negative discard padding is invalid.
-    LOG(PR_LOG_DEBUG, ("Opus error, negative discard padding"));
-    mHitAudioDecodeError = true;
-  }
-  if (discardPadding > 0) {
-    CheckedInt64 discardFrames = UsecsToFrames(discardPadding / NS_PER_USEC,
-                                               mInfo.mAudio.mRate);
-    if (!discardFrames.isValid()) {
-      NS_WARNING("Int overflow in DiscardPadding");
-      return false;
-    }
-    if (discardFrames.value() > frames) {
-      // Discarding more than the entire packet is invalid.
-      LOG(PR_LOG_DEBUG, ("Opus error, discard padding larger than packet"));
+    if (!mAudioDecoder->Decode(data, length, aHolder->Offset(), tstamp, discardPadding, &total_frames)) {
       mHitAudioDecodeError = true;
       return false;
     }
-    LOG(PR_LOG_DEBUG, ("Opus decoder discarding %d of %d frames",
-                       int32_t(discardFrames.value()), frames));
-    // Padding discard is only supposed to happen on the final packet.
-    // Record the discard so we can return an error if another packet is
-    // decoded.
-    mPaddingDiscarded = true;
-    int32_t keepFrames = frames - discardFrames.value();
-    frames = keepFrames;
   }
 
-  // Apply the header gain if one was specified.
-#ifdef MOZ_SAMPLE_TYPE_FLOAT32
-  if (mOpusParser->mGain != 1.0f) {
-    float gain = mOpusParser->mGain;
-    int samples = frames * channels;
-    for (int i = 0; i < samples; i++) {
-      buffer[i] *= gain;
-    }
-  }
-#else
-  if (mOpusParser->mGain_Q16 != 65536) {
-    int64_t gain_Q16 = mOpusParser->mGain_Q16;
-    int samples = frames * channels;
-    for (int i = 0; i < samples; i++) {
-      int32_t val = static_cast<int32_t>((gain_Q16*buffer[i] + 32768)>>16);
-      buffer[i] = static_cast<AudioDataValue>(MOZ_CLIP_TO_15(val));
-    }
-  }
-#endif
-
-  CheckedInt64 duration = FramesToUsecs(frames, mInfo.mAudio.mRate);
-  if (!duration.isValid()) {
-    NS_WARNING("Int overflow converting WebM audio duration");
-    return false;
-  }
-  CheckedInt64 time = startTime - mCodecDelay;
-  if (!time.isValid()) {
-    NS_WARNING("Int overflow shifting tstamp by codec delay");
-    return false;
-  };
-  AudioQueue().Push(new AudioData(aOffset,
-                                  time.value(),
-                                  duration.value(),
-                                  frames,
-                                  buffer.forget(),
-                                  mInfo.mAudio.mChannels,
-                                  mInfo.mAudio.mRate));
-
-  mAudioFrames += frames;
+  mAudioFrames += total_frames;
 
   return true;
 }

--- a/dom/media/webm/WebMReader.h
+++ b/dom/media/webm/WebMReader.h
@@ -17,14 +17,6 @@
 
 #include "mozilla/layers/LayersTypes.h"
 
-#ifdef MOZ_TREMOR
-#include "tremor/ivorbiscodec.h"
-#else
-#include "vorbis/codec.h"
-#endif
-
-#include "OpusParser.h"
-
 namespace mozilla {
 static const unsigned NS_PER_USEC = 1000;
 static const double NS_PER_S = 1e9;
@@ -138,6 +130,21 @@ public:
   virtual ~WebMVideoDecoder() {}
 };
 
+// Class to handle various audio decode paths
+class WebMAudioDecoder
+{
+public:
+  virtual nsresult Init() = 0;
+  virtual void Shutdown() = 0;
+  virtual nsresult ResetDecode() = 0;
+  virtual nsresult DecodeHeader(const unsigned char* aData, size_t aLength) = 0;
+  virtual nsresult FinishInit(AudioInfo& aInfo) = 0;
+  virtual bool Decode(const unsigned char* aData, size_t aLength,
+                      int64_t aOffset, uint64_t aTstampUsecs,
+                      int64_t aDiscardPadding, int32_t* aTotalFrames) = 0;
+  virtual ~WebMAudioDecoder() {}
+};
+
 class WebMReader : public MediaDecoderReader
 {
 public:
@@ -201,11 +208,9 @@ public:
   void SetLastVideoFrameTime(int64_t aFrameTime);
   layers::LayersBackend GetLayersBackendType() { return mLayersBackendType; }
   FlushableMediaTaskQueue* GetVideoTaskQueue() { return mVideoTaskQueue; }
+  uint64_t GetCodecDelay() { return mCodecDelay; }
 
 protected:
-  // Setup opus decoder
-  bool InitOpusDecoder();
-
   // Decode a nestegg packet of audio data. Push the audio data on the
   // audio queue. Returns true when there's more audio to decode,
   // false if the audio is finished, end of file has been reached,
@@ -213,12 +218,6 @@ protected:
   // must be held during this call. The caller is responsible for freeing
   // aPacket.
   bool DecodeAudioPacket(NesteggPacketHolder* aHolder);
-  bool DecodeVorbis(const unsigned char* aData, size_t aLength,
-                    int64_t aOffset, uint64_t aTstampUsecs,
-                    int32_t* aTotalFrames);
-  bool DecodeOpus(const unsigned char* aData, size_t aLength,
-                  int64_t aOffset, uint64_t aTstampUsecs,
-                  nestegg_packet* aPacket);
 
   // Release context and set to null. Called when an error occurs during
   // reading metadata or destruction of the reader itself.
@@ -246,21 +245,8 @@ private:
   // or decoder thread only.
   nestegg* mContext;
 
-  // The video decoder
+  nsAutoPtr<WebMAudioDecoder> mAudioDecoder;
   nsAutoPtr<WebMVideoDecoder> mVideoDecoder;
-
-  // Vorbis decoder state
-  vorbis_info mVorbisInfo;
-  vorbis_comment mVorbisComment;
-  vorbis_dsp_state mVorbisDsp;
-  vorbis_block mVorbisBlock;
-  int64_t mPacketCount;
-
-  // Opus decoder state
-  nsAutoPtr<OpusParser> mOpusParser;
-  OpusMSDecoder *mOpusDecoder;
-  uint16_t mSkip;        // Samples left to trim before playback.
-  uint64_t mSeekPreroll; // Nanoseconds to discard after seeking.
 
   // Queue of video and audio packets that have been read but not decoded. These
   // must only be accessed from the decode thread.
@@ -279,6 +265,9 @@ private:
 
   // Number of microseconds that must be discarded from the start of the Stream.
   uint64_t mCodecDelay;
+
+  // Nanoseconds to discard after seeking.
+  uint64_t mSeekPreroll;
 
   // Calculate the frame duration from the last decodeable frame using the
   // previous frame's timestamp.  In NS.
@@ -308,11 +297,6 @@ private:
   // Booleans to indicate if we have audio and/or video data
   bool mHasVideo;
   bool mHasAudio;
-
-  // Opus padding should only be discarded on the final packet.  Once this
-  // is set to true, if the reader attempts to decode any further packets it
-  // will raise an error so we can indicate that the file is invalid.
-  bool mPaddingDiscarded;
 };
 
 } // namespace mozilla

--- a/dom/media/webm/moz.build
+++ b/dom/media/webm/moz.build
@@ -13,6 +13,7 @@ EXPORTS += [
 ]
 
 UNIFIED_SOURCES += [
+    'AudioDecoder.cpp',
     'SoftwareWebMVideoDecoder.cpp',
     'WebMBufferedParser.cpp',
     'WebMDecoder.cpp',


### PR DESCRIPTION
Instead of duplicating all this code in both WebMReader and (future) WebMDemuxer, this PR splits it out to its own file.

Tested and plays Ogg Vorbis and Opus audio (using the test at http://hpr.dogphilosophy.net/test/). Also tested WebM on YouTube (just in case), with no regressions seen there either.

Tag #1119.