### PR TITLE
Fix preprocessor build warnings

### DIFF
--- a/browser/base/jar.mn
+++ b/browser/base/jar.mn
@@ -99,7 +99,7 @@ browser.jar:
         content/browser/openLocation.js               (content/openLocation.js)
         content/browser/openLocation.xul              (content/openLocation.xul)
         content/browser/safeMode.css                  (content/safeMode.css)
-*       content/browser/safeMode.js                   (content/safeMode.js)
+        content/browser/safeMode.js                   (content/safeMode.js)
 *       content/browser/safeMode.xul                  (content/safeMode.xul)
 *       content/browser/sanitize.js                   (content/sanitize.js)
 *       content/browser/sanitize.xul                  (content/sanitize.xul)

--- a/browser/components/preferences/jar.mn
+++ b/browser/components/preferences/jar.mn
@@ -35,7 +35,7 @@ browser.jar:
     content/browser/preferences/privacy.js
     content/browser/preferences/sanitize.xul
     content/browser/preferences/sanitize.js
-*   content/browser/preferences/security.xul
+    content/browser/preferences/security.xul
     content/browser/preferences/security.js
     content/browser/preferences/selectBookmark.xul
     content/browser/preferences/selectBookmark.js

--- a/browser/locales/Makefile.in
+++ b/browser/locales/Makefile.in
@@ -67,6 +67,9 @@ endif
 SEARCHPLUGINS_NAMES = $(shell cat $(call MERGE_FILE,/searchplugins/list.txt))
 SEARCHPLUGINS_PATH := $(FINAL_TARGET)/searchplugins
 SEARCHPLUGINS := $(addsuffix .xml,$(SEARCHPLUGINS_NAMES))
+# Some locale-specific search plugins may have preprocessor directives, but the
+# default en-US ones do not.
+SEARCHPLUGINS_FLAGS := --silence-missing-directive-warnings
 PP_TARGETS += SEARCHPLUGINS
 
 # Required for l10n.mk - defines a list of app sub dirs that should


### PR DESCRIPTION
This solves following build warnings:
```
[..]\browser\base\content/safeMode.js: WARNING: no useful preprocessor directives found
[..]\browser\components\preferences\security.xul: WARNING: no preprocessor directives found
[..]/browser/locales/en-US/searchplugins/duckduckgo-palemoon.xml: WARNING: no preprocessor directives found
[..]/browser/locales/en-US/searchplugins/bing.xml: WARNING: no preprocessor directives found
[..]/browser/locales/en-US/searchplugins/ecosia.xml: WARNING: no preprocessor directives found
[..]/browser/locales/en-US/searchplugins/twitter.xml: WARNING: no preprocessor directives found
[..]/browser/locales/en-US/searchplugins/wikipedia.xml: WARNING: no preprocessor directives found
[..]/browser/locales/en-US/searchplugins/yahoo.xml: WARNING: no preprocessor directives found
```

Task #1244.