### PR TITLE
Migrate more code from MediaDecoder to DecodedStream

### DIFF
--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -158,11 +158,6 @@ private:
   nsRefPtr<MediaStream> mStream;
 };
 
-OutputStreamData::OutputStreamData()
-{
-  //
-}
-
 OutputStreamData::~OutputStreamData()
 {
   mListener->Forget();

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -194,6 +194,33 @@ DecodedStream::DestroyData()
 {
 	MOZ_ASSERT(NS_IsMainThread());
   GetReentrantMonitor().AssertCurrentThreadIn();
+
+	// Avoid the redundant blocking to output stream.
+  if (!mData) {
+    return;
+  }
+
+  // All streams are having their SourceMediaStream disconnected, so they
+  // need to be explicitly blocked again.
+  auto& outputStreams = OutputStreams();
+  for (int32_t i = outputStreams.Length() - 1; i >= 0; --i) {
+    OutputStreamData& os = outputStreams[i];
+    // Explicitly remove all existing ports.
+    // This is not strictly necessary but it's good form.
+    MOZ_ASSERT(os.mPort, "Double-delete of the ports!");
+    os.mPort->Destroy();
+    os.mPort = nullptr;
+    // During cycle collection, nsDOMMediaStream can be destroyed and send
+    // its Destroy message before this decoder is destroyed. So we have to
+    // be careful not to send any messages after the Destroy().
+    if (os.mStream->IsDestroyed()) {
+      // Probably the DOM MediaStream was GCed. Clean up.
+      outputStreams.RemoveElementAt(i);
+    } else {
+      os.mStream->ChangeExplicitBlockerCount(1);
+    }
+  }
+
   mData = nullptr;
 }
 
@@ -222,6 +249,8 @@ DecodedStream::GetReentrantMonitor()
 void
 DecodedStream::Connect(OutputStreamData* aStream)
 {
+	MOZ_ASSERT(NS_IsMainThread());
+  GetReentrantMonitor().AssertCurrentThreadIn();
   NS_ASSERTION(!aStream->mPort, "Already connected?");
 
   // The output stream must stay in sync with the decoded stream, so if

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -219,4 +219,18 @@ DecodedStream::GetReentrantMonitor()
   return mMonitor;
 }
 
+void
+DecodedStream::Connect(OutputStreamData* aStream)
+{
+  NS_ASSERTION(!aStream->mPort, "Already connected?");
+
+  // The output stream must stay in sync with the decoded stream, so if
+  // either stream is blocked, we block the other.
+  aStream->mPort = aStream->mStream->AllocateInputPort(mData->mStream,
+      MediaInputPort::FLAG_BLOCK_INPUT | MediaInputPort::FLAG_BLOCK_OUTPUT);
+  // Unblock the output stream now. While it's connected to DecodedStream,
+  // DecodedStream is responsible for controlling blocking.
+  aStream->mStream->ChangeExplicitBlockerCount(-1);
+}
+
 } // namespace mozilla

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -273,4 +273,19 @@ DecodedStream::Connect(OutputStreamData* aStream)
   aStream->mStream->ChangeExplicitBlockerCount(-1);
 }
 
+void
+DecodedStream::Connect(ProcessedMediaStream* aStream, bool aFinishWhenEnded)
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  GetReentrantMonitor().AssertCurrentThreadIn();
+
+  OutputStreamData* os = OutputStreams().AppendElement();
+  os->Init(this, aStream);
+  Connect(os);
+  if (aFinishWhenEnded) {
+    // Ensure that aStream finishes the moment mDecodedStream does.
+    aStream->SetAutofinish(true);
+  }
+}
+
 } // namespace mozilla

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -203,4 +203,10 @@ DecodedStream::RecreateData(MediaDecoder* aDecoder, int64_t aInitialTime,
   mData.reset(new DecodedStreamData(aDecoder, aInitialTime, aStream));
 }
 
+nsTArray<OutputStreamData>&
+DecodedStream::OutputStreams()
+{
+  return mOutputStreams;
+}
+
 } // namespace mozilla

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -230,7 +230,18 @@ DecodedStream::RecreateData(int64_t aInitialTime, SourceMediaStream* aStream)
 	MOZ_ASSERT(NS_IsMainThread());
   GetReentrantMonitor().AssertCurrentThreadIn();
   MOZ_ASSERT(!mData);
+
   mData.reset(new DecodedStreamData(aInitialTime, aStream));
+
+	// Note that the delay between removing ports in DestroyDecodedStream
+  // and adding new ones won't cause a glitch since all graph operations
+  // between main-thread stable states take effect atomically.
+  auto& outputStreams = OutputStreams();
+  for (int32_t i = outputStreams.Length() - 1; i >= 0; --i) {
+    OutputStreamData& os = outputStreams[i];
+    MOZ_ASSERT(!os.mStream->IsDestroyed(), "Should've been removed in DestroyData()");
+    Connect(&os);
+  }
 }
 
 nsTArray<OutputStreamData>&

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -6,16 +6,15 @@
 
 #include "DecodedStream.h"
 #include "MediaStreamGraph.h"
-#include "MediaDecoder.h"
+#include "mozilla/ReentrantMonitor.h"
 
 namespace mozilla {
 
 class DecodedStreamGraphListener : public MediaStreamListener {
   typedef MediaStreamListener::MediaStreamGraphEvent MediaStreamGraphEvent;
 public:
-  DecodedStreamGraphListener(MediaStream* aStream, DecodedStreamData* aData)
-    : mData(aData)
-    , mMutex("DecodedStreamGraphListener::mMutex")
+  explicit DecodedStreamGraphListener(MediaStream* aStream)
+    : mMutex("DecodedStreamGraphListener::mMutex")
     , mStream(aStream)
     , mLastOutputTime(aStream->StreamTimeToMicroseconds(aStream->GetCurrentTime()))
     , mStreamFinishedOnMainThread(false) {}
@@ -52,7 +51,6 @@ public:
   void Forget()
   {
     MOZ_ASSERT(NS_IsMainThread());
-    mData = nullptr;
     MutexAutoLock lock(mMutex);
     mStream = nullptr;
   }
@@ -64,9 +62,6 @@ public:
   }
 
 private:
-  // Main thread only
-  DecodedStreamData* mData;
-
   Mutex mMutex;
   // Members below are protected by mMutex.
   nsRefPtr<MediaStream> mStream;
@@ -74,14 +69,12 @@ private:
   bool mStreamFinishedOnMainThread;
 };
 
-DecodedStreamData::DecodedStreamData(MediaDecoder* aDecoder,
-                                     int64_t aInitialTime,
+DecodedStreamData::DecodedStreamData(int64_t aInitialTime,
                                      SourceMediaStream* aStream)
   : mAudioFramesWritten(0)
   , mInitialTime(aInitialTime)
   , mNextVideoTime(-1)
   , mNextAudioTime(-1)
-  , mDecoder(aDecoder)
   , mStreamInitialized(false)
   , mHaveSentFinish(false)
   , mHaveSentFinishAudio(false)
@@ -90,7 +83,7 @@ DecodedStreamData::DecodedStreamData(MediaDecoder* aDecoder,
   , mHaveBlockedForPlayState(false)
   , mHaveBlockedForStateMachineNotPlaying(false)
 {
-  mListener = new DecodedStreamGraphListener(mStream, this);
+  mListener = new DecodedStreamGraphListener(mStream);
   mStream->AddListener(mListener);
 }
 
@@ -115,8 +108,8 @@ DecodedStreamData::GetClock() const
 class OutputStreamListener : public MediaStreamListener {
   typedef MediaStreamListener::MediaStreamGraphEvent MediaStreamGraphEvent;
 public:
-  OutputStreamListener(MediaDecoder* aDecoder, MediaStream* aStream)
-    : mDecoder(aDecoder), mStream(aStream) {}
+  OutputStreamListener(DecodedStream* aDecodedStream, MediaStream* aStream)
+    : mDecodedStream(aDecodedStream), mStream(aStream) {}
 
   void NotifyEvent(MediaStreamGraph* aGraph, MediaStreamGraphEvent event) override
   {
@@ -130,22 +123,22 @@ public:
   void Forget()
   {
     MOZ_ASSERT(NS_IsMainThread());
-    mDecoder = nullptr;
+    mDecodedStream = nullptr;
   }
 
 private:
   void DoNotifyFinished()
   {
     MOZ_ASSERT(NS_IsMainThread());
-    if (!mDecoder) {
+    if (!mDecodedStream) {
       return;
     }
 
     // Remove the finished stream so it won't block the decoded stream.
-    ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
-    auto& streams = mDecoder->OutputStreams();
-    // Don't read |mDecoder| in the loop since removing the element will lead
-    // to ~OutputStreamData() which will call Forget() to reset |mDecoder|.
+    ReentrantMonitorAutoEnter mon(mDecodedStream->GetReentrantMonitor());
+    auto& streams = mDecodedStream->OutputStreams();
+    // Don't read |mDecodedStream| in the loop since removing the element will lead
+    // to ~OutputStreamData() which will call Forget() to reset |mDecodedStream|.
     for (int32_t i = streams.Length() - 1; i >= 0; --i) {
       auto& os = streams[i];
       MediaStream* p = os.mStream.get();
@@ -161,7 +154,7 @@ private:
   }
 
   // Main thread only
-  MediaDecoder* mDecoder;
+  DecodedStream* mDecodedStream;
   nsRefPtr<MediaStream> mStream;
 };
 
@@ -176,37 +169,54 @@ OutputStreamData::~OutputStreamData()
 }
 
 void
-OutputStreamData::Init(MediaDecoder* aDecoder, ProcessedMediaStream* aStream)
+OutputStreamData::Init(DecodedStream* aDecodedStream, ProcessedMediaStream* aStream)
 {
   mStream = aStream;
-  mListener = new OutputStreamListener(aDecoder, aStream);
+  mListener = new OutputStreamListener(aDecodedStream, aStream);
   aStream->AddListener(mListener);
+}
+
+DecodedStream::DecodedStream(ReentrantMonitor& aMonitor)
+  : mMonitor(aMonitor)
+{
+  //
 }
 
 DecodedStreamData*
 DecodedStream::GetData()
 {
+	GetReentrantMonitor().AssertCurrentThreadIn();
   return mData.get();
 }
 
 void
 DecodedStream::DestroyData()
 {
+	MOZ_ASSERT(NS_IsMainThread());
+  GetReentrantMonitor().AssertCurrentThreadIn();
   mData = nullptr;
 }
 
 void
-DecodedStream::RecreateData(MediaDecoder* aDecoder, int64_t aInitialTime,
-                            SourceMediaStream* aStream)
+DecodedStream::RecreateData(int64_t aInitialTime, SourceMediaStream* aStream)
 {
+	MOZ_ASSERT(NS_IsMainThread());
+  GetReentrantMonitor().AssertCurrentThreadIn();
   MOZ_ASSERT(!mData);
-  mData.reset(new DecodedStreamData(aDecoder, aInitialTime, aStream));
+  mData.reset(new DecodedStreamData(aInitialTime, aStream));
 }
 
 nsTArray<OutputStreamData>&
 DecodedStream::OutputStreams()
 {
+	GetReentrantMonitor().AssertCurrentThreadIn();
   return mOutputStreams;
+}
+
+ReentrantMonitor&
+DecodedStream::GetReentrantMonitor()
+{
+  return mMonitor;
 }
 
 } // namespace mozilla

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -183,4 +183,24 @@ OutputStreamData::Init(MediaDecoder* aDecoder, ProcessedMediaStream* aStream)
   aStream->AddListener(mListener);
 }
 
+DecodedStreamData*
+DecodedStream::GetData()
+{
+  return mData.get();
+}
+
+void
+DecodedStream::DestroyData()
+{
+  mData = nullptr;
+}
+
+void
+DecodedStream::RecreateData(MediaDecoder* aDecoder, int64_t aInitialTime,
+                            SourceMediaStream* aStream)
+{
+  MOZ_ASSERT(!mData);
+  mData.reset(new DecodedStreamData(aDecoder, aInitialTime, aStream));
+}
+
 } // namespace mozilla

--- a/dom/media/DecodedStream.h
+++ b/dom/media/DecodedStream.h
@@ -8,6 +8,7 @@
 #define DecodedStream_h_
 
 #include "nsRefPtr.h"
+#include "mozilla/UniquePtr.h"
 #include "mozilla/gfx/Point.h"
 
 namespace mozilla {
@@ -89,6 +90,17 @@ public:
   // mPort connects DecodedStreamData::mStream to our mStream.
   nsRefPtr<MediaInputPort> mPort;
   nsRefPtr<OutputStreamListener> mListener;
+};
+
+class DecodedStream {
+public:
+  DecodedStreamData* GetData();
+  void DestroyData();
+  void RecreateData(MediaDecoder* aDecoder, int64_t aInitialTime,
+                    SourceMediaStream* aStream);
+
+private:
+  UniquePtr<DecodedStreamData> mData;
 };
 
 } // namespace mozilla

--- a/dom/media/DecodedStream.h
+++ b/dom/media/DecodedStream.h
@@ -100,9 +100,10 @@ public:
   void RecreateData(int64_t aInitialTime, SourceMediaStream* aStream);
   nsTArray<OutputStreamData>& OutputStreams();
   ReentrantMonitor& GetReentrantMonitor();
-  void Connect(OutputStreamData* aStream);
+  void Connect(ProcessedMediaStream* aStream, bool aFinishWhenEnded);
 
 private:
+  void Connect(OutputStreamData* aStream);
   UniquePtr<DecodedStreamData> mData;
   // Data about MediaStreams that are being fed by the decoder.
   nsTArray<OutputStreamData> mOutputStreams;

--- a/dom/media/DecodedStream.h
+++ b/dom/media/DecodedStream.h
@@ -100,6 +100,7 @@ public:
   void RecreateData(int64_t aInitialTime, SourceMediaStream* aStream);
   nsTArray<OutputStreamData>& OutputStreams();
   ReentrantMonitor& GetReentrantMonitor();
+  void Connect(OutputStreamData* aStream);
 
 private:
   UniquePtr<DecodedStreamData> mData;

--- a/dom/media/DecodedStream.h
+++ b/dom/media/DecodedStream.h
@@ -19,7 +19,6 @@ class SourceMediaStream;
 class ProcessedMediaStream;
 class DecodedStream;
 class DecodedStreamGraphListener;
-class OutputStreamData;
 class OutputStreamListener;
 class ReentrantMonitor;
 
@@ -79,11 +78,6 @@ public:
 
 class OutputStreamData {
 public:
-  // Compiler-generated default constructor needs the complete definition
-  // of OutputStreamListener when constructing OutputStreamData. Provide our
-  // own default constructor for forward declaration of OutputStreamListener
-  // to work.
-  OutputStreamData();
   ~OutputStreamData();
   void Init(DecodedStream* aDecodedStream, ProcessedMediaStream* aStream);
   nsRefPtr<ProcessedMediaStream> mStream;

--- a/dom/media/DecodedStream.h
+++ b/dom/media/DecodedStream.h
@@ -14,13 +14,14 @@
 
 namespace mozilla {
 
-class MediaDecoder;
 class MediaInputPort;
 class SourceMediaStream;
 class ProcessedMediaStream;
+class DecodedStream;
 class DecodedStreamGraphListener;
 class OutputStreamData;
 class OutputStreamListener;
+class ReentrantMonitor;
 
 namespace layers {
 class Image;
@@ -36,8 +37,7 @@ class Image;
  */
 class DecodedStreamData {
 public:
-  DecodedStreamData(MediaDecoder* aDecoder, int64_t aInitialTime,
-                    SourceMediaStream* aStream);
+  DecodedStreamData(int64_t aInitialTime, SourceMediaStream* aStream);
   ~DecodedStreamData();
   bool IsFinished() const;
   int64_t GetClock() const;
@@ -55,7 +55,6 @@ public:
   // to the output stream.
   int64_t mNextVideoTime; // microseconds
   int64_t mNextAudioTime; // microseconds
-  MediaDecoder* mDecoder;
   // The last video image sent to the stream. Useful if we need to replicate
   // the image.
   nsRefPtr<layers::Image> mLastVideoImage;
@@ -86,7 +85,7 @@ public:
   // to work.
   OutputStreamData();
   ~OutputStreamData();
-  void Init(MediaDecoder* aDecoder, ProcessedMediaStream* aStream);
+  void Init(DecodedStream* aDecodedStream, ProcessedMediaStream* aStream);
   nsRefPtr<ProcessedMediaStream> mStream;
   // mPort connects DecodedStreamData::mStream to our mStream.
   nsRefPtr<MediaInputPort> mPort;
@@ -95,16 +94,18 @@ public:
 
 class DecodedStream {
 public:
+	explicit DecodedStream(ReentrantMonitor& aMonitor);
   DecodedStreamData* GetData();
   void DestroyData();
-  void RecreateData(MediaDecoder* aDecoder, int64_t aInitialTime,
-                    SourceMediaStream* aStream);
+  void RecreateData(int64_t aInitialTime, SourceMediaStream* aStream);
   nsTArray<OutputStreamData>& OutputStreams();
+  ReentrantMonitor& GetReentrantMonitor();
 
 private:
   UniquePtr<DecodedStreamData> mData;
   // Data about MediaStreams that are being fed by the decoder.
   nsTArray<OutputStreamData> mOutputStreams;
+  ReentrantMonitor& mMonitor;
 };
 
 } // namespace mozilla

--- a/dom/media/DecodedStream.h
+++ b/dom/media/DecodedStream.h
@@ -8,6 +8,7 @@
 #define DecodedStream_h_
 
 #include "nsRefPtr.h"
+#include "nsTArray.h"
 #include "mozilla/UniquePtr.h"
 #include "mozilla/gfx/Point.h"
 
@@ -98,9 +99,12 @@ public:
   void DestroyData();
   void RecreateData(MediaDecoder* aDecoder, int64_t aInitialTime,
                     SourceMediaStream* aStream);
+  nsTArray<OutputStreamData>& OutputStreams();
 
 private:
   UniquePtr<DecodedStreamData> mData;
+  // Data about MediaStreams that are being fed by the decoder.
+  nsTArray<OutputStreamData> mOutputStreams;
 };
 
 } // namespace mozilla

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -367,13 +367,7 @@ void MediaDecoder::AddOutputStream(ProcessedMediaStream* aStream,
     if (!GetDecodedStream()) {
       RecreateDecodedStream(mLogicalPosition);
     }
-    OutputStreamData* os = OutputStreams().AppendElement();
-    os->Init(&mDecodedStream, aStream);
-    mDecodedStream.Connect(os);
-    if (aFinishWhenEnded) {
-      // Ensure that aStream finishes the moment mDecodedStream does.
-      aStream->SetAutofinish(true);
-    }
+    mDecodedStream.Connect(aStream, aFinishWhenEnded);
   }
 
   // This can be called before Load(), in which case our mDecoderStateMachine

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -391,8 +391,7 @@ void MediaDecoder::RecreateDecodedStream(int64_t aStartTimeUSecs)
 
   DestroyDecodedStream();
 
-  mDecodedStream.RecreateData(this, aStartTimeUSecs,
-    MediaStreamGraph::GetInstance()->CreateSourceStream(nullptr));
+  mDecodedStream.RecreateData(aStartTimeUSecs, MediaStreamGraph::GetInstance()->CreateSourceStream(nullptr));
 
   // Note that the delay between removing ports in DestroyDecodedStream
   // and adding new ones won't cause a glitch since all graph operations
@@ -427,7 +426,7 @@ void MediaDecoder::AddOutputStream(ProcessedMediaStream* aStream,
       RecreateDecodedStream(mLogicalPosition);
     }
     OutputStreamData* os = OutputStreams().AppendElement();
-    os->Init(this, aStream);
+    os->Init(&mDecodedStream, aStream);
     ConnectDecodedStreamToOutputStream(os);
     if (aFinishWhenEnded) {
       // Ensure that aStream finishes the moment mDecodedStream does.
@@ -491,6 +490,7 @@ MediaDecoder::MediaDecoder() :
   mMediaSeekable(true),
   mSameOriginMedia(false),
   mReentrantMonitor("media.decoder"),
+  mDecodedStream(mReentrantMonitor),
   mEstimatedDuration(AbstractThread::MainThread(), NullableTimeUnit(),
                      "MediaDecoder::mEstimatedDuration (Canonical)"),
   mExplicitDuration(AbstractThread::MainThread(), Maybe<double>(),

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -300,19 +300,6 @@ void MediaDecoder::SetVolume(double aVolume)
   mVolume = aVolume;
 }
 
-void MediaDecoder::ConnectDecodedStreamToOutputStream(OutputStreamData* aStream)
-{
-  NS_ASSERTION(!aStream->mPort, "Already connected?");
-
-  // The output stream must stay in sync with the decoded stream, so if
-  // either stream is blocked, we block the other.
-  aStream->mPort = aStream->mStream->AllocateInputPort(GetDecodedStream()->mStream,
-      MediaInputPort::FLAG_BLOCK_INPUT | MediaInputPort::FLAG_BLOCK_OUTPUT);
-  // Unblock the output stream now. While it's connected to mDecodedStream,
-  // mDecodedStream is responsible for controlling blocking.
-  aStream->mStream->ChangeExplicitBlockerCount(-1);
-}
-
 void MediaDecoder::UpdateDecodedStream()
 {
   MOZ_ASSERT(NS_IsMainThread());
@@ -401,7 +388,7 @@ void MediaDecoder::RecreateDecodedStream(int64_t aStartTimeUSecs)
     OutputStreamData& os = outputStreams[i];
     MOZ_ASSERT(!os.mStream->IsDestroyed(),
         "Should've been removed in DestroyDecodedStream()");
-    ConnectDecodedStreamToOutputStream(&os);
+    mDecodedStream.Connect(&os);
   }
   UpdateStreamBlockingForStateMachinePlaying();
 
@@ -427,7 +414,7 @@ void MediaDecoder::AddOutputStream(ProcessedMediaStream* aStream,
     }
     OutputStreamData* os = OutputStreams().AppendElement();
     os->Init(&mDecodedStream, aStream);
-    ConnectDecodedStreamToOutputStream(os);
+    mDecodedStream.Connect(os);
     if (aFinishWhenEnded) {
       // Ensure that aStream finishes the moment mDecodedStream does.
       aStream->SetAutofinish(true);

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -339,8 +339,9 @@ void MediaDecoder::DestroyDecodedStream()
 
   // All streams are having their SourceMediaStream disconnected, so they
   // need to be explicitly blocked again.
-  for (int32_t i = mOutputStreams.Length() - 1; i >= 0; --i) {
-    OutputStreamData& os = mOutputStreams[i];
+  auto& outputStreams = OutputStreams();
+  for (int32_t i = outputStreams.Length() - 1; i >= 0; --i) {
+    OutputStreamData& os = outputStreams[i];
     // Explicitly remove all existing ports.
     // This is not strictly necessary but it's good form.
     MOZ_ASSERT(os.mPort, "Double-delete of the ports!");
@@ -351,7 +352,7 @@ void MediaDecoder::DestroyDecodedStream()
     // be careful not to send any messages after the Destroy().
     if (os.mStream->IsDestroyed()) {
       // Probably the DOM MediaStream was GCed. Clean up.
-      mOutputStreams.RemoveElementAt(i);
+      outputStreams.RemoveElementAt(i);
     } else {
       os.mStream->ChangeExplicitBlockerCount(1);
     }
@@ -396,8 +397,9 @@ void MediaDecoder::RecreateDecodedStream(int64_t aStartTimeUSecs)
   // Note that the delay between removing ports in DestroyDecodedStream
   // and adding new ones won't cause a glitch since all graph operations
   // between main-thread stable states take effect atomically.
-  for (int32_t i = mOutputStreams.Length() - 1; i >= 0; --i) {
-    OutputStreamData& os = mOutputStreams[i];
+  auto& outputStreams = OutputStreams();
+  for (int32_t i = outputStreams.Length() - 1; i >= 0; --i) {
+    OutputStreamData& os = outputStreams[i];
     MOZ_ASSERT(!os.mStream->IsDestroyed(),
         "Should've been removed in DestroyDecodedStream()");
     ConnectDecodedStreamToOutputStream(&os);
@@ -424,7 +426,7 @@ void MediaDecoder::AddOutputStream(ProcessedMediaStream* aStream,
     if (!GetDecodedStream()) {
       RecreateDecodedStream(mLogicalPosition);
     }
-    OutputStreamData* os = mOutputStreams.AppendElement();
+    OutputStreamData* os = OutputStreams().AppendElement();
     os->Init(this, aStream);
     ConnectDecodedStreamToOutputStream(os);
     if (aFinishWhenEnded) {

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -314,40 +314,6 @@ void MediaDecoder::UpdateDecodedStream()
   }
 }
 
-void MediaDecoder::DestroyDecodedStream()
-{
-  MOZ_ASSERT(NS_IsMainThread());
-  GetReentrantMonitor().AssertCurrentThreadIn();
-
-  // Avoid the redundant blocking to output stream.
-  if (!GetDecodedStream()) {
-    return;
-  }
-
-  // All streams are having their SourceMediaStream disconnected, so they
-  // need to be explicitly blocked again.
-  auto& outputStreams = OutputStreams();
-  for (int32_t i = outputStreams.Length() - 1; i >= 0; --i) {
-    OutputStreamData& os = outputStreams[i];
-    // Explicitly remove all existing ports.
-    // This is not strictly necessary but it's good form.
-    MOZ_ASSERT(os.mPort, "Double-delete of the ports!");
-    os.mPort->Destroy();
-    os.mPort = nullptr;
-    // During cycle collection, nsDOMMediaStream can be destroyed and send
-    // its Destroy message before this decoder is destroyed. So we have to
-    // be careful not to send any messages after the Destroy().
-    if (os.mStream->IsDestroyed()) {
-      // Probably the DOM MediaStream was GCed. Clean up.
-      outputStreams.RemoveElementAt(i);
-    } else {
-      os.mStream->ChangeExplicitBlockerCount(1);
-    }
-  }
-
-  mDecodedStream = nullptr;
-}
-
 void MediaDecoder::UpdateStreamBlockingForStateMachinePlaying()
 {
   GetReentrantMonitor().AssertCurrentThreadIn();
@@ -376,8 +342,7 @@ void MediaDecoder::RecreateDecodedStream(int64_t aStartTimeUSecs)
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
   DECODER_LOG("RecreateDecodedStream aStartTimeUSecs=%lld!", aStartTimeUSecs);
 
-  DestroyDecodedStream();
-
+  mDecodedStream.DestroyData();
   mDecodedStream.RecreateData(aStartTimeUSecs, MediaStreamGraph::GetInstance()->CreateSourceStream(nullptr));
 
   // Note that the delay between removing ports in DestroyDecodedStream
@@ -573,7 +538,7 @@ MediaDecoder::~MediaDecoder()
     // Don't destroy the decoded stream until destructor in order to keep the
     // invariant that the decoded stream is always available in capture mode.
     ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
-    DestroyDecodedStream();
+    mDecodedStream.DestroyData();
   }
   MediaMemoryTracker::RemoveMediaDecoder(this);
   UnpinForSeek();

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -345,16 +345,6 @@ void MediaDecoder::RecreateDecodedStream(int64_t aStartTimeUSecs)
   mDecodedStream.DestroyData();
   mDecodedStream.RecreateData(aStartTimeUSecs, MediaStreamGraph::GetInstance()->CreateSourceStream(nullptr));
 
-  // Note that the delay between removing ports in DestroyDecodedStream
-  // and adding new ones won't cause a glitch since all graph operations
-  // between main-thread stable states take effect atomically.
-  auto& outputStreams = OutputStreams();
-  for (int32_t i = outputStreams.Length() - 1; i >= 0; --i) {
-    OutputStreamData& os = outputStreams[i];
-    MOZ_ASSERT(!os.mStream->IsDestroyed(),
-        "Should've been removed in DestroyDecodedStream()");
-    mDecodedStream.Connect(&os);
-  }
   UpdateStreamBlockingForStateMachinePlaying();
 
   GetDecodedStream()->mHaveBlockedForPlayState = mPlayState != PLAY_STATE_PLAYING;

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -394,11 +394,6 @@ public:
   void UpdateDecodedStream();
 
   /**
-   * Disconnects mDecodedStream->mStream from all outputs and clears
-   * mDecodedStream.
-   */
-  void DestroyDecodedStream();
-  /**
    * Recreates mDecodedStream. Call this to create mDecodedStream at first,
    * and when seeking, to ensure a new stream is set up with fresh buffers.
    * aStartTimeUSecs is relative to the state machine's mStartTime.

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -423,7 +423,7 @@ public:
   DecodedStreamData* GetDecodedStream()
   {
     GetReentrantMonitor().AssertCurrentThreadIn();
-    return mDecodedStream;
+    return mDecodedStream.GetData();
   }
 
   // Add an output stream. All decoder output will be sent to the stream.
@@ -1005,7 +1005,7 @@ protected:
   // Only written on the main thread while holding the monitor. Therefore it
   // can be read on any thread while holding the monitor, or on the main thread
   // without holding the monitor.
-  nsAutoPtr<DecodedStreamData> mDecodedStream;
+  DecodedStream mDecodedStream;
 
   // Media duration according to the demuxer's current estimate.
   //

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -415,10 +415,11 @@ public:
    * Decoder monitor must be held.
    */
   void UpdateStreamBlockingForStateMachinePlaying();
+
   nsTArray<OutputStreamData>& OutputStreams()
   {
     GetReentrantMonitor().AssertCurrentThreadIn();
-    return mOutputStreams;
+    return mDecodedStream.OutputStreams();
   }
   DecodedStreamData* GetDecodedStream()
   {
@@ -998,8 +999,6 @@ private:
   ReentrantMonitor mReentrantMonitor;
 
 protected:
-  // Data about MediaStreams that are being fed by this decoder.
-  nsTArray<OutputStreamData> mOutputStreams;
   // The SourceMediaStream we are using to feed the mOutputStreams. This stream
   // is never exposed outside the decoder.
   // Only written on the main thread while holding the monitor. Therefore it

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -391,11 +391,6 @@ public:
   // replaying after the input as ended. In the latter case, the new source is
   // not connected to streams created by captureStreamUntilEnded.
 
-  /**
-   * Connects mDecodedStream->mStream to aStream->mStream.
-   */
-  void ConnectDecodedStreamToOutputStream(OutputStreamData* aStream);
-
   void UpdateDecodedStream();
 
   /**

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -406,11 +406,6 @@ public:
    */
   void UpdateStreamBlockingForStateMachinePlaying();
 
-  nsTArray<OutputStreamData>& OutputStreams()
-  {
-    GetReentrantMonitor().AssertCurrentThreadIn();
-    return mDecodedStream.OutputStreams();
-  }
   DecodedStreamData* GetDecodedStream()
   {
     GetReentrantMonitor().AssertCurrentThreadIn();

--- a/dom/media/omx/MediaOmxCommonDecoder.cpp
+++ b/dom/media/omx/MediaOmxCommonDecoder.cpp
@@ -53,7 +53,7 @@ bool
 MediaOmxCommonDecoder::CheckDecoderCanOffloadAudio()
 {
   return (mCanOffloadAudio && !mFallbackToStateMachine &&
-          !OutputStreams().Length() && mPlaybackRate == 1.0);
+          !GetDecodedStream() && mPlaybackRate == 1.0);
 }
 
 void

--- a/dom/media/omx/MediaOmxCommonDecoder.cpp
+++ b/dom/media/omx/MediaOmxCommonDecoder.cpp
@@ -53,7 +53,7 @@ bool
 MediaOmxCommonDecoder::CheckDecoderCanOffloadAudio()
 {
   return (mCanOffloadAudio && !mFallbackToStateMachine &&
-          !mOutputStreams.Length() && mPlaybackRate == 1.0);
+          !OutputStreams().Length() && mPlaybackRate == 1.0);
 }
 
 void


### PR DESCRIPTION
Just what it says in the tin. Additionally, this PR cleans up some no longer needed code in the MediaDecoder (thanks to DecodedStream).

The end goal of these patches is that (once I get a bit more code moved around) I'll be able to streamline and simplify some more code in both the MediaDecoder and the MDSM, decreasing some of the complexity which in turn lowers the chance of bugs/race conditions in addition to making it easier to port more changes from Mozilla in the future.

Built and tested this commit set on YouTube, YouTube Live, Twitch, Vimeo, etc. No issues seen on Linux.