### PR TITLE
JS - DOM - Selection API - getSelection() should exist on XMLDocument

### DIFF
--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -12967,3 +12967,19 @@ nsIDocument::GetFonts(ErrorResult& aRv)
 
   return presContext->Fonts();
 }
+
+Selection*
+nsIDocument::GetSelection(ErrorResult& aRv)
+{
+  nsCOMPtr<nsPIDOMWindow> window = GetInnerWindow();
+  if (!window) {
+    return nullptr;
+  }
+
+  NS_ASSERTION(window->IsInnerWindow(), "Should have inner window here!");
+  if (!window->IsCurrentInnerWindow()) {
+    return nullptr;
+  }
+
+  return static_cast<nsGlobalWindow*>(window.get())->GetSelection(aRv);
+}

--- a/dom/base/nsIDocument.h
+++ b/dom/base/nsIDocument.h
@@ -122,6 +122,7 @@ class GlobalObject;
 class NodeFilter;
 class NodeIterator;
 class ProcessingInstruction;
+class Selection;
 class StyleSheetList;
 class SVGDocument;
 class Touch;
@@ -722,6 +723,8 @@ public:
    * Return the root element for this document.
    */
   Element* GetRootElement() const;
+
+  mozilla::dom::Selection* GetSelection(mozilla::ErrorResult& aRv);
 
   virtual nsViewportInfo GetViewportInfo(const mozilla::ScreenIntSize& aDisplaySize) = 0;
 

--- a/dom/html/nsHTMLDocument.cpp
+++ b/dom/html/nsHTMLDocument.cpp
@@ -2223,24 +2223,8 @@ NS_IMETHODIMP
 nsHTMLDocument::GetSelection(nsISelection** aReturn)
 {
   ErrorResult rv;
-  NS_IF_ADDREF(*aReturn = GetSelection(rv));
+  NS_IF_ADDREF(*aReturn = nsDocument::GetSelection(rv));
   return rv.ErrorCode();
-}
-
-Selection*
-nsHTMLDocument::GetSelection(ErrorResult& aRv)
-{
-  nsCOMPtr<nsPIDOMWindow> window = do_QueryInterface(GetScopeObject());
-  if (!window) {
-    return nullptr;
-  }
-
-  NS_ASSERTION(window->IsInnerWindow(), "Should have inner window here!");
-  if (!window->IsCurrentInnerWindow()) {
-    return nullptr;
-  }
-
-  return static_cast<nsGlobalWindow*>(window.get())->GetSelection(aRv);
 }
 
 NS_IMETHODIMP

--- a/dom/html/nsHTMLDocument.h
+++ b/dom/html/nsHTMLDocument.h
@@ -234,7 +234,6 @@ public:
   {
     // Deprecated
   }
-  mozilla::dom::Selection* GetSelection(mozilla::ErrorResult& aRv);
   // The XPCOM CaptureEvents works fine for us.
   // The XPCOM ReleaseEvents works fine for us.
   // We're picking up GetLocation from Document

--- a/dom/webidl/Document.webidl
+++ b/dom/webidl/Document.webidl
@@ -392,6 +392,12 @@ partial interface Document {
   void removeAnonymousContent(AnonymousContent aContent);
 };
 
+// http://w3c.github.io/selection-api/#extensions-to-document-interface
+partial interface Document {
+  [Throws]
+  Selection? getSelection();
+};
+
 // Extension to give chrome JS the ability to determine whether
 // the user has interacted with the document or not.
 partial interface Document {

--- a/dom/webidl/HTMLDocument.webidl
+++ b/dom/webidl/HTMLDocument.webidl
@@ -74,10 +74,6 @@ interface HTMLDocument : Document {
 
   readonly attribute HTMLAllCollection all;
 
-  // https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#selections
-  [Throws]
-  Selection? getSelection();
-
   // @deprecated These are old Netscape 4 methods. Do not use,
   //             the implementation is no-op.
   // XXXbz do we actually need these anymore?


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/moebius/pull/121

__Steps to reproduce__

Go to:
HTML:
\- http://www.palemoon.org/
XML:
\- https://www.w3schools.com/xml/note.xml

\- Select some text

\- Scratchpad:
`alert(document.getSelection());`

__Expected results:__
[selected text]

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=718711

---

I've created the new build (x32, Windows) but tested.
