### PR TITLE
[minor fix] DevTools - Storage - arrows convention for ascending/descending order

### DIFF
--- a/toolkit/themes/shared/devtools/netmonitor.inc.css
+++ b/toolkit/themes/shared/devtools/netmonitor.inc.css
@@ -85,19 +85,13 @@
   transition: background-color 0.1s ease-in-out;
 }
 
-.requests-menu-header-button:hover {
+.requests-menu-header-button:not([sorted]):hover {
   background-color: rgba(0,0,0,0.10);
 }
 
-.requests-menu-header-button:hover:active {
-  background-color: rgba(0,0,0,0.25);
-}
-
-.requests-menu-header-button:not(:active)[sorted] {
-  background-color: rgba(0,0,0,0.15);
-}
-
 .requests-menu-header-button[sorted] {
+  background-color: var(--theme-selection-background);
+  color: var(--theme-selection-color);
   background-position: right 6px center;
 }
 

--- a/toolkit/themes/shared/devtools/widgets.inc.css
+++ b/toolkit/themes/shared/devtools/widgets.inc.css
@@ -1183,34 +1183,31 @@
 }
 
 /* Table widget column header colors are taken from netmonitor.inc.css to match
-   the look of both the tables. This needs to be updated along with netmonitor
-   header colors in bug 951714 */
+   the look of both the tables. */
 
 .table-widget-column-header {
-  background: rgba(0,0,0,0);
   position: sticky;
   top: 0;
   width: 100%;
+  margin: 0;
   padding: 5px 0 0 !important;
   color: inherit;
   text-align: center;
   font-weight: inherit !important;
-  transition: background-color 0.1s ease-in-out;
+  border-bottom: 1px solid var(--theme-splitter-color);
+  border-image: linear-gradient(transparent 15%, var(--theme-splitter-color) 15%, var(--theme-splitter-color) 85%, transparent 85%) 1 1;
+  background-repeat: no-repeat;
 }
 
-.table-widget-column-header:hover {
-  background-image: linear-gradient(rgba(0,0,0,0.10), rgba(0,0,0,0.10));
-}
-
-.table-widget-column-header:hover:active {
-  background-image: linear-gradient(rgba(0,0,0,0.25), rgba(0,0,0,0.25));
-}
-
-.table-widget-column-header:not(:active)[sorted] {
-  background-image: linear-gradient(rgba(0,0,0,0.15), rgba(0,0,0,0.15));
+.table-widget-column-header:not([sorted]):hover {
+  background-image: linear-gradient(rgba(0,0,0,0.10),rgba(0,0,0,0.10));
 }
 
 .table-widget-column-header[sorted] {
+  background-color: var(--theme-selection-background);
+  color: var(--theme-selection-color);
+  border-image: linear-gradient(var(--theme-splitter-color), var(--theme-splitter-color)) 1 1;
+  box-shadow: -0.5px 0px 0px 0.5px var(--theme-splitter-color);
   background-position: right 6px center;
 }
 
@@ -1219,13 +1216,11 @@
 }
 
 .table-widget-column-header[sorted=ascending] {
-  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#descending");
-  background-repeat: no-repeat;
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#ascending");
 }
 
 .table-widget-column-header[sorted=descending] {
-  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#ascending");
-  background-repeat: no-repeat;
+  background-image: url("chrome://global/skin/devtools/sort-arrows.svg#descending");
 }
 
 /* Cells */


### PR DESCRIPTION
Follow up: #1154

---

![1](https://user-images.githubusercontent.com/2373486/28247420-5f475a30-6a30-11e7-9f1b-0b508a200223.png)
![1_](https://user-images.githubusercontent.com/2373486/28247423-6707a2f2-6a30-11e7-8bb3-33854d8b3c25.png)

vs.

![2](https://user-images.githubusercontent.com/2373486/28247427-6e82db82-6a30-11e7-934e-baa53c67e5ed.png)
![2_](https://user-images.githubusercontent.com/2373486/28247429-73cccf80-6a30-11e7-8203-1156bc03a888.png)

---

See also (partially):
https://bugzilla.mozilla.org/show_bug.cgi?id=1049020

---

You add the label `Devtools`, please.
You add the label `Theme changes`, please.

---

I've created the new build (x32, Windows) and tested.
