### PR TITLE
[regression] Permissions - install - the default whitelist did display in the Exceptions window

### DIFF
--- a/browser/components/preferences/permissions.js
+++ b/browser/components/preferences/permissions.js
@@ -6,6 +6,8 @@
 const nsIPermissionManager = Components.interfaces.nsIPermissionManager;
 const nsICookiePermission = Components.interfaces.nsICookiePermission;
 
+const NOTIFICATION_FLUSH_PERMISSIONS = "flush-pending-permissions";
+
 function Permission(host, rawHost, type, capability, perm) 
 {
   this.host = host;
@@ -183,6 +185,7 @@ var gPermissionManager = {
 
     var os = Components.classes["@mozilla.org/observer-service;1"]
                        .getService(Components.interfaces.nsIObserverService);
+    os.notifyObservers(null, NOTIFICATION_FLUSH_PERMISSIONS, this._type);
     os.addObserver(this, "perm-changed", false);
 
     this._loadPermissions();


### PR DESCRIPTION
Ad:
https://forum.palemoon.org/viewtopic.php?f=3&p=117348#p117348
> This differs, BTW, from PM 26 and earlier, where the default whitelist did display in the Exceptions window, could be removed/edited in the UI.

---

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=697314

---

You add the label `Regression`, please.

---

I've created the new build (x32, Windows) and tested.
