### PR TITLE
[suggestion, minor fix] Installer - style clean up

### DIFF
--- a/browser/installer/windows/nsis/installer.nsi
+++ b/browser/installer/windows/nsis/installer.nsi
@@ -82,7 +82,6 @@ VIAddVersionKey "OriginalFilename" "setup.exe"
 !insertmacro InitHashAppModelId
 !insertmacro IsHandlerForInstallDir
 !insertmacro IsPinnedToTaskBar
-!insertmacro IsUserAdmin
 !insertmacro LogDesktopShortcut
 !insertmacro LogQuickLaunchShortcut
 !insertmacro LogStartMenuShortcut

--- a/toolkit/mozapps/installer/windows/nsis/common.nsh
+++ b/toolkit/mozapps/installer/windows/nsis/common.nsh
@@ -7183,40 +7183,6 @@
   !verbose pop
 !macroend
 
-!macro IsUserAdmin
-  ; Copied from: http://nsis.sourceforge.net/IsUserAdmin
-  Function IsUserAdmin
-    Push $R0
-    Push $R1
-    Push $R2
-
-    ClearErrors
-    UserInfo::GetName
-    IfErrors Win9x
-    Pop $R1
-    UserInfo::GetAccountType
-    Pop $R2
-
-    StrCmp $R2 "Admin" 0 Continue
-    StrCpy $R0 "true"
-    Goto Done
-
-    Continue:
-
-    StrCmp $R2 "" Win9x
-    StrCpy $R0 "false"
-    Goto Done
-
-    Win9x:
-    StrCpy $R0 "true"
-
-    Done:
-    Pop $R2
-    Pop $R1
-    Exch $R0
-  FunctionEnd
-!macroend
-
 /**
  * Retrieve if present or generate and store a 64 bit hash of an install path
  * using the City Hash algorithm.  On return the resulting id is saved in the


### PR DESCRIPTION
Ad #1244 (this is indirectly related)

Throws warnings:

"browser\installer\windows\nsis\uninstaller.nsi"
```
Variable "MaintCertKey" not referenced or never set, wasting memory!
```

```
warning: uninstall function "un.UninstallServiceIfNotUsed" not referenced
- zeroing code (2003-2047) out`

warning: install function "IsUserAdmin" not referenced
- zeroing code (629-657) out
```

See:
https://github.com/MoonchildProductions/Pale-Moon/issues/178

---

I've created the new build/installer (x32, Windows).
