### PR TITLE
StatusBar - improvements

### DIFF
--- a/browser/components/statusbar/content/prefs.xul
+++ b/browser/components/statusbar/content/prefs.xul
@@ -156,24 +156,14 @@
 		<commandset id="status4evar-commandset-status">
 		</commandset>
 
-		<tabbox id="status4evar-tabbox-progress" flex="1">
-			<tabs id="status4evar-tabs-progress">
-				<tab id="status4evar-tab-progress-toolbar" label="&status4evar.tab.toolbar;" />
-			</tabs>
+		<checkbox id="status4evar-progress-toolbar-force-check" preference="status4evar-pref-progress-toolbar-force" label="&status4evar.progress.toolbar.force.label;" />
 
-			<tabpanels id="status4evar-tabpanels-progress" flex="1">
-				<tabpanel id="status4evar-tabpanel-progress-toolbar" orient="vertical">
-					<checkbox id="status4evar-progress-toolbar-force-check" preference="status4evar-pref-progress-toolbar-force" label="&status4evar.progress.toolbar.force.label;" />
+		<checkbox id="status4evar-progress-toolbar-style-check" preference="status4evar-pref-progress-toolbar-style" label="&status4evar.progress.style.label;"
+							onsyncfrompreference="return status4evarPrefs.progressToolbarStyleSync();" />
 
-					<checkbox id="status4evar-progress-toolbar-style-check" preference="status4evar-pref-progress-toolbar-style" label="&status4evar.progress.style.label;"
-					          onsyncfrompreference="return status4evarPrefs.progressToolbarStyleSync();" />
-
-					<vbox class="css-bg-editor" preference="status4evar-pref-progress-toolbar-css" preference-editable="true" flex="1">
-						<progressmeter id="status4evar-progress-bar" value="75" flex="1" />
-					</vbox>
-				</tabpanel>
-			</tabpanels>
-		</tabbox>
+		<vbox class="css-bg-editor" preference="status4evar-pref-progress-toolbar-css" preference-editable="true" flex="1">
+			<progressmeter id="status4evar-progress-bar" value="75" flex="1" />
+		</vbox>
 	</prefpane>
 
 	<prefpane id="status4evar-pane-download" label="&status4evar.pane.download;">

--- a/browser/locales/en-US/chrome/browser/statusbar/statusbar-prefs.dtd
+++ b/browser/locales/en-US/chrome/browser/statusbar/statusbar-prefs.dtd
@@ -18,13 +18,11 @@
 <!ENTITY status4evar.option.tooltip "Tooltip">
 <!ENTITY status4evar.option.bottom "Bottom">
 <!ENTITY status4evar.option.top "Top">
-<!ENTITY status4evar.option.fill "Fill">
 <!ENTITY status4evar.option.dlcount "Download count">
 <!ENTITY status4evar.option.dltime "Time remaining">
 <!ENTITY status4evar.option.both "Both">
 <!ENTITY status4evar.option.right "Right">
 <!ENTITY status4evar.option.left "Left">
-<!ENTITY status4evar.option.fixed "Fixed">
 <!ENTITY status4evar.option.simple "Simple">
 <!ENTITY status4evar.option.advanced "Advanced">
 <!ENTITY status4evar.option.browse "Browse">
@@ -59,9 +57,6 @@
 
 <!ENTITY status4evar.status.toolbar.maxLength.label "Max status text length:">
 
-<!ENTITY status4evar.status.currentUrl "Current Location">
-<!ENTITY status4evar.status.statusText "Status Text">
-
 <!ENTITY status4evar.status.urlbar.firefox.builtin.caption "Firefox compatibility features">
 <!ENTITY browser.urlbar.formatting.enabled.label "Enable domain highlighting">
 <!ENTITY browser.urlbar.trimming.enabled.label "Enable protocol hiding (http:// and ftp://)">
@@ -71,7 +66,7 @@
 
 <!ENTITY status4evar.progress.style.label "Use a custom style">
 
-<!ENTITY status4evar.progress.toolbar.force.label "Always show the status bar item">
+<!ENTITY status4evar.progress.toolbar.force.label "Always show progress meter">
 
 <!ENTITY status4evar.editor.label "Editor:">
 <!ENTITY status4evar.editor.css.color.label "Color:">


### PR DESCRIPTION
Ad #1345, #1347 

## 1) pref.xul

Ad https://forum.palemoon.org/viewtopic.php?f=3&p=122998#p122998

> You can move Progress Meter anywhere you want

## 2) statusbar-prefs.dtd

Style clean up

`status4evar.option.fill`
`status4evar.option.fixed`
`status4evar.status.currentUrl`
`status4evar.status.statusText`
- unused values

`status4evar.progress.toolbar.force.label`
- [suggestion] it should be more understandable

---

You add the label `String changes`, please.

---

I've created the new build (x32, Windows) and tested.

---

Edited:
#### ~~If you want to rethink it...~~
- https://forum.palemoon.org/viewtopic.php?f=3&t=16820#p123033

> ...it was crowded from a code perspective, and resulted in more than a dozen or so practical issues that would affect people who did NOT use this experimental feature (>95%). The only sane solution was removing the code causing these problems.

~~...these commits must be reverted:~~
https://github.com/MoonchildProductions/Pale-Moon/commit/83f30d3fb46b7edd8957f6467b2611ec2d5a96b0
https://github.com/MoonchildProductions/Pale-Moon/commit/0bbfbfdee4a4c3c2cd717f15ac6922a4d2ac2db1
https://github.com/MoonchildProductions/Pale-Moon/commit/2ad8c6c431ab82a2f419b8f2d0d1d264bee91e16
https://github.com/MoonchildProductions/Pale-Moon/commit/a222ebf685c4cfaf5522bef55e6bf2a1955bd7f7
https://github.com/MoonchildProductions/Pale-Moon/commit/d8c63e71f3398d2a9ec5f2e03c68c2f9bd60f712
