### PR TITLE
HTTP - HTTP2 - method: OPTIONS (Web Compatibility)

### DIFF
--- a/netwerk/protocol/http/Http2Stream.cpp
+++ b/netwerk/protocol/http/Http2Stream.cpp
@@ -495,8 +495,7 @@ Http2Stream::GenerateOpen()
     firstFrameFlags |= Http2Session::kFlag_END_STREAM;
   } else if (head->IsPost() ||
              head->IsPut() ||
-             head->IsConnect() ||
-             head->IsOptions()) {
+             head->IsConnect()) {
     // place fin in a data frame even for 0 length messages for iterop
   } else if (!mRequestBodyLenRemaining) {
     // for other HTTP extension methods, rely on the content-length


### PR DESCRIPTION
An example:
https://glitch.com/edit/#!/pixelatize (with the unstable version PM)

Throws an error in Browser Console:
```
"Unhandled promise rejection"
Object { readyState: 0, getResponseHeader:
.ajax/y.getResponseHeader(a), getAllResponseHeaders:
.ajax/y.getAllResponseHeaders(), setRequestHeader:
.ajax/y.setRequestHeader(a, b), overrideMimeType:
.ajax/y.overrideMimeType(a), statusCode:
.ajax/y.statusCode(a), abort:
.ajax/y.abort(a),
state: .Deferred/e.state(),
always: .Deferred/e.always(),
catch: .Deferred/e.catch(a),...}
linters.min.js:1:260669
[198]
```

Actual results:
![1](https://user-images.githubusercontent.com/2373486/28513322-f66a9f1e-7055-11e7-8e6f-101f2c266fae.png)

Expected results:
![2](https://user-images.githubusercontent.com/2373486/28513325-fa559fd4-7055-11e7-93dc-2c1c79a35ff0.png)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1259459

---

You add the label `Web Compatibility`, please.

---

I've created the new build (x32, Windows) and tested.
