### PR TITLE
Eagerly perform tail dispatch for a given task queue when shutting it down

### DIFF
--- a/dom/media/MediaTaskQueue.cpp
+++ b/dom/media/MediaTaskQueue.cpp
@@ -159,10 +159,11 @@ MediaTaskQueue::AwaitShutdownAndIdle()
 nsRefPtr<ShutdownPromise>
 MediaTaskQueue::BeginShutdown()
 {
-  // Make sure there are no tasks for this queue waiting in the caller's tail
-  // dispatcher.
-  MOZ_ASSERT_IF(AbstractThread::GetCurrent(),
-                !AbstractThread::GetCurrent()->TailDispatcher().HasTasksFor(this));
+  // Dispatch any tasks for this queue waiting in the caller's tail dispatcher,
+  // since this is the last opportunity to do so.
+  if (AbstractThread* currentThread = AbstractThread::GetCurrent()) {
+    currentThread->TailDispatcher().DispatchTasksFor(this);
+  }
 
   MonitorAutoLock mon(mQueueMonitor);
   mIsShutdown = true;


### PR DESCRIPTION
Currently we assert against this case (shutting down when a task is still in the dispatcher). With these patches, we will now properly handle this situation in the MediaTaskQueue instead of expecting the caller to deal with it.

Tested on Linux by running through all the usual video sites and watching various resolutions videos, live streams, etc. and no issues seen.