### PR TITLE
DevTools - Scratchpad - fix some old bugs (Ctrl+Shift+R / Reload and Run)

### DIFF
--- a/toolkit/devtools/scratchpad/scratchpad.xul
+++ b/toolkit/devtools/scratchpad/scratchpad.xul
@@ -117,7 +117,7 @@
   <key id="sp-key-reloadAndRun"
        key="&reloadAndRun.key;"
        command="sp-cmd-reloadAndRun"
-       modifiers="accel,shift"/>
+       modifiers="accel,alt"/>
   <key id="sp-key-evalFunction"
        key="&evalFunction.key;"
        command="sp-cmd-evalFunction"


### PR DESCRIPTION
See:
https://bugzilla.mozilla.org/show_bug.cgi?id=995756

__Steps to reproduce:__
> I open `Scratchpad` -> `Execute` menu and find `Reload and Run Ctrl+Shift+R`.
When I press Ctrl+Shift+R the CodeMirror Replace: prompt appears instead

This is a third party code:
https://github.com/MoonchildProductions/Pale-Moon/blob/27.4.0_Release/toolkit/devtools/sourceeditor/codemirror/codemirror.js#L4693

The bug is present in the latest version of Firefox (56 Nightly 2017-07-31).

`Ctrl,Shift` -> `Ctrl,Alt`...
Throws an information:
`Key event not available on some keyboard layouts: key="r" modifiers="accel,alt"`
AFAIK: But I do not think it's a big problem.

---

You add the label `Devtools` and `UXP-task`, please.

---

I've created the new build (x32, Windows) and tested.
