### PR TITLE
window.onerror catches JSON.parse error in Promise fulfillment (follow up)

### DIFF
--- a/dom/base/ScriptSettings.cpp
+++ b/dom/base/ScriptSettings.cpp
@@ -519,7 +519,7 @@ AutoJSAPI::ReportException()
 bool
 AutoJSAPI::PeekException(JS::MutableHandle<JS::Value> aVal)
 {
-  MOZ_ASSERT_IF(mIsMainThread, CxPusherIsStackTop());
+  MOZ_ASSERT(CxPusherIsStackTop());
   MOZ_ASSERT(HasException());
   MOZ_ASSERT(js::GetContextCompartment(cx()));
   if (!JS_GetPendingException(cx(), aVal)) {


### PR DESCRIPTION
Ad #1398 (#1079)

See:
https://hg.mozilla.org/mozilla-central/rev/bf248ceb561b#l1.174

---

__You add the label `Verification needed`, please.__

---

I've created the new build (x32, Windows) and tested.
