### PR TITLE
JS - DOM - the vertical text - scrolling with middle button

### DIFF
--- a/dom/base/Element.h
+++ b/dom/base/Element.h
@@ -798,12 +798,24 @@ public:
   {
     return nsPresContext::AppUnitsToIntCSSPixels(GetClientAreaRect().height);
   }
+  int32_t ScrollTopMin()
+  {
+    nsIScrollableFrame* sf = GetScrollFrame();
+    return sf ?
+           nsPresContext::AppUnitsToIntCSSPixels(sf->GetScrollRange().y) : 0;
+  }
   int32_t ScrollTopMax()
   {
     nsIScrollableFrame* sf = GetScrollFrame();
     return sf ?
            nsPresContext::AppUnitsToIntCSSPixels(sf->GetScrollRange().YMost()) :
            0;
+  }
+  int32_t ScrollLeftMin()
+  {
+    nsIScrollableFrame* sf = GetScrollFrame();
+    return sf ?
+           nsPresContext::AppUnitsToIntCSSPixels(sf->GetScrollRange().x) : 0;
   }
   int32_t ScrollLeftMax()
   {

--- a/dom/base/nsGlobalWindow.h
+++ b/dom/base/nsGlobalWindow.h
@@ -1005,6 +1005,8 @@ public:
   float GetMozInnerScreenX(mozilla::ErrorResult& aError);
   float GetMozInnerScreenY(mozilla::ErrorResult& aError);
   float GetDevicePixelRatio(mozilla::ErrorResult& aError);
+  int32_t GetScrollMinX(mozilla::ErrorResult& aError);
+  int32_t GetScrollMinY(mozilla::ErrorResult& aError);
   int32_t GetScrollMaxX(mozilla::ErrorResult& aError);
   int32_t GetScrollMaxY(mozilla::ErrorResult& aError);
   bool GetFullScreen(mozilla::ErrorResult& aError);
@@ -1315,8 +1317,7 @@ public:
   // Outer windows only.
   mozilla::CSSPoint GetScrollXY(bool aDoFlush);
 
-  void GetScrollMaxXY(int32_t* aScrollMaxX, int32_t* aScrollMaxY,
-                      mozilla::ErrorResult& aError);
+  int32_t GetScrollBoundaryOuter(mozilla::Side aSide);
 
   // Outer windows only.
   nsresult GetInnerSize(mozilla::CSSIntSize& aSize);

--- a/dom/browser-element/BrowserElementPanning.js
+++ b/dom/browser-element/BrowserElementPanning.js
@@ -375,8 +375,10 @@ const ContentPanning = {
       let isScrollableTextarea = (node.tagName == 'TEXTAREA' &&
           (node.scrollHeight > node.clientHeight ||
            node.scrollWidth > node.clientWidth ||
-           ('scrollLeftMax' in node && node.scrollLeftMax > 0) ||
-           ('scrollTopMax' in node && node.scrollTopMax > 0)));
+           ('scrollLeftMin' in node && 'scrollLeftMax' in node &&
+            node.scrollLeftMin != node.scrollLeftMax) ||
+           ('scrollTopMin' in node && 'scrollTopMax' in node &&
+            node.scrollTopMin != node.scrollTopMax)));
       if (isScroll || isAuto || isScrollableTextarea) {
         return node;
       }
@@ -384,7 +386,8 @@ const ContentPanning = {
       node = node.parentNode;
     }
 
-    if (nodeContent.scrollMaxX || nodeContent.scrollMaxY) {
+    if (nodeContent.scrollMaxX != nodeContent.scrollMinX ||
+        nodeContent.scrollMaxY != nodeContent.scrollMinY) {
       return nodeContent;
     }
 

--- a/dom/inputmethod/forms.js
+++ b/dom/inputmethod/forms.js
@@ -79,7 +79,7 @@ let FormVisibility = {
     // we also care about the window this is the more
     // common case where the content is larger then
     // the viewport/screen.
-    if (win.scrollMaxX || win.scrollMaxY) {
+    if (win.scrollMaxX != win.scrollMinX || win.scrollMaxY != win.scrollMinY) {
       return win;
     }
 

--- a/dom/interfaces/base/nsIDOMWindow.idl
+++ b/dom/interfaces/base/nsIDOMWindow.idl
@@ -388,6 +388,8 @@ interface nsIDOMWindow : nsISupports
 
   /* The maximum offset that the window can be scrolled to
      (i.e., the document width/height minus the scrollport width/height) */
+  readonly attribute long                               scrollMinX;
+  readonly attribute long                               scrollMinY;
   readonly attribute long                               scrollMaxX;
   readonly attribute long                               scrollMaxY;
 

--- a/dom/webidl/Element.webidl
+++ b/dom/webidl/Element.webidl
@@ -198,11 +198,13 @@ partial interface Element {
   readonly attribute long clientHeight;
 
   // Mozilla specific stuff
-  /* The maximum offset that the element can be scrolled to
+  /* The minimum/maximum offset that the element can be scrolled to
      (i.e., the value that scrollLeft/scrollTop would be clamped to if they were
      set to arbitrarily large values. */
-  readonly attribute long scrollTopMax;
-  readonly attribute long scrollLeftMax;
+  [ChromeOnly] readonly attribute long scrollTopMin;
+               readonly attribute long scrollTopMax;
+  [ChromeOnly] readonly attribute long scrollLeftMin;
+               readonly attribute long scrollLeftMax;
 };
 
 // http://dvcs.w3.org/hg/undomanager/raw-file/tip/undomanager.html

--- a/dom/webidl/Window.webidl
+++ b/dom/webidl/Window.webidl
@@ -296,6 +296,8 @@ partial interface Window {
 
   /* The maximum offset that the window can be scrolled to
      (i.e., the document width/height minus the scrollport width/height) */
+  [ChromeOnly, Throws]  readonly attribute long   scrollMinX;
+  [ChromeOnly, Throws]  readonly attribute long   scrollMinY;
   [Replaceable, Throws] readonly attribute long   scrollMaxX;
   [Replaceable, Throws] readonly attribute long   scrollMaxY;
 

--- a/gfx/2d/BaseRect.h
+++ b/gfx/2d/BaseRect.h
@@ -367,6 +367,18 @@ struct BaseRect {
   T XMost() const { return x + width; }
   T YMost() const { return y + height; }
 
+  // Get the coordinate of the edge on the given side.
+  T Edge(mozilla::Side aSide) const
+  {
+    switch (aSide) {
+      case NS_SIDE_TOP: return Y();
+      case NS_SIDE_RIGHT: return XMost();
+      case NS_SIDE_BOTTOM: return YMost();
+      case NS_SIDE_LEFT: return X();
+    }
+    MOZ_CRASH("Incomplete switch");
+  }
+
   // Moves one edge of the rect without moving the opposite edge.
   void SetLeftEdge(T aX) {
     MOZ_ASSERT(aX <= XMost());

--- a/mobile/android/chrome/content/browser.js
+++ b/mobile/android/chrome/content/browser.js
@@ -5304,7 +5304,8 @@ var BrowserEventHandler = {
        * - It's a select element showing multiple rows
        */
       if (checkElem) {
-        if ((elem.scrollTopMax > 0 || elem.scrollLeftMax > 0) &&
+        if ((elem.scrollTopMin != elem.scrollTopMax ||
+             elem.scrollLeftMin != elem.scrollLeftMax) &&
             (this._hasScrollableOverflow(elem) ||
              elem.matches("textarea")) ||
             (elem instanceof HTMLInputElement && elem.mozIsTextField(false)) ||

--- a/toolkit/content/browser-content.js
+++ b/toolkit/content/browser-content.js
@@ -85,7 +85,7 @@ let ClickEventHandler = {
       // do not allow horizontal scrolling for select elements, it leads
       // to visual artifacts and is not the expected behavior anyway
       if (!(this._scrollable instanceof content.HTMLSelectElement) &&
-          this._scrollable.scrollLeftMax &&
+          this._scrollable.scrollLeftMin != this._scrollable.scrollLeftMax &&
           scrollingAllowed.indexOf(overflowx) >= 0) {
         this._scrolldir = scrollVert ? "NSEW" : "EW";
         break;
@@ -97,9 +97,10 @@ let ClickEventHandler = {
 
     if (!this._scrollable) {
       this._scrollable = aNode.ownerDocument.defaultView;
-      if (this._scrollable.scrollMaxX > 0) {
-        this._scrolldir = this._scrollable.scrollMaxY > 0 ? "NSEW" : "EW";
-      } else if (this._scrollable.scrollMaxY > 0) {
+      if (this._scrollable.scrollMaxX != this._scrollable.scrollMinX) {
+        this._scrolldir = this._scrollable.scrollMaxY !=
+                          this._scrollable.scrollMinY ? "NSEW" : "EW";
+      } else if (this._scrollable.scrollMaxY != this._scrollable.scrollMinY) {
         this._scrolldir = "NS";
       } else if (this._scrollable.frameElement) {
         this.findNearestScrollableElement(this._scrollable.frameElement);

--- a/toolkit/devtools/gcli/commands/screenshot.js
+++ b/toolkit/devtools/gcli/commands/screenshot.js
@@ -120,8 +120,8 @@ exports.items = [
           // Bug 961832: GCLI screenshot shows fixed position element in wrong
           // position if we don't scroll to top
           window.scrollTo(0,0);
-          width = window.innerWidth + window.scrollMaxX;
-          height = window.innerHeight + window.scrollMaxY;
+          width = window.innerWidth + window.scrollMaxX - window.scrollMinX;
+          height = window.innerHeight + window.scrollMaxY - window.scrollMinY;
         } else if (node) {
           let lh = new LayoutHelpers(window);
           let rect = lh.getRect(node, window);

--- a/toolkit/devtools/tilt/tilt-utils.js
+++ b/toolkit/devtools/tilt/tilt-utils.js
@@ -371,8 +371,10 @@ TiltUtils.DOM = {
     aContentWindow)
   {
     return {
-      width: aContentWindow.innerWidth + aContentWindow.scrollMaxX,
-      height: aContentWindow.innerHeight + aContentWindow.scrollMaxY
+      width: aContentWindow.innerWidth +
+        aContentWindow.scrollMaxX - aContentWindow.scrollMinX,
+      height: aContentWindow.innerHeight +
+        aContentWindow.scrollMaxY - aContentWindow.scrollMinY
     };
   },
 


### PR DESCRIPTION
Ad https://forum.palemoon.org/viewtopic.php?f=29&t=16769

> Middle Click doesn't show scroll icon on vertical text page.

An example:
http://www.asahi-net.or.jp/~sd5a-ucd/freefonts/Oradano-Mincho/

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=962249
https://bugzilla.mozilla.org/show_bug.cgi?id=1219243

---

You add the label `Verification Needed`, please.

---

I've created the new build (x32, Windows) and tested:
- An horizontal / vertical page
- `DevTools` - `Developer Toolbar` - `screenshot`
