### PR TITLE
PopupNotifications - support "learnMoreURL"

### DIFF
--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -6346,9 +6346,6 @@ var gIdentityHandler = {
     if (PopupNotifications.getNotification("mixed-content-blocked", gBrowser.selectedBrowser))
       return;
 
-    let helplink = document.getElementById("mixed-content-blocked-helplink");
-    helplink.href = Services.urlFormatter.formatURLPref("browser.mixedcontent.warning.infoURL");
-
     let brandBundle = document.getElementById("bundle_brand");
     let brandShortName = brandBundle.getString("brandShortName");
     let messageString = gNavigatorBundle.getFormattedString("mixedContentBlocked.message", [brandShortName]);
@@ -6369,6 +6366,7 @@ var gIdentityHandler = {
     ];
     let options = {
       dismissed: true,
+      learnMoreURL: Services.urlFormatter.formatURLPref("browser.mixedcontent.warning.infoURL"),
     };
     PopupNotifications.show(gBrowser.selectedBrowser, "mixed-content-blocked",
                             messageString, "mixed-content-blocked-notification-icon",

--- a/browser/base/content/popup-notifications.inc
+++ b/browser/base/content/popup-notifications.inc
@@ -76,17 +76,9 @@
       </popupnotificationcontent>
     </popupnotification>
 
-    <popupnotification id="geolocation-notification" hidden="true">
-      <popupnotificationcontent orient="vertical" align="start">
-        <separator class="thin"/>
-        <label id="geolocation-learnmore-link" class="text-link"/>
-      </popupnotificationcontent>
-    </popupnotification>
-
     <popupnotification id="servicesInstall-notification" hidden="true">
       <popupnotificationcontent orient="vertical" align="start">
-        <separator class="thin"/>
-        <label id="servicesInstall-learnmore-link" class="text-link"/>
+        <!-- XXX bug 974146, tests are looking for this, can't remove yet. -->
       </popupnotificationcontent>
     </popupnotification>
 
@@ -101,8 +93,5 @@
       <popupnotificationcontent orient="vertical" align="start">
         <separator/>
         <description id="mixed-content-blocked-moreinfo">&mixedContentBlocked.moreinfo;</description>
-        <separator/>
-        <label id="mixed-content-blocked-helplink" class="text-link"
-               value="&mixedContentBlocked.helplink;"/>
       </popupnotificationcontent>
     </popupnotification>

--- a/browser/components/nsBrowserGlue.js
+++ b/browser/components/nsBrowserGlue.js
@@ -1733,17 +1733,20 @@ ContentPermissionPrompt.prototype = {
     if (aRequest.type == "pointerLock") {
       // If there's no mainAction, this is the autoAllow warning prompt.
       let autoAllow = !mainAction;
-      aOptions = {
-        removeOnDismissal: autoAllow,
-        eventCallback: type => {
-          if (type == "removed") {
-            browser.removeEventListener("mozfullscreenchange", onFullScreen, true);
-            if (autoAllow) {
-              aRequest.allow();
-            }
+
+      if (!aOptions)
+        aOptions = {};
+
+      aOptions.removeOnDismissal = autoAllow;
+      aOptions.eventCallback = type => {
+        if (type == "removed") {
+          browser.removeEventListener("mozfullscreenchange", onFullScreen, true);
+          if (autoAllow) {
+            aRequest.allow();
           }
-        },
-      };
+        }
+      }
+
     }
 
     var popup = chromeWin.PopupNotifications.show(browser, aNotificationId, aMessage, aAnchorId,
@@ -1800,14 +1803,12 @@ ContentPermissionPrompt.prototype = {
       });
     }
 
-    var requestingWindow = aRequest.window.top;
-    var chromeWin = this._getChromeWindow(requestingWindow).wrappedJSObject;
-    var link = chromeWin.document.getElementById("geolocation-learnmore-link");
-    link.value = browserBundle.GetStringFromName("geolocation.learnMore");
-    link.href = Services.urlFormatter.formatURLPref("browser.geolocation.warning.infoURL");
+    var options = {
+                    learnMoreURL: Services.urlFormatter.formatURLPref("browser.geolocation.warning.infoURL"),
+                  };
 
     this._showPrompt(aRequest, message, "geo", actions, "geolocation",
-                     "geo-notification-icon", null);
+                     "geo-notification-icon", options);
   },
 
   _promptWebNotifications : function(aRequest) {

--- a/browser/locales/en-US/chrome/browser/browser.dtd
+++ b/browser/locales/en-US/chrome/browser/browser.dtd
@@ -649,7 +649,6 @@ just addresses the organization to follow, e.g. "This site is run by " -->
 <!ENTITY webrtcIndicatorButton.label "Camera / Microphone Access">
 <!ENTITY webrtcIndicatorButton.tooltip "Display sites you are currently sharing your camera or microphone with">
 
-<!ENTITY mixedContentBlocked.helplink "Learn more">
 <!ENTITY mixedContentBlocked.moreinfo "Most websites will still work properly even when this content is blocked.">
 
 <!ENTITY pointerLock.notification.message "Press ESC at any time to show it again.">

--- a/browser/locales/en-US/chrome/browser/browser.properties
+++ b/browser/locales/en-US/chrome/browser/browser.properties
@@ -294,9 +294,6 @@ geolocation.neverShareLocation=Never Share Location
 geolocation.neverShareLocation.accesskey=N
 geolocation.shareWithSite=Would you like to share your location with %S?
 geolocation.shareWithFile=Would you like to share your location with the file %S?
-# LOCALIZATION NOTE (geolocation.learnMore): Use the unicode ellipsis char, \u2026,
-# or use "..." if \u2026 doesn't suit traditions in your locale.
-geolocation.learnMore=Learn More…
 
 webNotifications.showForSession=Show for this session
 webNotifications.showForSession.accesskey=s

--- a/browser/modules/PopupNotifications.jsm
+++ b/browser/modules/PopupNotifications.jsm
@@ -238,6 +238,10 @@ PopupNotifications.prototype = {
    *                     A string. URL of the image to be displayed in the popup.
    *                     Normally specified in CSS using list-style-image and the
    *                     .popup-notification-icon[popupid=...] selector.
+   *        learnMoreURL:
+   *                     A string URL. Setting this property will make the
+   *                     prompt display a "Learn More" link that, when clicked,
+   *                     opens the URL in a new tab.
    * @returns the Notification object corresponding to the added notification.
    */
   show: function PopupNotifications_show(browser, id, message, anchorID,
@@ -524,6 +528,11 @@ PopupNotifications.prototype = {
 
       if (n.options.popupIconURL)
         popupnotification.setAttribute("icon", n.options.popupIconURL);
+      if (n.options.learnMoreURL)
+        popupnotification.setAttribute("learnmoreurl", n.options.learnMoreURL);
+      else
+        popupnotification.removeAttribute("learnmoreurl");
+
       popupnotification.notification = n;
 
       if (n.secondaryActions) {


### PR DESCRIPTION
Examples:

## 1) Mixed contents

https://mixed-script.badssl.com/

## 2) Geo locations

https://pocasi.seznam.cz/

## 3) Others

Scratchpad: `Environment` - `Browser`

``` javascript
var win = Components.classes["@mozilla.org/appshell/window-mediator;1"]
    .getService(Components.interfaces.nsIWindowMediator)
    .getMostRecentWindow("navigator:browser");

var action = {
    "label": "OK",
    "accessKey": "O",
    "callback": function () {},
  };

var options = {
  "learnMoreURL": "https://www.palemoon.org/",
};

win.PopupNotifications.show(
    win.gBrowser.selectedBrowser, "notification",
    "Text", null, action, [], options);
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=967349

---

You add the label `String changes`, please.

---

I've created the new build (x32, Windows) and tested.
