### PR TITLE
URL - whitespace characters (an error: 0x00, 0x09, 0x0A, 0x0D => 0x00 (only))

### DIFF
--- a/netwerk/base/nsStandardURL.cpp
+++ b/netwerk/base/nsStandardURL.cpp
@@ -1241,13 +1241,10 @@ nsStandardURL::SetSpec(const nsACString &input)
     if (!spec || !*spec)
         return NS_ERROR_MALFORMED_URI;
 
-    int32_t refPos = input.FindChar('#');
-    if (refPos != kNotFound) {
-        const nsCSubstring& sub = Substring(input, refPos, input.Length());
-        nsresult rv = CheckRefCharacters(sub);
-        if (NS_FAILED(rv)) {
-            return rv;
-        }
+    // NUL characters aren't allowed
+    // \r\n\t are stripped out instead of returning error(see below)
+    if (input.FindChar('\0') != kNotFound) {
+        return NS_ERROR_MALFORMED_URI;
     }
 
     // Make a backup of the curent URL
@@ -2524,27 +2521,6 @@ nsStandardURL::SetQuery(const nsACString &input)
     return NS_OK;
 }
 
-nsresult
-nsStandardURL::CheckRefCharacters(const nsACString &input)
-{
-    nsACString::const_iterator start, end;
-    input.BeginReading(start);
-    input.EndReading(end);
-    for (; start != end; ++start) {
-        switch (*start) {
-            case 0x00:
-            case 0x09:
-            case 0x0A:
-            case 0x0D:
-                // These characters are not allowed in the Ref part.
-                return NS_ERROR_MALFORMED_URI;
-            default:
-                continue;
-        }
-    }
-    return NS_OK;
-}
-
 NS_IMETHODIMP
 nsStandardURL::SetRef(const nsACString &input)
 {
@@ -2555,9 +2531,8 @@ nsStandardURL::SetRef(const nsACString &input)
 
     LOG(("nsStandardURL::SetRef [ref=%s]\n", ref));
 
-    nsresult rv = CheckRefCharacters(input);
-    if (NS_FAILED(rv)) {
-        return rv;
+    if (input.FindChar('\0') != kNotFound) {
+        return NS_ERROR_MALFORMED_URI;
     }
 
     if (mPath.mLen < 0)

--- a/netwerk/base/nsStandardURL.h
+++ b/netwerk/base/nsStandardURL.h
@@ -240,8 +240,6 @@ private:
 
     void FindHostLimit(nsACString::const_iterator& aStart,
                        nsACString::const_iterator& aEnd);
-    // Checks that the Ref contains only allowed characters
-    nsresult CheckRefCharacters(const nsACString &input);
 
     // mSpec contains the normalized version of the URL spec (UTF-8 encoded).
     nsCString mSpec;


### PR DESCRIPTION
Ad https://forum.palemoon.org/viewtopic.php?f=29&p=118429

Can't drag some bookmarks to desktop, e.g.:
https://en.wikipedia.org/wiki/Wikipedia:Templates_for_discussion/Log/2017_July_27#Template:Recent_death_Aboriginal_Aus

---

These characters: 0x09, 0x0A, 0x0D (\t\n\r) are stripped out instead of returning error.

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1189852

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1272284
https://bugzilla.mozilla.org/show_bug.cgi?id=1271955
https://bugzilla.mozilla.org/show_bug.cgi?id=1190027
etc.
But it is more risky. Meanwhile, there were many fixes.

---

I've created the new build (x32, Windows) and tested.
