### PR TITLE
Remove Mozilla plugincheck from about:plugins

### DIFF
--- a/dom/locales/en-US/chrome/plugins.properties
+++ b/dom/locales/en-US/chrome/plugins.properties
@@ -9,7 +9,6 @@
 title_label=About Plugins
 installedplugins_label=Installed plugins
 nopluginsareinstalled_label=No installed plugins found
-findpluginupdates_label=Find updates for installed plugins at
 file_label=File:
 path_label=Path:
 version_label=Version:

--- a/toolkit/content/plugins.css
+++ b/toolkit/content/plugins.css
@@ -30,10 +30,6 @@ div#outside {
   font-weight: bold;
 }
 
-div#findpluginupdates {
-  margin-top: 2em;
-}
-
 .plugname {
   margin-top: 2em;
   margin-bottom: 1em;

--- a/toolkit/content/plugins.html
+++ b/toolkit/content/plugins.html
@@ -75,18 +75,6 @@
     enabledplugins.appendChild(document.createTextNode(pluginsbundle.GetStringFromName(label)));
     fragment.appendChild(enabledplugins);
 
-    // "Find updates for installed plugins at " ...
-    var findpluginupdates = document.createElement("div");
-    findpluginupdates.setAttribute("id", "findpluginupdates");
-    findpluginupdates.appendChild(document.createTextNode(pluginsbundle.GetStringFromName("findpluginupdates_label") + " "));
-    fragment.appendChild(findpluginupdates);
-
-    // ... "mozilla.com/plugincheck"
-    var pluginupdates = document.createElement("a");
-    pluginupdates.setAttribute("href", regionbundle.GetStringFromName("pluginupdates_url"));
-    pluginupdates.appendChild(document.createTextNode(regionbundle.GetStringFromName("pluginupdates_label")));
-    findpluginupdates.appendChild(pluginupdates);
-
     fragment.appendChild(document.createElement("hr"));
 
     var stateNames = {};


### PR DESCRIPTION
Since plugincheck service does not work for non-Firefox browsers, remaining pieces of the related code should be trashed.