### PR TITLE
[minor fix] PopupNotifications - throws an error

### DIFF
--- a/browser/modules/PopupNotifications.jsm
+++ b/browser/modules/PopupNotifications.jsm
@@ -432,7 +432,9 @@ PopupNotifications.prototype = {
   _dismiss: function PopupNotifications_dismiss() {
     let browser = this.panel.firstChild &&
                   this.panel.firstChild.notification.browser;
-    this.panel.hidePopup();
+    if (typeof this.panel.hidePopup === "function") {
+      this.panel.hidePopup();
+    }
     if (browser)
       browser.focus();
   },
@@ -442,7 +444,9 @@ PopupNotifications.prototype = {
    */
   _hidePanel: function PopupNotifications_hide() {
     this._ignoreDismissal = true;
-    this.panel.hidePopup();
+    if (typeof this.panel.hidePopup === "function") {
+      this.panel.hidePopup();
+    }
     this._ignoreDismissal = false;
   },
 


### PR DESCRIPTION
__Steps to reproduce:__
- A message is generated (a Popup Notification)
- The loading message is dismissed and the browser window is closed
- ...throws an error in Browser Console:
```
addons.manager
WARN	InstallListener threw exception when calling onDownloadCancelled:
TypeError: this.panel.hidePopup is not a function
(resource://app/modules/PopupNotifications.jsm:435:4)
JS Stack trace: PopupNotifications_dismiss@PopupNotifications.jsm:435:5
< PopupNotifications_update@PopupNotifications.jsm:661:9
< PopupNotifications_remove@PopupNotifications.jsm:371:7
< Notification_remove@PopupNotifications.jsm:69:5
< maybeRemove@browser.js:150:9
< AMI_callInstallListeners@AddonManager.jsm:1551:15
< AMP_callInstallListeners@AddonManager.jsm:2553:1
< AI_cancel@XPIProvider.jsm:5072:1
< AIW_cancel@XPIProvider.jsm:6077:5
< BrowserListener.prototype.cancelInstalls@AddonManager.jsm:384:9
< BrowserListener.prototype.observe@AddonManager.jsm:398:5
```
---

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1151796

---

I've created the new build (x32, Windows) and tested.
