### PR TITLE
Preferences - the blocklist - level - throws an error

### DIFF
--- a/browser/components/preferences/preferences.xul
+++ b/browser/components/preferences/preferences.xul
@@ -55,7 +55,7 @@
             style="&prefWinMinSize.styleGNOME;"
 #endif
 #endif
-            onunload="gSecurityPane.syncAddonSecurityLevel();">
+            onunload="if (typeof gSecurityPane != 'undefined') gSecurityPane.syncAddonSecurityLevel();">
 
     <script type="application/javascript" src="chrome://browser/content/utilityOverlay.js"/>
 


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/commit/c5fe9772080deaf98e3ac5b6fce83b6a416cf349 (unstable version)

__Steps to reproduce (e.g.)__
Main menu: `Tools` - `Options` - `Privacy` - `History` -> change any value... - `OK`
(if you do not use the Security panel!)

Throws an error in Browser Console:
```
ReferenceError: gSecurityPane is not defined preferences.xul:1:0
```
