### PR TITLE
Revert "Allow disabling HW acceleration even when SharedDecoderManage…

### DIFF
--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -448,15 +448,11 @@ void
 MediaFormatReader::DisableHardwareAcceleration()
 {
   MOZ_ASSERT(OnTaskQueue());
-  if (HasVideo()) {
-    mPlatform->DisableHardwareAcceleration();
-    Flush(TrackInfo::kVideoTrack);
-    mVideo.mDecoder->Shutdown();
-    mVideo.mDecoder = nullptr;
-    if (!EnsureDecodersSetup()) {
-      LOG("Unable to re-create decoder, aborting");
-      NotifyError(TrackInfo::kVideoTrack);
-      return;
+  if (HasVideo() && mSharedDecoderManager) {
+    mSharedDecoderManager->DisableHardwareAcceleration();
+
+    if (!mSharedDecoderManager->Recreate(mInfo.mVideo)) {
+      mVideo.mError = true;
     }
     ScheduleUpdate(TrackInfo::kVideoTrack);
   }


### PR DESCRIPTION
…r isn't used"

This reverts commit 67cb802 and restores the behavior of 27.4.2.


With light testing on Youtube this seems to resolve the higher than normal CPU usage when playing 60fps video (https://forum.palemoon.org/viewtopic.php?f=29&t=16797&p=123027)