### PR TITLE
Restore (updated) SSUAO for YouTube

### DIFF
--- a/browser/branding/shared/pref/uaoverrides.inc
+++ b/browser/branding/shared/pref/uaoverrides.inc
@@ -32,6 +32,7 @@ pref("@GUAO_PREF@.calendar.yahoo.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) 
 pref("@GUAO_PREF@.google.com","Mozilla/5.0 (@OS_SLICE@ rv:52.9) @GK_SLICE@ @GRE_VERSION_SLICE@ Firefox/52.9 @PM_SLICE@");
 pref("@GUAO_PREF@.googlevideos.com","Mozilla/5.0 (@OS_SLICE@ rv:38.9) @GK_SLICE@ @GRE_VERSION_SLICE@ Firefox/38.9 @PM_SLICE@");
 pref("@GUAO_PREF@.gstatic.com","Mozilla/5.0 (@OS_SLICE@ rv:31.9) @GK_SLICE@ @GRE_VERSION_SLICE@ Firefox/31.9 @PM_SLICE@");
+pref("@GUAO_PREF@.youtube.com","Mozilla/5.0 (@OS_SLICE@ rv:52.9) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
 pref("@GUAO_PREF@.gaming.youtube.com","Mozilla/5.0 (@OS_SLICE@ rv:52.9) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
 
 pref("@GUAO_PREF@.netflix.com","Mozilla/5.0 (@OS_SLICE@ rv:27.0) @GK_SLICE@ Firefox/27.0");


### PR DESCRIPTION
Otherwise on live streams, YouTube replaces the live chat box with a "Your browser is out of date" message.

I tested using all three user agent modes on current trunk build, but none worked. Using this SSUAO restores live chat functionality on YouTube.