### PR TITLE
Improve button stylings on Windows (+small cleanup)

### DIFF
--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -3469,7 +3469,7 @@ toolbar[brighttext] #addonbar-closebutton {
          (-moz-os-version: windows-win10) {
     /* Fade text stylings on window inactivity */
     :root:not(:-moz-lwtheme):-moz-window-inactive {
-      --window-text-color: ThreeDShadow;
+      --window-text-color: rgba(0, 0, 0, 0.5);
     }
   }
   

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -34,17 +34,21 @@
   --toolbar-custom-color: hsl(210,75%,92%);
   --toolbar-highlight-top: rgba(255,255,255,.5);
   --toolbar-highlight-bottom: transparent;
-  
+
   --toolbarbutton-background-color: hsla(210,32%,93%,.3);
   --toolbarbutton-border-radius: 2.5px;
   --toolbarbutton-border-color: hsla(210,54%,20%,.2);
-  
+
+  --toolbarbutton-image: url("chrome://browser/skin/Toolbar.png");
+  --toolbarbutton-glass-image: url("chrome://browser/skin/Toolbar-glass.png");
+  --toolbarbutton-inverted-image: url("chrome://browser/skin/Toolbar-inverted.png");
+
   --tab-background: linear-gradient(transparent, hsla(0,0%,45%,.1) 1px, hsla(0,0%,32%,.2) 80%, hsla(0,0%,0%,.2));
   --tab-background-hover: linear-gradient(hsla(0,0%,100%,.3) 1px, hsla(0,0%,75%,.2) 80%, hsla(0,0%,60%,.2));
   --tab-border-radius: 6px;
   --tab-box-shadow: inset 0.5px 1px 1px var(--tab-selected-highlight);
   --tab-selected-highlight: rgba(255,255,255,.7);
-  
+
   --window-text-color: currentColor;
 }
 
@@ -739,15 +743,15 @@ menuitem.bookmark-item {
 /* ::::: primary toolbar buttons ::::: */
 
 .toolbarbutton-1 {
-  list-style-image: url("chrome://browser/skin/Toolbar.png");
+  list-style-image: var(--toolbarbutton-image);
 }
 
 toolbar[brighttext] .toolbarbutton-1 {
-  list-style-image: url("chrome://browser/skin/Toolbar-inverted.png");
+  list-style-image: var(--toolbarbutton-inverted-image);
 }
 
 .toolbarbutton-1:not(:-moz-lwtheme) {
-  list-style-image: url("chrome://browser/skin/Toolbar-glass.png");
+  list-style-image: var(--toolbarbutton-glass-image);
 }
 
 .toolbarbutton-1[disabled=true] > .toolbarbutton-icon,
@@ -1100,14 +1104,14 @@ toolbar[mode=full] .toolbarbutton-1 > .toolbarbutton-menubutton-button {
 }
 
 #home-button.bookmark-item {
-  list-style-image: url("chrome://browser/skin/Toolbar.png");
+  list-style-image: var(--toolbarbutton-image);
 }
 toolbar[brighttext] #home-button.bookmark-item {
-  list-style-image: url("chrome://browser/skin/Toolbar-inverted.png");
+  list-style-image: var(--toolbarbutton-inverted-image);
 }
 
 #home-button.bookmark-item:not(:-moz-lwtheme) {
-  list-style-image: url("chrome://browser/skin/Toolbar-glass.png");
+  list-style-image: var(--toolbarbutton-glass-image);
 }
 
 #home-button {
@@ -1129,15 +1133,15 @@ toolbar[brighttext] #home-button.bookmark-item {
 }
 
 #bookmarks-menu-button.bookmark-item {
-  list-style-image: url("chrome://browser/skin/Toolbar.png");
+  list-style-image: var(--toolbarbutton-image);
 }
 
 toolbar[brighttext] #bookmarks-menu-button.bookmark-item {
-  list-style-image: url("chrome://browser/skin/Toolbar-inverted.png");
+  list-style-image: var(--toolbarbutton-inverted-image);
 }
 
 #bookmarks-menu-button.bookmark-item:not(:-moz-lwtheme) {
-  list-style-image: url("chrome://browser/skin/Toolbar-glass.png");
+  list-style-image: var(--toolbarbutton-glass-image);
 }
 
 #print-button {
@@ -3493,7 +3497,7 @@ toolbar[brighttext] #addonbar-closebutton {
   #TabsToolbar[tabsontop=true] :-moz-any(@primaryToolbarButtons@) > toolbarbutton > .toolbarbutton-icon:not(:-moz-lwtheme),
   #nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child :-moz-any(@primaryToolbarButtons@):not(:-moz-any(#alltabs-button,#new-tab-button,#sync-button[status])) > .toolbarbutton-icon:not(:-moz-lwtheme),
   #nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child :-moz-any(@primaryToolbarButtons@) > toolbarbutton > .toolbarbutton-icon:not(:-moz-lwtheme) {
-    list-style-image: url("chrome://browser/skin/Toolbar-glass.png");
+    list-style-image: var(--toolbarbutton-glass-image);
   }
 
   :-moz-any(#toolbar-menubar, #TabsToolbar[tabsontop=true], #nav-bar[tabsontop=false]) .toolbarbutton-1 > .toolbarbutton-menu-dropmarker:not(:-moz-lwtheme),

--- a/browser/themes/windows/downloads/downloads.css
+++ b/browser/themes/windows/downloads/downloads.css
@@ -302,7 +302,7 @@ richlistitem[type="download"]:hover > stack > .downloadButton.downloadRetry:acti
   position: relative;
 }
 
-#navigator-toolbox[iconsize=large][mode=icons] > #nav-bar[brighttext] #downloads-indicator-anchor {
+#navigator-toolbox[iconsize=large][mode=icons] > #nav-bar[brighttext] #downloads-indicator[counter] > #downloads-indicator-anchor {
   /* Use a dark download button when appropriate to improve text legibility */
   background: hsla(94,56%,18%,.3) padding-box;
   background-image: linear-gradient(hsla(0,0%,0%,.1), hsla(0,0%,0%,.4));
@@ -326,6 +326,13 @@ toolbar[brighttext] #downloads-indicator-icon {
                               0, 108, 18, 90) center no-repeat;
 }
 
+:-moz-any(#toolbar-menubar, #nav-bar[tabsontop=false]) #downloads-indicator-icon:not(:-moz-lwtheme),
+#TabsToolbar[tabsontop=true] #downloads-indicator-icon:not(:-moz-lwtheme),
+#nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child #downloads-indicator-icon:not(:-moz-lwtheme) {
+  background: -moz-image-rect(var(--toolbarbutton-glass-image),
+                              0, 108, 18, 90) center no-repeat;
+}
+
 #downloads-indicator[attention] > #downloads-indicator-anchor > #downloads-indicator-icon {
   background-image: url("chrome://browser/skin/downloads/download-glow.png");
 }
@@ -341,6 +348,13 @@ toolbar[brighttext] #downloads-indicator-icon {
 
 toolbar[brighttext] #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter {
   background: -moz-image-rect(var(--toolbarbutton-inverted-image),
+                              0, 108, 18, 90) center no-repeat;
+}
+
+:-moz-any(#toolbar-menubar, #nav-bar[tabsontop=false]) #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter:not(:-moz-lwtheme),
+#TabsToolbar[tabsontop=true] #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter:not(:-moz-lwtheme),
+#nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter:not(:-moz-lwtheme) {
+  background: -moz-image-rect(var(--toolbarbutton-glass-image),
                               0, 108, 18, 90) center no-repeat;
 }
 

--- a/browser/themes/windows/downloads/downloads.css
+++ b/browser/themes/windows/downloads/downloads.css
@@ -315,14 +315,14 @@ richlistitem[type="download"]:hover > stack > .downloadButton.downloadRetry:acti
 /*** Main indicator icon ***/
 
 #downloads-indicator-icon {
-  background: -moz-image-rect(url("chrome://browser/skin/Toolbar.png"),
+  background: -moz-image-rect(var(--toolbarbutton-image),
                               0, 108, 18, 90) center no-repeat;
   min-width: 18px;
   min-height: 18px;
 }
 
 toolbar[brighttext] #downloads-indicator-icon {
-  background: -moz-image-rect(url("chrome://browser/skin/Toolbar-inverted.png"),
+  background: -moz-image-rect(var(--toolbarbutton-inverted-image),
                               0, 108, 18, 90) center no-repeat;
 }
 
@@ -334,13 +334,13 @@ toolbar[brighttext] #downloads-indicator-icon {
    equivalent to -moz-any([progress], [paused]). */
 
 #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter {
-  background: -moz-image-rect(url("chrome://browser/skin/Toolbar.png"),
+  background: -moz-image-rect(var(--toolbarbutton-image),
                               0, 108, 18, 90) center no-repeat;
   background-size: 12px;
 }
 
 toolbar[brighttext] #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter {
-  background: -moz-image-rect(url("chrome://browser/skin/Toolbar-inverted.png"),
+  background: -moz-image-rect(var(--toolbarbutton-inverted-image),
                               0, 108, 18, 90) center no-repeat;
 }
 

--- a/browser/themes/windows/jar.mn
+++ b/browser/themes/windows/jar.mn
@@ -98,7 +98,7 @@ browser.jar:
         skin/classic/browser/newtab/controls.png                     (newtab/controls.png)
         skin/classic/browser/newtab/noise.png                        (newtab/noise.png)
         skin/classic/browser/places/places.css                       (places/places.css)
-*       skin/classic/browser/places/organizer.css                    (places/organizer.css)
+        skin/classic/browser/places/organizer.css                    (places/organizer.css)
         skin/classic/browser/places/editBookmark.png                 (places/editBookmark.png)
         skin/classic/browser/places/bookmark.png                     (places/bookmark.png)
         skin/classic/browser/places/query.png                        (places/query.png)

--- a/browser/themes/windows/places/organizer.css
+++ b/browser/themes/windows/places/organizer.css
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-%filter substitution
-%define toolbarHighlight rgba(255,255,255,.5)
-%define customToolbarColor hsl(210,75%,92%)
- 
+:root {
+  --toolbar-custom-color: hsl(210,75%,92%);
+  --toolbar-highlight-top: rgba(255,255,255,.5);
+  --toolbarbutton-image: url("chrome://browser/skin/Toolbar.png");
+}
+
 /* Toolbar */
 #placesToolbar {
   padding: 3px;
@@ -18,7 +20,7 @@
 
 #back-button,
 #forward-button {
-  list-style-image: url("chrome://browser/skin/Toolbar.png");
+  list-style-image: var(--toolbarbutton-image);
 }
 
 #back-button {
@@ -211,7 +213,7 @@
   }
 
   #placesToolbar {
-    background-image: linear-gradient(@toolbarHighlight@, transparent);
+    background-image: linear-gradient(var(--toolbar-highlight-top), transparent);
   }
 }
 
@@ -225,7 +227,7 @@
   }
 
   #placesToolbar {
-    background-color: @customToolbarColor@;
+    background-color: var(--toolbar-custom-color);
     color: black;
   }
 

--- a/browser/themes/windows/statusbar/overlay.css
+++ b/browser/themes/windows/statusbar/overlay.css
@@ -36,7 +36,7 @@
 	background: -moz-image-rect(var(--toolbarbutton-image), 0, 108, 18, 90) center no-repeat;
 }
 
-#status4evar-download-button:-moz-lwtheme-brighttext #status4evar-download-icon
+toolbar[brighttext] #status4evar-download-button #status4evar-download-icon
 {
 	background: -moz-image-rect(var(--toolbarbutton-inverted-image), 0, 108, 18, 90) center no-repeat;
 }

--- a/browser/themes/windows/statusbar/overlay.css
+++ b/browser/themes/windows/statusbar/overlay.css
@@ -33,12 +33,12 @@
 
 #status4evar-download-button #status4evar-download-icon
 {
-	background: -moz-image-rect(url("chrome://browser/skin/Toolbar.png"), 0, 108, 18, 90) center no-repeat;
+	background: -moz-image-rect(var(--toolbarbutton-image), 0, 108, 18, 90) center no-repeat;
 }
 
 #status4evar-download-button:-moz-lwtheme-brighttext #status4evar-download-icon
 {
-	background: -moz-image-rect(url("chrome://browser/skin/Toolbar-inverted.png"), 0, 108, 18, 90) center no-repeat;
+	background: -moz-image-rect(var(--toolbarbutton-inverted-image), 0, 108, 18, 90) center no-repeat;
 }
 
 #status4evar-download-button[attention] #status4evar-download-icon

--- a/browser/themes/windows/statusbar/overlay.css
+++ b/browser/themes/windows/statusbar/overlay.css
@@ -41,6 +41,13 @@
 	background: -moz-image-rect(var(--toolbarbutton-inverted-image), 0, 108, 18, 90) center no-repeat;
 }
 
+:-moz-any(#toolbar-menubar, #nav-bar[tabsontop=false]) #status4evar-download-button #status4evar-download-icon:not(:-moz-lwtheme),
+#TabsToolbar[tabsontop=true] #status4evar-download-button #status4evar-download-icon:not(:-moz-lwtheme),
+#nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child #status4evar-download-button #status4evar-download-icon:not(:-moz-lwtheme)
+{
+	background: -moz-image-rect(var(--toolbarbutton-glass-image), 0, 108, 18, 90) center no-repeat;
+}
+
 #status4evar-download-button[attention] #status4evar-download-icon
 {
 	background-image: url("chrome://browser/skin/downloads/download-glow.png");


### PR DESCRIPTION
This is (at least partially) ref #1405.

The `#downloads-indicator` has been tweaked such that the dark-background styling it previously would use in any `brighttext` situation, is only now shown when `counter` is `true` (as in, when there is a download time shown on the indicator). When a download has finished, the indicator returns to the previous style.

I have also improved consistency with these buttons and the rest of the toolbar - namely, the `#download-indicator` and `#status4evar-download-button` now both correctly adopt the glass icon styling when appropriate (and as an added bonus, the `#status4evar-download-button` now correctly changes on `brighttext`, rather than just `-moz-lwtheme-brighttext`).

![Glass download indicators](https://i.imgur.com/VBc5PGV.png)

To help with the `brighttext` issue on Windows 10 (and Windows 8), I have also changed the inactive text colour from `ThreeDShadow` to `rgba(0, 0, 0, 0.5)`.

![Inactive text](https://i.imgur.com/AJpDJvW.png)

While I was making these changes, I also did a bit of cleanup: to save listing the full URL of our toolbar images each time (as well as make it easier for anyone to swap them out), I have abstracted the toolbar images into variables. To do this in `organizer.css` though (where the toolbar images are also used), I had to define the other variables in there anyway, since they can't read from the variables in `browser.css`. This removes its dependency on the pre-processor too, which has been edited accordingly.