### PR TITLE
Remove unnecessary preprocessing of safeMode.js

### DIFF
--- a/browser/base/content/safeMode.js
+++ b/browser/base/content/safeMode.js
@@ -1,7 +1,7 @@
-# -*- Mode: Java; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+/* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Cc = Components.classes,
       Ci = Components.interfaces,

--- a/browser/base/jar.mn
+++ b/browser/base/jar.mn
@@ -99,7 +99,7 @@ browser.jar:
         content/browser/openLocation.js               (content/openLocation.js)
         content/browser/openLocation.xul              (content/openLocation.xul)
         content/browser/safeMode.css                  (content/safeMode.css)
-*       content/browser/safeMode.js                   (content/safeMode.js)
+        content/browser/safeMode.js                   (content/safeMode.js)
 *       content/browser/safeMode.xul                  (content/safeMode.xul)
 *       content/browser/sanitize.js                   (content/sanitize.js)
 *       content/browser/sanitize.xul                  (content/sanitize.xul)


### PR DESCRIPTION
Follow-up to #1389, https://github.com/MoonchildProductions/Pale-Moon/commit/9a44165b281d3f6eab019e18dd64ba6dc19bf286.

See also [bug 325901](https://bugzilla.mozilla.org/show_bug.cgi?id=325901).