### PR TITLE
DevTools - Scratchpad - fix some old bugs (Find, Find Again)

### DIFF
--- a/toolkit/devtools/scratchpad/scratchpad.js
+++ b/toolkit/devtools/scratchpad/scratchpad.js
@@ -153,6 +153,12 @@ var Scratchpad = {
    */
   _setupCommandListeners: function SP_setupCommands() {
     let commands = {
+      "cmd_find": () => {
+        goDoCommand('cmd_find');
+      },
+      "cmd_findAgain": () => {
+        goDoCommand('cmd_findAgain');
+      },
       "cmd_gotoLine": () => {
         goDoCommand('cmd_gotoLine');
       },

--- a/toolkit/devtools/scratchpad/scratchpad.xul
+++ b/toolkit/devtools/scratchpad/scratchpad.xul
@@ -36,6 +36,8 @@
 <commandset id="editMenuCommands"/>
 
 <commandset id="sourceEditorCommands">
+  <command id="cmd_find" oncommand=";"/>
+  <command id="cmd_findAgain" oncommand=";"/>
   <command id="cmd_gotoLine" oncommand=";"/>
 </commandset>
 
@@ -196,8 +198,16 @@
       <menuseparator/>
       <menuitem id="menu_selectAll"/>
       <menuseparator/>
-      <menuitem id="menu_find"/>
-      <menuitem id="menu_findAgain"/>
+      <menuitem id="se-menu-find"
+          label="&findCmd.label;"
+          accesskey="&findCmd.accesskey;"
+          key="key_find"
+          command="cmd_find"/>
+      <menuitem id="se-menu-findAgain"
+          label="&findAgainCmd.label;"
+          accesskey="&findAgainCmd.accesskey;"
+          key="key_findAgain"
+          command="cmd_findAgain"/>
       <menuseparator/>
       <menuitem id="se-menu-gotoLine"
           label="&gotoLineCmd.label;"


### PR DESCRIPTION
See https://github.com/greasemonkey/greasemonkey/issues/2535

> When I'm editing a script (i.e. open Scratchpad), when in the menu I click Edit > Find - nothing is happening, the yellow Find box popups only by shortcut keys Ctrl + F.
Even more odd happens with Edit > Find next, it's always grayed out thus unclicable,
but again, Ctrl + G works.

The bug is present in the latest version of Firefox (56 Nightly 2017-07-31).

---

You add the label `Devtools` and `UXP-task`, please.

---

I've created the new build (x32, Windows) and tested.
