### PR TITLE
[build, suggestion] Building with "--enable-debug" - fix some warnings

### DIFF
--- a/browser/base/content/sync/utils.js
+++ b/browser/base/content/sync/utils.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Equivalent to 0600 permissions; used for saved Sync Recovery Key.
+// Equivalent to 0o600 permissions; used for saved Sync Recovery Key.
 // This constant can be replaced when the equivalent values are available to
 // chrome JS; see Bug 433295 and Bug 757351.
 const PERMISSIONS_RWUSR = 0x180;

--- a/browser/components/feeds/FeedWriter.js
+++ b/browser/components/feeds/FeedWriter.js
@@ -637,7 +637,7 @@ FeedWriter.prototype = {
         Cc["@mozilla.org/browser/feeds/result-service;1"].
         getService(Ci.nsIFeedResultService);
 
-    var result = null;
+    result = null;
     try {
       result = 
         feedService.getFeedResult(this._getOriginalURI(this._window));

--- a/layout/base/nsLayoutUtils.cpp
+++ b/layout/base/nsLayoutUtils.cpp
@@ -6042,8 +6042,9 @@ nsLayoutUtils::DrawSingleImage(gfxContext&            aContext,
   nscoord appUnitsPerCSSPixel = nsDeviceContext::AppUnitsPerCSSPixel();
   nsIntSize pixelImageSize(ComputeSizeForDrawingWithFallback(aImage, aDest.Size()));
   if (pixelImageSize.width < 1 || pixelImageSize.height < 1) {
-    NS_WARNING("Image width or height is non-positive");
-    return DrawResult::TEMPORARY_ERROR;
+    NS_ASSERTION(pixelImageSize.width >= 0 && pixelImageSize.height >= 0,
+                 "Image width or height is negative");
+    return DrawResult::SUCCESS;  // no point in drawing a zero size image
   }
 
   nsSize imageSize(pixelImageSize.width * appUnitsPerCSSPixel,

--- a/layout/tools/layout-debug/ui/content/layoutdebug.js
+++ b/layout/tools/layout-debug/ui/content/layoutdebug.js
@@ -382,7 +382,7 @@ RTestURLList.prototype = {
     var data = this.mCurrentURL.dir.clone();
     data.append( this.mIsBaseline ? "baseline" : "verify");
     if (!data.exists())
-      data.create(nsIFile.DIRECTORY_TYPE, 0777)
+      data.create(nsIFile.DIRECTORY_TYPE, 0o777)
     data.append(basename);
 
     dump("Writing regression data to " +

--- a/mobile/android/components/HelperAppDialog.js
+++ b/mobile/android/components/HelperAppDialog.js
@@ -289,7 +289,7 @@ HelperAppLauncherDialog.prototype = {
           aLocalFile.leafName = aLocalFile.leafName.replace(/^(.*\()\d+\)/, "$1" + (collisionCount+1) + ")");
         }
       }
-      aLocalFile.create(Ci.nsIFile.NORMAL_FILE_TYPE, 0600);
+      aLocalFile.create(Ci.nsIFile.NORMAL_FILE_TYPE, 0o600);
     }
     catch (e) {
       dump("*** exception in validateLeafName: " + e + "\n");
@@ -300,7 +300,7 @@ HelperAppLauncherDialog.prototype = {
       if (aLocalFile.leafName == "" || aLocalFile.isDirectory()) {
         aLocalFile.append("unnamed");
         if (aLocalFile.exists())
-          aLocalFile.createUnique(Ci.nsIFile.NORMAL_FILE_TYPE, 0600);
+          aLocalFile.createUnique(Ci.nsIFile.NORMAL_FILE_TYPE, 0o600);
       }
     }
   },

--- a/mobile/android/components/SessionStore.js
+++ b/mobile/android/components/SessionStore.js
@@ -665,7 +665,7 @@ SessionStore.prototype = {
     // Convert buffer to an encoded string and sync write to disk
     let bytes = String.fromCharCode.apply(null, new Uint16Array(aBuffer));
     let stream = Cc["@mozilla.org/network/file-output-stream;1"].createInstance(Ci.nsIFileOutputStream);
-    stream.init(aFile, 0x02 | 0x08 | 0x20, 0666, 0);
+    stream.init(aFile, 0x02 | 0x08 | 0x20, 0o666, 0);
     stream.write(bytes, bytes.length);
     stream.close();
 

--- a/security/manager/pki/resources/content/pippki.js
+++ b/security/manager/pki/resources/content/pippki.js
@@ -137,7 +137,7 @@ function exportToFile(parent, cert)
     var fos = Components.classes["@mozilla.org/network/file-output-stream;1"].
               createInstance(Components.interfaces.nsIFileOutputStream);
     // flags: PR_WRONLY | PR_CREATE_FILE | PR_TRUNCATE
-    fos.init(file, 0x02 | 0x08 | 0x20, 00644, 0);
+    fos.init(file, 0x02 | 0x08 | 0x20, 0o0644, 0);
     written = fos.write(content, content.length);
     fos.close();
   }

--- a/toolkit/commonjs/dev/volcan.js
+++ b/toolkit/commonjs/dev/volcan.js
@@ -138,7 +138,7 @@ var Client = Class({
           .then(this.onReady.bind(this, this.root), this.onFail);
     } else {
       var actor = this.get(packet.from) || this.root;
-      var event = actor.events[packet.type];
+      event = actor.events[packet.type];
       if (event) {
         var message = new MessageEvent(packet.type, {
           data: event.read(packet)

--- a/toolkit/commonjs/sdk/lang/weak-set.js
+++ b/toolkit/commonjs/sdk/lang/weak-set.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+"use strict";
+
 module.metadata = {
   "stability": "experimental"
 };
-
-"use strict";
 
 const { Cu } = require("chrome");
 

--- a/toolkit/components/feeds/FeedProcessor.js
+++ b/toolkit/components/feeds/FeedProcessor.js
@@ -50,7 +50,7 @@ const RSS090NS = "http://my.netscape.com/rdf/simple/0.9/";
 
 /***** Some general utils *****/
 function strToURI(link, base) {
-  var base = base || null;
+  base = base || null;
   if (!gIoService)
     gIoService = Cc[IO_CONTRACTID].getService(Ci.nsIIOService);
   try {
@@ -871,7 +871,7 @@ XHTMLHandler.prototype = {
   },
   endDocument: function XH_endDocument() {
   },
-  startElement: function XH_startElement(uri, localName, qName, attributes) {
+  startElement: function XH_startElement(namespace, localName, qName, attributes) {
     ++this._depth;
     this._inScopeNS.push([]);
 
@@ -882,7 +882,7 @@ XHTMLHandler.prototype = {
       return;
 
     // If it's an XHTML element, record it. Otherwise, it's ignored.
-    if (uri == XHTML_NS) {
+    if (namespace == XHTML_NS) {
       this._buf += "<" + localName;
       var uri;
       for (var i=0; i < attributes.length; ++i) {

--- a/toolkit/devtools/qrcode/decoder/index.js
+++ b/toolkit/devtools/qrcode/decoder/index.js
@@ -19,7 +19,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-GridSampler = {};
+var GridSampler = {};
 
 GridSampler.checkAndNudgePoints = function(image, points) {
   var width = qrcode.width;
@@ -833,7 +833,7 @@ function BitMatrixParser(bitMatrix) {
   };
 }
 
-DataMask = {};
+var DataMask = {};
 
 DataMask.forReference = function(reference) {
   if (reference < 0 || reference > 7) {
@@ -975,9 +975,9 @@ function ReedSolomonDecoder(field) {
     var dataMatrix = false;
     var noError = true;
     for (var i = 0; i < twoS; i++) {
-      var eval = poly.evaluateAt(this.field.exp(dataMatrix ? i + 1 : i));
-      syndromeCoefficients[syndromeCoefficients.length - 1 - i] = eval;
-      if (eval != 0) {
+      var value = poly.evaluateAt(this.field.exp(dataMatrix ? i + 1 : i));
+      syndromeCoefficients[syndromeCoefficients.length - 1 - i] = value;
+      if (value != 0) {
         noError = false;
       }
     }
@@ -1303,7 +1303,7 @@ GF256.addOrSubtract = function(a, b) {
   return a ^ b;
 };
 
-Decoder = {};
+var Decoder = {};
 
 Decoder.rsDecoder = new ReedSolomonDecoder(GF256.QR_CODE_FIELD);
 

--- a/toolkit/devtools/sourceeditor/autocomplete.js
+++ b/toolkit/devtools/sourceeditor/autocomplete.js
@@ -188,17 +188,17 @@ function destroyAutoCompletion(ctx) {
  * Provides suggestions to autocomplete the current token/word being typed.
  */
 function autoComplete({ ed, cm }) {
-  let private = autocompleteMap.get(ed);
-  let { completer, popup } = private;
-  if (!completer || private.insertingSuggestion || private.doNotAutocomplete) {
-    private.insertingSuggestion = false;
+  let autocompleteOpts = autocompleteMap.get(ed);
+  let { completer, popup } = autocompleteOpts;
+  if (!completer || autocompleteOpts.insertingSuggestion || autocompleteOpts.doNotAutocomplete) {
+    autocompleteOpts.insertingSuggestion = false;
     return;
   }
   let cur = ed.getCursor();
   completer.complete(cm.getRange({line: 0, ch: 0}, cur), cur)
     .then(suggestions => {
     if (!suggestions || !suggestions.length || suggestions[0].preLabel == null) {
-      private.suggestionInsertedOnce = false;
+      autocompleteOpts.suggestionInsertedOnce = false;
       popup.hidePopup();
       ed.emit("after-suggest");
       return;
@@ -213,7 +213,7 @@ function autoComplete({ ed, cm }) {
     popup.hidePopup();
     popup.setItems(suggestions);
     popup.openPopup(cursorElement, -1 * left, 0);
-    private.suggestionInsertedOnce = false;
+    autocompleteOpts.suggestionInsertedOnce = false;
     // This event is used in tests.
     ed.emit("after-suggest");
   }).then(null, Cu.reportError);
@@ -224,12 +224,12 @@ function autoComplete({ ed, cm }) {
  * when `reverse` is not true. Opposite otherwise.
  */
 function cycleSuggestions(ed, reverse) {
-  let private = autocompleteMap.get(ed);
-  let { popup, completer } = private;
+  let autocompleteOpts = autocompleteMap.get(ed);
+  let { popup, completer } = autocompleteOpts;
   let cur = ed.getCursor();
-  private.insertingSuggestion = true;
-  if (!private.suggestionInsertedOnce) {
-    private.suggestionInsertedOnce = true;
+  autocompleteOpts.insertingSuggestion = true;
+  if (!autocompleteOpts.suggestionInsertedOnce) {
+    autocompleteOpts.suggestionInsertedOnce = true;
     let firstItem;
     if (reverse) {
       firstItem = popup.getItemAtIndex(popup.itemCount - 1);
@@ -264,55 +264,55 @@ function cycleSuggestions(ed, reverse) {
  * keypresses.
  */
 function onEditorKeypress({ ed, Editor }, cm, event) {
-  let private = autocompleteMap.get(ed);
+  let autocompleteOpts = autocompleteMap.get(ed);
 
   // Do not try to autocomplete with multiple selections.
   if (ed.hasMultipleSelections()) {
-    private.doNotAutocomplete = true;
-    private.popup.hidePopup();
+    autocompleteOpts.doNotAutocomplete = true;
+    autocompleteOpts.popup.hidePopup();
     return;
   }
 
   if ((event.ctrlKey || event.metaKey) && event.keyCode == event.DOM_VK_SPACE) {
     // When Ctrl/Cmd + Space is pressed, two simultaneous keypresses are emitted
     // first one for just the Ctrl/Cmd and second one for combo. The first one
-    // leave the private.doNotAutocomplete as true, so we have to make it false
-    private.doNotAutocomplete = false;
+    // leave the autocompleteOpts.doNotAutocomplete as true, so we have to make it false
+    autocompleteOpts.doNotAutocomplete = false;
     return;
   }
 
   if (event.ctrlKey || event.metaKey || event.altKey) {
-    private.doNotAutocomplete = true;
-    private.popup.hidePopup();
+    autocompleteOpts.doNotAutocomplete = true;
+    autocompleteOpts.popup.hidePopup();
     return;
   }
 
   switch (event.keyCode) {
     case event.DOM_VK_RETURN:
-      private.doNotAutocomplete = true;
+      autocompleteOpts.doNotAutocomplete = true;
       break;
 
     case event.DOM_VK_ESCAPE:
-      if (private.popup.isOpen)
+      if (autocompleteOpts.popup.isOpen)
         event.preventDefault();
     case event.DOM_VK_LEFT:
     case event.DOM_VK_RIGHT:
     case event.DOM_VK_HOME:
     case event.DOM_VK_END:
-      private.doNotAutocomplete = true;
-      private.popup.hidePopup();
+      autocompleteOpts.doNotAutocomplete = true;
+      autocompleteOpts.popup.hidePopup();
       break;
 
     case event.DOM_VK_BACK_SPACE:
     case event.DOM_VK_DELETE:
       if (ed.config.mode == Editor.modes.css)
-        private.completer.invalidateCache(ed.getCursor().line)
-      private.doNotAutocomplete = true;
-      private.popup.hidePopup();
+        autocompleteOpts.completer.invalidateCache(ed.getCursor().line)
+      autocompleteOpts.doNotAutocomplete = true;
+      autocompleteOpts.popup.hidePopup();
       break;
 
     default:
-      private.doNotAutocomplete = false;
+      autocompleteOpts.doNotAutocomplete = false;
   }
 }
 

--- a/toolkit/devtools/tern/def.js
+++ b/toolkit/devtools/tern/def.js
@@ -77,7 +77,8 @@
       }
     },
     word: function(re) {
-      var word = "", ch, re = re || /[\w$]/;
+      var word = "", ch;
+      re = re || /[\w$]/;
       while ((ch = this.spec.charAt(this.pos)) && re.test(ch)) { word += ch; ++this.pos; }
       return word;
     },
@@ -187,7 +188,7 @@
         if (top && this.forceNew) return new infer.Obj(base);
         return infer.getInstance(base);
       } else if (this.eat(":")) {
-        var name = this.word(/[\w$\.]/)
+        name = this.word(/[\w$\.]/)
         return infer.getSymbol(name)
       } else if (comp && this.eat("!")) {
         var arg = this.word(/\d/);

--- a/xpcom/ds/nsINIProcessor.js
+++ b/xpcom/ds/nsINIProcessor.js
@@ -144,7 +144,7 @@ INIProcessor.prototype = {
         let safeStream = Cc["@mozilla.org/network/safe-file-output-stream;1"].
                          createInstance(Ci.nsIFileOutputStream);
         safeStream.init(aFile, MODE_WRONLY | MODE_CREATE | MODE_TRUNCATE,
-                        0600, null);
+                        0o600, null);
 
         var outputStream = Cc["@mozilla.org/network/buffered-output-stream;1"].
                            createInstance(Ci.nsIBufferedOutputStream);

--- a/xpfe/appshell/nsWindowMediator.cpp
+++ b/xpfe/appshell/nsWindowMediator.cpp
@@ -584,12 +584,10 @@ nsWindowMediator::GetZLevel(nsIXULWindow *aWindow, uint32_t *_retval)
 {
   NS_ENSURE_ARG_POINTER(_retval);
   *_retval = nsIXULWindow::normalZ;
+  // This can fail during window destruction.
   nsWindowInfo *info = GetInfoFor(aWindow);
   if (info) {
     *_retval = info->mZLevel;
-  } else {
-    NS_WARNING("getting z level of unregistered window");
-    // this goes off during window destruction
   }
   return NS_OK;
 }


### PR DESCRIPTION
Ad https://forum.palemoon.org/viewtopic.php?f=5&t=16924

---

```
WARNING: getting z level of unregistered window:
file [drive]:\[path]\xpfe\appshell\nsWindowMediator.cpp, line 591
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1307212

---

```
WARNING: Image width or height is non-positive:
file [drive]:\[path]\layout\base\nsLayoutUtils.cpp, line 6045
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1317464

---

```
JavaScript strict warning: resource://gre/components/FeedProcessor.js, line 53:
TypeError: variable base redeclares argument
JavaScript strict warning: resource://gre/components/FeedProcessor.js, line 887:
TypeError: variable uri redeclares argument
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1245649

---

```
JavaScript strict warning: resource://gre/components/FeedWriter.js, line 636:
TypeError: variable result redeclares argument
```

See:
https://github.com/MoonchildProductions/Pale-Moon/pull/1207 (follow up)

---

```
JavaScript strict warning: resource://gre/components/nsINIProcessor.js, line 147:
(etc.)
SyntaxError: octal literals and octal escape sequences are deprecated
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1248252

---

```
JavaScript strict warning: resource://gre/modules/commonjs/dev/volcan.js, line 141:
TypeError: variable event redeclares argument
```

---

```
JavaScript strict warning: resource://gre/modules/commonjs/sdk/lang/weak-set.js, line 9:
SyntaxError: 'use strict' statement won't be enforced as a directive because it isn't in directive prologue position
```

---

```
JavaScript strict warning: resource://gre/modules/devtools/qrcode/decoder/index.js, line 978:
SyntaxError: redefining eval is deprecated
JavaScript strict warning: resource://gre/modules/devtools/qrcode/decoder/index.js, line 22:
ReferenceError: assignment to undeclared variable GridSampler
JavaScript strict warning: resource://gre/modules/devtools/qrcode/decoder/index.js, line 836:
ReferenceError: assignment to undeclared variable DataMask
JavaScript strict warning: resource://gre/modules/devtools/qrcode/decoder/index.js, line 1306:
ReferenceError: assignment to undeclared variable Decoder
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1152836 (partially)
https://bugzilla.mozilla.org/show_bug.cgi?id=1202902 (partially)

---

```
JavaScript strict warning: resource://gre/modules/devtools/tern/def.js, line 80:
TypeError: variable re redeclares argument
JavaScript strict warning: resource://gre/modules/devtools/tern/def.js, line 190:
TypeError: variable name redeclares argument
```

```
JavaScript strict warning: resource://gre/modules/devtools/sourceeditor/autocomplete.js, line 191:
SyntaxError: private is a reserved identifier
```
\+ Lines:
192,193,194,201,216,227,228,230,231,232,267,271,272,280,285,286,292,296,302,303,309,310,311,315

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1206463

---

Partially `UXP task`.

---

I've created the new build (x32, Windows) and tested:
building; feeds; DevTools - Source Editor - autocomplete

