### PR TITLE
[minor fix] DevTools - network - proxy - throws an errors (sometimes)

### DIFF
--- a/toolkit/devtools/webconsole/network-monitor.js
+++ b/toolkit/devtools/webconsole/network-monitor.js
@@ -940,8 +940,23 @@ NetworkMonitor.prototype = {
 
     let response = {};
     response.httpVersion = statusLineArray.shift();
-    response.remoteAddress = aHttpActivity.channel.remoteAddress;
-    response.remotePort = aHttpActivity.channel.remotePort;
+    // XXX: 
+    // Sometimes, when using a proxy server (manual proxy configuration),
+    // throws an errors:
+    // 0x80040111 (NS_ERROR_NOT_AVAILABLE)
+    // [nsIHttpChannelInternal.remoteAddress]
+    response.remoteAddress = null;
+    try {
+      response.remoteAddress = aHttpActivity.channel.remoteAddress;
+    } catch (e) {
+      Cu.reportError(e);
+    }
+    response.remotePort = null;
+    try {
+      response.remotePort = aHttpActivity.channel.remotePort;
+    } catch (e) {
+      Cu.reportError(e);
+    }
     response.status = statusLineArray.shift();
     response.statusText = statusLineArray.join(" ");
     response.headersSize = aExtraStringData.length;


### PR DESCRIPTION
Sometimes, when using a proxy server (manual proxy configuration), throws an errors:
```
Handler function NM_observeActivity threw an exception:
[Exception... "Component returned failure code:
0x80040111 (NS_ERROR_NOT_AVAILABLE) [nsIHttpChannelInternal.remoteAddress]"
nsresult: "0x80040111 (NS_ERROR_NOT_AVAILABLE)"
location: "JS frame :: resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/toolkit/webconsole/network-monitor.js
:: NM__onResponseHeader :: line 943"  data: no]
Stack:
NM__onResponseHeader@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/toolkit/webconsole/network-monitor.js:943:4
NM_observeActivity@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/toolkit/webconsole/network-monitor.js:652:8
makeInfallible/<@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/devtools/DevToolsUtils.js:82:13
Line: 943, column: 0
DevToolsUtils.js:58:0

```

An screenshot:
![screenshot](https://user-images.githubusercontent.com/2373486/28479000-e9dab3bc-6e5a-11e7-9ff8-3febd240c574.png)

This error must not be critical.

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1228715
https://forums.getfoxyproxy.org/viewtopic.php?f=4&t=1874

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows) and tested.
