### PR TITLE
[minor fix] Throws a warning in the Browser Console

### DIFF
--- a/dom/base/WindowNamedPropertiesHandler.cpp
+++ b/dom/base/WindowNamedPropertiesHandler.cpp
@@ -96,6 +96,10 @@ WindowNamedPropertiesHandler::getOwnPropDescriptor(JSContext* aCx,
     return false;
   }
 
+  if (str.IsEmpty()) {
+    return true;
+  }
+
   // Grab the DOM window.
   JS::Rooted<JSObject*> global(aCx, JS_GetGlobalForObject(aCx, aProxy));
   nsGlobalWindow* win = xpc::WindowOrNull(global);


### PR DESCRIPTION
__Steps to reproduce:__

1) Open Scratchpad

2) Menu: `Environment-Content`

3) Insert the code:
```
window[""];
```

4) Run

5) The result:

Throws a warning in the Browser Console:
```
Empty string passed to getElementById().
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1271135

---

I've created the new build (x32, Windows) and tested.
