### PR TITLE
Remove unused pref layout.frame_rate.precise

### DIFF
--- a/b2g/app/b2g.js
+++ b/b2g/app/b2g.js
@@ -471,15 +471,6 @@ pref("dom.mozTCPSocket.enabled", true);
 // WebPayment
 pref("dom.mozPay.enabled", true);
 
-// "Preview" landing of bug 710563, which is bogged down in analysis
-// of talos regression.  This is a needed change for higher-framerate
-// CSS animations, and incidentally works around an apparent bug in
-// our handling of requestAnimationFrame() listeners, which are
-// supposed to enable this REPEATING_PRECISE_CAN_SKIP behavior.  The
-// secondary bug isn't really worth investigating since it's obseleted
-// by bug 710563.
-pref("layout.frame_rate.precise", true);
-
 // Handle hardware buttons in the b2g chrome package
 pref("b2g.keys.menu.enabled", true);
 

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -2559,18 +2559,6 @@ pref("layout.frame_rate", -1);
 // pref to dump the display list to the log. Useful for debugging drawing.
 pref("layout.display-list.dump", false);
 
-// pref to control precision of the frame rate timer. When true,
-// we use a "precise" timer, which means each notification fires
-// Nms after the start of the last notification. That means if the
-// processing of the notification is slow, the timer can fire immediately
-// after we've just finished processing the last notification, which might
-// lead to starvation problems.
-// When false, we use a "slack" timer which fires Nms after the *end*
-// of the last notification. This can give less tight frame rates
-// but provides more time for other operations when the browser is
-// heavily loaded.
-pref("layout.frame_rate.precise", false);
-
 // pref to control whether layout warnings that are hit quite often are enabled
 pref("layout.spammy_warnings.enabled", true);
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1356751 and https://forum.palemoon.org/viewtopic.php?p=121476#p121476.

This should be applied to UXP too.