### PR TITLE
[suggestion] Main menu - Restart normally

### DIFF
--- a/browser/base/content/baseMenuOverlay.xul
+++ b/browser/base/content/baseMenuOverlay.xul
@@ -65,7 +65,11 @@
         <menuitem id="helpSafeMode"
                   accesskey="&helpSafeMode.accesskey;"
                   label="&helpSafeMode.label;"
-                  oncommand="safeModeRestart();"/>
+                  oncommand="restart(true);"/>
+        <menuitem id="helpRestart"
+                  accesskey="&helpRestart.accesskey;"
+                  label="&helpRestart.label;"
+                  oncommand="restart(false);"/>
         <menuseparator id="aboutSeparator"/>
         <menuitem id="aboutName"
                   accesskey="&aboutProduct.accesskey;"

--- a/browser/base/content/browser-appmenu.inc
+++ b/browser/base/content/browser-appmenu.inc
@@ -384,7 +384,10 @@
             <menuseparator/>
             <menuitem id="appmenu_safeMode"
                       label="&appMenuSafeMode.label;"
-                      oncommand="safeModeRestart();"/>
+                      oncommand="restart(true);"/>
+            <menuitem id="appmenu_restart"
+                      label="&appMenuRestart.label;"
+                      oncommand="restart(false);"/>
             <menuseparator/>
             <menuitem id="appmenu_about"
                       label="&aboutProduct.label;"

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -6846,14 +6846,29 @@ Object.defineProperty(this, "HUDService", {
 });
 #endif
 
-// Prompt user to restart the browser in safe mode
-function safeModeRestart()
+// Prompt user to restart the browser in safe mode or normally
+function restart(safeMode)
 {
-  // prompt the user to confirm
-  let promptTitle = gNavigatorBundle.getString("safeModeRestartPromptTitle");
+  let promptTitleString = null;
+  let promptMessageString = null;
+  let restartTextString = null;
+  if (safeMode) {
+    promptTitleString = "safeModeRestartPromptTitle";
+    promptMessageString = "safeModeRestartPromptMessage";
+    restartTextString = "safeModeRestartButton";
+  } else {
+    promptTitleString = "restartNormalPromptTitle";
+    promptMessageString = "restartNormalPromptMessage";
+    restartTextString = "restartNormalButton";
+  }
+
+  let flags = Ci.nsIAppStartup.eAttemptQuit;
+
+  // Prompt the user to confirm
+  let promptTitle = gNavigatorBundle.getString(promptTitleString);
   let promptMessage =
-    gNavigatorBundle.getString("safeModeRestartPromptMessage");
-  let restartText = gNavigatorBundle.getString("safeModeRestartButton");
+    gNavigatorBundle.getString(promptMessageString);
+  let restartText = gNavigatorBundle.getString(restartTextString);
   let buttonFlags = (Services.prompt.BUTTON_POS_0 *
                      Services.prompt.BUTTON_TITLE_IS_STRING) +
                     (Services.prompt.BUTTON_POS_1 *
@@ -6863,8 +6878,13 @@ function safeModeRestart()
   let rv = Services.prompt.confirmEx(window, promptTitle, promptMessage,
                                      buttonFlags, restartText, null, null,
                                      null, {});
+
   if (rv == 0) {
-    Services.startup.restartInSafeMode(Ci.nsIAppStartup.eAttemptQuit);
+    if (safeMode) {    
+      Services.startup.restartInSafeMode(flags);
+    } else {
+      Services.startup.quit(flags | Ci.nsIAppStartup.eRestart);
+    }
   }
 }
 

--- a/browser/locales/en-US/chrome/browser/baseMenuOverlay.dtd
+++ b/browser/locales/en-US/chrome/browser/baseMenuOverlay.dtd
@@ -20,7 +20,9 @@
 <!ENTITY productHelp.accesskey    "H">
 <!ENTITY helpMac.commandkey       "?">
 <!ENTITY helpSafeMode.label       "Restart with Add-ons Disabled…">
-<!ENTITY helpSafeMode.accesskey   "R">
+<!ENTITY helpSafeMode.accesskey   "D">
+<!ENTITY helpRestart.label        "Restart normally…">
+<!ENTITY helpRestart.accesskey    "R">
 
 <!ENTITY helpTroubleshootingInfo.label      "Troubleshooting Information">
 <!ENTITY helpTroubleshootingInfo.accesskey  "T">

--- a/browser/locales/en-US/chrome/browser/browser.dtd
+++ b/browser/locales/en-US/chrome/browser/browser.dtd
@@ -334,7 +334,7 @@ These should match what Safari and other Apple applications use on OS X Lion. --
 <!ENTITY appMenuWebDeveloper.label "Web Developer">
 <!ENTITY appMenuGettingStarted.label "Getting Started">
 <!ENTITY appMenuSafeMode.label "Restart with Add-ons Disabled…">
-<!ENTITY appMenuSafeMode.accesskey "R">
+<!ENTITY appMenuRestart.label "Restart normally…">
 
 <!ENTITY openCmd.commandkey           "l">
 <!ENTITY urlbar.placeholder2          "Search or enter address">

--- a/browser/locales/en-US/chrome/browser/browser.properties
+++ b/browser/locales/en-US/chrome/browser/browser.properties
@@ -348,6 +348,11 @@ safeModeRestartPromptTitle=Restart with Add-ons Disabled
 safeModeRestartPromptMessage=Are you sure you want to disable all add-ons and restart?
 safeModeRestartButton=Restart
 
+# restartNormally
+restartNormalPromptTitle=Restart normally
+restartNormalPromptMessage=Are you sure you want to restart Pale Moon?
+restartNormalButton=Restart
+
 # LOCALIZATION NOTE (browser.menu.showCharacterEncoding): Set to the string
 # "true" (spelled and capitalized exactly that way) to show the "Character
 # Encoding" menu in the main Firefox button on Windows. Any other value will


### PR DESCRIPTION
Ad https://forum.palemoon.org/viewtopic.php?f=13&t=16467

- `Restart normally…` in the Help menu
- Remove unused (AFAIK) `appMenuSafeMode.accesskey`

---

You add the label `String changes`, please.

---

I've created the new build (x32, Windows) and tested.
