### PR TITLE
[minor fix] JS - DOM - a string propagate out exceptions from the nsJSScriptTimeoutHandler constructor

### DIFF
--- a/dom/base/nsJSTimeoutHandler.cpp
+++ b/dom/base/nsJSTimeoutHandler.cpp
@@ -423,11 +423,10 @@ already_AddRefed<nsIScriptTimeoutHandler>
 NS_CreateJSTimeoutHandler(JSContext* aCx, nsGlobalWindow *aWindow,
                           const nsAString& aExpression, ErrorResult& aError)
 {
-  ErrorResult rv;
   bool allowEval = false;
   nsRefPtr<nsJSScriptTimeoutHandler> handler =
-    new nsJSScriptTimeoutHandler(aCx, aWindow, aExpression, &allowEval, rv);
-  if (rv.Failed() || !allowEval) {
+    new nsJSScriptTimeoutHandler(aCx, aWindow, aExpression, &allowEval, aError);
+  if (aError.Failed() || !allowEval) {
     return nullptr;
   }
 


### PR DESCRIPTION
An example:
https://bug1230698.bmoattachments.org/attachment.cgi?id=8696126

Actual results:
Browser Console is empty.

Expected results:
Throws an error in Browser Console:
```
NS_ERROR_NOT_INITIALIZED:
attachment.cgi:11:0
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1230698

---

I've created the new build (x32, Windows) and tested.
