### PR TITLE
Explicitly typecast GetAsNode() in nsINode.cpp

### DIFF
--- a/dom/base/nsINode.cpp
+++ b/dom/base/nsINode.cpp
@@ -1596,7 +1596,7 @@ GetNodeFromNodeOrString(const OwningNodeOrString& aNode,
                         nsIDocument* aDocument)
 {
   if (aNode.IsNode()) {
-    nsCOMPtr<nsINode> node = aNode.GetAsNode();
+    nsCOMPtr<nsINode> node = static_cast<nsCOMPtr<nsINode>>(aNode.GetAsNode());
     return node.forget();
   }
 


### PR DESCRIPTION
Resolves #1410.


Fixes GCC build bustage introduced in #1411. Verified local build compiles successfully and lightly tested functionality.