### PR TITLE
Confine Glass download icons to Windows Compositor mode

### DIFF
--- a/browser/themes/windows/downloads/downloads.css
+++ b/browser/themes/windows/downloads/downloads.css
@@ -326,11 +326,13 @@ toolbar[brighttext] #downloads-indicator-icon {
                               0, 108, 18, 90) center no-repeat;
 }
 
-:-moz-any(#toolbar-menubar, #nav-bar[tabsontop=false]) #downloads-indicator-icon:not(:-moz-lwtheme),
-#TabsToolbar[tabsontop=true] #downloads-indicator-icon:not(:-moz-lwtheme),
-#nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child #downloads-indicator-icon:not(:-moz-lwtheme) {
-  background: -moz-image-rect(var(--toolbarbutton-glass-image),
-                              0, 108, 18, 90) center no-repeat;
+@media (-moz-windows-compositor) {
+  :-moz-any(#toolbar-menubar, #nav-bar[tabsontop=false]) #downloads-indicator-icon:not(:-moz-lwtheme),
+  #TabsToolbar[tabsontop=true] #downloads-indicator-icon:not(:-moz-lwtheme),
+  #nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child #downloads-indicator-icon:not(:-moz-lwtheme) {
+    background: -moz-image-rect(var(--toolbarbutton-glass-image),
+                                0, 108, 18, 90) center no-repeat;
+  }
 }
 
 #downloads-indicator[attention] > #downloads-indicator-anchor > #downloads-indicator-icon {
@@ -351,11 +353,13 @@ toolbar[brighttext] #downloads-indicator:not([counter]) > #downloads-indicator-a
                               0, 108, 18, 90) center no-repeat;
 }
 
-:-moz-any(#toolbar-menubar, #nav-bar[tabsontop=false]) #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter:not(:-moz-lwtheme),
-#TabsToolbar[tabsontop=true] #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter:not(:-moz-lwtheme),
-#nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter:not(:-moz-lwtheme) {
-  background: -moz-image-rect(var(--toolbarbutton-glass-image),
-                              0, 108, 18, 90) center no-repeat;
+@media (-moz-windows-compositor) {
+  :-moz-any(#toolbar-menubar, #nav-bar[tabsontop=false]) #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter:not(:-moz-lwtheme),
+  #TabsToolbar[tabsontop=true] #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter:not(:-moz-lwtheme),
+  #nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child #downloads-indicator:not([counter]) > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter:not(:-moz-lwtheme) {
+    background: -moz-image-rect(var(--toolbarbutton-glass-image),
+                                0, 108, 18, 90) center no-repeat;
+  }
 }
 
 #downloads-indicator:not([counter])[attention] > #downloads-indicator-anchor > #downloads-indicator-progress-area > #downloads-indicator-counter {

--- a/browser/themes/windows/statusbar/overlay.css
+++ b/browser/themes/windows/statusbar/overlay.css
@@ -41,11 +41,14 @@ toolbar[brighttext] #status4evar-download-button #status4evar-download-icon
 	background: -moz-image-rect(var(--toolbarbutton-inverted-image), 0, 108, 18, 90) center no-repeat;
 }
 
-:-moz-any(#toolbar-menubar, #nav-bar[tabsontop=false]) #status4evar-download-button #status4evar-download-icon:not(:-moz-lwtheme),
-#TabsToolbar[tabsontop=true] #status4evar-download-button #status4evar-download-icon:not(:-moz-lwtheme),
-#nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child #status4evar-download-button #status4evar-download-icon:not(:-moz-lwtheme)
+@media (-moz-windows-compositor)
 {
-	background: -moz-image-rect(var(--toolbarbutton-glass-image), 0, 108, 18, 90) center no-repeat;
+  :-moz-any(#toolbar-menubar, #nav-bar[tabsontop=false]) #status4evar-download-button #status4evar-download-icon:not(:-moz-lwtheme),
+  #TabsToolbar[tabsontop=true] #status4evar-download-button #status4evar-download-icon:not(:-moz-lwtheme),
+  #nav-bar + #customToolbars + #PersonalToolbar[collapsed=true] + #TabsToolbar[tabsontop=false]:last-child #status4evar-download-button #status4evar-download-icon:not(:-moz-lwtheme)
+  {
+    background: -moz-image-rect(var(--toolbarbutton-glass-image), 0, 108, 18, 90) center no-repeat;
+  }
 }
 
 #status4evar-download-button[attention] #status4evar-download-icon


### PR DESCRIPTION
Ref #1405 

I forgot about non-compositor modes, so this just makes sure that `Toolbar-glass.png` icons aren't used in non-compositor mode.