### PR TITLE
DevTools - Browser Console - restore sessions

### DIFF
--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -6839,7 +6839,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "gDevToolsBrowser",
 Object.defineProperty(this, "HUDService", {
   get: function HUDService_getter() {
     let devtools = Cu.import("resource://gre/modules/devtools/Loader.jsm", {}).devtools;
-    return devtools.require("devtools/webconsole/hudservice");
+    return devtools.require("devtools/webconsole/hudservice").HUDService;
   },
   configurable: true,
   enumerable: true

--- a/browser/components/sessionstore/SessionStore.jsm
+++ b/browser/components/sessionstore/SessionStore.jsm
@@ -107,6 +107,15 @@ XPCOMUtils.defineLazyModuleGetter(this, "NetUtil",
 #ifdef MOZ_DEVTOOLS
 XPCOMUtils.defineLazyModuleGetter(this, "ScratchpadManager",
   "resource://gre/modules/devtools/scratchpad-manager.jsm");
+
+Object.defineProperty(this, "HUDService", {
+  get: function HUDService_getter() {
+    let devtools = Cu.import("resource://gre/modules/devtools/Loader.jsm", {}).devtools;
+    return devtools.require("devtools/webconsole/hudservice").HUDService;
+  },
+  configurable: true,
+  enumerable: true
+});
 #endif  
   
 XPCOMUtils.defineLazyModuleGetter(this, "DocumentUtils",
@@ -1735,8 +1744,14 @@ let SessionStoreInternal = {
     }
 
 #ifdef MOZ_DEVTOOLS
+    // Scratchpad
     if (lastSessionState.scratchpads) {
       ScratchpadManager.restoreSession(lastSessionState.scratchpads);
+    }
+
+    // The Browser Console
+    if (lastSessionState.browserConsole) {
+      HUDService.restoreBrowserConsoleSession();
     }
 #endif
 
@@ -2558,9 +2573,15 @@ let SessionStoreInternal = {
       recentCrashes: this._recentCrashes
     };
 
+    var scratchpads = null;
+    var browserConsole = null;
 #ifdef MOZ_DEVTOOLS
+    // Scratchpad
     // get open Scratchpad window states too
-    var scratchpads = ScratchpadManager.getSessionState();
+    scratchpads = ScratchpadManager.getSessionState();
+
+    // The Browser Console
+    browserConsole = HUDService.getBrowserConsoleSessionState();
 #endif
 
     return {
@@ -2569,7 +2590,8 @@ let SessionStoreInternal = {
       _closedWindows: lastClosedWindowsCopy,
 #ifdef MOZ_DEVTOOLS
       session: session,
-      scratchpads: scratchpads
+      scratchpads: scratchpads,
+      browserConsole: browserConsole
 #else
       session: session
 #endif
@@ -2796,6 +2818,11 @@ let SessionStoreInternal = {
 #ifdef MOZ_DEVTOOLS
     if (aState.scratchpads) {
       ScratchpadManager.restoreSession(aState.scratchpads);
+    }
+
+    // The Browser Console
+    if (aState.browserConsole) {
+      HUDService.restoreBrowserConsoleSession();
     }
 
 #endif

--- a/toolkit/devtools/devtools-clhandler.js
+++ b/toolkit/devtools/devtools-clhandler.js
@@ -49,10 +49,10 @@ devtoolsCommandlineHandler.prototype = {
           "resource://gre/modules/devtools/Loader.jsm", {}).devtools;
       // Load the browser devtools main module as the loader's main module.
       Cu.import("resource://gre/modules/devtools/gDevTools.jsm");
-      let hudservice = devtools.require("devtools/webconsole/hudservice");
+      let {HUDService} = devtools.require("devtools/webconsole/hudservice");
       let console = Cu.import(
           "resource://gre/modules/devtools/Console.jsm", {}).console;
-      hudservice.toggleBrowserConsole().then(null, console.error);
+      HUDService.toggleBrowserConsole().then(null, console.error);
     } else {
       // The Browser Console was already open.
       window.focus();

--- a/toolkit/devtools/framework/toolbox.js
+++ b/toolkit/devtools/framework/toolbox.js
@@ -15,7 +15,7 @@ let {Cc, Ci, Cu} = require("chrome");
 let {Promise: promise} = require("resource://gre/modules/Promise.jsm");
 let EventEmitter = require("devtools/toolkit/event-emitter");
 let {getHighlighterUtils} = require("devtools/framework/toolbox-highlighter-utils");
-let HUDService = require("devtools/webconsole/hudservice");
+let {HUDService} = require("devtools/webconsole/hudservice");
 let {showDoorhanger} = require("devtools/shared/doorhanger");
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");

--- a/toolkit/devtools/webconsole/hudservice.js
+++ b/toolkit/devtools/webconsole/hudservice.js
@@ -50,7 +50,24 @@ HUD_SERVICE.prototype =
    */
   consoles: null,
 
+  _browerConsoleSessionState: false,
+  storeBrowserConsoleSessionState() {
+    this._browerConsoleSessionState = !!this.getBrowserConsole();
+  },
+  getBrowserConsoleSessionState() {
+    return this._browerConsoleSessionState;
+  },
+
   /**
+   * Restore the Browser Console as provided by SessionStore.
+   */
+  restoreBrowserConsoleSession: function HS_restoreBrowserConsoleSession() {
+    if (!HUDService.getBrowserConsole()) {
+      HUDService.toggleBrowserConsole();
+    }
+  },
+
+   /**
    * Assign a function to this property to listen for every request that
    * completes. Used by unit tests. The callback takes one argument: the HTTP
    * activity object as received from the remote Web Console.
@@ -713,6 +730,9 @@ BrowserConsole.prototype = Heritage.extend(WebConsole.prototype,
       return this._bc_init;
     }
 
+    // Only add the shutdown observer if we've opened a Browser Console window.
+    ShutdownObserver.init();
+
     this.ui._filterPrefsPrefix = BROWSER_CONSOLE_FILTER_PREFS_PREFIX;
 
     let window = this.iframeWindow;
@@ -768,16 +788,32 @@ BrowserConsole.prototype = Heritage.extend(WebConsole.prototype,
 });
 
 const HUDService = new HUD_SERVICE();
+exports.HUDService = HUDService;
 
-(() => {
-  let methods = ["openWebConsole", "openBrowserConsole",
-                 "toggleBrowserConsole", "getOpenWebConsole",
-                 "getBrowserConsole", "getHudByWindow",
-                 "openBrowserConsoleOrFocus", "getHudReferenceById"];
-  for (let method of methods) {
-    exports[method] = HUDService[method].bind(HUDService);
+/**
+ * The ShutdownObserver listens for app shutdown and saves the current state
+ * of the Browser Console for session restore.
+ */
+var ShutdownObserver = {
+  _initialized: false,
+  init() {
+    if (this._initialized) {
+      return;
+    }
+
+    Services.obs.addObserver(this, "quit-application-granted", false);
+
+    this._initialized = true;
+  },
+
+  observe(message, topic) {
+    if (topic == "quit-application-granted") {
+      HUDService.storeBrowserConsoleSessionState();
+      this.uninit();
+    }
+  },
+
+  uninit() {
+    Services.obs.removeObserver(this, "quit-application-granted");
   }
-
-  exports.consoles = HUDService.consoles;
-  exports.lastFinishedRequest = HUDService.lastFinishedRequest;
-})();
+};

--- a/toolkit/devtools/webconsole/panel.js
+++ b/toolkit/devtools/webconsole/panel.js
@@ -8,7 +8,7 @@ const {Cc, Ci, Cu} = require("chrome");
 
 loader.lazyImporter(this, "devtools", "resource://gre/modules/devtools/Loader.jsm");
 loader.lazyImporter(this, "promise", "resource://gre/modules/Promise.jsm", "Promise");
-loader.lazyGetter(this, "HUDService", () => require("devtools/webconsole/hudservice"));
+loader.lazyRequireGetter(this, "HUDService", "devtools/webconsole/hudservice", true);
 loader.lazyGetter(this, "EventEmitter", () => require("devtools/toolkit/event-emitter"));
 loader.lazyImporter(this, "gDevTools", "resource://gre/modules/devtools/gDevTools.jsm");
 


### PR DESCRIPTION
__Restore the Browser Console window__

Ad https://github.com/MoonchildProductions/moebius/pull/112

An example:
- Open the Browser Console
- Restart the browser
(The menu: Help - Troubleshooting Information - Restart normally...)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1388552 (partially)

---

You add the label `Devtools`, please.

---

I've created the new build (x32, Windows) and tested.
