### PR TITLE
[minor fix] Build - warnings - unreferenced local variable

### DIFF
--- a/gfx/cairo/cairo/src/cairo-win32-surface.c
+++ b/gfx/cairo/cairo/src/cairo-win32-surface.c
@@ -521,7 +521,6 @@ _cairo_win32_surface_d3d9_lock_rect (cairo_win32_surface_t  *surface,
 				   cairo_image_surface_t **local_out)
 {
     cairo_image_surface_t *local;
-    cairo_int_status_t status;
 
     RECT rectin = { x, y, x+width, y+height };
     D3DLOCKED_RECT rectout;

--- a/gfx/cairo/libpixman/src/pixman-fast-path.c
+++ b/gfx/cairo/libpixman/src/pixman-fast-path.c
@@ -1256,7 +1256,6 @@ scaled_bilinear_scanline_8888_8888_OVER (uint32_t *       dst,
 	uint32_t br = src_bottom [pixman_fixed_to_int (vx) + 1];
 	uint32_t src;
 	uint32_t d;
-	uint32_t result;
 	d = *dst;
 	src = bilinear_interpolation (tl, tr,
 				      bl, br,

--- a/gfx/qcms/iccread.c
+++ b/gfx/qcms/iccread.c
@@ -1303,7 +1303,7 @@ void qcms_data_from_unicode_path(const wchar_t *path, void **mem, size_t *size)
 #define ICC_PROFILE_HEADER_LENGTH 128
 void qcms_data_create_rgb_with_gamma(qcms_CIE_xyY white_point, qcms_CIE_xyYTRIPLE primaries, float gamma, void **mem, size_t *size)
 {
-	uint32_t length, offset, index, xyz_count, trc_count;
+	uint32_t length, index, xyz_count, trc_count;
 	size_t tag_table_offset, tag_data_offset;
 	void *data;
 	struct matrix colorants;

--- a/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
@@ -3370,7 +3370,6 @@ size_t MPEG4Source::parseNALSize(const uint8_t *data) const {
 
 status_t MPEG4Source::lookForMoof() {
     off64_t offset = 0;
-    off64_t size;
     while (true) {
         uint32_t hdr[2];
         auto x = mDataSource->readAt(offset, hdr, 8);

--- a/media/libtheora/lib/x86_vc/mmxidct.c
+++ b/media/libtheora/lib/x86_vc/mmxidct.c
@@ -303,7 +303,6 @@ static const OC_ALIGN16(ogg_uint16_t) OC_IDCT_CONSTS[(1+7)*4]={
 #define OC_8          OC_MID(OC_EIGHT_OFFSET,0)
 
 static void oc_idct8x8_slow(ogg_int16_t _y[64],ogg_int16_t _x[64]){
-  int i;
   /*This routine accepts an 8x8 matrix, but in partially transposed form.
     Every 4x4 block is transposed.*/
   __asm{


### PR DESCRIPTION
Ad #1244

```
        {
          "column": null, 
          "line": 306, 
          "flag": "C4101", 
          "message": "'i' : unreferenced local variable", 
          "filename": "[drive]:\\[path]\\media\\libtheora\\lib\\x86_vc\\mmxidct.c"
        }
        {
          "column": null, 
          "line": 1306, 
          "flag": "C4101", 
          "message": "'offset' : unreferenced local variable", 
          "filename": "[drive]:\\[path]\\gfx\\qcms\\iccread.c"
        }, 
        {
          "column": null, 
          "line": 3373, 
          "flag": "C4101", 
          "message": "'size' : unreferenced local variable", 
          "filename": "[drive]:\\[path]\\media\\libstagefright\\frameworks\\av\\media\\libstagefright\\MPEG4Extractor.cpp"
        }
        {
          "column": null, 
          "line": 1259, 
          "flag": "C4101", 
          "message": "'result' : unreferenced local variable", 
          "filename": "[drive]:\\[path]\\gfx\\cairo\\libpixman\\src\\pixman-fast-path.c"
        }
        {
          "column": null, 
          "line": 524, 
          "flag": "C4101", 
          "message": "'status' : unreferenced local variable", 
          "filename": "[drive]:\\[path]\\gfx\\cairo\\cairo\\src\\cairo-win32-surface.c"
        }, 
```

---

I've created the new build (x32, Windows).
