### PR TITLE
Fix Object.values / Object.entries self-hosted implementation

### DIFF
--- a/js/src/builtin/Object.js
+++ b/js/src/builtin/Object.js
@@ -146,7 +146,7 @@ function ObjectEntries(O) {
     // Until https://bugzilla.mozilla.org/show_bug.cgi?id=1170372 implemented
     var attrs = ATTR_CONFIGURABLE | ATTR_ENUMERABLE | ATTR_WRITABLE;
 
-        // Steps 1-2.
+    // Steps 1-2.
     var object = ToObject(O);
 
     // Steps 3-4.

--- a/js/src/builtin/Object.js
+++ b/js/src/builtin/Object.js
@@ -131,7 +131,9 @@ function ObjectValues(O) {
             continue;
 
         var value = object[key];
-        _DefineDataProperty(values, valuesCount++, value);
+        // Until https://bugzilla.mozilla.org/show_bug.cgi?id=1170372 implemented
+        var attrs = ATTR_CONFIGURABLE | ATTR_ENUMERABLE | ATTR_WRITABLE;
+        _DefineDataProperty(values, valuesCount++, value, attrs);
     }
 
     // Step 5.
@@ -154,7 +156,9 @@ function ObjectEntries(O) {
             continue;
 
         var value = object[key];
-        _DefineDataProperty(entries, entriesCount++, [key, value]);
+        // Until https://bugzilla.mozilla.org/show_bug.cgi?id=1170372 implemented
+        var attrs = ATTR_CONFIGURABLE | ATTR_ENUMERABLE | ATTR_WRITABLE;
+        _DefineDataProperty(entries, entriesCount++, [key, value], attrs);
     }
 
     // Step 5.

--- a/js/src/builtin/Object.js
+++ b/js/src/builtin/Object.js
@@ -117,6 +117,9 @@ function ObjectLookupGetter(name) {
 
 // Draft proposal http://tc39.github.io/proposal-object-values-entries/#Object.values
 function ObjectValues(O) {
+    // Until https://bugzilla.mozilla.org/show_bug.cgi?id=1170372 implemented
+    var attrs = ATTR_CONFIGURABLE | ATTR_ENUMERABLE | ATTR_WRITABLE;
+
     // Steps 1-2.
     var object = ToObject(O);
 
@@ -131,8 +134,6 @@ function ObjectValues(O) {
             continue;
 
         var value = object[key];
-        // Until https://bugzilla.mozilla.org/show_bug.cgi?id=1170372 implemented
-        var attrs = ATTR_CONFIGURABLE | ATTR_ENUMERABLE | ATTR_WRITABLE;
         _DefineDataProperty(values, valuesCount++, value, attrs);
     }
 
@@ -142,7 +143,10 @@ function ObjectValues(O) {
 
 // Draft proposal http://tc39.github.io/proposal-object-values-entries/#Object.entries
 function ObjectEntries(O) {
-    // Steps 1-2.
+    // Until https://bugzilla.mozilla.org/show_bug.cgi?id=1170372 implemented
+    var attrs = ATTR_CONFIGURABLE | ATTR_ENUMERABLE | ATTR_WRITABLE;
+
+        // Steps 1-2.
     var object = ToObject(O);
 
     // Steps 3-4.
@@ -156,8 +160,6 @@ function ObjectEntries(O) {
             continue;
 
         var value = object[key];
-        // Until https://bugzilla.mozilla.org/show_bug.cgi?id=1170372 implemented
-        var attrs = ATTR_CONFIGURABLE | ATTR_ENUMERABLE | ATTR_WRITABLE;
         _DefineDataProperty(entries, entriesCount++, [key, value], attrs);
     }
 


### PR DESCRIPTION
Follow-up to #1293, see issue #1292.

Until we implement the [bug 1170372](https://bugzilla.mozilla.org/show_bug.cgi?id=1170372) in our tree, we need to explicitly specify the attributes in the _DefineDataProperty call when constructing Object.values / Object.entries.

Test: https://jsfiddle.net/3pq5pc9q/

I suggest to uplift this to 27.5_RelBranch.