### PR TITLE
Update preferences to use the new AUS infra.

### DIFF
--- a/browser/branding/official/pref/palemoon-branding.js
+++ b/browser/branding/official/pref/palemoon-branding.js
@@ -8,3 +8,26 @@ pref("app.releaseNotesURL", "http://www.palemoon.org/releasenotes.shtml");
 
 // Enable Firefox compatmode by default.
 pref("general.useragent.compatMode", 2);
+
+// ========================= updates ========================
+#if defined(XP_WIN)
+// Updates enabled
+pref("app.update.enabled", true);
+pref("app.update.cert.checkAttributes", true);
+
+// Interval: Time between checks for a new version (in seconds) -- 2 days for Pale Moon
+pref("app.update.interval", 172800);
+pref("app.update.promptWaitTime", 86400);
+
+// URL user can browse to manually if for some reason all update
+// installation attempts fail.
+pref("app.update.url.manual", "http://www.palemoon.org/");
+
+// A default value for the "More information about this update" link
+// supplied in the "An update is available" page of the update wizard. 
+pref("app.update.url.details", "http://www.palemoon.org/releasenotes.shtml");
+#else
+// Updates disabled (Linux, etc.)
+pref("app.update.enabled", false);
+pref("app.update.url", "");
+#endif

--- a/browser/branding/official/pref/palemoon-branding.js
+++ b/browser/branding/official/pref/palemoon-branding.js
@@ -22,10 +22,6 @@ pref("app.update.promptWaitTime", 86400);
 // URL user can browse to manually if for some reason all update
 // installation attempts fail.
 pref("app.update.url.manual", "http://www.palemoon.org/");
-
-// A default value for the "More information about this update" link
-// supplied in the "An update is available" page of the update wizard. 
-pref("app.update.url.details", "http://www.palemoon.org/releasenotes.shtml");
 #else
 // Updates disabled (Linux, etc.)
 pref("app.update.enabled", false);

--- a/browser/branding/shared/pref/preferences.inc
+++ b/browser/branding/shared/pref/preferences.inc
@@ -1,6 +1,3 @@
-#define BRANDING_DIRECTORY_OFFICIAL browser/branding/official
-#define BRANDING_DIRECTORY_UNSTABLE browser/branding/unstable
-
 #define APO_AM_URL addons.palemoon.org/integration/addon-manager
 #define APO_AUS_ARGS reqVersion=%REQ_VERSION%&id=%ITEM_ID%&version=%ITEM_VERSION%&maxAppVersion=%ITEM_MAXAPPVERSION%&status=%ITEM_STATUS%&appID=%APP_ID%&appVersion=%APP_VERSION%&appOS=%APP_OS%&appABI=%APP_ABI%&locale=%APP_LOCALE%&currentAppVersion=%CURRENT_APP_VERSION%&updateType=%UPDATE_TYPE%&compatMode=%COMPATIBILITY_MODE%
 
@@ -36,46 +33,7 @@ pref("browser.altClickSave", true); //SBaD,M! (#2)
 // ===| Application Update Service |===========================================
 
 pref("app.update.auto", false);
-
-#if MOZ_BRANDING_DIRECTORY == BRANDING_DIRECTORY_OFFICIAL && defined(XP_WIN)
-// Updates enabled
-pref("app.update.enabled", true);
-pref("app.update.url", "https://www.palemoon.org/update/%VERSION%/%BUILD_TARGET%/update.xml");
-pref("app.update.cert.checkAttributes", true);
-
-// Interval: Time between checks for a new version (in seconds) -- 2 days for Pale Moon
-pref("app.update.interval", 172800);
-pref("app.update.promptWaitTime", 86400);
-
-// URL user can browse to manually if for some reason all update
-// installation attempts fail.
-pref("app.update.url.manual", "http://www.palemoon.org/");
-
-// A default value for the "More information about this update" link
-// supplied in the "An update is available" page of the update wizard. 
-pref("app.update.url.details", "http://www.palemoon.org/releasenotes.shtml");
-#elif MOZ_BRANDING_DIRECTORY == BRANDING_DIRECTORY_UNSTABLE && defined(XP_WIN)
-// Updates enabled
-pref("app.update.enabled", true);
-pref("app.update.url", "https://www.palemoon.org/unstable/update.xml");
-pref("app.update.cert.checkAttributes", true);
-
-// Interval: Time between checks for a new version (in seconds) -- 6 hours for unstable
-pref("app.update.interval", 21600);
-pref("app.update.promptWaitTime", 86400);
-
-// URL user can browse to manually if for some reason all update installation
-// attempts fail.
-pref("app.update.url.manual", "http://www.palemoon.org/unstable/");
-
-// A default value for the "More information about this update" link
-// supplied in the "An update is available" page of the update wizard. 
-pref("app.update.url.details", "http://www.palemoon.org/unstable/");
-#else
-// Updates disabled
-pref("app.update.enabled", false);
-pref("app.update.url", "");
-#endif
+pref("app.update.url", "https://aus.palemoon.org/?application=%PRODUCT%&version=%VERSION%&arch=%BUILD_TARGET%&buildid=%BUILD_ID%&channel=%CHANNEL%");
 
 // The time interval between the downloading of mar file chunks in the
 // background (in seconds)

--- a/browser/branding/unofficial/pref/palemoon-branding.js
+++ b/browser/branding/unofficial/pref/palemoon-branding.js
@@ -5,3 +5,7 @@
 
 pref("startup.homepage_override_url","http://www.palemoon.org/unofficial.shtml");
 pref("app.releaseNotesURL", "http://www.palemoon.org/releasenotes.shtml");
+
+// Updates disabled
+pref("app.update.enabled", false);
+pref("app.update.url", "");

--- a/browser/branding/unstable/pref/palemoon-branding.js
+++ b/browser/branding/unstable/pref/palemoon-branding.js
@@ -9,7 +9,28 @@ pref("app.releaseNotesURL", "http://www.palemoon.org/unstable/releasenotes.shtml
 // Enable Firefox compatmode by default.
 pref("general.useragent.compatMode", 2);
 
+// ========================= updates ========================
+#if defined(XP_WIN)
 // Enable auto-updates for this channel
 pref("app.update.auto", true);
-pref("app.update.interval", 86400);
-pref("app.update.promptWaitTime", 10800);
+
+// Updates enabled
+pref("app.update.enabled", true);
+pref("app.update.cert.checkAttributes", true);
+
+// Interval: Time between checks for a new version (in seconds) -- 6 hours for unstable
+pref("app.update.interval", 21600);
+pref("app.update.promptWaitTime", 86400);
+
+// URL user can browse to manually if for some reason all update installation
+// attempts fail.
+pref("app.update.url.manual", "http://www.palemoon.org/unstable/");
+
+// A default value for the "More information about this update" link
+// supplied in the "An update is available" page of the update wizard. 
+pref("app.update.url.details", "http://www.palemoon.org/unstable/");
+#else
+// Updates disabled (Linux, etc.)
+pref("app.update.enabled", false);
+pref("app.update.url", "");
+#endif

--- a/browser/branding/unstable/pref/palemoon-branding.js
+++ b/browser/branding/unstable/pref/palemoon-branding.js
@@ -25,10 +25,6 @@ pref("app.update.promptWaitTime", 86400);
 // URL user can browse to manually if for some reason all update installation
 // attempts fail.
 pref("app.update.url.manual", "http://www.palemoon.org/unstable/");
-
-// A default value for the "More information about this update" link
-// supplied in the "An update is available" page of the update wizard. 
-pref("app.update.url.details", "http://www.palemoon.org/unstable/");
 #else
 // Updates disabled (Linux, etc.)
 pref("app.update.enabled", false);

--- a/browser/confvars.sh
+++ b/browser/confvars.sh
@@ -45,9 +45,9 @@ MOZ_APP_ID={8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}
 # This should usually be the same as the value MAR_CHANNEL_ID.
 # If more than one ID is needed, then you should use a comma separated list
 # of values.
-ACCEPTED_MAR_CHANNEL_IDS=palemoon-mozilla-beta,palemoon-mozilla-release
+ACCEPTED_MAR_CHANNEL_IDS=palemoon-release
 # The MAR_CHANNEL_ID must not contain the following 3 characters: ",\t "
-MAR_CHANNEL_ID=palemoon-mozilla-release
+MAR_CHANNEL_ID=palemoon-release
 MOZ_PROFILE_MIGRATOR=1
 MOZ_EXTENSION_MANAGER=1
 MOZ_APP_STATIC_INI=1

--- a/toolkit/mozapps/extensions/AddonManager.jsm
+++ b/toolkit/mozapps/extensions/AddonManager.jsm
@@ -48,11 +48,7 @@ const FILE_BLOCKLIST                  = "blocklist.xml";
 
 const BRANCH_REGEXP                   = /^([^\.]+\.[0-9]+[a-z]*).*/gi;
 const PREF_EM_CHECK_COMPATIBILITY_BASE = "extensions.checkCompatibility";
-#ifdef MOZ_COMPATIBILITY_NIGHTLY
-var PREF_EM_CHECK_COMPATIBILITY = PREF_EM_CHECK_COMPATIBILITY_BASE + ".nightly";
-#else
 var PREF_EM_CHECK_COMPATIBILITY;
-#endif
 
 const TOOLKIT_ID                      = "toolkit@mozilla.org";
 
@@ -860,10 +856,8 @@ var AddonManagerInternal = {
         this.validateBlocklist();
       }
 
-#ifndef MOZ_COMPATIBILITY_NIGHTLY
       PREF_EM_CHECK_COMPATIBILITY = PREF_EM_CHECK_COMPATIBILITY_BASE + "." +
                                     Services.appinfo.version.replace(BRANCH_REGEXP, "$1");
-#endif
 
       try {
         gCheckCompatibility = Services.prefs.getBoolPref(PREF_EM_CHECK_COMPATIBILITY);

--- a/toolkit/mozapps/extensions/moz.build
+++ b/toolkit/mozapps/extensions/moz.build
@@ -38,9 +38,6 @@ EXTRA_PP_JS_MODULES += [
     'AddonManager.jsm'
 ]
 
-if CONFIG['MOZ_UPDATE_CHANNEL'] not in ('aurora', 'beta', 'release', 'esr'):
-    DEFINES['MOZ_COMPATIBILITY_NIGHTLY'] = 1
-
 # Additional debugging info is exposed in debug builds
 if CONFIG['MOZ_EM_DEBUG']:
     DEFINES['MOZ_EM_DEBUG'] = 1

--- a/toolkit/mozapps/update/updater/Makefile.in
+++ b/toolkit/mozapps/update/updater/Makefile.in
@@ -13,16 +13,8 @@ endif
 
 include $(topsrcdir)/config/rules.mk
 
-ifneq (,$(filter beta release esr,$(MOZ_UPDATE_CHANNEL)))
-	PRIMARY_CERT = release_primary.der
-	SECONDARY_CERT = release_secondary.der
-else ifneq (,$(filter nightly aurora nightly-elm nightly-profiling nightly-oak nightly-ux,$(MOZ_UPDATE_CHANNEL)))
-	PRIMARY_CERT = nightly_aurora_level3_primary.der
-	SECONDARY_CERT = nightly_aurora_level3_secondary.der
-else
-	PRIMARY_CERT = dep1.der
-	SECONDARY_CERT = dep2.der
-endif
+PRIMARY_CERT = dep1.der
+SECONDARY_CERT = dep2.der
 
 CERT_HEADERS := primaryCert.h secondaryCert.h xpcshellCert.h
 


### PR DESCRIPTION
This splits out the branding-specifics to the individual pref files for easier maintenance, and changes the application update URL to `aus.*` for use of the new script.

Builds from this point forward require the proper `ac_add_options --enable-update-channel=` entry in `.mozconfig` to work as-intended:
- `release`: use release build options and release channel
- `unstable`: use default build options (current) and unstable channel
- undefined, default or unknown: use default build options and not be served active updates