### PR TITLE
Move DecodedStreamData from MediaDecoder to MediaDecoderStateMachine

### DIFF
--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -2814,12 +2814,6 @@ nsresult HTMLMediaElement::FinishDecoderSetup(MediaDecoder* aDecoder,
     mDecoder->SetMinimizePrerollUntilPlaybackStarts();
   }
 
-  for (uint32_t i = 0; i < mOutputStreams.Length(); ++i) {
-    OutputMediaStream* ms = &mOutputStreams[i];
-    aDecoder->AddOutputStream(ms->mStream->GetStream()->AsProcessedStream(),
-        ms->mFinishWhenEnded);
-  }
-
   // Update decoder principal before we start decoding, since it
   // can affect how we feed data to MediaStreams
   NotifyDecoderPrincipalChanged();
@@ -2829,6 +2823,12 @@ nsresult HTMLMediaElement::FinishDecoderSetup(MediaDecoder* aDecoder,
     SetDecoder(nullptr);
     LOG(PR_LOG_DEBUG, ("%p Failed to load for decoder %p", this, aDecoder));
     return rv;
+  }
+
+  for (uint32_t i = 0; i < mOutputStreams.Length(); ++i) {
+    OutputMediaStream* ms = &mOutputStreams[i];
+    aDecoder->AddOutputStream(ms->mStream->GetStream()->AsProcessedStream(),
+        ms->mFinishWhenEnded);
   }
 
   // Decoder successfully created, the decoder now owns the MediaResource

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -180,7 +180,7 @@ DecodedStream::DecodedStream(ReentrantMonitor& aMonitor)
 }
 
 DecodedStreamData*
-DecodedStream::GetData()
+DecodedStream::GetData() const
 {
 	GetReentrantMonitor().AssertCurrentThreadIn();
   return mData.get();
@@ -252,7 +252,7 @@ DecodedStream::OutputStreams()
 }
 
 ReentrantMonitor&
-DecodedStream::GetReentrantMonitor()
+DecodedStream::GetReentrantMonitor() const
 {
   return mMonitor;
 }

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -220,13 +220,16 @@ DecodedStream::DestroyData()
 }
 
 void
-DecodedStream::RecreateData(int64_t aInitialTime, SourceMediaStream* aStream)
+DecodedStream::RecreateData(int64_t aInitialTime, MediaStreamGraph* aGraph)
 {
 	MOZ_ASSERT(NS_IsMainThread());
   GetReentrantMonitor().AssertCurrentThreadIn();
-  MOZ_ASSERT(!mData);
+  MOZ_ASSERT((aGraph && !mData && OutputStreams().IsEmpty()) || // first time
+             (!aGraph && mData)); // 2nd time and later
 
-  mData.reset(new DecodedStreamData(aInitialTime, aStream));
+  auto source = aGraph->CreateSourceStream(nullptr);
+  DestroyData();
+  mData.reset(new DecodedStreamData(aInitialTime, source));
 
 	// Note that the delay between removing ports in DestroyDecodedStream
   // and adding new ones won't cause a glitch since all graph operations

--- a/dom/media/DecodedStream.cpp
+++ b/dom/media/DecodedStream.cpp
@@ -85,6 +85,8 @@ DecodedStreamData::DecodedStreamData(int64_t aInitialTime,
 {
   mListener = new DecodedStreamGraphListener(mStream);
   mStream->AddListener(mListener);
+  // Block the stream until the initialization is done.
+  mStream->ChangeExplicitBlockerCount(1);
 }
 
 DecodedStreamData::~DecodedStreamData()

--- a/dom/media/DecodedStream.h
+++ b/dom/media/DecodedStream.h
@@ -21,6 +21,7 @@ class DecodedStream;
 class DecodedStreamGraphListener;
 class OutputStreamListener;
 class ReentrantMonitor;
+class MediaStreamGraph;
 
 namespace layers {
 class Image;
@@ -91,7 +92,7 @@ public:
 	explicit DecodedStream(ReentrantMonitor& aMonitor);
   DecodedStreamData* GetData();
   void DestroyData();
-  void RecreateData(int64_t aInitialTime, SourceMediaStream* aStream);
+  void RecreateData(int64_t aInitialTime, MediaStreamGraph* aGraph);
   nsTArray<OutputStreamData>& OutputStreams();
   ReentrantMonitor& GetReentrantMonitor();
   void Connect(ProcessedMediaStream* aStream, bool aFinishWhenEnded);

--- a/dom/media/DecodedStream.h
+++ b/dom/media/DecodedStream.h
@@ -90,11 +90,11 @@ public:
 class DecodedStream {
 public:
 	explicit DecodedStream(ReentrantMonitor& aMonitor);
-  DecodedStreamData* GetData();
+  DecodedStreamData* GetData() const;
   void DestroyData();
   void RecreateData(int64_t aInitialTime, MediaStreamGraph* aGraph);
   nsTArray<OutputStreamData>& OutputStreams();
-  ReentrantMonitor& GetReentrantMonitor();
+  ReentrantMonitor& GetReentrantMonitor() const;
   void Connect(ProcessedMediaStream* aStream, bool aFinishWhenEnded);
 
 private:

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -342,9 +342,7 @@ void MediaDecoder::RecreateDecodedStream(int64_t aStartTimeUSecs)
   ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
   DECODER_LOG("RecreateDecodedStream aStartTimeUSecs=%lld!", aStartTimeUSecs);
 
-  mDecodedStream.DestroyData();
-  mDecodedStream.RecreateData(aStartTimeUSecs, MediaStreamGraph::GetInstance()->CreateSourceStream(nullptr));
-
+  mDecodedStream.RecreateData(aStartTimeUSecs, MediaStreamGraph::GetInstance());
   UpdateStreamBlockingForStateMachinePlaying();
 
   GetDecodedStream()->mHaveBlockedForPlayState = mPlayState != PLAY_STATE_PLAYING;

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -315,28 +315,6 @@ void MediaDecoder::UpdateStreamBlockingForPlayState()
   }
 }
 
-void MediaDecoder::UpdateStreamBlockingForStateMachinePlaying()
-{
-  GetReentrantMonitor().AssertCurrentThreadIn();
-  if (!GetDecodedStream()) {
-    return;
-  }
-  bool blockForStateMachineNotPlaying =
-    mDecoderStateMachine && !mDecoderStateMachine->IsPlaying();
-  if (blockForStateMachineNotPlaying != GetDecodedStream()->mHaveBlockedForStateMachineNotPlaying) {
-    GetDecodedStream()->mHaveBlockedForStateMachineNotPlaying = blockForStateMachineNotPlaying;
-    int32_t delta = blockForStateMachineNotPlaying ? 1 : -1;
-    if (NS_IsMainThread()) {
-      GetDecodedStream()->mStream->ChangeExplicitBlockerCount(delta);
-    } else {
-      nsCOMPtr<nsIRunnable> runnable =
-          NS_NewRunnableMethodWithArg<int32_t>(GetDecodedStream()->mStream.get(),
-              &MediaStream::ChangeExplicitBlockerCount, delta);
-      NS_DispatchToMainThread(runnable);
-    }
-  }
-}
-
 void MediaDecoder::RecreateDecodedStream(int64_t aStartTimeUSecs)
 {
   MOZ_ASSERT(NS_IsMainThread());
@@ -344,7 +322,6 @@ void MediaDecoder::RecreateDecodedStream(int64_t aStartTimeUSecs)
   DECODER_LOG("RecreateDecodedStream aStartTimeUSecs=%lld!", aStartTimeUSecs);
 
   mDecodedStream.RecreateData(aStartTimeUSecs, MediaStreamGraph::GetInstance());
-  UpdateStreamBlockingForStateMachinePlaying();
   UpdateStreamBlockingForPlayState();
 }
 

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -300,29 +300,12 @@ void MediaDecoder::SetVolume(double aVolume)
   mVolume = aVolume;
 }
 
-void MediaDecoder::RecreateDecodedStream(int64_t aStartTimeUSecs)
-{
-  MOZ_ASSERT(NS_IsMainThread());
-  ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
-  DECODER_LOG("RecreateDecodedStream aStartTimeUSecs=%lld!", aStartTimeUSecs);
-
-  mDecodedStream.RecreateData(aStartTimeUSecs, MediaStreamGraph::GetInstance());
-}
-
 void MediaDecoder::AddOutputStream(ProcessedMediaStream* aStream,
                                    bool aFinishWhenEnded)
 {
   MOZ_ASSERT(NS_IsMainThread());
-  DECODER_LOG("AddOutputStream aStream=%p!", aStream);
   MOZ_ASSERT(mDecoderStateMachine, "Must be called after Load().");
-
-  ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
-  if (!GetDecodedStream()) {
-    RecreateDecodedStream(mLogicalPosition);
-  }
-
-  mDecodedStream.Connect(aStream, aFinishWhenEnded);
-  mDecoderStateMachine->DispatchAudioCaptured();
+  mDecoderStateMachine->AddOutputStream(aStream, aFinishWhenEnded);
 }
 
 double MediaDecoder::GetDuration()
@@ -371,7 +354,6 @@ MediaDecoder::MediaDecoder() :
   mMediaSeekable(true),
   mSameOriginMedia(false),
   mReentrantMonitor("media.decoder"),
-  mDecodedStream(mReentrantMonitor),
   mEstimatedDuration(AbstractThread::MainThread(), NullableTimeUnit(),
                      "MediaDecoder::mEstimatedDuration (Canonical)"),
   mExplicitDuration(AbstractThread::MainThread(), Maybe<double>(),
@@ -463,12 +445,6 @@ void MediaDecoder::Shutdown()
 MediaDecoder::~MediaDecoder()
 {
   MOZ_ASSERT(NS_IsMainThread());
-  {
-    // Don't destroy the decoded stream until destructor in order to keep the
-    // invariant that the decoded stream is always available in capture mode.
-    ReentrantMonitorAutoEnter mon(GetReentrantMonitor());
-    mDecodedStream.DestroyData();
-  }
   MediaMemoryTracker::RemoveMediaDecoder(this);
   UnpinForSeek();
   MOZ_COUNT_DTOR(MediaDecoder);

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -391,8 +391,6 @@ public:
   // replaying after the input as ended. In the latter case, the new source is
   // not connected to streams created by captureStreamUntilEnded.
 
-  void UpdateStreamBlockingForPlayState();
-
   /**
    * Recreates mDecodedStream. Call this to create mDecodedStream at first,
    * and when seeking, to ensure a new stream is set up with fresh buffers.

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -391,7 +391,7 @@ public:
   // replaying after the input as ended. In the latter case, the new source is
   // not connected to streams created by captureStreamUntilEnded.
 
-  void UpdateDecodedStream();
+  void UpdateStreamBlockingForPlayState();
 
   /**
    * Recreates mDecodedStream. Call this to create mDecodedStream at first,

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -400,11 +400,6 @@ public:
    * Decoder monitor must be held.
    */
   void RecreateDecodedStream(int64_t aStartTimeUSecs);
-  /**
-   * Call this when mDecoderStateMachine or mDecoderStateMachine->IsPlaying() changes.
-   * Decoder monitor must be held.
-   */
-  void UpdateStreamBlockingForStateMachinePlaying();
 
   DecodedStreamData* GetDecodedStream()
   {

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -391,20 +391,6 @@ public:
   // replaying after the input as ended. In the latter case, the new source is
   // not connected to streams created by captureStreamUntilEnded.
 
-  /**
-   * Recreates mDecodedStream. Call this to create mDecodedStream at first,
-   * and when seeking, to ensure a new stream is set up with fresh buffers.
-   * aStartTimeUSecs is relative to the state machine's mStartTime.
-   * Decoder monitor must be held.
-   */
-  void RecreateDecodedStream(int64_t aStartTimeUSecs);
-
-  DecodedStreamData* GetDecodedStream()
-  {
-    GetReentrantMonitor().AssertCurrentThreadIn();
-    return mDecodedStream.GetData();
-  }
-
   // Add an output stream. All decoder output will be sent to the stream.
   // The stream is initially blocked. The decoder is responsible for unblocking
   // it while it is playing back.
@@ -977,13 +963,6 @@ private:
   ReentrantMonitor mReentrantMonitor;
 
 protected:
-  // The SourceMediaStream we are using to feed the mOutputStreams. This stream
-  // is never exposed outside the decoder.
-  // Only written on the main thread while holding the monitor. Therefore it
-  // can be read on any thread while holding the monitor, or on the main thread
-  // without holding the monitor.
-  DecodedStream mDecodedStream;
-
   // Media duration according to the demuxer's current estimate.
   //
   // Note that it's quite bizarre for this to live on the main thread - it would

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -325,6 +325,8 @@ MediaDecoderStateMachine::InitializationTask()
   mWatchManager.Watch(mObservedDuration, &MediaDecoderStateMachine::RecomputeDuration);
   mWatchManager.Watch(mPlayState, &MediaDecoderStateMachine::PlayStateChanged);
   mWatchManager.Watch(mLogicallySeeking, &MediaDecoderStateMachine::LogicallySeekingChanged);
+  mWatchManager.Watch(mPlayState, &MediaDecoderStateMachine::UpdateStreamBlockingForPlayState);
+  mWatchManager.Watch(mLogicallySeeking, &MediaDecoderStateMachine::UpdateStreamBlockingForPlayState);
 }
 
 bool MediaDecoderStateMachine::HasFutureAudio() {
@@ -483,6 +485,7 @@ void MediaDecoderStateMachine::SendStreamData()
 
       // Make sure stream blocking is updated before sending stream data so we
       // don't 'leak' data when the stream is supposed to be blocked.
+      UpdateStreamBlockingForPlayState();
       UpdateStreamBlockingForStateMachinePlaying();
       UpdateStreamBlocking(mediaStream, false);
     }
@@ -3521,6 +3524,23 @@ void MediaDecoderStateMachine::DispatchAudioCaptured()
     }
   });
   TaskQueue()->Dispatch(r.forget());
+}
+
+void MediaDecoderStateMachine::UpdateStreamBlockingForPlayState()
+{
+  ReentrantMonitorAutoEnter mon(mDecoder->GetReentrantMonitor());
+
+   auto stream = mDecoder->GetDecodedStream();
+   if (!stream) {
+     return;
+   }
+
+  bool blocking = mPlayState != MediaDecoder::PLAY_STATE_PLAYING ||
+                  mLogicallySeeking;
+  if (blocking != stream->mHaveBlockedForPlayState) {
+    stream->mHaveBlockedForPlayState = blocking;
+    UpdateStreamBlocking(stream->mStream, blocking);
+  }
 }
 
 void MediaDecoderStateMachine::UpdateStreamBlockingForStateMachinePlaying()

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -163,6 +163,10 @@ private:
   // constructor immediately after the task queue is created.
   void InitializationTask();
 
+  // Update blocking state of mDecodedStream when mPlayState or
+  // mLogicallySeeking change. Decoder monitor must be held.
+  void UpdateStreamBlockingForPlayState();
+
   // Call this IsPlaying() changes. Decoder monitor must be held.
   void UpdateStreamBlockingForStateMachinePlaying();
 

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -150,20 +150,7 @@ public:
     return mState;
   }
 
-  void DispatchAudioCaptured()
-  {
-    nsRefPtr<MediaDecoderStateMachine> self = this;
-    nsCOMPtr<nsIRunnable> r = NS_NewRunnableFunction([self] () -> void
-    {
-      MOZ_ASSERT(self->OnTaskQueue());
-      ReentrantMonitorAutoEnter mon(self->mDecoder->GetReentrantMonitor());
-      if (!self->mAudioCaptured) {
-        self->mAudioCaptured = true;
-        self->ScheduleStateMachine();
-      }
-    });
-    TaskQueue()->Dispatch(r.forget());
-  }
+  void DispatchAudioCaptured();
 
   // Check if the decoder needs to become dormant state.
   bool IsDormantNeeded();
@@ -175,6 +162,10 @@ private:
   // task that gets run on the task queue, and is dispatched from the MDSM
   // constructor immediately after the task queue is created.
   void InitializationTask();
+
+  // Call this IsPlaying() changes. Decoder monitor must be held.
+  void UpdateStreamBlockingForStateMachinePlaying();
+
   void Shutdown();
 public:
 

--- a/dom/media/omx/MediaOmxCommonDecoder.cpp
+++ b/dom/media/omx/MediaOmxCommonDecoder.cpp
@@ -53,7 +53,8 @@ bool
 MediaOmxCommonDecoder::CheckDecoderCanOffloadAudio()
 {
   return (mCanOffloadAudio && !mFallbackToStateMachine &&
-          !GetDecodedStream() && mPlaybackRate == 1.0);
+          !(GetStateMachine() && GetStateMachine()->GetDecodedStream()) &&
+          mPlaybackRate == 1.0);
 }
 
 void


### PR DESCRIPTION
Moving some more code around in the same vein as #1422.  In addition, this PR simplifies some of the code in MediaDecoder::Load() (thanks to the media tail dispatcher). This PR also should prevent some possible race conditions under certain circumstances.

Built and tested on YouTube, Twitch, Vimeo, etc. Works as intended on Linux.