### PR TITLE
StatusBar - follow up

### DIFF
--- a/browser/components/statusbar/status4evar.idl
+++ b/browser/components/statusbar/status4evar.idl
@@ -6,7 +6,7 @@
 
 interface nsIDOMWindow;
 
-[scriptable, uuid(b418cd1b-b172-4ef5-bfc5-fc555c87dbc4)]
+[scriptable, uuid(33d0433d-07be-4dc4-87fd-954057310efd)]
 interface nsIStatus4Evar : nsISupports
 {
 	readonly attribute boolean   addonbarBorderStyle;
@@ -47,6 +47,9 @@ interface nsIStatus4Evar : nsISupports
 	readonly attribute long      statusLinkOverDelayHide;
 
 	readonly attribute long      statusToolbarMaxLength;
+
+	readonly attribute boolean   statusToolbarInvertMirror;
+	readonly attribute boolean   statusToolbarMouseMirror;
 
 	void resetPrefs();
 	void updateWindow(in nsIDOMWindow win);

--- a/browser/components/statusbar/status4evar.js
+++ b/browser/components/statusbar/status4evar.js
@@ -18,7 +18,7 @@ function Status_4_Evar(){}
 
 Status_4_Evar.prototype =
 {
-	classID:        Components.ID("{b418cd1b-b172-4ef5-bfc5-fc555c87dbc4}"),
+	classID:        Components.ID("{33d0433d-07be-4dc4-87fd-954057310efd}"),
 	QueryInterface: XPCOMUtils.generateQI([
 	                     CI.nsISupportsWeakReference,
 	                     CI.nsIObserver,
@@ -61,6 +61,9 @@ Status_4_Evar.prototype =
 	statusLinkOverDelayHide:        150,
 
 	statusToolbarMaxLength:         0,
+
+	statusToolbarInvertMirror:       false,
+	statusToolbarMouseMirror:        true,
 
 	pref_registry:
 	{
@@ -397,6 +400,38 @@ Status_4_Evar.prototype =
 				if(status_widget)
 				{
 					status_widget.maxWidth = (this.statusToolbarMaxLength || "");
+				}
+			}
+		},
+
+		"status.popup.invertMirror":
+		{
+			update: function()
+			{
+				this.statusToolbarInvertMirror = this.prefs.getBoolPref("status.popup.invertMirror");
+			},
+			updateWindow: function(win)
+			{
+				let statusOverlay = win.caligon.status4evar.getters.statusOverlay;
+				if(statusOverlay)
+				{
+					statusOverlay.invertMirror = this.statusToolbarInvertMirror;
+				}
+			}
+		},
+
+		"status.popup.mouseMirror":
+		{
+			update: function()
+			{
+				this.statusToolbarMouseMirror = this.prefs.getBoolPref("status.popup.mouseMirror");
+			},
+			updateWindow: function(win)
+			{
+				let statusOverlay = win.caligon.status4evar.getters.statusOverlay;
+				if(statusOverlay)
+				{
+					statusOverlay.mouseMirror = this.statusToolbarMouseMirror;
 				}
 			}
 		}

--- a/browser/components/statusbar/status4evar.manifest
+++ b/browser/components/statusbar/status4evar.manifest
@@ -1,3 +1,3 @@
-component  {b418cd1b-b172-4ef5-bfc5-fc555c87dbc4} status4evar.js
-contract   @caligonstudios.com/status4evar;1      {b418cd1b-b172-4ef5-bfc5-fc555c87dbc4}
+component  {33d0433d-07be-4dc4-87fd-954057310efd} status4evar.js
+contract   @caligonstudios.com/status4evar;1      {33d0433d-07be-4dc4-87fd-954057310efd}
 category   profile-after-change Status-4-Evar     @caligonstudios.com/status4evar;1


### PR DESCRIPTION
Ad #1345

Ad `Remove Address bar bindings for status/linkover`
(https://github.com/MoonchildProductions/Pale-Moon/commit/d8c63e71f3398d2a9ec5f2e03c68c2f9bd60f712#diff-6fc5034c043e68f06f897e30f5b8bfdd)

\- follow up

---

###### `Status` - `Pop-up`
`Default to the right side`
`Swap sides when moused over`
- does not work

---

I've created the new build (x32, Windows) and tested.
