### PR TITLE
Rework media IsType Supported + HW accel fixes

### DIFF
--- a/dom/media/DecoderTraits.cpp
+++ b/dom/media/DecoderTraits.cpp
@@ -536,7 +536,6 @@ DecoderTraits::CanHandleMediaType(const char* aMIMEType,
   if (IsMP3SupportedType(nsDependentCString(aMIMEType))) {
     return CANPLAY_MAYBE;
   }
-#endif
 #ifdef MOZ_OMX_DECODER
   if (IsOmxSupportedType(nsDependentCString(aMIMEType))) {
     return CANPLAY_MAYBE;

--- a/dom/media/DecoderTraits.cpp
+++ b/dom/media/DecoderTraits.cpp
@@ -186,17 +186,20 @@ static char const *const gWebMCodecs[7] = {
   "opus",
   nullptr
 };
+#endif
 
 /* static */ bool
 DecoderTraits::IsWebMType(const nsACString& aType)
 {
+#ifdef MOZ_WEBM
   if (!MediaDecoder::IsWebMEnabled()) {
     return false;
   }
 
   return CodecListContains(gWebMTypes, aType);
-}
 #endif
+  return false;
+}
 
 #ifdef MOZ_OMX_DECODER
 static const char* const gOmxTypes[] = {
@@ -343,6 +346,15 @@ IsMP4SupportedType(const nsACString& aType,
 }
 #endif
 
+/* static */ bool
+DecoderTraits::IsMP4Type(const nsACString& aType)
+{
+#ifdef MOZ_FMP4
+  return IsMP4SupportedType(aType);
+#endif
+  return false;
+}
+
 static bool
 IsMP3SupportedType(const nsACString& aType,
                    const nsAString& aCodecs = EmptyString())
@@ -400,47 +412,44 @@ bool DecoderTraits::ShouldHandleMediaType(const char* aMIMEType)
 
 /* static */
 CanPlayStatus
-DecoderTraits::CanHandleMediaType(const char* aMIMEType,
-                                  bool aHaveRequestedCodecs,
-                                  const nsAString& aRequestedCodecs)
+DecoderTraits::CanHandleCodecsType(const char* aMIMEType,
+                                   const nsAString& aRequestedCodecs)
 {
   char const* const* codecList = nullptr;
-  CanPlayStatus result = CANPLAY_NO;
 #ifdef MOZ_RAW
   if (IsRawType(nsDependentCString(aMIMEType))) {
     codecList = gRawCodecs;
-    result = CANPLAY_MAYBE;
   }
 #endif
   if (IsOggType(nsDependentCString(aMIMEType))) {
     codecList = MediaDecoder::IsOpusEnabled() ? gOggCodecsWithOpus : gOggCodecs;
-    result = CANPLAY_MAYBE;
   }
 #ifdef MOZ_WAVE
   if (IsWaveType(nsDependentCString(aMIMEType))) {
     codecList = gWaveCodecs;
-    result = CANPLAY_MAYBE;
   }
 #endif
-#if defined(MOZ_WEBM) && !defined(MOZ_OMX_WEBM_DECODER)
+#if !defined(MOZ_OMX_WEBM_DECODER)
   if (IsWebMType(nsDependentCString(aMIMEType))) {
     codecList = gWebMCodecs;
-    result = CANPLAY_MAYBE;
   }
 #endif
 #ifdef MOZ_FMP4
-  if (IsMP4SupportedType(nsDependentCString(aMIMEType),
-                                     aRequestedCodecs)) {
-    return aHaveRequestedCodecs ? CANPLAY_YES : CANPLAY_MAYBE;
+  if (IsMP4Type(nsDependentCString(aMIMEType))) {
+    if (IsMP4SupportedType(nsDependentCString(aMIMEType), aRequestedCodecs)) {
+      return CANPLAY_YES;
+    } else {
+      // We can only reach this position if a particular codec was requested,
+      // fmp4 is supported and working: the codec must be invalid.
+      return CANPLAY_NO;
+    }
   }
 #endif
-if (IsMP3SupportedType(nsDependentCString(aMIMEType),
-                                     aRequestedCodecs)) {
-    return aHaveRequestedCodecs ? CANPLAY_YES : CANPLAY_MAYBE;
+  if (IsMP3SupportedType(nsDependentCString(aMIMEType), aRequestedCodecs)) {
+    return CANPLAY_YES;
   }
 #ifdef MOZ_OMX_DECODER
   if (IsOmxSupportedType(nsDependentCString(aMIMEType))) {
-    result = CANPLAY_MAYBE;
     if (nsDependentCString(aMIMEType).EqualsASCII("audio/mpeg")) {
       codecList = gMpegAudioCodecs;
 #ifdef MOZ_OMX_WEBM_DECODER
@@ -454,39 +463,18 @@ if (IsMP3SupportedType(nsDependentCString(aMIMEType),
   }
 #endif
 #ifdef MOZ_DIRECTSHOW
-  // Note: DirectShow should come before WMF, so that we prefer DirectShow's
-  // MP3 support over WMF's.
-  if (DirectShowDecoder::GetSupportedCodecs(nsDependentCString(aMIMEType), &codecList)) {
-    result = CANPLAY_MAYBE;
-  }
-#endif
-#ifdef MOZ_WMF
-  if (IsWMFSupportedType(nsDependentCString(aMIMEType))) {
-    if (!aHaveRequestedCodecs) {
-      return CANPLAY_MAYBE;
-    }
-    return WMFDecoder::CanPlayType(nsDependentCString(aMIMEType),
-                                   aRequestedCodecs)
-           ? CANPLAY_YES : CANPLAY_NO;
-  }
+  DirectShowDecoder::GetSupportedCodecs(nsDependentCString(aMIMEType), &codecList);
 #endif
 #ifdef MOZ_APPLEMEDIA
-  if (IsAppleMediaSupportedType(nsDependentCString(aMIMEType), &codecList)) {
-    result = CANPLAY_MAYBE;
-  }
+  IsAppleMediaSupportedType(nsDependentCString(aMIMEType), &codecList);
 #endif
 #ifdef MOZ_ANDROID_OMX
-  if (MediaDecoder::IsAndroidMediaEnabled() &&
-      GetAndroidMediaPluginHost()->FindDecoder(nsDependentCString(aMIMEType), &codecList))
-    result = CANPLAY_MAYBE;
-#endif
-#ifdef NECKO_PROTOCOL_rtsp
-  if (IsRtspSupportedType(nsDependentCString(aMIMEType))) {
-    result = CANPLAY_MAYBE;
+  if (MediaDecoder::IsAndroidMediaEnabled()) {
+    GetAndroidMediaPluginHost()->FindDecoder(nsDependentCString(aMIMEType), &codecList);
   }
 #endif
-  if (result == CANPLAY_NO || !aHaveRequestedCodecs || !codecList) {
-    return result;
+  if (!codecList) {
+    return CANPLAY_MAYBE;
   }
 
   // See http://www.rfc-editor.org/rfc/rfc4281.txt for the description
@@ -506,7 +494,86 @@ if (IsMP3SupportedType(nsDependentCString(aMIMEType),
     // Last codec name was empty
     return CANPLAY_NO;
   }
+
   return CANPLAY_YES;
+}
+
+/* static */
+CanPlayStatus
+DecoderTraits::CanHandleMediaType(const char* aMIMEType,
+                                  bool aHaveRequestedCodecs,
+                                  const nsAString& aRequestedCodecs)
+{
+  MOZ_ASSERT(NS_IsMainThread());
+
+  if (aHaveRequestedCodecs) {
+    CanPlayStatus result = CanHandleCodecsType(aMIMEType, aRequestedCodecs);
+    if (result == CANPLAY_NO || result == CANPLAY_YES) {
+      return result;
+    }
+  }
+#ifdef MOZ_RAW
+  if (IsRawType(nsDependentCString(aMIMEType))) {
+    return CANPLAY_MAYBE;
+  }
+#endif
+  if (IsOggType(nsDependentCString(aMIMEType))) {
+    return CANPLAY_MAYBE;
+  }
+#ifdef MOZ_WAVE
+  if (IsWaveType(nsDependentCString(aMIMEType))) {
+    return CANPLAY_MAYBE;
+  }
+#endif
+  if (IsMP4Type(nsDependentCString(aMIMEType))) {
+    return CANPLAY_MAYBE;
+  }
+#if !defined(MOZ_OMX_WEBM_DECODER)
+  if (IsWebMType(nsDependentCString(aMIMEType))) {
+    return CANPLAY_MAYBE;
+  }
+#endif
+  if (IsMP3SupportedType(nsDependentCString(aMIMEType))) {
+    return CANPLAY_MAYBE;
+  }
+#endif
+#ifdef MOZ_OMX_DECODER
+  if (IsOmxSupportedType(nsDependentCString(aMIMEType))) {
+    return CANPLAY_MAYBE;
+  }
+#endif
+#ifdef MOZ_DIRECTSHOW
+  if (DirectShowDecoder::GetSupportedCodecs(nsDependentCString(aMIMEType), nullptr)) {
+    return CANPLAY_MAYBE;
+  }
+#endif
+#ifdef MOZ_WMF
+  if (IsWMFSupportedType(nsDependentCString(aMIMEType))) {
+    if (!aHaveRequestedCodecs) {
+      return CANPLAY_MAYBE;
+    }
+    return WMFDecoder::CanPlayType(nsDependentCString(aMIMEType),
+                                   aRequestedCodecs)
+           ? CANPLAY_YES : CANPLAY_NO;
+  }
+#endif
+#ifdef MOZ_APPLEMEDIA
+  if (IsAppleMediaSupportedType(nsDependentCString(aMIMEType), nullptr)) {
+    return CANPLAY_MAYBE;
+  }
+#endif
+#ifdef MOZ_ANDROID_OMX
+  if (MediaDecoder::IsAndroidMediaEnabled() &&
+      EnsureAndroidMediaPluginHost()->FindDecoder(nsDependentCString(aMIMEType), nullptr)) {
+    return CANPLAY_MAYBE;
+  }
+#endif
+#ifdef NECKO_PROTOCOL_rtsp
+  if (IsRtspSupportedType(nsDependentCString(aMIMEType))) {
+    return CANPLAY_MAYBE;
+  }
+#endif
+  return CANPLAY_NO;
 }
 
 // Instantiates but does not initialize decoder.
@@ -588,12 +655,10 @@ if (IsMP3SupportedType(aType)) {
     return decoder.forget();
   }
 #endif
-#ifdef MOZ_WEBM
   if (DecoderTraits::IsWebMType(aType)) {
     decoder = new WebMDecoder();
     return decoder.forget();
   }
-#endif
 #ifdef MOZ_DIRECTSHOW
   // Note: DirectShow should come before WMF, so that we prefer DirectShow's
   // MP3 support over WMF's.
@@ -679,11 +744,9 @@ if (IsMP3SupportedType(aType)) {
     decoderReader = new AndroidMediaReader(aDecoder, aType);
   } else
 #endif
-#ifdef MOZ_WEBM
   if (IsWebMType(aType)) {
     decoderReader = new WebMReader(aDecoder);
   } else
-#endif
 #ifdef MOZ_DIRECTSHOW
   // Note: DirectShowReader is preferred for MP3, but if it's disabled we
   // fallback to the WMFReader.
@@ -726,9 +789,7 @@ bool DecoderTraits::IsSupportedInVideoDocument(const nsACString& aType)
     (IsOmxSupportedType(aType) &&
      !IsB2GSupportOnlyType(aType)) ||
 #endif
-#ifdef MOZ_WEBM
     IsWebMType(aType) ||
-#endif
 #ifdef MOZ_ANDROID_OMX
     (MediaDecoder::IsAndroidMediaEnabled() && IsAndroidMediaType(aType)) ||
 #endif

--- a/dom/media/DecoderTraits.h
+++ b/dom/media/DecoderTraits.h
@@ -29,13 +29,20 @@ class DecoderTraits {
 public:
   // Returns the CanPlayStatus indicating if we can handle this
   // MIME type. The MIME type should not include the codecs parameter.
-  // That parameter should be passed in aCodecs, and will only be
+  // That parameter should be passed in aRequestedCodecs, and will only be
   // used if whether a given MIME type being handled depends on the
   // codec that will be used.  If the codecs parameter has not been
   // specified, pass false in aHaveRequestedCodecs.
   static CanPlayStatus CanHandleMediaType(const char* aMIMEType,
                                           bool aHaveRequestedCodecs,
                                           const nsAString& aRequestedCodecs);
+
+  // Returns the CanPlayStatus indicating if we can handle this MIME type and
+  // codecs type natively. 
+  // The MIME type should not include the codecs parameter.
+  // That parameter is passed in aRequestedCodecs.
+  static CanPlayStatus CanHandleCodecsType(const char* aMIMEType,
+                                           const nsAString& aRequestedCodecs);
 
   // Returns true if we should handle this MIME type when it appears
   // as an <object> or as a toplevel page. If, in practice, our support
@@ -63,6 +70,7 @@ public:
   static bool DecoderWaitsForOnConnected(const nsACString& aType);
 
   static bool IsWebMType(const nsACString& aType);
+  static bool IsMP4Type(const nsACString& aType);
 };
 
 }

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -448,11 +448,15 @@ void
 MediaFormatReader::DisableHardwareAcceleration()
 {
   MOZ_ASSERT(OnTaskQueue());
-  if (HasVideo() && mSharedDecoderManager) {
-    mSharedDecoderManager->DisableHardwareAcceleration();
-
-    if (!mSharedDecoderManager->Recreate(mInfo.mVideo)) {
-      mVideo.mError = true;
+  if (HasVideo()) {
+    mPlatform->DisableHardwareAcceleration();
+    Flush(TrackInfo::kVideoTrack);
+    mVideo.mDecoder->Shutdown();
+    mVideo.mDecoder = nullptr;
+    if (!EnsureDecodersSetup()) {
+      LOG("Unable to re-create decoder, aborting");
+      NotifyError(TrackInfo::kVideoTrack);
+      return;
     }
     ScheduleUpdate(TrackInfo::kVideoTrack);
   }

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -160,10 +160,6 @@ MediaFormatReader::Shutdown()
 void
 MediaFormatReader::InitLayersBackendType()
 {
-  if (!IsVideoContentType(mDecoder->GetResource()->GetContentType())) {
-    // Not playing video, we don't care about the layers backend type.
-    return;
-  }
   // Extract the layer manager backend type so that platform decoders
   // can determine whether it's worthwhile using hardware accelerated
   // video decoding.

--- a/dom/media/mediasource/MediaSource.cpp
+++ b/dom/media/mediasource/MediaSource.cpp
@@ -80,41 +80,40 @@ IsTypeSupported(const nsAString& aType)
   nsAutoString mimeType;
   nsresult rv = parser.GetType(mimeType);
   if (NS_FAILED(rv)) {
-    return NS_ERROR_DOM_NOT_SUPPORTED_ERR;
+    return NS_ERROR_DOM_INVALID_STATE_ERR;
   }
-  bool found = false;
+  NS_ConvertUTF16toUTF8 mimeTypeUTF8(mimeType);
+
+  nsAutoString codecs;
+  bool hasCodecs = NS_SUCCEEDED(parser.GetParameter("codecs", codecs));
+
   for (uint32_t i = 0; gMediaSourceTypes[i]; ++i) {
     if (mimeType.EqualsASCII(gMediaSourceTypes[i])) {
-      if ((mimeType.EqualsASCII("video/mp4") ||
-           mimeType.EqualsASCII("audio/mp4")) &&
-          !Preferences::GetBool("media.mediasource.mp4.enabled", false)) {
-        return NS_ERROR_DOM_INVALID_STATE_ERR;
+      if (DecoderTraits::IsMP4Type(mimeTypeUTF8)) {
+        if (!Preferences::GetBool("media.mediasource.mp4.enabled", false)) {
+          return NS_ERROR_DOM_NOT_SUPPORTED_ERR;
+        }
+        if (hasCodecs &&
+            DecoderTraits::CanHandleCodecsType(mimeTypeUTF8.get(),
+                                               codecs) == CANPLAY_NO) {
+          return NS_ERROR_DOM_INVALID_STATE_ERR;
+        }
+        return NS_OK;
+      } else if (DecoderTraits::IsWebMType(mimeTypeUTF8)) {
+        if (!Preferences::GetBool("media.mediasource.webm.enabled", false) ||
+            Preferences::GetBool("media.mediasource.format-reader", false)) {
+          return NS_ERROR_DOM_NOT_SUPPORTED_ERR;
+        }
+        if (hasCodecs &&
+            DecoderTraits::CanHandleCodecsType(mimeTypeUTF8.get(),
+                                               codecs) == CANPLAY_NO) {
+          return NS_ERROR_DOM_INVALID_STATE_ERR;
+        }
+        return NS_OK;
       }
-      if ((mimeType.EqualsASCII("video/webm") ||
-           mimeType.EqualsASCII("audio/webm")) &&
-          !Preferences::GetBool("media.mediasource.webm.enabled", false)) {
-        return NS_ERROR_DOM_INVALID_STATE_ERR;
-      }
-      found = true;
-      break;
     }
   }
-  if (!found) {
-    return NS_ERROR_DOM_NOT_SUPPORTED_ERR;
-  }
-  // Check aType against HTMLMediaElement list of MIME types.  Since we've
-  // already restricted the container format, this acts as a specific check
-  // of any specified "codecs" parameter of aType.
-  if (dom::HTMLMediaElement::GetCanPlay(aType) == CANPLAY_NO) {
-    return NS_ERROR_DOM_NOT_SUPPORTED_ERR;
-  }
-
-  if (Preferences::GetBool("media.mediasource.format-reader", false) &&
-      !mimeType.EqualsASCII("video/mp4") && !mimeType.EqualsASCII("audio/mp4")) {
-    return NS_ERROR_DOM_NOT_SUPPORTED_ERR;
-  }
-
-  return NS_OK;
+  return NS_ERROR_DOM_NOT_SUPPORTED_ERR;
 }
 
 namespace dom {


### PR DESCRIPTION
Followup to #1033.

The PR fixes the following:

- Reworks DecoderTraits:CanHandleMediaType and properly reports the mimetype in MSE. Currently, MSE only checks the file type (be it MP4 or WebM), and if the HTMLMediaElement can play that type of file. With this PR, MSE will now only report MP4 support if the required support is found on the system (primarily applies to Linux here, should FFmpeg not be installed on the system for example).
- Similarly, MediaResource often does not reliably detect the format (and doesn't work at all with the new MSE) when determining if HW acceleration can be used or not. With this PR, we let the PlatformDecoderModule determine this instead based on parsed metadata. This possibly could help with reports on the forum of high CPU usage? (Though it should be noted that I did not see a noticeable difference in CPU usage during my testing of this).
- Fixed a small bug where HW acceleration could not be disabled for video playback when using new MSE.

I've been testing this the past couple hours and have seen no issues. Tested with both MP4 and WebM on YouTube, videos on Vimeo and Twitch, as well as all the tests on [Quirksmode](http://quirksmode.org/html5/tests/video.html) and [dogphilosophy.net](http://hpr.dogphilosophy.net/test/).

This definitely needs thorough testing on Windows to make sure that all supported formats are still playable (due to the CanHandleMediaType and MSE mimetype reporting changes). As such, I'm adding the `Verification Needed` label.