### PR TITLE
URL/Address/Location bar - suggestions in location bar cannot be hidden by clicking dropmarker again

### DIFF
--- a/toolkit/content/widgets/autocomplete.xml
+++ b/toolkit/content/widgets/autocomplete.xml
@@ -386,7 +386,10 @@
 
       <method name="toggleHistoryPopup">
         <body><![CDATA[
-          if (!this.popup.popupOpen)
+          // If this method is called on the same event tick as the popup gets
+          // hidden, do nothing to avoid re-opening the popup when the drop
+          // marker is clicked while the popup is still open.
+          if (!this.popup.isPopupHidingTick && !this.popup.popupOpen)
             this.showHistoryPopup();
           else
             this.closePopup();
@@ -812,6 +815,7 @@ extends="chrome://global/content/bindings/popup.xml#popup">
     <implementation implements="nsIAutoCompletePopup">
       <field name="mInput">null</field>
       <field name="mPopupOpen">false</field>
+      <field name="mIsPopupHidingTick">false</field>
 
       <!-- =================== nsIAutoCompletePopup =================== -->
 
@@ -823,6 +827,9 @@ extends="chrome://global/content/bindings/popup.xml#popup">
 
       <property name="popupOpen" readonly="true"
                 onget="return this.mPopupOpen;"/>
+
+      <property name="isPopupHidingTick" readonly="true"
+                onget="return this.mIsPopupHidingTick;"/>
 
       <method name="closePopup">
         <body>
@@ -929,6 +936,14 @@ extends="chrome://global/content/bindings/popup.xml#popup">
 
         this.removeAttribute("autocompleteinput");
         this.mPopupOpen = false;
+
+        // Prevent opening popup from historydropmarker mousedown handler
+        // on the same event tick the popup is hidden by the same mousedown
+        // event.
+        this.mIsPopupHidingTick = true;
+        setTimeout(() => {
+          this.mIsPopupHidingTick = false;
+        }, 0);
 
         // Reset the maxRows property to the cached "normal" value, and reset
         // _normalMaxRows so that we can detect whether it was set by the input
@@ -1950,18 +1965,9 @@ extends="chrome://global/content/bindings/popup.xml#popup">
   </binding>
 
   <binding id="history-dropmarker" extends="chrome://global/content/bindings/general.xml#dropmarker">
-    <implementation>
-      <method name="showPopup">
-        <body><![CDATA[
-          var textbox = document.getBindingParent(this);
-          textbox.showHistoryPopup();
-        ]]></body>
-      </method>
-    </implementation>
-
     <handlers>
       <handler event="mousedown" button="0"><![CDATA[
-        this.showPopup();
+        document.getBindingParent(this).toggleHistoryPopup();
       ]]></handler>
     </handlers>
   </binding>


### PR DESCRIPTION
Ad https://forum.palemoon.org/viewtopic.php?f=29&t=16838

> I click the URLBar dropdown button, then I click it again.
> Result.
> The menu doesn't close. (or closes, then instantly re-opens)
>
> Expected result:
> The menu closes. (And doesn't try to re-open)

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1148716

---

I've created the new build (x32, Windows) and tested.
