### PR TITLE
Prevent crash when more than one MediaPromise is rejected

### DIFF
--- a/dom/media/MediaPromise.h
+++ b/dom/media/MediaPromise.h
@@ -239,6 +239,11 @@ private:
 
     void Reject(const RejectValueType& aRejectValue)
     {
+      if (!mPromise) {
+        // Already rejected.
+        return;
+      }
+
       mPromise->Reject(aRejectValue, __func__);
       mPromise = nullptr;
       mResolveValues.Clear();

--- a/dom/media/gtest/TestMediaPromise.cpp
+++ b/dom/media/gtest/TestMediaPromise.cpp
@@ -207,6 +207,8 @@ TEST(MediaPromise, PromiseAllReject)
     promises.AppendElement(TestPromise::CreateAndResolve(22, __func__));
     promises.AppendElement(TestPromise::CreateAndReject(32.0, __func__));
     promises.AppendElement(TestPromise::CreateAndResolve(42, __func__));
+    // Ensure that more than one rejection doesn't cause a crash.
+    promises.AppendElement(TestPromise::CreateAndReject(52.0, __func__));
 
     TestPromise::All(queue, promises)->Then(queue, __func__,
       DO_FAIL,


### PR DESCRIPTION
A simple fix to prevent the browser from crashing if more than one MediaPromise is rejected.

Tested on Linux and no issues seen.