### PR TITLE
JS - DOM - node - implement DOM4 methods: prepend(), append(), before(), after() and replaceWith() (partially)

### DIFF
--- a/dom/base/Element.cpp
+++ b/dom/base/Element.cpp
@@ -3390,7 +3390,8 @@ Element::InsertAdjacent(const nsAString& aWhere,
     }
     parent->InsertBefore(*aNode, this, aError);
   } else if (aWhere.LowerCaseEqualsLiteral("afterbegin")) {
-    static_cast<nsINode*>(this)->InsertBefore(*aNode, GetFirstChild(), aError);
+    nsCOMPtr<nsINode> refNode = GetFirstChild();
+    static_cast<nsINode*>(this)->InsertBefore(*aNode, refNode, aError);
   } else if (aWhere.LowerCaseEqualsLiteral("beforeend")) {
     static_cast<nsINode*>(this)->AppendChild(*aNode, aError);
   } else if (aWhere.LowerCaseEqualsLiteral("afterend")) {
@@ -3398,7 +3399,8 @@ Element::InsertAdjacent(const nsAString& aWhere,
     if (!parent) {
       return nullptr;
     }
-    parent->InsertBefore(*aNode, GetNextSibling(), aError);
+    nsCOMPtr<nsINode> refNode = GetNextSibling();
+    parent->InsertBefore(*aNode, refNode, aError);
   } else {
     aError.Throw(NS_ERROR_DOM_SYNTAX_ERR);
     return nullptr;

--- a/dom/base/nsINode.cpp
+++ b/dom/base/nsINode.cpp
@@ -1591,6 +1591,168 @@ nsINode::GetNextElementSibling() const
   return nullptr;
 }
 
+static already_AddRefed<nsINode>
+GetNodeFromNodeOrString(const OwningNodeOrString& aNode,
+                        nsIDocument* aDocument)
+{
+  if (aNode.IsNode()) {
+    nsCOMPtr<nsINode> node = aNode.GetAsNode();
+    return node.forget();
+  }
+
+  if (aNode.IsString()){
+    nsRefPtr<nsTextNode> textNode =
+      aDocument->CreateTextNode(aNode.GetAsString());
+    return textNode.forget();
+  }
+
+  MOZ_CRASH("Impossible type");
+}
+
+/**
+ * Implement the algorithm specified at
+ * https://dom.spec.whatwg.org/#converting-nodes-into-a-node for |prepend()|,
+ * |append()|, |before()|, |after()|, and |replaceWith()| APIs.
+ */
+static already_AddRefed<nsINode>
+ConvertNodesOrStringsIntoNode(const Sequence<OwningNodeOrString>& aNodes,
+                              nsIDocument* aDocument,
+                              ErrorResult& aRv)
+{
+  if (aNodes.Length() == 1) {
+    return GetNodeFromNodeOrString(aNodes[0], aDocument);
+  }
+
+  nsCOMPtr<nsINode> fragment = aDocument->CreateDocumentFragment();
+
+  for (const auto& node : aNodes) {
+    nsCOMPtr<nsINode> childNode = GetNodeFromNodeOrString(node, aDocument);
+    fragment->AppendChild(*childNode, aRv);
+    if (aRv.Failed()) {
+      return nullptr;
+    }
+  }
+
+  return fragment.forget();
+}
+
+static void
+InsertNodesIntoHashset(const Sequence<OwningNodeOrString>& aNodes,
+                       nsTHashtable<nsPtrHashKey<nsINode>>& aHashset)
+{
+  for (const auto& node : aNodes) {
+    if (node.IsNode()) {
+      aHashset.PutEntry(node.GetAsNode());
+    }
+  }
+}
+
+static nsINode*
+FindViablePreviousSibling(const nsINode& aNode,
+                          const Sequence<OwningNodeOrString>& aNodes)
+{
+  nsTHashtable<nsPtrHashKey<nsINode>> nodeSet(16);
+  InsertNodesIntoHashset(aNodes, nodeSet);
+
+  nsINode* viablePreviousSibling = nullptr;
+  for (nsINode* sibling = aNode.GetPreviousSibling(); sibling;
+       sibling = sibling->GetPreviousSibling()) {
+    if (!nodeSet.Contains(sibling)) {
+      viablePreviousSibling = sibling;
+      break;
+    }
+  }
+
+  return viablePreviousSibling;
+}
+
+static nsINode*
+FindViableNextSibling(const nsINode& aNode,
+                      const Sequence<OwningNodeOrString>& aNodes)
+{
+  nsTHashtable<nsPtrHashKey<nsINode>> nodeSet(16);
+  InsertNodesIntoHashset(aNodes, nodeSet);
+
+  nsINode* viableNextSibling = nullptr;
+  for (nsINode* sibling = aNode.GetNextSibling(); sibling;
+       sibling = sibling->GetNextSibling()) {
+    if (!nodeSet.Contains(sibling)) {
+      viableNextSibling = sibling;
+      break;
+    }
+  }
+
+  return viableNextSibling;
+}
+
+void
+nsINode::Before(const Sequence<OwningNodeOrString>& aNodes,
+                ErrorResult& aRv)
+{
+  nsCOMPtr<nsINode> parent = GetParentNode();
+  if (!parent) {
+    return;
+  }
+
+  nsCOMPtr<nsINode> viablePreviousSibling =
+    FindViablePreviousSibling(*this, aNodes);
+
+  nsCOMPtr<nsINode> node =
+    ConvertNodesOrStringsIntoNode(aNodes, OwnerDoc(), aRv);
+  if (aRv.Failed()) {
+    return;
+  }
+
+  viablePreviousSibling = viablePreviousSibling ?
+    viablePreviousSibling->GetNextSibling() : parent->GetFirstChild();
+
+  parent->InsertBefore(*node, viablePreviousSibling, aRv);
+}
+
+void
+nsINode::After(const Sequence<OwningNodeOrString>& aNodes,
+               ErrorResult& aRv)
+{
+  nsCOMPtr<nsINode> parent = GetParentNode();
+  if (!parent) {
+    return;
+  }
+
+  nsCOMPtr<nsINode> viableNextSibling = FindViableNextSibling(*this, aNodes);
+
+  nsCOMPtr<nsINode> node =
+    ConvertNodesOrStringsIntoNode(aNodes, OwnerDoc(), aRv);
+  if (aRv.Failed()) {
+    return;
+  }
+
+  parent->InsertBefore(*node, viableNextSibling, aRv);
+}
+
+void
+nsINode::ReplaceWith(const Sequence<OwningNodeOrString>& aNodes,
+                     ErrorResult& aRv)
+{
+  nsCOMPtr<nsINode> parent = GetParentNode();
+  if (!parent) {
+    return;
+  }
+
+  nsCOMPtr<nsINode> viableNextSibling = FindViableNextSibling(*this, aNodes);
+
+  nsCOMPtr<nsINode> node =
+    ConvertNodesOrStringsIntoNode(aNodes, OwnerDoc(), aRv);
+  if (aRv.Failed()) {
+    return;
+  }
+
+  if (parent == GetParentNode()) {
+    parent->ReplaceChild(*node, *this, aRv);
+  } else {
+    parent->InsertBefore(*node, viableNextSibling, aRv);
+  }
+}
+
 void
 nsINode::Remove()
 {
@@ -1632,6 +1794,32 @@ nsINode::GetLastElementChild() const
   }
 
   return nullptr;
+}
+
+void
+nsINode::Prepend(const Sequence<OwningNodeOrString>& aNodes,
+                 ErrorResult& aRv)
+{
+  nsCOMPtr<nsINode> node =
+    ConvertNodesOrStringsIntoNode(aNodes, OwnerDoc(), aRv);
+  if (aRv.Failed()) {
+    return;
+  }
+
+  InsertBefore(*node, mFirstChild, aRv);
+}
+
+void
+nsINode::Append(const Sequence<OwningNodeOrString>& aNodes,
+                 ErrorResult& aRv)
+{
+  nsCOMPtr<nsINode> node =
+    ConvertNodesOrStringsIntoNode(aNodes, OwnerDoc(), aRv);
+  if (aRv.Failed()) {
+    return;
+  }
+
+  AppendChild(*node, aRv);
 }
 
 void

--- a/dom/base/nsINode.h
+++ b/dom/base/nsINode.h
@@ -73,6 +73,8 @@ class Element;
 class EventHandlerNonNull;
 class OnErrorEventHandlerNonNull;
 template<typename T> class Optional;
+class OwningNodeOrString;
+template<typename> class Sequence;
 class Text;
 class TextOrElementOrDocument;
 struct DOMPointInit;
@@ -265,8 +267,12 @@ public:
   typedef mozilla::dom::DOMPointInit DOMPointInit;
   typedef mozilla::dom::DOMQuad DOMQuad;
   typedef mozilla::dom::DOMRectReadOnly DOMRectReadOnly;
+  typedef mozilla::dom::OwningNodeOrString OwningNodeOrString;
   typedef mozilla::dom::TextOrElementOrDocument TextOrElementOrDocument;
   typedef mozilla::ErrorResult ErrorResult;
+
+  template<class T>
+  using Sequence = mozilla::dom::Sequence<T>;
 
   NS_DECLARE_STATIC_IID_ACCESSOR(NS_INODE_IID)
 
@@ -1655,6 +1661,11 @@ public:
   // ChildNode methods
   mozilla::dom::Element* GetPreviousElementSibling() const;
   mozilla::dom::Element* GetNextElementSibling() const;
+
+  void Before(const Sequence<OwningNodeOrString>& aNodes, ErrorResult& aRv);
+  void After(const Sequence<OwningNodeOrString>& aNodes, ErrorResult& aRv);
+  void ReplaceWith(const Sequence<OwningNodeOrString>& aNodes,
+                   ErrorResult& aRv);
   /**
    * Remove this node from its parent, if any.
    */
@@ -1663,6 +1674,9 @@ public:
   // ParentNode methods
   mozilla::dom::Element* GetFirstElementChild() const;
   mozilla::dom::Element* GetLastElementChild() const;
+
+  void Prepend(const Sequence<OwningNodeOrString>& aNodes, ErrorResult& aRv);
+  void Append(const Sequence<OwningNodeOrString>& aNodes, ErrorResult& aRv);
 
   void GetBoxQuads(const BoxQuadOptions& aOptions,
                    nsTArray<nsRefPtr<DOMQuad> >& aResult,

--- a/dom/bindings/Codegen.py
+++ b/dom/bindings/Codegen.py
@@ -11043,6 +11043,7 @@ class CGDescriptor(CGThing):
             hasPromiseReturningMethod) = False, False, False, False, False, False
         jsonifierMethod = None
         crossOriginMethods, crossOriginGetters, crossOriginSetters = set(), set(), set()
+        unscopableNames = list()
         for n in descriptor.interface.namedConstructors:
             cgThings.append(CGClassConstructor(descriptor, n,
                                                NamedConstructorName(n)))
@@ -11055,6 +11056,9 @@ class CGDescriptor(CGThing):
             props = memberProperties(m, descriptor)
 
             if m.isMethod():
+                if m.getExtendedAttribute("Unscopable"):
+                    assert not m.isStatic()
+                    unscopableNames.append(m.identifier.name)
                 if props.isJsonifier:
                     jsonifierMethod = m
                 elif not m.isIdentifierLess() or m == descriptor.operations['Stringifier']:
@@ -11076,6 +11080,9 @@ class CGDescriptor(CGThing):
                     raise TypeError("Stringifier attributes not supported yet. "
                                     "See bug 824857.\n"
                                     "%s" % m.location)
+                if m.getExtendedAttribute("Unscopable"):
+                    assert not m.isStatic()
+                    unscopableNames.append(m.identifier.name)
                 if m.isStatic():
                     assert descriptor.interface.hasInterfaceObject()
                     cgThings.append(CGStaticGetter(descriptor, m))
@@ -11260,8 +11267,18 @@ class CGDescriptor(CGThing):
             cgThings.extend(CGClearCachedValueMethod(descriptor, m) for
                             m in clearableCachedAttrs(descriptor))
 
+        haveUnscopables = (len(unscopableNames) != 0 and
+                           descriptor.interface.hasInterfacePrototypeObject())
+        if haveUnscopables:
+            cgThings.append(
+                CGList([CGGeneric("static const char* const unscopableNames[] = {"),
+                        CGIndenter(CGList([CGGeneric('"%s"' % name) for
+                                           name in unscopableNames] +
+                                          [CGGeneric("nullptr")], ",\n")),
+                        CGGeneric("};\n")], "\n"))
+
         # CGCreateInterfaceObjectsMethod needs to come after our
-        # CGDOMJSClass, if any.
+        # CGDOMJSClass and unscopables, if any.
         cgThings.append(CGCreateInterfaceObjectsMethod(descriptor, properties))
 
         # CGGetProtoObjectMethod and CGGetConstructorObjectMethod need

--- a/dom/bindings/parser/WebIDL.py
+++ b/dom/bindings/parser/WebIDL.py
@@ -3455,6 +3455,14 @@ class IDLAttribute(IDLInterfaceMember):
                                   "readonly attributes" % attr.value(),
                                   [attr.location, self.location])
             self._setDependsOn(attr.value())
+        elif identifier == "Unscopable":
+            if not attr.noArguments():
+                raise WebIDLError("[Unscopable] must take no arguments",
+                                  [attr.location])
+            if self.isStatic():
+                raise WebIDLError("[Unscopable] is only allowed on non-static "
+                                  "attributes and operations",
+                                  [attr.location, self.location])
         elif (identifier == "Pref" or
               identifier == "SetterThrows" or
               identifier == "Throws" or
@@ -4078,6 +4086,14 @@ class IDLMethod(IDLInterfaceMember, IDLScope):
                 raise WebIDLError("[DependsOn] takes an identifier",
                                   [attr.location])
             self._setDependsOn(attr.value())
+        elif identifier == "Unscopable":
+            if not attr.noArguments():
+                raise WebIDLError("[Unscopable] must take no arguments",
+                                  [attr.location])
+            if self.isStatic():
+                raise WebIDLError("[Unscopable] is only allowed on non-static "
+                                  "attributes and operations",
+                                  [attr.location, self.location])
         elif (identifier == "Throws" or
               identifier == "NewObject" or
               identifier == "ChromeOnly" or

--- a/dom/webidl/ChildNode.webidl
+++ b/dom/webidl/ChildNode.webidl
@@ -9,10 +9,13 @@
 
 [NoInterfaceObject]
 interface ChildNode {
-// Not implemented yet:
-//  void before((Node or DOMString)... nodes);
-//  void after((Node or DOMString)... nodes);
-//  void replace((Node or DOMString)... nodes);
+  [Throws, Unscopable]
+  void before((Node or DOMString)... nodes);
+  [Throws, Unscopable]
+  void after((Node or DOMString)... nodes);
+  [Throws, Unscopable]
+  void replaceWith((Node or DOMString)... nodes);
+  [Unscopable]
   void remove();
 };
 

--- a/dom/webidl/ParentNode.webidl
+++ b/dom/webidl/ParentNode.webidl
@@ -18,7 +18,8 @@ interface ParentNode {
   [Pure]
   readonly attribute unsigned long childElementCount;
 
-  // Not implemented yet
-  // void prepend((Node or DOMString)... nodes);
-  // void append((Node or DOMString)... nodes);
+  [Throws, Unscopable]
+  void prepend((Node or DOMString)... nodes);
+  [Throws, Unscopable]
+  void append((Node or DOMString)... nodes);
 };

--- a/testing/web-platform/meta/dom/interfaces.html.ini
+++ b/testing/web-platform/meta/dom/interfaces.html.ini
@@ -9,12 +9,6 @@
   [Document interface: attribute origin]
     expected: FAIL
 
-  [Document interface: operation prepend([object Object\],[object Object\])]
-    expected: FAIL
-
-  [Document interface: operation append([object Object\],[object Object\])]
-    expected: FAIL
-
   [Document interface: operation query(DOMString)]
     expected: FAIL
 
@@ -22,18 +16,6 @@
     expected: FAIL
 
   [Document interface: xmlDoc must inherit property "origin" with the proper type (3)]
-    expected: FAIL
-
-  [Document interface: xmlDoc must inherit property "prepend" with the proper type (29)]
-    expected: FAIL
-
-  [Document interface: calling prepend([object Object\],[object Object\]) on xmlDoc with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Document interface: xmlDoc must inherit property "append" with the proper type (30)]
-    expected: FAIL
-
-  [Document interface: calling append([object Object\],[object Object\]) on xmlDoc with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: xmlDoc must inherit property "query" with the proper type (31)]
@@ -51,28 +33,10 @@
   [DOMImplementation interface: operation hasFeature()]
     expected: FAIL
 
-  [DocumentFragment interface: operation prepend([object Object\],[object Object\])]
-    expected: FAIL
-
-  [DocumentFragment interface: operation append([object Object\],[object Object\])]
-    expected: FAIL
-
   [DocumentFragment interface: operation query(DOMString)]
     expected: FAIL
 
   [DocumentFragment interface: operation queryAll(DOMString)]
-    expected: FAIL
-
-  [DocumentFragment interface: document.createDocumentFragment() must inherit property "prepend" with the proper type (5)]
-    expected: FAIL
-
-  [DocumentFragment interface: calling prepend([object Object\],[object Object\]) on document.createDocumentFragment() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [DocumentFragment interface: document.createDocumentFragment() must inherit property "append" with the proper type (6)]
-    expected: FAIL
-
-  [DocumentFragment interface: calling append([object Object\],[object Object\]) on document.createDocumentFragment() with too few arguments must throw TypeError]
     expected: FAIL
 
   [DocumentFragment interface: document.createDocumentFragment() must inherit property "query" with the proper type (7)]
@@ -87,33 +51,6 @@
   [DocumentFragment interface: calling queryAll(DOMString) on document.createDocumentFragment() with too few arguments must throw TypeError]
     expected: FAIL
 
-  [DocumentType interface: operation before([object Object\],[object Object\])]
-    expected: FAIL
-
-  [DocumentType interface: operation after([object Object\],[object Object\])]
-    expected: FAIL
-
-  [DocumentType interface: operation replace([object Object\],[object Object\])]
-    expected: FAIL
-
-  [DocumentType interface: document.doctype must inherit property "before" with the proper type (3)]
-    expected: FAIL
-
-  [DocumentType interface: calling before([object Object\],[object Object\]) on document.doctype with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [DocumentType interface: document.doctype must inherit property "after" with the proper type (4)]
-    expected: FAIL
-
-  [DocumentType interface: calling after([object Object\],[object Object\]) on document.doctype with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [DocumentType interface: document.doctype must inherit property "replace" with the proper type (5)]
-    expected: FAIL
-
-  [DocumentType interface: calling replace([object Object\],[object Object\]) on document.doctype with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Element interface: attribute namespaceURI]
     expected: FAIL
 
@@ -123,37 +60,10 @@
   [Element interface: attribute localName]
     expected: FAIL
 
-  [Element interface: operation prepend([object Object\],[object Object\])]
-    expected: FAIL
-
-  [Element interface: operation append([object Object\],[object Object\])]
-    expected: FAIL
-
   [Element interface: operation query(DOMString)]
     expected: FAIL
 
   [Element interface: operation queryAll(DOMString)]
-    expected: FAIL
-
-  [Element interface: operation before([object Object\],[object Object\])]
-    expected: FAIL
-
-  [Element interface: operation after([object Object\],[object Object\])]
-    expected: FAIL
-
-  [Element interface: operation replace([object Object\],[object Object\])]
-    expected: FAIL
-
-  [Element interface: element must inherit property "prepend" with the proper type (25)]
-    expected: FAIL
-
-  [Element interface: calling prepend([object Object\],[object Object\]) on element with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Element interface: element must inherit property "append" with the proper type (26)]
-    expected: FAIL
-
-  [Element interface: calling append([object Object\],[object Object\]) on element with too few arguments must throw TypeError]
     expected: FAIL
 
   [Element interface: element must inherit property "query" with the proper type (27)]
@@ -168,91 +78,10 @@
   [Element interface: calling queryAll(DOMString) on element with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Element interface: element must inherit property "before" with the proper type (33)]
-    expected: FAIL
-
-  [Element interface: calling before([object Object\],[object Object\]) on element with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Element interface: element must inherit property "after" with the proper type (34)]
-    expected: FAIL
-
-  [Element interface: calling after([object Object\],[object Object\]) on element with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Element interface: element must inherit property "replace" with the proper type (35)]
-    expected: FAIL
-
-  [Element interface: calling replace([object Object\],[object Object\]) on element with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Attr interface: existence and properties of interface object]
     expected: FAIL
 
   [Attr interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [CharacterData interface: operation before([object Object\],[object Object\])]
-    expected: FAIL
-
-  [CharacterData interface: operation after([object Object\],[object Object\])]
-    expected: FAIL
-
-  [CharacterData interface: operation replace([object Object\],[object Object\])]
-    expected: FAIL
-
-  [CharacterData interface: document.createTextNode("abc") must inherit property "before" with the proper type (9)]
-    expected: FAIL
-
-  [CharacterData interface: calling before([object Object\],[object Object\]) on document.createTextNode("abc") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CharacterData interface: document.createTextNode("abc") must inherit property "after" with the proper type (10)]
-    expected: FAIL
-
-  [CharacterData interface: calling after([object Object\],[object Object\]) on document.createTextNode("abc") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CharacterData interface: document.createTextNode("abc") must inherit property "replace" with the proper type (11)]
-    expected: FAIL
-
-  [CharacterData interface: calling replace([object Object\],[object Object\]) on document.createTextNode("abc") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CharacterData interface: xmlDoc.createProcessingInstruction("abc", "def") must inherit property "before" with the proper type (9)]
-    expected: FAIL
-
-  [CharacterData interface: calling before([object Object\],[object Object\]) on xmlDoc.createProcessingInstruction("abc", "def") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CharacterData interface: xmlDoc.createProcessingInstruction("abc", "def") must inherit property "after" with the proper type (10)]
-    expected: FAIL
-
-  [CharacterData interface: calling after([object Object\],[object Object\]) on xmlDoc.createProcessingInstruction("abc", "def") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CharacterData interface: xmlDoc.createProcessingInstruction("abc", "def") must inherit property "replace" with the proper type (11)]
-    expected: FAIL
-
-  [CharacterData interface: calling replace([object Object\],[object Object\]) on xmlDoc.createProcessingInstruction("abc", "def") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CharacterData interface: document.createComment("abc") must inherit property "before" with the proper type (9)]
-    expected: FAIL
-
-  [CharacterData interface: calling before([object Object\],[object Object\]) on document.createComment("abc") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CharacterData interface: document.createComment("abc") must inherit property "after" with the proper type (10)]
-    expected: FAIL
-
-  [CharacterData interface: calling after([object Object\],[object Object\]) on document.createComment("abc") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CharacterData interface: document.createComment("abc") must inherit property "replace" with the proper type (11)]
-    expected: FAIL
-
-  [CharacterData interface: calling replace([object Object\],[object Object\]) on document.createComment("abc") with too few arguments must throw TypeError]
     expected: FAIL
 
   [DOMTokenList interface: operation add(DOMString)]
@@ -267,37 +96,16 @@
   [DOMTokenList interface: calling remove(DOMString) on document.body.classList with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Document interface: xmlDoc must inherit property "prepend" with the proper type (31)]
-    expected: FAIL
-
-  [Document interface: xmlDoc must inherit property "append" with the proper type (32)]
-    expected: FAIL
-
   [Document interface: xmlDoc must inherit property "query" with the proper type (33)]
     expected: FAIL
 
   [Document interface: xmlDoc must inherit property "queryAll" with the proper type (34)]
     expected: FAIL
 
-  [Element interface: element must inherit property "prepend" with the proper type (33)]
-    expected: FAIL
-
-  [Element interface: element must inherit property "append" with the proper type (34)]
-    expected: FAIL
-
   [Element interface: element must inherit property "query" with the proper type (35)]
     expected: FAIL
 
   [Element interface: element must inherit property "queryAll" with the proper type (36)]
-    expected: FAIL
-
-  [Element interface: element must inherit property "before" with the proper type (41)]
-    expected: FAIL
-
-  [Element interface: element must inherit property "after" with the proper type (42)]
-    expected: FAIL
-
-  [Element interface: element must inherit property "replace" with the proper type (43)]
     expected: FAIL
 
   [Attr interface: attribute textContent]
@@ -307,12 +115,6 @@
     expected: FAIL
 
   [Document interface: xmlDoc must inherit property "inputEncoding" with the proper type (6)]
-    expected: FAIL
-
-  [Document interface: xmlDoc must inherit property "prepend" with the proper type (32)]
-    expected: FAIL
-
-  [Document interface: xmlDoc must inherit property "append" with the proper type (33)]
     expected: FAIL
 
   [Document interface: xmlDoc must inherit property "query" with the proper type (34)]

--- a/testing/web-platform/meta/html/dom/interfaces.html.ini
+++ b/testing/web-platform/meta/html/dom/interfaces.html.ini
@@ -168,18 +168,6 @@
   [Document interface: iframe.contentDocument must inherit property "all" with the proper type (80)]
     expected: FAIL
 
-  [Document interface: iframe.contentDocument must inherit property "prepend" with the proper type (86)]
-    expected: FAIL
-
-  [Document interface: calling prepend([object Object\],[object Object\]) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Document interface: iframe.contentDocument must inherit property "append" with the proper type (87)]
-    expected: FAIL
-
-  [Document interface: calling append([object Object\],[object Object\]) on iframe.contentDocument with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "query" with the proper type (88)]
     expected: FAIL
 
@@ -370,18 +358,6 @@
     expected: FAIL
 
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "all" with the proper type (80)]
-    expected: FAIL
-
-  [Document interface: document.implementation.createDocument(null, "", null) must inherit property "prepend" with the proper type (86)]
-    expected: FAIL
-
-  [Document interface: calling prepend([object Object\],[object Object\]) on document.implementation.createDocument(null, "", null) with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Document interface: document.implementation.createDocument(null, "", null) must inherit property "append" with the proper type (87)]
-    expected: FAIL
-
-  [Document interface: calling append([object Object\],[object Object\]) on document.implementation.createDocument(null, "", null) with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "query" with the proper type (88)]
@@ -663,18 +639,6 @@
   [HTMLElement interface: document.createElement("noscript") must inherit property "ontoggle" with the proper type (92)]
     expected: FAIL
 
-  [Element interface: document.createElement("noscript") must inherit property "prepend" with the proper type (31)]
-    expected: FAIL
-
-  [Element interface: calling prepend([object Object\],[object Object\]) on document.createElement("noscript") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Element interface: document.createElement("noscript") must inherit property "append" with the proper type (32)]
-    expected: FAIL
-
-  [Element interface: calling append([object Object\],[object Object\]) on document.createElement("noscript") with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Element interface: document.createElement("noscript") must inherit property "query" with the proper type (33)]
     expected: FAIL
 
@@ -685,24 +649,6 @@
     expected: FAIL
 
   [Element interface: calling queryAll(DOMString) on document.createElement("noscript") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Element interface: document.createElement("noscript") must inherit property "before" with the proper type (39)]
-    expected: FAIL
-
-  [Element interface: calling before([object Object\],[object Object\]) on document.createElement("noscript") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Element interface: document.createElement("noscript") must inherit property "after" with the proper type (40)]
-    expected: FAIL
-
-  [Element interface: calling after([object Object\],[object Object\]) on document.createElement("noscript") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Element interface: document.createElement("noscript") must inherit property "replace" with the proper type (41)]
-    expected: FAIL
-
-  [Element interface: calling replace([object Object\],[object Object\]) on document.createElement("noscript") with too few arguments must throw TypeError]
     expected: FAIL
 
   [HTMLElement must be primary interface of document.createElement("bdi")]
@@ -3147,12 +3093,6 @@
   [Document interface: iframe.contentDocument must inherit property "all" with the proper type (81)]
     expected: FAIL
 
-  [Document interface: iframe.contentDocument must inherit property "prepend" with the proper type (87)]
-    expected: FAIL
-
-  [Document interface: iframe.contentDocument must inherit property "append" with the proper type (88)]
-    expected: FAIL
-
   [Document interface: iframe.contentDocument must inherit property "query" with the proper type (89)]
     expected: FAIL
 
@@ -3298,12 +3238,6 @@
     expected: FAIL
 
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "all" with the proper type (81)]
-    expected: FAIL
-
-  [Document interface: document.implementation.createDocument(null, "", null) must inherit property "prepend" with the proper type (87)]
-    expected: FAIL
-
-  [Document interface: document.implementation.createDocument(null, "", null) must inherit property "append" with the proper type (88)]
     expected: FAIL
 
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "query" with the proper type (89)]


### PR DESCRIPTION
Ad #1410 (#1409)


See:

https://bugzilla.mozilla.org/show_bug.cgi?id=911477
https://bugzilla.mozilla.org/show_bug.cgi?id=1301777

https://bugzilla.mozilla.org/show_bug.cgi?id=1308922 (partially - follow up (?)):

__Are these changes correct?__
https://github.com/MoonchildProductions/Pale-Moon/commit/afaa122df5a839ccf1e5c6cd8f6ce548c35fc741#diff-9dc8f8c6d5d189b71696d2f9a06188d4L3365
https://github.com/MoonchildProductions/Pale-Moon/commit/afaa122df5a839ccf1e5c6cd8f6ce548c35fc741#diff-9dc8f8c6d5d189b71696d2f9a06188d4L3372

https://bugzilla.mozilla.org/show_bug.cgi?id=1104955 (partially - without `Symbol.unscopables`)

\+`RefPtr` => `nsRefPtr`

---

I've created the new build (x32, Windows) and tested:

https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/prepend#Examples
https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append#Examples
https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/before#Examples
https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/after#Examples
https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/replaceWith#Examples
