### PR TITLE
Guard against early states in UpdateNextFrameStatus

### DIFF
--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -3229,7 +3229,10 @@ void MediaDecoderStateMachine::UpdateNextFrameStatus()
 
   MediaDecoderOwner::NextFrameStatus status;
   const char* statusString;
-  if (IsBuffering()) {
+  if (mState <= DECODER_STATE_DECODING_FIRSTFRAME) {
+    status = MediaDecoderOwner::NEXT_FRAME_UNAVAILABLE;
+    statusString = "NEXT_FRAME_UNAVAILABLE";
+  } else if (IsBuffering()) {
     status = MediaDecoderOwner::NEXT_FRAME_UNAVAILABLE_BUFFERING;
     statusString = "NEXT_FRAME_UNAVAILABLE_BUFFERING";
   } else if (IsSeeking()) {


### PR DESCRIPTION
This patch prevents mNextFrameStatus from potentially advancing too early in some situations, which can cause undesirable behavior.

Tested and appears to work as intended on Linux.