### PR TITLE
Expose extra network connection preferences in the UI

### DIFF
--- a/browser/components/preferences/connection.js
+++ b/browser/components/preferences/connection.js
@@ -42,11 +42,11 @@ var gConnectionsDialog = {
     if ("@mozilla.org/system-proxy-settings;1" in Components.classes)
       document.getElementById("systemPref").removeAttribute("hidden");
   },
-  
+
   proxyTypeChanged: function ()
   {
     var proxyTypePref = document.getElementById("network.proxy.type");
-    
+
     // Update http
     var httpProxyURLPref = document.getElementById("network.proxy.http");
     httpProxyURLPref.disabled = proxyTypePref.value != 1;
@@ -58,14 +58,27 @@ var gConnectionsDialog = {
 
     var shareProxiesPref = document.getElementById("network.proxy.share_proxy_settings");
     shareProxiesPref.disabled = proxyTypePref.value != 1;
-    
+
+    var autologinProxyPref = document.getElementById("signon.autologin.proxy");
+    autologinProxyPref.disabled = proxyTypePref.value == 0;
+
     var noProxiesPref = document.getElementById("network.proxy.no_proxies_on");
     noProxiesPref.disabled = proxyTypePref.value != 1;
-    
+
     var autoconfigURLPref = document.getElementById("network.proxy.autoconfig_url");
     autoconfigURLPref.disabled = proxyTypePref.value != 2;
 
     this.updateReloadButton();
+  },
+
+  updateDNSPref: function ()
+  {
+    var socksVersionPref = document.getElementById("network.proxy.socks_version");
+    var socksDNSPref = document.getElementById("network.proxy.socks_remote_dns");
+    var proxyTypePref = document.getElementById("network.proxy.type");
+    var isDefinitelySocks4 = !socksVersionPref.disabled && socksVersionPref.value == 4;
+    socksDNSPref.disabled = (isDefinitelySocks4 || proxyTypePref.value == 0);
+    return undefined;
   },
 
   updateReloadButton: function ()
@@ -126,7 +139,7 @@ var gConnectionsDialog = {
     }
     var socksVersionPref = document.getElementById("network.proxy.socks_version");
     socksVersionPref.disabled = proxyTypePref.value != 1 || shareProxiesPref.value;
-    
+    this.updateDNSPref();
     return undefined;
   },
   

--- a/browser/components/preferences/connection.xul
+++ b/browser/components/preferences/connection.xul
@@ -28,7 +28,8 @@
             helpTopic="prefs-connection-settings">
 
     <preferences>
-      <preference id="network.proxy.type"         name="network.proxy.type"         type="int" onchange="gConnectionsDialog.proxyTypeChanged();"/>
+      <preference id="network.proxy.type"         name="network.proxy.type"         type="int"
+                                                                onchange="gConnectionsDialog.proxyTypeChanged();"/>
       <preference id="network.proxy.http"         name="network.proxy.http"         type="string"/>
       <preference id="network.proxy.http_port"    name="network.proxy.http_port"    type="int"/>
       <preference id="network.proxy.ftp"          name="network.proxy.ftp"          type="string"/>
@@ -37,17 +38,15 @@
       <preference id="network.proxy.ssl_port"     name="network.proxy.ssl_port"     type="int"/>
       <preference id="network.proxy.socks"        name="network.proxy.socks"        type="string"/>
       <preference id="network.proxy.socks_port"   name="network.proxy.socks_port"   type="int"/>
-      <preference id="network.proxy.socks_version"  name="network.proxy.socks_version"  type="int"/>
+      <preference id="network.proxy.socks_version"  name="network.proxy.socks_version"  type="int"
+                                                                onchange="gConnectionsDialog.updateDNSPref();"/>
+      <preference id="network.proxy.socks_remote_dns"  name="network.proxy.socks_remote_dns"  type="bool"/>
       <preference id="network.proxy.no_proxies_on"  name="network.proxy.no_proxies_on"  type="string"/>
       <preference id="network.proxy.autoconfig_url" name="network.proxy.autoconfig_url" type="string"/>
-      <preference id="network.proxy.share_proxy_settings"
-                  name="network.proxy.share_proxy_settings"
-                  type="bool"/>
-      
+      <preference id="network.proxy.share_proxy_settings" name="network.proxy.share_proxy_settings" type="bool"/>
+      <preference id="signon.autologin.proxy"       name="signon.autologin.proxy"       type="bool"/>
       <preference id="pref.advanced.proxies.disable_button.reload"
-                  name="pref.advanced.proxies.disable_button.reload"
-                  type="bool"/>
-
+                                                    name="pref.advanced.proxies.disable_button.reload" type="bool"/>
       <preference id="network.proxy.backup.ftp"          name="network.proxy.backup.ftp"          type="string"/>
       <preference id="network.proxy.backup.ftp_port"     name="network.proxy.backup.ftp_port"     type="int"/>
       <preference id="network.proxy.backup.ssl"          name="network.proxy.backup.ssl"          type="string"/>
@@ -55,7 +54,7 @@
       <preference id="network.proxy.backup.socks"        name="network.proxy.backup.socks"        type="string"/>
       <preference id="network.proxy.backup.socks_port"   name="network.proxy.backup.socks_port"   type="int"/>
     </preferences>
-    
+
     <script type="application/javascript" src="chrome://browser/content/preferences/connection.js"/>
 
     <stringbundle id="preferencesBundle" src="chrome://browser/locale/preferences/preferences.properties"/>
@@ -135,8 +134,8 @@
               <spacer/>
               <radiogroup id="networkProxySOCKSVersion" orient="horizontal"
                           preference="network.proxy.socks_version">
-                <radio id="networkProxySOCKSVersion4" value="4" label="&socks4.label;" accesskey="&socks4.accesskey;" />
-                <radio id="networkProxySOCKSVersion5" value="5" label="&socks5.label;" accesskey="&socks5.accesskey;" />
+                <radio id="networkProxySOCKSVersion4" value="4" label="&socks4.label;" accesskey="&socks4.accesskey;"/>
+                <radio id="networkProxySOCKSVersion5" value="5" label="&socks5.label;" accesskey="&socks5.accesskey;"/>
               </radiogroup>
             </row>
             <label value="&noproxy.label;" accesskey="&noproxy.accesskey;" control="networkProxyNone"/>
@@ -154,7 +153,12 @@
                   preference="pref.advanced.proxies.disable_button.reload"/>
         </hbox>
       </radiogroup>
+      <separator class="thin"/>
+      <checkbox id="autologinProxy" preference="signon.autologin.proxy"
+                label="&autologinproxy.label;" accesskey="&autologinproxy.accesskey;"
+                tooltiptext="&autologinproxy.tooltip;"/>
+      <checkbox id="networkProxySOCKSRemoteDNS" preference="network.proxy.socks_remote_dns"
+                label="&socksRemoteDNS.label;" accesskey="&socksRemoteDNS.accesskey;"/>
     </groupbox>
   </prefpane>
 </prefwindow>
-

--- a/browser/locales/en-US/chrome/browser/preferences/connection.dtd
+++ b/browser/locales/en-US/chrome/browser/preferences/connection.dtd
@@ -32,6 +32,8 @@
 <!ENTITY  socks4.accesskey              "K">
 <!ENTITY  socks5.label                  "SOCKS v5">
 <!ENTITY  socks5.accesskey              "v">
+<!ENTITY  socksRemoteDNS.label          "Send DNS queries through the proxy when using SOCKS v5">
+<!ENTITY  socksRemoteDNS.accesskey      "d">
 <!ENTITY  port.label                    "Port:">
 <!ENTITY  HTTPport.accesskey            "P">
 <!ENTITY  SSLport.accesskey             "o">
@@ -42,3 +44,6 @@
 <!ENTITY  noproxyExplain.label          "Example: .palemoon.org, .net.nz, 192.168.1.0/24">
 <!ENTITY  shareproxy.label              "Use this proxy server for all protocols">
 <!ENTITY  shareproxy.accesskey          "s">
+<!ENTITY  autologinproxy.label          "Do not prompt for authentication if password is saved">
+<!ENTITY  autologinproxy.accesskey      "i">
+<!ENTITY  autologinproxy.tooltip        "This option silently authenticates you to proxies when you have saved credentials for them. You will be prompted if authentication fails.">

--- a/browser/locales/en-US/chrome/browser/preferences/connection.dtd
+++ b/browser/locales/en-US/chrome/browser/preferences/connection.dtd
@@ -32,7 +32,7 @@
 <!ENTITY  socks4.accesskey              "K">
 <!ENTITY  socks5.label                  "SOCKS v5">
 <!ENTITY  socks5.accesskey              "v">
-<!ENTITY  socksRemoteDNS.label          "Send DNS queries through the proxy when using SOCKS v5">
+<!ENTITY  socksRemoteDNS.label          "Use proxy to perform DNS queries (SOCKS v5 only)">
 <!ENTITY  socksRemoteDNS.accesskey      "d">
 <!ENTITY  port.label                    "Port:">
 <!ENTITY  HTTPport.accesskey            "P">


### PR DESCRIPTION
* Autologin to proxy if password is saved (`signon.autologin.proxy`), see bugs [#910670](https://bugzilla.mozilla.org/show_bug.cgi?id=910670), [#974394](https://bugzilla.mozilla.org/show_bug.cgi?id=974394)
* Use remote DNS with SOCKS5 (`network.proxy.socks_remote_dns`), see bugs [#665319](https://bugzilla.mozilla.org/show_bug.cgi?id=665319), [#1249494](https://bugzilla.mozilla.org/show_bug.cgi?id=1249494)

![palemoon_2017-09-25_17-02-39](https://user-images.githubusercontent.com/340855/30812435-67f51da0-a213-11e7-9e5d-34f10e05fa02.png)

Resolves #1364.