### PR TITLE
Vectorimage signed/unsigned mismatch

### DIFF
--- a/image/src/VectorImage.cpp
+++ b/image/src/VectorImage.cpp
@@ -841,7 +841,7 @@ VectorImage::CreateSurfaceAndShow(const SVGDrawingParameters& aParams)
   // x or y > maxDimension, because for vector images this can cause bad perf
   // issues if large sizes are scaled repeatedly (a rather common scenario)
   // that can quickly exhaust the cache.
-  uint32_t maxDimension = 400;
+  int32_t maxDimension = 400;
   
   bool bypassCache = bool(aParams.flags & FLAG_BYPASS_SURFACE_CACHE) ||
                      // Refuse to cache animated images:
@@ -850,8 +850,8 @@ VectorImage::CreateSurfaceAndShow(const SVGDrawingParameters& aParams)
                      // The image is too big to fit in the cache:
                      !SurfaceCache::CanHold(aParams.size) ||
                      // Image x or y is larger than our cache cap:
-                     unsigned(aParams.size.width) > maxDimension ||
-                     unsigned(aParams.size.height) > maxDimension;
+                     aParams.size.width > maxDimension ||
+                     aParams.size.height > maxDimension;
   if (bypassCache)
     return Show(svgDrawable, aParams);
 

--- a/image/src/VectorImage.cpp
+++ b/image/src/VectorImage.cpp
@@ -850,8 +850,8 @@ VectorImage::CreateSurfaceAndShow(const SVGDrawingParameters& aParams)
                      // The image is too big to fit in the cache:
                      !SurfaceCache::CanHold(aParams.size) ||
                      // Image x or y is larger than our cache cap:
-                     aParams.size.width > maxDimension ||
-                     aParams.size.height > maxDimension;
+                     unsigned(aParams.size.width) > maxDimension ||
+                     unsigned(aParams.size.height) > maxDimension;
   if (bypassCache)
     return Show(svgDrawable, aParams);
 


### PR DESCRIPTION
Throws a/an warning/error:
```
e:\palemoon-source\image\src\VectorImage.cpp(853) :
error C2220: warning treated as error - no 'object' file generated
Warning: C4018 in e:\palemoon-source\image\src\VectorImage.cpp:
'>' : signed/unsigned mismatch
e:\palemoon-source\image\src\VectorImage.cpp(853) :
warning C4018: '>': signed/unsigned mismatch
Warning: C4018 in e:\palemoon-source\image\src\VectorImage.cpp:
'>' : signed/unsigned mismatch
e:\palemoon-source\image\src\VectorImage.cpp(854) :
warning C4018: '>' : signed/unsigned mismatch
```

---

You add the label `Build Bustage`, please.

---

Ad:
https://github.com/MoonchildProductions/Pale-Moon/commit/1204d78ee7a411d85bc987c6fa81096904971e8c

See also:
https://github.com/MoonchildProductions/Pale-Moon/pull/923
https://github.com/MoonchildProductions/Pale-Moon/issues/1244

---

I've created the new build (x32, Windows) and tested.

---

Or: `uint32_t` -> `int32_t` ?
