### PR TITLE
StatusBar - follow up

### DIFF
--- a/browser/components/statusbar/content/prefs.js
+++ b/browser/components/statusbar/content/prefs.js
@@ -175,7 +175,7 @@ var status4evarPrefs =
 		{
 			this.progressToolbarCSSPref.value = "#33FF33";
 		}
-		this.dynamicProgressStyle.cssRules[2].style.background = this.progressToolbarCSSPref.value;
+		this.dynamicProgressStyle.cssRules[1].style.background = this.progressToolbarCSSPref.value;
 	},
 
 	progressToolbarStyleChanged: function()
@@ -209,8 +209,8 @@ var status4evarPrefs =
 
 	get downloadProgressPref()
 	{
-		delete this.downloadPRogressPref;
-		return this.downloadPRogressPref = document.getElementById("status4evar-pref-download-progress");
+		delete this.downloadProgressPref;
+		return this.downloadProgressPref = document.getElementById("status4evar-pref-download-progress");
 	},
 
 	get downloadProgressColorActivePref()

--- a/browser/components/statusbar/content/prefs.xul
+++ b/browser/components/statusbar/content/prefs.xul
@@ -148,19 +148,12 @@
 		<preferences>
 			<preference id="status4evar-pref-progress-toolbar-force"          name="status4evar.progress.toolbar.force"          type="bool" />
 			<preference id="status4evar-pref-progress-toolbar-style"          name="status4evar.progress.toolbar.style"          type="bool"
-			            onchange="status4evarPrefs.progressUrlbarStyleChanged();" />
+			            onchange="status4evarPrefs.progressToolbarStyleChanged();" />
 			<preference id="status4evar-pref-progress-toolbar-css"            name="status4evar.progress.toolbar.css"            type="string"
 			            onchange="status4evarPrefs.progressToolbarCSSChanged();" />
-			<preference id="status4evar-pref-progress-urlbar"                 name="status4evar.progress.urlbar"                 type="int"
-			            onchange="status4evarPrefs.progressUrlbarChanged();" />
-			<preference id="status4evar-pref-progress-urlbar-style"           name="status4evar.progress.urlbar.style"           type="bool"
-			            onchange="status4evarPrefs.progressToolbarStyleChanged();" />
-			<preference id="status4evar-pref-progress-urlbar-css"             name="status4evar.progress.urlbar.css"             type="string"
-			            onchange="status4evarPrefs.progressUrlbarCSSChanged();" />
 		</preferences>
 
 		<commandset id="status4evar-commandset-status">
-			<command id="status4evar-command-progress-urlbar"   oncommand="status4evarPrefs.progressUrlbarToggle();" />
 		</commandset>
 
 		<tabbox id="status4evar-tabbox-progress" flex="1">
@@ -292,7 +285,7 @@
 		<preferences>
 			<preference id="status4evar-pref-advanced-status-detectFullScreen" name="status4evar.advanced.status.detectFullScreen" type="bool" />
 			<preference id="status4evar-pref-advanced-status-detectVideo"      name="status4evar.advanced.status.detectVideo"      type="bool" />
-			<preference id="browser-pref-urlbar-trimming-enabled"        name="browser.urlbar.trimURLs"                type="bool" />
+			<preference id="browser-pref-urlbar-trimming-enabled"              name="browser.urlbar.trimURLs"                      type="bool" />
 		</preferences>
 
 		<vbox flex="1">

--- a/browser/components/statusbar/status4evar.js
+++ b/browser/components/statusbar/status4evar.js
@@ -152,7 +152,7 @@ Status_4_Evar.prototype =
 			},
 			updateDynamicStyle: function(sheet)
 			{
-				sheet.cssRules[4].style.backgroundColor = this.downloadColorActive;
+				sheet.cssRules[2].style.backgroundColor = this.downloadColorActive;
 			}
 		},
 
@@ -164,7 +164,7 @@ Status_4_Evar.prototype =
 			},
 			updateDynamicStyle: function(sheet)
 			{
-				sheet.cssRules[5].style.backgroundColor = this.downloadColorPaused;
+				sheet.cssRules[3].style.backgroundColor = this.downloadColorPaused;
 			}
 		},
 
@@ -263,7 +263,7 @@ Status_4_Evar.prototype =
 			},
 			updateDynamicStyle: function(sheet)
 			{
-				sheet.cssRules[2].style.background = this.progressToolbarCSS;
+				sheet.cssRules[1].style.background = this.progressToolbarCSS;
 			}
 		},
 

--- a/browser/locales/en-US/chrome/browser/statusbar/statusbar-prefs.dtd
+++ b/browser/locales/en-US/chrome/browser/statusbar/statusbar-prefs.dtd
@@ -8,14 +8,12 @@
 
 <!ENTITY status4evar.tab.general "General">
 <!ENTITY status4evar.tab.toolbar "Status Bar">
-<!ENTITY status4evar.tab.urlbar "Address Bar">
 <!ENTITY status4evar.tab.popup "Pop-up">
 <!ENTITY status4evar.tab.tabs "Tabs">
 
 <!ENTITY status4evar.option.none "None">
 <!ENTITY status4evar.option.nothing "Nothing">
 <!ENTITY status4evar.option.toolbar "Status Bar">
-<!ENTITY status4evar.option.urlbar "Address Bar">
 <!ENTITY status4evar.option.popup "Pop-up">
 <!ENTITY status4evar.option.tooltip "Tooltip">
 <!ENTITY status4evar.option.bottom "Bottom">
@@ -61,8 +59,6 @@
 
 <!ENTITY status4evar.status.toolbar.maxLength.label "Max status text length:">
 
-<!ENTITY status4evar.status.urlbar.align.label "Status alignment:">
-<!ENTITY status4evar.status.urlbar.color.label "Status color:">
 <!ENTITY status4evar.status.currentUrl "Current Location">
 <!ENTITY status4evar.status.statusText "Status Text">
 
@@ -74,9 +70,6 @@
 <!ENTITY status4evar.status.popup.mouseMirror.label "Swap sides when moused over">
 
 <!ENTITY status4evar.progress.style.label "Use a custom style">
-
-<!ENTITY status4evar.progress.urlbar.enable.label "Show progress in the Address Bar">
-<!ENTITY status4evar.progress.urlbar.line.label "Line style:">
 
 <!ENTITY status4evar.progress.toolbar.force.label "Always show the status bar item">
 


### PR DESCRIPTION
Ad `Reorganize and clean up status preferences.`
(https://github.com/MoonchildProductions/Pale-Moon/commit/2ad8c6c431ab82a2f419b8f2d0d1d264bee91e16#diff-6fc5034c043e68f06f897e30f5b8bfdd)

Ad `Remove Address bar bindings for status/linkover`
(https://github.com/MoonchildProductions/Pale-Moon/commit/d8c63e71f3398d2a9ec5f2e03c68c2f9bd60f712#diff-6fc5034c043e68f06f897e30f5b8bfdd)

\- follow up

\- style clean up

---

Throws in Browser Console:
```
TypeError: sheet.cssRules[4] is undefined
status4evar.js:155:4
TypeError: sheet.cssRules[5] is undefined
status4evar.js:167:4
TypeError: status4evarPrefs.progressUrlbarStyleChanged is not a function
prefs.xul:1:0
```

---

You add the label `String changes`, please.

---

I've created the new build (x32, Windows) and tested.
