### PR TITLE
Downloads - It can't delete from history - using the context menu: "Remove From History"

### DIFF
--- a/browser/components/downloads/content/allDownloadsViewOverlay.js
+++ b/browser/components/downloads/content/allDownloadsViewOverlay.js
@@ -688,7 +688,10 @@ DownloadElementShell.prototype = {
       }
       case "cmd_delete": {
         if (this._dataItem)
-          this._dataItem.remove();
+          Downloads.getList(Downloads.ALL)
+                   .then(list => list.remove(this._dataItem._download))
+                   .then(() => this._dataItem._download.finalize(true))
+                   .catch(Cu.reportError);
         if (this._placesNode)
           PlacesUtils.bhistory.removePage(this._downloadURIObj);
         break;

--- a/browser/components/downloads/content/downloads.js
+++ b/browser/components/downloads/content/downloads.js
@@ -1478,7 +1478,10 @@ DownloadsViewItemController.prototype = {
   commands: {
     cmd_delete: function DVIC_cmd_delete()
     {
-      this.dataItem.remove();
+      Downloads.getList(Downloads.ALL)
+               .then(list => list.remove(this.dataItem._download))
+               .then(() => this.dataItem._download.finalize(true))
+               .catch(Cu.reportError);
       PlacesUtils.bhistory.removePage(NetUtil.newURI(this.dataItem.uri));
     },
 


### PR DESCRIPTION
Ad #630 

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1115983 (partially)

---

You add the label `Verification Needed`, please.
Patches must be tested (with as many "variables" as possible).

(maybe also `Uplift Wanted`?)

---

I've created the new build (x32, Windows) and tested.
