### PR TITLE
Clear QuotaManager storage along with Offline Website Data

### DIFF
--- a/browser/modules/QuotaManager.jsm
+++ b/browser/modules/QuotaManager.jsm
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ 
+this.EXPORTED_SYMBOLS = ["QuotaManagerHelper"];
+
+Components.utils.import('resource://gre/modules/Services.jsm');
+
+const Cc = Components.classes;
+const Ci = Components.interfaces;
+
+this.QuotaManagerHelper = {
+  clear: function(isShutDown) {
+    try {
+      var stord = Services.dirsvc.get("ProfD", Ci.nsIFile);
+      stord.append("storage");
+      if (stord.exists() && stord.isDirectory()) {
+        var doms = {};
+        for (var stor of ["default", "permanent", "temporary"]) {
+          var storsubd = stord.clone();
+          storsubd.append(stor);
+          if (storsubd.exists() && storsubd.isDirectory()) {
+            var entries = storsubd.directoryEntries;
+            while(entries.hasMoreElements()) {
+              var host, entry = entries.getNext();
+              entry.QueryInterface(Ci.nsIFile);
+              if ((host = /^(https?|file)\+\+\+(.+)$/.exec(entry.leafName)) !== null) {
+                if (isShutDown) {
+                  entry.remove(true);
+                } else {
+                  doms[host[1] + "://" + host[2]] = true;
+                }
+              }
+            }
+          }
+        }
+        var qm = Cc["@mozilla.org/dom/quota/manager;1"].getService(Ci.nsIQuotaManager);
+        for (var dom in doms) {
+          var uri = Services.io.newURI(dom, null, null);
+          qm.clearStoragesForURI(uri);
+        }
+      }
+    } catch(er) {}
+  }
+};

--- a/browser/modules/moz.build
+++ b/browser/modules/moz.build
@@ -18,6 +18,7 @@ EXTRA_JS_MODULES += [
     'openLocationLastURL.jsm',
     'PageMenu.jsm',
     'PopupNotifications.jsm',
+    'QuotaManager.jsm',
     'SharedFrame.jsm',
     'webrtcUI.jsm'
 ]


### PR DESCRIPTION
* If 'Offline Website Data' is selected to be cleared when Pale Moon closes, then QuotaManager data (IndexedDB and asm.js cache) should be removed as well
* If you manually clear the history (Ctrl+Shift+Del) with time range set to 'Everything' when 'Offline Website Data' is selected, then QuotaManager data should be also removed

See forum topics ([1](https://forum.palemoon.org/viewtopic.php?f=3&t=16736), [2](https://forum.palemoon.org/viewtopic.php?f=13&t=16198)) and [bug #1047098](https://bugzilla.mozilla.org/show_bug.cgi?id=1047098) (currently it's a [blocker](https://bugzilla.mozilla.org/show_bug.cgi?id=1047098#c41) for the upcoming firefox56).