### PR TITLE
Fix warnings from MakeNSIS

### DIFF
--- a/browser/installer/windows/nsis/installer.nsi
+++ b/browser/installer/windows/nsis/installer.nsi
@@ -96,7 +96,6 @@ VIAddVersionKey "OriginalFilename" "setup.exe"
 !insertmacro UnloadUAC
 !insertmacro WriteRegStr2
 !insertmacro WriteRegDWORD2
-!insertmacro CheckIfRegistryKeyExists
 
 !include shared.nsh
 

--- a/browser/installer/windows/nsis/uninstaller.nsi
+++ b/browser/installer/windows/nsis/uninstaller.nsi
@@ -80,7 +80,6 @@ VIAddVersionKey "OriginalFilename" "helper.exe"
 !insertmacro UnloadUAC
 !insertmacro WriteRegDWORD2
 !insertmacro WriteRegStr2
-!insertmacro CheckIfRegistryKeyExists
 
 !insertmacro un.ChangeMUIHeaderImage
 !insertmacro un.CheckForFilesInUse


### PR DESCRIPTION
Don't import `CheckIfRegistryKeyExists` macro that unused since [bug #1049521](https://bugzilla.mozilla.org/show_bug.cgi?id=1049521) was implemented.

This solves following build warnings:
```
warning: install function "CheckIfRegistryKeyExists" not referenced - zeroing code (1430-1460) out
1 warning:
  install function "CheckIfRegistryKeyExists" not referenced - zeroing code (1430-1460) out
```

Task #1244.