### PR TITLE
Split more code from WebMReader + small fixes

### DIFF
--- a/dom/media/VideoUtils.cpp
+++ b/dom/media/VideoUtils.cpp
@@ -44,6 +44,11 @@ CheckedInt64 UsecsToFrames(int64_t aUsecs, uint32_t aRate) {
   return SaferMultDiv(aUsecs, aRate, USECS_PER_S);
 }
 
+// Format TimeUnit as number of frames at given rate.
+CheckedInt64 TimeUnitToFrames(const media::TimeUnit& aTime, uint32_t aRate) {
+  return UsecsToFrames(aTime.ToMicroseconds(), aRate);
+}
+
 nsresult SecondsToUsecs(double aSeconds, int64_t& aOutUsecs) {
   if (aSeconds * double(USECS_PER_S) > INT64_MAX) {
     return NS_ERROR_FAILURE;

--- a/dom/media/VideoUtils.h
+++ b/dom/media/VideoUtils.h
@@ -138,6 +138,9 @@ CheckedInt64 FramesToUsecs(int64_t aFrames, uint32_t aRate);
 // overflow while calulating the conversion.
 CheckedInt64 UsecsToFrames(int64_t aUsecs, uint32_t aRate);
 
+// Format TimeUnit as number of frames at given rate.
+CheckedInt64 TimeUnitToFrames(const media::TimeUnit& aTime, uint32_t aRate);
+
 // Converts milliseconds to seconds.
 #define MS_TO_SECONDS(ms) ((double)(ms) / (PR_MSEC_PER_SEC))
 

--- a/dom/media/webm/IntelWebMVideoDecoder.cpp
+++ b/dom/media/webm/IntelWebMVideoDecoder.cpp
@@ -189,7 +189,7 @@ IntelWebMVideoDecoder::Demux(nsRefPtr<VP8Sample>& aSample, bool* aEOS)
   nsRefPtr<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
   if (next_holder) {
     next_tstamp = holder->Timestamp();
-    mReader->PushVideoPacket(next_holder.forget());
+    mReader->PushVideoPacket(next_holder);
   } else {
     next_tstamp = tstamp;
     next_tstamp += tstamp - mReader->GetLastVideoFrameTime();

--- a/dom/media/webm/NesteggPacketHolder.h
+++ b/dom/media/webm/NesteggPacketHolder.h
@@ -74,6 +74,37 @@ private:
   NesteggPacketHolder& operator= (NesteggPacketHolder const& aOther);
 };
 
+// Queue for holding nestegg packets.
+class WebMPacketQueue {
+ public:
+  int32_t GetSize() {
+    return mQueue.size();
+  }
+
+  void Push(NesteggPacketHolder* aItem) {
+    mQueue.push_back(aItem);
+  }
+
+  void PushFront(NesteggPacketHolder* aItem) {
+    mQueue.push_front(Move(aItem));
+  }
+
+  nsRefPtr<NesteggPacketHolder> PopFront() {
+    nsRefPtr<NesteggPacketHolder> result = mQueue.front();
+    mQueue.pop_front();
+    return result;
+  }
+
+  void Reset() {
+    while (!mQueue.empty()) {
+      mQueue.pop_front();
+    }
+  }
+
+private:
+  std::deque<nsRefPtr<NesteggPacketHolder>> mQueue;
+};
+
 } // namespace mozilla
 
 #endif

--- a/dom/media/webm/NesteggPacketHolder.h
+++ b/dom/media/webm/NesteggPacketHolder.h
@@ -1,0 +1,79 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim:set ts=2 sw=2 sts=2 et cindent: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#if !defined(NesteggPacketHolder_h_)
+#define NesteggPacketHolder_h_
+
+#include <stdint.h>
+#include "nsAutoRef.h"
+#include "nestegg/nestegg.h"
+
+namespace mozilla {
+
+// Holds a nestegg_packet, and its file offset. This is needed so we
+// know the offset in the file we've played up to, in order to calculate
+// whether it's likely we can play through to the end without needing
+// to stop to buffer, given the current download rate.
+class NesteggPacketHolder {
+public:
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(NesteggPacketHolder)
+  NesteggPacketHolder() : mPacket(nullptr), mOffset(-1), mTimestamp(-1), mIsKeyframe(false) {}
+
+  bool Init(nestegg_packet* aPacket, int64_t aOffset, unsigned aTrack, bool aIsKeyframe)
+  {
+    uint64_t timestamp_ns;
+    if (nestegg_packet_tstamp(aPacket, &timestamp_ns) == -1) {
+      return false;
+    }
+
+    // We store the timestamp as signed microseconds so that it's easily
+    // comparable to other timestamps we have in the system.
+    mTimestamp = timestamp_ns / 1000;
+    mPacket = aPacket;
+    mOffset = aOffset;
+    mTrack = aTrack;
+    mIsKeyframe = aIsKeyframe;
+
+    return true;
+  }
+
+  nestegg_packet* Packet() { MOZ_ASSERT(IsInitialized()); return mPacket; }
+  int64_t Offset() { MOZ_ASSERT(IsInitialized()); return mOffset; }
+  int64_t Timestamp() { MOZ_ASSERT(IsInitialized()); return mTimestamp; }
+  unsigned Track() { MOZ_ASSERT(IsInitialized()); return mTrack; }
+  bool IsKeyframe() { MOZ_ASSERT(IsInitialized()); return mIsKeyframe; }
+
+private:
+  ~NesteggPacketHolder()
+  {
+    nestegg_free_packet(mPacket);
+  }
+
+  bool IsInitialized() { return mOffset >= 0; }
+
+  nestegg_packet* mPacket;
+
+  // Offset in bytes. This is the offset of the end of the Block
+  // which contains the packet.
+  int64_t mOffset;
+
+  // Packet presentation timestamp in microseconds.
+  int64_t mTimestamp;
+
+  // Track ID.
+  unsigned mTrack;
+
+  // Does this packet contain a keyframe?
+  bool mIsKeyframe;
+
+  // Copy constructor and assignment operator not implemented. Don't use them!
+  NesteggPacketHolder(const NesteggPacketHolder &aOther);
+  NesteggPacketHolder& operator= (NesteggPacketHolder const& aOther);
+};
+
+} // namespace mozilla
+
+#endif

--- a/dom/media/webm/SoftwareWebMVideoDecoder.cpp
+++ b/dom/media/webm/SoftwareWebMVideoDecoder.cpp
@@ -13,6 +13,7 @@
 #include "TimeUnits.h"
 #include "VorbisUtils.h"
 #include "WebMBufferedParser.h"
+#include "NesteggPacketHolder.h"
 #include "prsystem.h"
 
 #include <algorithm>

--- a/dom/media/webm/SoftwareWebMVideoDecoder.cpp
+++ b/dom/media/webm/SoftwareWebMVideoDecoder.cpp
@@ -131,7 +131,7 @@ SoftwareWebMVideoDecoder::DecodeVideoFrame(bool &aKeyframeSkip,
   nsRefPtr<NesteggPacketHolder> next_holder(mReader->NextPacket(WebMReader::VIDEO));
   if (next_holder) {
     next_tstamp = next_holder->Timestamp();
-    mReader->PushVideoPacket(next_holder.forget());
+    mReader->PushVideoPacket(next_holder);
   } else {
     next_tstamp = tstamp;
     next_tstamp += tstamp - mReader->GetLastVideoFrameTime();

--- a/dom/media/webm/WebMBufferedParser.h
+++ b/dom/media/webm/WebMBufferedParser.h
@@ -225,7 +225,7 @@ private:
 
 class WebMBufferedState final
 {
-  NS_INLINE_DECL_REFCOUNTING(WebMBufferedState)
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(WebMBufferedState)
 
 public:
   WebMBufferedState() : mReentrantMonitor("WebMBufferedState") {

--- a/dom/media/webm/WebMReader.cpp
+++ b/dom/media/webm/WebMReader.cpp
@@ -543,7 +543,7 @@ bool WebMReader::DecodeAudioPacket(NesteggPacketHolder* aHolder)
   return true;
 }
 
-already_AddRefed<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackType)
+nsRefPtr<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackType)
 {
   // The packet queue that packets will be pushed on if they
   // are not the type we are interested in.
@@ -580,18 +580,18 @@ already_AddRefed<NesteggPacketHolder> WebMReader::NextPacket(TrackType aTrackTyp
 
     if (hasOtherType && otherTrack == holder->Track()) {
       // Save the packet for when we want these packets
-      otherPackets.Push(holder.forget());
+      otherPackets.Push(holder);
       continue;
     }
 
     // The packet is for the track we want to play
     if (hasType && ourTrack == holder->Track()) {
-      return holder.forget();
+      return holder;
     }
   } while (true);
 }
 
-already_AddRefed<NesteggPacketHolder>
+nsRefPtr<NesteggPacketHolder>
 WebMReader::DemuxPacket()
 {
   nestegg_packet* packet;
@@ -635,7 +635,7 @@ WebMReader::DemuxPacket()
     return nullptr;
   }
 
-  return holder.forget();
+  return holder;
 }
 
 bool WebMReader::DecodeAudioData()
@@ -661,10 +661,10 @@ bool WebMReader::FilterPacketByTime(int64_t aEndTime, WebMPacketQueue& aOutput)
     }
     int64_t tstamp = holder->Timestamp();
     if (tstamp >= aEndTime) {
-      PushVideoPacket(holder.forget());
+      PushVideoPacket(holder);
       return true;
     } else {
-      aOutput.PushFront(holder.forget());
+      aOutput.PushFront(holder);
     }
   }
 
@@ -697,7 +697,7 @@ int64_t WebMReader::GetNextKeyframeTime(int64_t aTimeThreshold)
       keyframeTime = holder->Timestamp();
     }
 
-    skipPacketQueue.PushFront(holder.forget());
+    skipPacketQueue.PushFront(holder);
   }
 
   uint32_t size = skipPacketQueue.GetSize();
@@ -722,9 +722,9 @@ bool WebMReader::DecodeVideoFrame(bool &aKeyframeSkip, int64_t aTimeThreshold)
   return mVideoDecoder->DecodeVideoFrame(aKeyframeSkip, aTimeThreshold);
 }
 
-void WebMReader::PushVideoPacket(already_AddRefed<NesteggPacketHolder> aItem)
+void WebMReader::PushVideoPacket(NesteggPacketHolder* aItem)
 {
-    mVideoPackets.PushFront(Move(aItem));
+    mVideoPackets.PushFront(aItem);
 }
 
 nsRefPtr<MediaDecoderReader::SeekPromise>

--- a/dom/media/webm/WebMReader.h
+++ b/dom/media/webm/WebMReader.h
@@ -17,70 +17,11 @@
 
 #include "mozilla/layers/LayersTypes.h"
 
+#include "NesteggPacketHolder.h"
+
 namespace mozilla {
 static const unsigned NS_PER_USEC = 1000;
 static const double NS_PER_S = 1e9;
-
-// Holds a nestegg_packet, and its file offset. This is needed so we
-// know the offset in the file we've played up to, in order to calculate
-// whether it's likely we can play through to the end without needing
-// to stop to buffer, given the current download rate.
-class NesteggPacketHolder {
-public:
-  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(NesteggPacketHolder)
-  NesteggPacketHolder() : mPacket(nullptr), mOffset(-1), mTimestamp(-1), mIsKeyframe(false) {}
-
-  bool Init(nestegg_packet* aPacket, int64_t aOffset, unsigned aTrack, bool aIsKeyframe)
-  {
-    uint64_t timestamp_ns;
-    if (nestegg_packet_tstamp(aPacket, &timestamp_ns) == -1) {
-      return false;
-    }
-
-    // We store the timestamp as signed microseconds so that it's easily
-    // comparable to other timestamps we have in the system.
-    mTimestamp = timestamp_ns / 1000;
-    mPacket = aPacket;
-    mOffset = aOffset;
-    mTrack = aTrack;
-    mIsKeyframe = aIsKeyframe;
-
-    return true;
-  }
-
-  nestegg_packet* Packet() { MOZ_ASSERT(IsInitialized()); return mPacket; }
-  int64_t Offset() { MOZ_ASSERT(IsInitialized()); return mOffset; }
-  int64_t Timestamp() { MOZ_ASSERT(IsInitialized()); return mTimestamp; }
-  unsigned Track() { MOZ_ASSERT(IsInitialized()); return mTrack; }
-  bool IsKeyframe() { MOZ_ASSERT(IsInitialized()); return mIsKeyframe; }
-
-private:
-  ~NesteggPacketHolder()
-  {
-    nestegg_free_packet(mPacket);
-  }
-
-  bool IsInitialized() { return mOffset >= 0; }
-
-  nestegg_packet* mPacket;
-
-  // Offset in bytes. This is the offset of the end of the Block
-  // which contains the packet.
-  int64_t mOffset;
-
-  // Packet presentation timestamp in microseconds.
-  int64_t mTimestamp;
-
-  // Track ID.
-  unsigned mTrack;
-
-  // Does this packet contain a keyframe?
-  bool mIsKeyframe;
-
-  // Copy constructor and assignment operator not implemented. Don't use them!
-  NesteggPacketHolder(const NesteggPacketHolder &aOther);
-  NesteggPacketHolder& operator= (NesteggPacketHolder const& aOther);
-};
 
 class WebMBufferedState;
 

--- a/dom/media/webm/WebMReader.h
+++ b/dom/media/webm/WebMReader.h
@@ -24,37 +24,7 @@ static const unsigned NS_PER_USEC = 1000;
 static const double NS_PER_S = 1e9;
 
 class WebMBufferedState;
-
-// Queue for holding nestegg packets.
-class WebMPacketQueue {
- public:
-   int32_t GetSize() {
-    return mQueue.size();
-  }
-
-  void Push(already_AddRefed<NesteggPacketHolder> aItem) {
-    mQueue.push_back(Move(aItem));
-  }
-
-  void PushFront(already_AddRefed<NesteggPacketHolder> aItem) {
-    mQueue.push_front(Move(aItem));
-  }
-
-  already_AddRefed<NesteggPacketHolder> PopFront() {
-    nsRefPtr<NesteggPacketHolder> result = mQueue.front().forget();
-    mQueue.pop_front();
-    return result.forget();
-  }
-
-  void Reset() {
-    while (!mQueue.empty()) {
-      mQueue.pop_front();
-    }
-  }
-
-private:
-  std::deque<nsRefPtr<NesteggPacketHolder>> mQueue;
-};
+class WebMPacketQueue;
 
 class WebMReader;
 
@@ -137,10 +107,10 @@ public:
   // Read a packet from the nestegg file. Returns nullptr if all packets for
   // the particular track have been read. Pass VIDEO or AUDIO to indicate the
   // type of the packet we want to read.
-  already_AddRefed<NesteggPacketHolder> NextPacket(TrackType aTrackType);
+  nsRefPtr<NesteggPacketHolder> NextPacket(TrackType aTrackType);
 
   // Pushes a packet to the front of the video packet queue.
-  virtual void PushVideoPacket(already_AddRefed<NesteggPacketHolder> aItem);
+  virtual void PushVideoPacket(NesteggPacketHolder* aItem);
 
   int GetVideoCodec();
   nsIntRect GetPicture();
@@ -180,7 +150,7 @@ private:
 
   // Internal method that demuxes the next packet from the stream. The caller
   // is responsible for making sure it doesn't get lost.
-  already_AddRefed<NesteggPacketHolder> DemuxPacket();
+  nsRefPtr<NesteggPacketHolder> DemuxPacket();
 
   // libnestegg context for webm container. Access on state machine thread
   // or decoder thread only.

--- a/dom/media/webm/moz.build
+++ b/dom/media/webm/moz.build
@@ -6,6 +6,7 @@
 
 EXPORTS += [
     'IntelWebMVideoDecoder.h',
+    'NesteggPacketHolder.h',
     'SoftwareWebMVideoDecoder.h',
     'WebMBufferedParser.h',
     'WebMDecoder.h',


### PR DESCRIPTION
More prep work on the road to completing #1119:

- Split NesteggPacketHolder and WebMPacketQueue from WebMReader so it can be used by both WebMReader and WebMDemuxer without having to duplicate code.
- Use nsRefPtr instead of already_AddRefed in WebMPacketQueue.
- Mark WebMBufferedParser refcounting as thread-safe.
- Add TimeUnitToFrames method for use by WebM.

Tested on YouTube and Quirksmode with both MSE enabled and disabled and all works as intended.
