### PR TITLE
[minor fix] Build - warnings

### DIFF
--- a/dom/media/webaudio/blink/DynamicsCompressorKernel.cpp
+++ b/dom/media/webaudio/blink/DynamicsCompressorKernel.cpp
@@ -167,7 +167,7 @@ float DynamicsCompressorKernel::kAtSlope(float desiredSlope)
     float x = WebAudioUtils::ConvertDecibelsToLinear(xDb);
 
     // Approximate k given initial values.
-    float minK = 0.1;
+    float minK = 0.1f;
     float maxK = 10000;
     float k = 5;
 

--- a/dom/media/webaudio/blink/PeriodicWave.cpp
+++ b/dom/media/webaudio/blink/PeriodicWave.cpp
@@ -244,7 +244,7 @@ void PeriodicWave::createBandLimitedTables(const float* realData, const float* i
 
 void PeriodicWave::generateBasicWaveform(OscillatorType shape)
 {
-    const float piFloat = M_PI;
+    const float piFloat = float(M_PI);
     unsigned fftSize = periodicWaveSize();
     unsigned halfSize = fftSize / 2 + 1;
 

--- a/js/src/vm/ErrorObject.h
+++ b/js/src/vm/ErrorObject.h
@@ -34,19 +34,6 @@ class ErrorObject : public NativeObject
     friend JSObject*
     ::js_InitExceptionClasses(JSContext* cx, JS::HandleObject global);
 
-    /* For access to assignInitialShape. */
-    friend bool
-    EmptyShape::ensureInitialCustomShape<ErrorObject>(ExclusiveContext* cx,
-                                                      Handle<ErrorObject*> obj);
-
-    /*
-     * Assign the initial error shape to the empty object.  (This shape does
-     * *not* include .message, which must be added separately if needed; see
-     * ErrorObject::init.)
-     */
-    static Shape*
-    assignInitialShape(ExclusiveContext* cx, Handle<ErrorObject*> obj);
-
     static bool
     init(JSContext* cx, Handle<ErrorObject*> obj, JSExnType type,
          ScopedJSFreePtr<JSErrorReport>* errorReport, HandleString fileName, HandleString stack,
@@ -84,6 +71,14 @@ class ErrorObject : public NativeObject
     create(JSContext* cx, JSExnType type, HandleString stack, HandleString fileName,
            uint32_t lineNumber, uint32_t columnNumber, ScopedJSFreePtr<JSErrorReport>* report,
            HandleString message);
+
+    /*
+     * Assign the initial error shape to the empty object.  (This shape does
+     * *not* include .message, which must be added separately if needed; see
+     * ErrorObject::init.)
+     */
+    static Shape*
+    assignInitialShape(ExclusiveContext* cx, Handle<ErrorObject*> obj);
 
     JSExnType type() const {
         return JSExnType(getReservedSlot(EXNTYPE_SLOT).toInt32());

--- a/js/src/vm/RegExpObject.h
+++ b/js/src/vm/RegExpObject.h
@@ -376,6 +376,14 @@ class RegExpObject : public NativeObject
     createNoStatics(ExclusiveContext* cx, HandleAtom atom, RegExpFlag flags,
                     frontend::TokenStream* ts, LifoAlloc& alloc);
 
+    /*
+     * Compute the initial shape to associate with fresh RegExp objects,
+     * encoding their initial properties. Return the shape after
+     * changing |obj|'s last property to it.
+     */
+    static Shape*
+    assignInitialShape(ExclusiveContext* cx, Handle<RegExpObject*> obj);
+
     /* Accessors. */
 
     static unsigned lastIndexSlot() { return LAST_INDEX_SLOT; }
@@ -445,19 +453,6 @@ class RegExpObject : public NativeObject
 
   private:
     friend class RegExpObjectBuilder;
-
-    /* For access to assignInitialShape. */
-    friend bool
-    EmptyShape::ensureInitialCustomShape<RegExpObject>(ExclusiveContext* cx,
-                                                       Handle<RegExpObject*> obj);
-
-    /*
-     * Compute the initial shape to associate with fresh RegExp objects,
-     * encoding their initial properties. Return the shape after
-     * changing |obj|'s last property to it.
-     */
-    static Shape*
-    assignInitialShape(ExclusiveContext* cx, Handle<RegExpObject*> obj);
 
     bool init(ExclusiveContext* cx, HandleAtom source, RegExpFlag flags);
 

--- a/js/src/vm/StringObject.h
+++ b/js/src/vm/StringObject.h
@@ -31,6 +31,14 @@ class StringObject : public NativeObject
     static inline StringObject* create(JSContext* cx, HandleString str,
                                        NewObjectKind newKind = GenericObject);
 
+    /*
+     * Compute the initial shape to associate with fresh String objects, which
+     * encodes the initial length property. Return the shape after changing
+     * |obj|'s last property to it.
+     */
+    static Shape*
+    assignInitialShape(ExclusiveContext* cx, Handle<StringObject*> obj);
+
     JSString* unbox() const {
         return getFixedSlot(PRIMITIVE_VALUE_SLOT).toString();
     }
@@ -58,19 +66,6 @@ class StringObject : public NativeObject
     /* For access to init, as String.prototype is special. */
     friend JSObject*
     ::js_InitStringClass(JSContext* cx, js::HandleObject global);
-
-    /* For access to assignInitialShape. */
-    friend bool
-    EmptyShape::ensureInitialCustomShape<StringObject>(ExclusiveContext* cx,
-                                                       Handle<StringObject*> obj);
-
-    /*
-     * Compute the initial shape to associate with fresh String objects, which
-     * encodes the initial length property. Return the shape after changing
-     * |obj|'s last property to it.
-     */
-    static Shape*
-    assignInitialShape(ExclusiveContext* cx, Handle<StringObject*> obj);
 };
 
 } // namespace js

--- a/mozglue/build/WindowsDllBlocklist.cpp
+++ b/mozglue/build/WindowsDllBlocklist.cpp
@@ -429,12 +429,16 @@ DllBlockSet::Add(const char* name, unsigned long long version)
 void
 DllBlockSet::Write(HANDLE file)
 {
-  AutoCriticalSection lock(&sLock);
-  DWORD nBytes;
+  // It would be nicer to use AutoCriticalSection here. However, its destructor
+  // might not run if an exception occurs, in which case we would never leave
+  // the critical section. (MSVC warns about this possibility.) So we
+  // enter and leave manually.
+  ::EnterCriticalSection(&sLock);
 
   // Because this method is called after a crash occurs, and uses heap memory,
   // protect this entire block with a structured exception handler.
   MOZ_SEH_TRY {
+    DWORD nBytes;
     for (DllBlockSet* b = gFirst; b; b = b->mNext) {
       // write name[,v.v.v.v];
       WriteFile(file, b->mName, strlen(b->mName), &nBytes, nullptr);
@@ -458,6 +462,8 @@ DllBlockSet::Write(HANDLE file)
     }
   }
   MOZ_SEH_EXCEPT (EXCEPTION_EXECUTE_HANDLER) { }
+
+  ::LeaveCriticalSection(&sLock);
 }
 
 static

--- a/rdf/datasource/nsFileSystemDataSource.cpp
+++ b/rdf/datasource/nsFileSystemDataSource.cpp
@@ -849,7 +849,7 @@ FileSystemDataSource::GetVolumeList(nsISimpleEnumerator** aResult)
 
     for (volNum = 0; volNum < 26; volNum++)
     {
-        swprintf( drive, L"%c:\\", volNum + (char16_t)'A');
+        swprintf_s(drive, 32, L"%c:\\", volNum + (char16_t)'A');
 
         driveType = GetDriveTypeW(drive);
         if (driveType != DRIVE_UNKNOWN && driveType != DRIVE_NO_ROOT_DIR)


### PR DESCRIPTION
Ad #1244

---

```
    "[drive]:\\[path]\\dom\\media\\webaudio\\blink\\DynamicsCompressorKernel.cpp": {
      "hash": "08ffafccb598ac198ffa2ace6ae5e9bda79cebd8", 
      "warnings": [
        {
          "column": null, 
          "line": 170, 
          "flag": "C4305", 
          "message": "'initializing' : truncation from 'double' to 'float'", 
          "filename": "[drive]:\\[path]\\dom\\media\\webaudio\\blink\\DynamicsCompressorKernel.cpp"
        }
      ]
    }, 
    "[drive]:\\[path]\\dom\\media\\webaudio\\blink\\PeriodicWave.cpp": {
      "hash": "e8d2edd7df8501174373ac253a7208e6b67e201d", 
      "warnings": [
        {
          "column": null, 
          "line": 247, 
          "flag": "C4305", 
          "message": "'initializing' : truncation from 'double' to 'const float'", 
          "filename": "[drive]:\\[path]\\dom\\media\\webaudio\\blink\\PeriodicWave.cpp"
        }
      ]
    }, 
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1204195

---

```
    "[drive]:\\[path]\\js\\src\\vm\\StringObject.h": {
      "hash": "df210b7a80943f330c2cddb1354d3e6d2df735bf", 
      "warnings": [
        {
          "column": null, 
          "line": 65, 
          "flag": "C4396", 
          "message": "'js::EmptyShape::ensureInitialCustomShape' : the inline specifier cannot be used when a friend declaration refers to a specialization of a function template", 
          "filename": "[drive]:\\[path]\\js\\src\\vm\\StringObject.h"
        }
      ]
    }, 
    "[drive]:\\[path]\\js\\src\\vm\\RegExpObject.h": {
      "hash": "dd71ad679a2e90ccd6c161b1233557928c89699c", 
      "warnings": [
        {
          "column": null, 
          "line": 452, 
          "flag": "C4396", 
          "message": "'js::EmptyShape::ensureInitialCustomShape' : the inline specifier cannot be used when a friend declaration refers to a specialization of a function template", 
          "filename": "[drive]:\\[path]\\js\\src\\vm\\RegExpObject.h"
        }
      ]
    }, 
    "[drive]:\\[path]\\js\\src\\vm\\ErrorObject.h": {
      "hash": "7033db1ff7bfe2bdb0c09397005b3b2c155b1c4b", 
      "warnings": [
        {
          "column": null, 
          "line": 40, 
          "flag": "C4396", 
          "message": "'js::EmptyShape::ensureInitialCustomShape' : the inline specifier cannot be used when a friend declaration refers to a specialization of a function template", 
          "filename": "[drive]:\\[path]\\js\\src\\vm\\ErrorObject.h"
        }
      ]
    }, 
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1127511

---


```
    "[drive]:\\[path]\\rdf\\datasource\\nsFileSystemDataSource.cpp": {
      "hash": "9c9b445d74a01b6c874b9deb7fba1b86faabe082", 
      "warnings": [
        {
          "column": null, 
          "line": 852, 
          "flag": "C4996", 
          "message": "'swprintf': swprintf has been changed to conform with the ISO C standard, adding an extra character count parameter. To use traditional Microsoft swprintf, set _CRT_NON_CONFORMING_SWPRINTFS.", 
          "filename": "[drive]:\\[path]\\rdf\\datasource\\nsFileSystemDataSource.cpp"
        }
      ]
    }, 
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1205148

---


```
    "[drive]:\\[path]\\mozglue\\build\\WindowsDllBlocklist.cpp": {
      "hash": "64611a69b2cccad421d549b9c498d13ba4aff8cb", 
      "warnings": [
        {
          "column": null, 
          "filename": "[drive]:\\[path]\\mozglue\\build\\WindowsDllBlocklist.cpp", 
          "flag": "C4509", 
          "line": 461, 
          "message": "nonstandard extension used: '`anonymous-namespace'::DllBlockSet::Write' uses SEH and 'lock' has destructor"
        }
      ]
    }, 
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1203553

---

I've created the new build (x32, Windows).
