### PR TITLE
Improve timing of canplay and canplaythrough firing

### DIFF
--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -3546,7 +3546,12 @@ HTMLMediaElement::UpdateReadyStateInternal()
     MetadataLoaded(&mediaInfo, nsAutoPtr<const MetadataTags>(nullptr));
   }
 
-  if (NextFrameStatus() == MediaDecoderOwner::NEXT_FRAME_UNAVAILABLE_SEEKING) {
+  enum NextFrameStatus nextFrameStatus = NextFrameStatus();
+  if (mDecoder && nextFrameStatus == NEXT_FRAME_UNAVAILABLE) {
+    nextFrameStatus = mDecoder->NextFrameBufferedStatus();
+  }
+
+  if (nextFrameStatus == MediaDecoderOwner::NEXT_FRAME_UNAVAILABLE_SEEKING) {
     ChangeReadyState(nsIDOMHTMLMediaElement::HAVE_METADATA);
     return;
   }
@@ -3575,9 +3580,9 @@ HTMLMediaElement::UpdateReadyStateInternal()
     return;
   }
 
-  if (NextFrameStatus() != MediaDecoderOwner::NEXT_FRAME_AVAILABLE) {
+  if (nextFrameStatus != MediaDecoderOwner::NEXT_FRAME_AVAILABLE) {
     ChangeReadyState(nsIDOMHTMLMediaElement::HAVE_CURRENT_DATA);
-    if (!mWaitingFired && NextFrameStatus() == MediaDecoderOwner::NEXT_FRAME_UNAVAILABLE_BUFFERING) {
+    if (!mWaitingFired && nextFrameStatus == MediaDecoderOwner::NEXT_FRAME_UNAVAILABLE_BUFFERING) {
       FireTimeUpdate(false);
       DispatchAsyncEvent(NS_LITERAL_STRING("waiting"));
       mWaitingFired = true;

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -1616,6 +1616,21 @@ MediaDecoder::RemoveMediaTracks()
   mMediaTracksConstructed = false;
 }
 
+MediaDecoderOwner::NextFrameStatus
+MediaDecoder::NextFrameBufferedStatus()
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  // Next frame hasn't been decoded yet.
+  // Use the buffered range to consider if we have the next frame available.
+  media::TimeUnit currentPosition =
+    media::TimeUnit::FromMicroseconds(CurrentPosition());
+  media::TimeInterval interval(currentPosition,
+                               currentPosition + media::TimeUnit::FromMicroseconds(DEFAULT_NEXT_FRAME_AVAILABLE_BUFFERED));
+  return GetBuffered().Contains(interval)
+    ? MediaDecoderOwner::NEXT_FRAME_AVAILABLE
+    : MediaDecoderOwner::NEXT_FRAME_UNAVAILABLE;
+}
+
 MediaMemoryTracker::MediaMemoryTracker()
 {
 }

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -581,7 +581,7 @@ public:
 
   // Returns true if we can play the entire media through without stopping
   // to buffer, given the current download and playback rates.
-  bool CanPlayThrough();
+  virtual bool CanPlayThrough();
 
   void SetAudioChannel(dom::AudioChannel aChannel) { mAudioChannel = aChannel; }
   dom::AudioChannel GetAudioChannel() { return mAudioChannel; }

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -857,6 +857,7 @@ public:
   }
 
   virtual MediaDecoderOwner::NextFrameStatus NextFrameStatus() { return mNextFrameStatus; }
+  virtual MediaDecoderOwner::NextFrameStatus NextFrameBufferedStatus();
 
 protected:
   virtual ~MediaDecoder();
@@ -946,6 +947,11 @@ protected:
 
   // Media data resource.
   nsRefPtr<MediaResource> mResource;
+
+	// Amount of buffered data ahead of current time required to consider that
+  // the next frame is available.
+  // An arbitrary value of 250ms is used.
+  static const int DEFAULT_NEXT_FRAME_AVAILABLE_BUFFERED = 250000;
 
 private:
   // The state machine object for handling the decoding. It is safe to

--- a/dom/media/mediasource/MediaSourceDecoder.cpp
+++ b/dom/media/mediasource/MediaSourceDecoder.cpp
@@ -320,10 +320,7 @@ MediaSourceDecoder::CanPlayThrough()
   }
   TimeUnit duration = TimeUnit::FromSeconds(mMediaSource->Duration());
   TimeUnit currentPosition = TimeUnit::FromMicroseconds(CurrentPosition());
-  if (duration.IsInfinite()) {
-    // We can't make an informed decision and just assume that it's a live stream
-    return true;
-  } else if (duration <= currentPosition) {
+  if (duration <= currentPosition) {
     return true;
   }
   // If we have data up to the mediasource's duration or 30s ahead, we can

--- a/dom/media/mediasource/MediaSourceDecoder.cpp
+++ b/dom/media/mediasource/MediaSourceDecoder.cpp
@@ -16,6 +16,7 @@
 #include "VideoUtils.h"
 #include "MediaFormatReader.h"
 #include "MediaSourceDemuxer.h"
+#include <algorithm>
 
 #ifdef PR_LOGGING
 extern PRLogModuleInfo* GetMediaSourceLog();
@@ -307,6 +308,32 @@ MediaSourceDecoder::NextFrameBufferedStatus()
   return GetBuffered().Contains(interval)
     ? MediaDecoderOwner::NEXT_FRAME_AVAILABLE
     : MediaDecoderOwner::NEXT_FRAME_UNAVAILABLE;
+}
+
+bool
+MediaSourceDecoder::CanPlayThrough()
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  if (IsNaN(mMediaSource->Duration())) {
+    // Don't have any data yet.
+    return false;
+  }
+  TimeUnit duration = TimeUnit::FromSeconds(mMediaSource->Duration());
+  TimeUnit currentPosition = TimeUnit::FromMicroseconds(CurrentPosition());
+  if (duration.IsInfinite()) {
+    // We can't make an informed decision and just assume that it's a live stream
+    return true;
+  } else if (duration <= currentPosition) {
+    return true;
+  }
+  // If we have data up to the mediasource's duration or 30s ahead, we can
+  // assume that we can play without interruption.
+  TimeUnit timeAhead =
+    std::min(duration, currentPosition + TimeUnit::FromSeconds(30));
+  TimeInterval interval(currentPosition,
+                        timeAhead,
+                        MediaSourceDemuxer::EOS_FUZZ);
+  return GetBuffered().Contains(interval);
 }
 
 already_AddRefed<SourceBufferDecoder>

--- a/dom/media/mediasource/MediaSourceDecoder.cpp
+++ b/dom/media/mediasource/MediaSourceDecoder.cpp
@@ -294,6 +294,21 @@ MediaSourceDecoder::GetDuration()
   return ExplicitDuration();
 }
 
+MediaDecoderOwner::NextFrameStatus
+MediaSourceDecoder::NextFrameBufferedStatus()
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  // Next frame hasn't been decoded yet.
+  // Use the buffered range to consider if we have the next frame available.
+  TimeUnit currentPosition = TimeUnit::FromMicroseconds(CurrentPosition());
+  TimeInterval interval(currentPosition,
+                        currentPosition + media::TimeUnit::FromMicroseconds(DEFAULT_NEXT_FRAME_AVAILABLE_BUFFERED),
+                        MediaSourceDemuxer::EOS_FUZZ);
+  return GetBuffered().Contains(interval)
+    ? MediaDecoderOwner::NEXT_FRAME_AVAILABLE
+    : MediaDecoderOwner::NEXT_FRAME_UNAVAILABLE;
+}
+
 already_AddRefed<SourceBufferDecoder>
 MediaSourceDecoder::SelectDecoder(int64_t aTarget,
                                   int64_t aTolerance,

--- a/dom/media/mediasource/MediaSourceDecoder.h
+++ b/dom/media/mediasource/MediaSourceDecoder.h
@@ -97,6 +97,8 @@ public:
   // buffered data. Used for debugging purposes.
   void GetMozDebugReaderData(nsAString& aString);
 
+	MediaDecoderOwner::NextFrameStatus NextFrameBufferedStatus() override;
+
 private:
   void DoSetMediaSourceDuration(double aDuration);
 

--- a/dom/media/mediasource/MediaSourceDecoder.h
+++ b/dom/media/mediasource/MediaSourceDecoder.h
@@ -98,6 +98,7 @@ public:
   void GetMozDebugReaderData(nsAString& aString);
 
 	MediaDecoderOwner::NextFrameStatus NextFrameBufferedStatus() override;
+	bool CanPlayThrough() override;
 
 private:
   void DoSetMediaSourceDuration(double aDuration);

--- a/dom/media/mediasource/MediaSourceDemuxer.h
+++ b/dom/media/mediasource/MediaSourceDemuxer.h
@@ -54,6 +54,9 @@ public:
   void DetachSourceBuffer(TrackBuffersManager* aSourceBuffer);
   MediaTaskQueue* GetTaskQueue() { return mTaskQueue; }
 
+	// Gap allowed between frames.
+  static const media::TimeUnit EOS_FUZZ;
+
 private:
   ~MediaSourceDemuxer();
   friend class MediaSourceTrackDemuxer;

--- a/dom/media/mediasource/test/mochitest.ini
+++ b/dom/media/mediasource/test/mochitest.ini
@@ -32,6 +32,8 @@ skip-if = (toolkit == 'android' || buildapp == 'mulet') #timeout android/mulet o
 [test_MediaSource.html]
 [test_MediaSource_disabled.html]
 [test_OnEvents.html]
+[test_PlayEvents.html]
+skip-if = ((os == "win" && os_version == "5.1") || (os != "win" && os != "mac")) # Only supported on osx and vista+
 [test_SeekableAfterEndOfStream.html]
 [test_SeekableAfterEndOfStreamSplit.html]
 [test_SeekableBeforeEndOfStream.html]

--- a/dom/media/mediasource/test/test_PlayEvents.html
+++ b/dom/media/mediasource/test/test_PlayEvents.html
@@ -1,0 +1,156 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>MSE: basic functionality</title>
+  <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="text/javascript" src="mediasource.js"></script>
+  <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
+</head>
+<body>
+<pre id="test">
+<script class="testbody" type="text/javascript">
+
+SimpleTest.waitForExplicitFinish();
+
+// This test checks that readyState is properly set and the appropriate events are being fired accordingly:
+// 1. Load 1.6s of data and ensure that canplay event is fired.
+// 2. Load data to have a complete buffered range from 0 to duration and ensure that canplaythrough is fired.
+// 3. Seek to an area with no buffered data, and ensure that readyState goes back to HAVE_METADATA
+// 4. Load 1.6s of data at the seek position and ensure that canplay is fired and that readyState is now HAVE_FUTURE_DATA
+// 5. Start playing video and check that once it reaches a position with no data, readyState goes back to HAVE_CURRENT_DATA and waiting event is fired.
+// 6. Add 1.6s of data once video element fired waiting, that canplay is fired once readyState is HAVE_FUTURE_DATA.
+// 7. Finally load data to the end and ensure that canplaythrough is fired and that readyState is now HAVE_ENOUGH_DATA
+
+runWithMSE(function(ms, el) {
+  el.controls = true;
+  once(ms, 'sourceopen').then(function() {
+    ok(true, "Receive a sourceopen event");
+    var videosb = ms.addSourceBuffer("video/mp4");
+    el.addEventListener("error", function(e) {
+      ok(false, "should not fire '" + e + "' event");
+    });
+    is(el.readyState, el.HAVE_NOTHING, "readyState is HAVE_NOTHING");
+    fetchAndLoad(videosb, 'bipbop/bipbop_video', ['init'], '.mp4')
+    .then(once.bind(null, el, 'loadedmetadata'))
+    .then(function() {
+       ok(true, "got loadedmetadata event");
+       var promises = [];
+       promises.push(once(el, 'loadeddata'));
+       promises.push(once(el, 'canplay'));
+       // Load [0, 1.601666). We must ensure that we load over 25 frames as the
+       // windows H264 decoder will not produce a sample until then
+       // (bug 1191138).
+       promises.push(fetchAndLoad(videosb, 'bipbop/bipbop_video', range(1, 3), '.m4s'));
+       return Promise.all(promises);
+    })
+    .then(function() {
+      ok(true, "got canplay event");
+      // set element duration to 3.203333s. We do so in order to guarantee that
+      // the end of the buffered range will be equal to duration, causing
+      // canplaythrough to be fired later.
+      ms.duration = 3.203333;
+      return once(el, 'durationchange');
+    })
+    .then(function() {
+      ok(true, "got durationchange event");
+      var promises = [];
+      promises.push(once(el, 'canplaythrough'));
+      // Load [0.801666, 3.203333]
+      promises.push(fetchAndLoad(videosb, 'bipbop/bipbop_video', range(3, 5), '.m4s'));
+      return Promise.all(promises);
+    })
+    .then(function() {
+      ok(true, "got canplaythrough event");
+     // set element duration to 9.203333s, this value is set to coincide with
+     // data added later (we now have an empty range from 6s to 9.203333s).
+     ms.duration = 9.203333;
+     return once(el, 'durationchange');
+    })
+    .then(function() {
+      ok(true, "got durationchange event");
+      // An arbitrary value, so we are guaranteed to be in a range with no data.
+      el.currentTime = 6;
+      videosb.timestampOffset = 6;
+      ok(el.seeking, "seeking started");
+      return once(el, 'seeking');
+    })
+    .then(function() {
+      ok(true, "got seeking event");
+      is(el.readyState, el.HAVE_METADATA, "readyState is HAVE_METADATA");
+      var promises = [];
+      promises.push(once(el, 'seeked'));
+      promises.push(once(el, 'canplay'));
+      // Load [6+0, 6+1.601666)
+      promises.push(fetchAndLoad(videosb, 'bipbop/bipbop_video', range(1, 3), '.m4s'));
+      return Promise.all(promises);
+    })
+    .then(function() {
+      ok(true, "got seeked and canplay event");
+      is(el.currentTime, 6, "seeked to 6s");
+      is(el.readyState, el.HAVE_FUTURE_DATA, "readyState is HAVE_FUTURE_DATA");
+      var promises = [];
+      promises.push(once(el, 'canplaythrough'));
+      // Load [6+1.60166, 6+3.203333]
+      promises.push(fetchAndLoad(videosb, 'bipbop/bipbop_video', range(3, 5), '.m4s'));
+      return Promise.all(promises);
+    })
+    .then(function() {
+      ok(true, "got canplaythrough event");
+      // set element duration to 19.805s, this value is set to coincide with
+      // data added later (we now have an empty range from 15 to 19.805).
+      ms.duration = 19.805;
+      return once(el, 'durationchange');
+    })
+    .then(function() {
+      ok(true, "got durationchange event");
+      el.currentTime = 15;
+      videosb.timestampOffset = 15;
+      ok(el.seeking, "seeking started");
+      return once(el, 'seeking');
+    })
+    .then(function() {
+      ok(true, "got seeking event");
+      var promises = [];
+      promises.push(once(el, 'seeked'));
+      // Load [15+0, 15+1.601666)
+      promises.push(fetchAndLoad(videosb, 'bipbop/bipbop_video', range(1, 3), '.m4s'));
+      return Promise.all(promises);
+    })
+    .then(function() {
+      ok(true, "got seeked event");
+      // Load [15+1.60166, 15+3.203333]
+      return fetchAndLoad(videosb, 'bipbop/bipbop_video', range(3, 5), '.m4s');
+    })
+    .then(function() {
+      ok(true, "data loaded");
+      // Playback we play for a little while then stall.
+      var promises = [];
+      promises.push(once(el, 'playing'));
+      promises.push(once(el, 'waiting'));
+      el.play();
+      return Promise.all(promises);
+    })
+    .then(function() {
+      ok(true, "got playing and waiting event");
+      // Playback has stalled, readyState is back to HAVE_CURRENT_DATA.
+      is(el.readyState, el.HAVE_CURRENT_DATA, "readyState is HAVE_CURRENT_DATA");
+      var promises = [];
+      promises.push(once(el, 'playing'));
+      promises.push(once(el, 'canplay'));
+      promises.push(once(el, 'canplaythrough'));
+      // Load [15+3.203333, 15+4.805)
+      // Our final buffered range will now be [0, 3.203333)[6, 9.203333)[15, 19.805)
+      promises.push(fetchAndLoad(videosb, 'bipbop/bipbop_video', range(5, 7), '.m4s'));
+      return Promise.all(promises);
+    })
+    .then(function() {
+      ok(true, "got playing, canplay and canplaythrough event");
+      SimpleTest.finish();
+    })
+  });
+});
+
+</script>
+</pre>
+</body>
+</html>


### PR DESCRIPTION
This set of commits should resolve #1430.

I have built and tested this on the Gabien site. Videos now play, but the first couple seconds of audio "stutters" and doesn't play correctly. However, after the first couple seconds the stream begins playing fine. So there's still an issue here (likely a race condition as mentioned in #1430), but the streams are at least playable now. Baby steps!

I've also (very) lightly tested this on YouTube with no issues seen. I'll do some more extensive testing of this tomorrow, but in the meantime it should be good to ship out in an unstable build.