### PR TITLE
More Windows theme fixes

### DIFF
--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -45,7 +45,7 @@
   --tab-box-shadow: inset 0.5px 1px 1px var(--tab-selected-highlight);
   --tab-selected-highlight: rgba(255,255,255,.7);
   
-  --window-text-color: inherit;
+  --window-text-color: currentColor;
 }
 
 :root:-moz-lwtheme-brighttext {
@@ -65,6 +65,10 @@
 
 #main-menubar {
   -moz-box-flex: 1; /* make menu items expand to fill toolbar height */
+}
+
+#main-menubar > menu:not(:-moz-lwtheme) {
+  color: inherit; /* allow menubar items to be styled */
 }
 
 #navigator-toolbox {
@@ -3424,18 +3428,15 @@ toolbar[brighttext] #addonbar-closebutton {
  
 /* ==== Windows 8/10 (flat color) styling ==== */
 
-  @media (-moz-os-version: windows-win8),
-         (-moz-os-version: windows-win10) {
-    /* On dark window frames, use a light text color instead of fog on Win8/10 */
+  @media (-moz-os-version: windows-win8) {
+    /* Use a light text styling on dark window frames */
     :root[darkwindowframe="true"]:not(:-moz-lwtheme):not(:-moz-window-inactive) {
       --window-text-color: white;
     }
+  }
 
-    /* Allow menubar menus to be styled */
-    #main-menubar > menu:not(:-moz-lwtheme) {
-      color: inherit;
-    }
-    
+  @media (-moz-os-version: windows-win8),
+         (-moz-os-version: windows-win10) {
     /* Fade text stylings on window inactivity */
     :root:not(:-moz-lwtheme):-moz-window-inactive {
       --window-text-color: ThreeDShadow;


### PR DESCRIPTION
Follow-up to #1221 

This fixes var errors in the browser console, and also makes sure that the menubar text on Windows 7 Aero is always black on inactive windows (in non `lwtheme` mode). It also does a small bit of style cleanup on Windows 10 (we don't need `darkwindowframe` for the `--window-text-color` var there anymore because of #1229).