### PR TITLE
Handle uninstalls of restartless addons in XPIProvider

### DIFF
--- a/toolkit/mozapps/extensions/AddonManager.jsm
+++ b/toolkit/mozapps/extensions/AddonManager.jsm
@@ -2754,14 +2754,22 @@ this.AddonManager = {
   // The combination of all scopes.
   SCOPE_ALL: 15,
 
-  // 1-15 are different built-in views for the add-on type
+  // Add-on type is expected to be displayed in the UI in a list.
   VIEW_TYPE_LIST: "list",
 
+  // Constants describing how add-on types behave.
+
+  // If no add-ons of a type are installed, then the category for that add-on
+  // type should be hidden in the UI.
   TYPE_UI_HIDE_EMPTY: 16,
   // Indicates that this add-on type supports the ask-to-activate state.
   // That is, add-ons of this type can be set to be optionally enabled
   // on a case-by-case basis.
   TYPE_SUPPORTS_ASK_TO_ACTIVATE: 32,
+  // The add-on type natively supports undo for restartless uninstalls.
+  // If this flag is not specified, the UI is expected to handle this via
+  // disabling the add-on, and performing the actual uninstall at a later time.
+  TYPE_SUPPORTS_UNDO_RESTARTLESS_UNINSTALL: 64,
 
   // Constants for Addon.applyBackgroundUpdates.
   // Indicates that the Addon should not update automatically.

--- a/toolkit/mozapps/extensions/content/extensions.js
+++ b/toolkit/mozapps/extensions/content/extensions.js
@@ -1651,7 +1651,7 @@ function doPendingUninstalls(aListBox) {
   var listitem = aListBox.firstChild;
   while (listitem) {
     if (listitem.getAttribute("pending") == "uninstall" &&
-        !(listitem.opRequiresRestart("UNINSTALL")))
+        !(listitem.opRequiresRestart("uninstall")))
       items.push(listitem.mAddon);
     listitem = listitem.nextSibling;
   }

--- a/toolkit/mozapps/extensions/content/extensions.js
+++ b/toolkit/mozapps/extensions/content/extensions.js
@@ -1651,7 +1651,7 @@ function doPendingUninstalls(aListBox) {
   var listitem = aListBox.firstChild;
   while (listitem) {
     if (listitem.getAttribute("pending") == "uninstall" &&
-        !listitem.isPending("uninstall"))
+        !(listitem.opRequiresRestart("UNINSTALL")))
       items.push(listitem.mAddon);
     listitem = listitem.nextSibling;
   }

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -785,6 +785,16 @@
         ]]></body>
       </method>
 
+      <method name="typeHasFlag">
+        <parameter name="aFlag"/>
+        <body><![CDATA[
+          let flag = AddonManager["TYPE_" + aFlag];
+          let type = AddonManager.addonTypes[this.mAddon.type];
+
+          return !!(type.flags & flag);
+        ]]></body>
+      </method>
+
       <method name="isPending">
         <parameter name="aAction"/>
         <body><![CDATA[
@@ -1368,8 +1378,7 @@
           this._preferencesBtn.hidden = (!this.mAddon.optionsURL) ||
                                         this.mAddon.optionsType == AddonManager.OPTIONS_TYPE_INLINE_INFO;
 
-          let addonType = AddonManager.addonTypes[this.mAddon.type];
-          if (addonType.flags & AddonManager.TYPE_SUPPORTS_ASK_TO_ACTIVATE) {
+          if (this.typeHasFlag("SUPPORTS_ASK_TO_ACTIVATE")) {
             this._enableBtn.disabled = true;
             this._disableBtn.disabled = true;
             this._askToActivateMenuitem.disabled = !this.hasPermission("ask_to_activate");
@@ -1602,9 +1611,11 @@
 
       <method name="uninstall">
         <body><![CDATA[
-          // If uninstalling does not require a restart then just disable it
-          // and show the undo UI.
-          if (!this.opRequiresRestart("uninstall")) {
+          // If uninstalling does not require a restart and the type doesn't
+          // support undoing of restartless uninstalls, then we fake it by
+          // just disabling it it, and doing the real uninstall later.
+          if (!this.opRequiresRestart("uninstall") &&
+              !this.typeHasFlag("SUPPORTS_UNDO_RESTARTLESS_UNINSTALL")) {
             this.setAttribute("wasDisabled", this.mAddon.userDisabled);
 
             // We must set userDisabled to true first, this will call
@@ -1614,7 +1625,7 @@
             // This won't update any other add-on manager views (bug 582002)
             this.setAttribute("pending", "uninstall");
           } else {
-            this.mAddon.uninstall();
+            this.mAddon.uninstall(true);
           }
         ]]></body>
       </method>
@@ -1856,7 +1867,7 @@
                                                                      [this.mAddon.name],
                                                                      1);
 
-        if (!this.isPending("uninstall"))
+        if (!this.opRequiresRestart("uninstall"))
           this._restartBtn.setAttribute("hidden", true);
 
         gEventManager.registerAddonListener(this, this.mAddon.id);

--- a/toolkit/mozapps/extensions/test/addons/test_undoincompatible/bootstrap.js
+++ b/toolkit/mozapps/extensions/test/addons/test_undoincompatible/bootstrap.js
@@ -1,0 +1,1 @@
+Components.utils.import("resource://xpcshell-data/BootstrapMonitor.jsm").monitor(this);

--- a/toolkit/mozapps/extensions/test/addons/test_undoincompatible/install.rdf
+++ b/toolkit/mozapps/extensions/test/addons/test_undoincompatible/install.rdf
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+
+  <Description about="urn:mozilla:install-manifest">
+    <em:id>incompatible@tests.mozilla.org</em:id>
+    <em:version>1.0</em:version>
+    <em:bootstrap>true</em:bootstrap>
+
+    <!-- Front End MetaData -->
+    <em:name>Incompatible Addon</em:name>
+    <em:description>I am incompatible</em:description>
+
+    <em:iconURL>chrome://foo/skin/icon.png</em:iconURL>
+    <em:aboutURL>chrome://foo/content/about.xul</em:aboutURL>
+    <em:optionsURL>chrome://foo/content/options.xul</em:optionsURL>
+
+    <em:targetApplication>
+      <Description>
+        <em:id>xpcshell@tests.mozilla.org</em:id>
+        <em:minVersion>2</em:minVersion>
+        <em:maxVersion>2</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+
+  </Description>
+</RDF>

--- a/toolkit/mozapps/extensions/test/addons/test_undouninstall1/bootstrap.js
+++ b/toolkit/mozapps/extensions/test/addons/test_undouninstall1/bootstrap.js
@@ -1,0 +1,1 @@
+Components.utils.import("resource://xpcshell-data/BootstrapMonitor.jsm").monitor(this);

--- a/toolkit/mozapps/extensions/test/addons/test_undouninstall1/install.rdf
+++ b/toolkit/mozapps/extensions/test/addons/test_undouninstall1/install.rdf
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+
+  <Description about="urn:mozilla:install-manifest">
+    <em:id>undouninstall1@tests.mozilla.org</em:id>
+    <em:version>1.0</em:version>
+    <em:bootstrap>true</em:bootstrap>
+
+    <!-- Front End MetaData -->
+    <em:name>Test Bootstrap 1</em:name>
+    <em:description>Test Description</em:description>
+
+    <em:iconURL>chrome://foo/skin/icon.png</em:iconURL>
+    <em:aboutURL>chrome://foo/content/about.xul</em:aboutURL>
+    <em:optionsURL>chrome://foo/content/options.xul</em:optionsURL>
+
+    <em:targetApplication>
+      <Description>
+        <em:id>xpcshell@tests.mozilla.org</em:id>
+        <em:minVersion>1</em:minVersion>
+        <em:maxVersion>1</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+
+  </Description>
+</RDF>

--- a/toolkit/mozapps/extensions/test/browser/browser_bug596336.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_bug596336.js
@@ -126,8 +126,7 @@ add_test(function() {
       // Force XBL to apply
       item.clientTop;
 
-      ok(aAddon.userDisabled, "Add-on should be disabled");
-      ok(!aAddon.pendingUninstall, "Add-on should not be pending uninstall");
+      ok(!!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should be pending uninstall");
       is_element_visible(get_class_node(item, "pending"), "Pending message should be visible");
 
       install_addon("browser_bug596336_2", function() {
@@ -161,8 +160,7 @@ add_test(function() {
       // Force XBL to apply
       item.clientTop;
 
-      ok(aAddon.userDisabled, "Add-on should be disabled");
-      ok(!aAddon.pendingUninstall, "Add-on should not be pending uninstall");
+      ok(!!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should be pending uninstall");
       is_element_visible(get_class_node(item, "pending"), "Pending message should be visible");
 
       install_addon("browser_bug596336_2", function() {

--- a/toolkit/mozapps/extensions/test/browser/browser_uninstalling.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_uninstalling.js
@@ -128,7 +128,7 @@ add_test(function() {
       // Force XBL to apply
       item.clientTop;
 
-      ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+      ok(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL, "Add-on should be pending uninstall");
       button = gDocument.getAnonymousElementByAttribute(item, "anonid", "remove-btn");
       isnot(button, null, "Should have a remove button");
       ok(!button.disabled, "Button should not be disabled");
@@ -221,7 +221,7 @@ add_test(function() {
 
       is(item.getAttribute("pending"), "uninstall", "Add-on should be uninstalling");
 
-      ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+      ok(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL, "Add-on should be pending uninstall");
       ok(!aAddon.isActive, "Add-on should be inactive");
 
       var button = gDocument.getAnonymousElementByAttribute(item, "anonid", "restart-btn");
@@ -342,7 +342,7 @@ add_test(function() {
 
       is(item.getAttribute("pending"), "uninstall", "Add-on should be uninstalling");
 
-      ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+      ok(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL, "Add-on should be pending uninstall");
       ok(!aAddon.isActive, "Add-on should be inactive");
 
       var button = gDocument.getAnonymousElementByAttribute(item, "anonid", "restart-btn");
@@ -405,7 +405,7 @@ add_test(function() {
 
       is(item.getAttribute("pending"), "uninstall", "Add-on should be uninstalling");
 
-      ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+      ok(!!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should be pending uninstall");
       ok(!aAddon.isActive, "Add-on should be inactive");
 
       var button = gDocument.getAnonymousElementByAttribute(item, "anonid", "restart-btn");
@@ -531,7 +531,7 @@ add_test(function() {
           isnot(item, null, "Should have found the add-on in the list");
           is(item.getAttribute("pending"), "uninstall", "Add-on should be uninstalling");
 
-          ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+          ok(!!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should be pending uninstall");
           ok(!aAddon.isActive, "Add-on should be inactive");
 
           // Force XBL to apply
@@ -598,7 +598,7 @@ add_test(function() {
           isnot(item, null, "Should have found the add-on in the list");
           is(item.getAttribute("pending"), "uninstall", "Add-on should be uninstalling");
 
-          ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+          ok(!!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should be pending uninstall");
           ok(!aAddon.isActive, "Add-on should be inactive");
 
           // Force XBL to apply
@@ -809,7 +809,7 @@ add_test(function() {
 
       is(item.getAttribute("pending"), "uninstall", "Add-on should be uninstalling");
 
-      ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+      ok(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL, "Add-on should be pending uninstall");
       ok(!aAddon.isActive, "Add-on should be inactive");
 
       button = gDocument.getAnonymousElementByAttribute(item, "anonid", "restart-btn");
@@ -888,7 +888,7 @@ add_test(function() {
 
       is(item.getAttribute("pending"), "uninstall", "Add-on should be uninstalling");
 
-      ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+      ok(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL, "Add-on should be pending uninstall");
       ok(!aAddon.isActive, "Add-on should be inactive");
 
       button = gDocument.getAnonymousElementByAttribute(item, "anonid", "restart-btn");
@@ -964,7 +964,7 @@ add_test(function() {
 
       is(item.getAttribute("pending"), "uninstall", "Add-on should be uninstalling");
 
-      ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+      ok(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL, "Add-on should be pending uninstall");
       ok(!aAddon.isActive, "Add-on should be inactive");
 
       button = gDocument.getAnonymousElementByAttribute(item, "anonid", "restart-btn");
@@ -1046,7 +1046,7 @@ add_test(function() {
 
       is(item.getAttribute("pending"), "uninstall", "Add-on should be uninstalling");
 
-      ok(!(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL), "Add-on should not be pending uninstall");
+      ok(aAddon.pendingOperations & AddonManager.PENDING_UNINSTALL, "Add-on should be pending uninstall");
       ok(!aAddon.isActive, "Add-on should be inactive");
 
       var button = gDocument.getAnonymousElementByAttribute(item, "anonid", "restart-btn");

--- a/toolkit/mozapps/extensions/test/browser/head.js
+++ b/toolkit/mozapps/extensions/test/browser/head.js
@@ -635,7 +635,8 @@ function MockProvider(aUseAsyncCallbacks, aTypes) {
     id: "extension",
     name: "Extensions",
     uiPriority: 4000,
-    flags: AddonManager.TYPE_UI_VIEW_LIST
+    flags: AddonManager.TYPE_UI_VIEW_LIST |
+           AddonManager.TYPE_SUPPORTS_UNDO_RESTARTLESS_UNINSTALL,
   }] : aTypes;
 
   var self = this;
@@ -1088,7 +1089,8 @@ function MockAddon(aId, aName, aType, aOperationsRequiringRestart) {
 
 MockAddon.prototype = {
   get shouldBeActive() {
-    return !this.appDisabled && !this._userDisabled;
+    return !this.appDisabled && !this._userDisabled &&
+           !(this.pendingOperations & AddonManager.PENDING_UNINSTALL);
   },
 
   get appDisabled() {
@@ -1160,16 +1162,19 @@ MockAddon.prototype = {
     // Tests can implement this if they need to
   },
 
-  uninstall: function() {
-    if (this.pendingOperations & AddonManager.PENDING_UNINSTALL)
+  uninstall: function(aAlwaysAllowUndo = false) {
+    if ((this.operationsRequiringRestart & AddonManager.OP_NEED_RESTART_UNINSTALL)
+        && this.pendingOperations & AddonManager.PENDING_UNINSTALL)
       throw Components.Exception("Add-on is already pending uninstall");
 
-    var needsRestart = !!(this.operationsRequiringRestart & AddonManager.OP_NEEDS_RESTART_UNINSTALL);
+    var needsRestart = aAlwaysAllowUndo || !!(this.operationsRequiringRestart & AddonManager.OP_NEEDS_RESTART_UNINSTALL);
     this.pendingOperations |= AddonManager.PENDING_UNINSTALL;
     AddonManagerPrivate.callAddonListeners("onUninstalling", this, needsRestart);
     if (!needsRestart) {
       this.pendingOperations -= AddonManager.PENDING_UNINSTALL;
       this._provider.removeAddon(this);
+    } else if (!(this.operationsRequiringRestart & AddonManager.OP_NEEDS_RESTART_DISABLE)) {
+      this.isActive = false;
     }
   },
 
@@ -1178,6 +1183,7 @@ MockAddon.prototype = {
       throw Components.Exception("Add-on is not pending uninstall");
 
     this.pendingOperations -= AddonManager.PENDING_UNINSTALL;
+    this.isActive = this.shouldBeActive;
     AddonManagerPrivate.callAddonListeners("onOperationCancelled", this);
   },
 

--- a/toolkit/mozapps/extensions/test/xpcshell/head_addons.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/head_addons.js
@@ -1707,7 +1707,7 @@ function callback_soon(aFunction) {
  * its callback.
  */
 function promiseAddonsByIDs(list) {
-  return new Promise((resolve, reject) => AddonManager.getAddonsByIDs(list, resolve));
+  return new Promise(resolve => AddonManager.getAddonsByIDs(list, resolve));
 }
 
 /**
@@ -1718,7 +1718,20 @@ function promiseAddonsByIDs(list) {
  * @resolve {AddonWrapper} The corresponding add-on, or null.
  */
 function promiseAddonByID(aId) {
-  return new Promise((resolve, reject) => AddonManager.getAddonByID(aId, resolve));
+  return new Promise(resolve => AddonManager.getAddonByID(aId, resolve));
+}
+
+/**
+ * A promise-based variant of AddonManager.getAddonsWithOperationsByTypes
+ *
+ * @param {array} aTypes The first argument to
+ *                       AddonManager.getAddonsWithOperationsByTypes
+ * @return {promise}
+ * @resolve {array} The list of add-ons sent by
+ *                  AddonManaget.getAddonsWithOperationsByTypes to its callback.
+ */
+function promiseAddonsWithOperationsByTypes(aTypes) {
+  return new Promise(resolve => AddonManager.getAddonsWithOperationsByTypes(aTypes, resolve));
 }
 
 /**

--- a/toolkit/mozapps/extensions/test/xpcshell/test_undothemeuninstall.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_undothemeuninstall.js
@@ -1,0 +1,421 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+// This verifies that forcing undo for uninstall works for themes
+Components.utils.import("resource://gre/modules/LightweightThemeManager.jsm");
+
+const PREF_GENERAL_SKINS_SELECTEDSKIN = "general.skins.selectedSkin";
+
+var defaultTheme = {
+  id: "default@tests.mozilla.org",
+  version: "1.0",
+  name: "Test 1",
+  internalName: "classic/1.0",
+  targetApplications: [{
+    id: "xpcshell@tests.mozilla.org",
+    minVersion: "1",
+    maxVersion: "1"
+  }]
+};
+
+var theme1 = {
+  id: "theme1@tests.mozilla.org",
+  version: "1.0",
+  name: "Test 1",
+  internalName: "theme1",
+  targetApplications: [{
+    id: "xpcshell@tests.mozilla.org",
+    minVersion: "1",
+    maxVersion: "1"
+  }]
+};
+
+const profileDir = gProfD.clone();
+profileDir.append("extensions");
+
+function dummyLWTheme(id) {
+  return {
+    id: id || Math.random().toString(),
+    name: Math.random().toString(),
+    headerURL: "http://lwttest.invalid/a.png",
+    footerURL: "http://lwttest.invalid/b.png",
+    textcolor: Math.random().toString(),
+    accentcolor: Math.random().toString()
+  };
+}
+
+// Sets up the profile by installing an add-on.
+function run_test() {
+  createAppInfo("xpcshell@tests.mozilla.org", "XPCShell", "1", "1.9.2");
+
+  startupManager();
+  do_register_cleanup(promiseShutdownManager);
+
+  run_next_test();
+}
+
+add_task(function* checkDefault() {
+  writeInstallRDFForExtension(defaultTheme, profileDir);
+  yield promiseRestartManager();
+
+  let d = yield promiseAddonByID("default@tests.mozilla.org");
+
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+});
+
+// Tests that uninstalling an enabled theme offers the option to undo
+add_task(function* uninstallEnabledOffersUndo() {
+  writeInstallRDFForExtension(theme1, profileDir);
+
+  yield promiseRestartManager();
+
+  let t1 = yield promiseAddonByID("theme1@tests.mozilla.org");
+
+  do_check_neq(t1, null);
+  do_check_true(t1.userDisabled);
+
+  t1.userDisabled = false;
+
+  yield promiseRestartManager();
+
+  let d = null;
+  [ t1, d ] = yield promiseAddonsByIDs(["theme1@tests.mozilla.org",
+                                        "default@tests.mozilla.org"]);
+  do_check_neq(d, null);
+  do_check_false(d.isActive);
+  do_check_true(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_neq(t1, null);
+  do_check_true(t1.isActive);
+  do_check_false(t1.userDisabled);
+  do_check_eq(t1.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "theme1");
+
+  prepare_test({
+    "default@tests.mozilla.org": [
+      "onEnabling"
+    ],
+    "theme1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  t1.uninstall(true);
+  ensure_test_completed();
+
+  do_check_neq(d, null);
+  do_check_false(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_ENABLE);
+
+  do_check_true(t1.isActive);
+  do_check_false(t1.userDisabled);
+  do_check_true(hasFlag(t1.pendingOperations, AddonManager.PENDING_UNINSTALL));
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "theme1");
+
+  yield promiseRestartManager();
+
+  [ t1, d ] = yield promiseAddonsByIDs(["theme1@tests.mozilla.org",
+                                        "default@tests.mozilla.org"]);
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(t1, null);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+});
+
+//Tests that uninstalling an enabled theme can be undone
+add_task(function* canUndoUninstallEnabled() {
+  writeInstallRDFForExtension(theme1, profileDir);
+
+  yield promiseRestartManager();
+
+  let t1 = yield promiseAddonByID("theme1@tests.mozilla.org");
+
+  do_check_neq(t1, null);
+  do_check_true(t1.userDisabled);
+
+  t1.userDisabled = false;
+
+  yield promiseRestartManager();
+
+  let d = null;
+  [ t1, d ] = yield promiseAddonsByIDs(["theme1@tests.mozilla.org",
+                                        "default@tests.mozilla.org"]);
+
+  do_check_neq(d, null);
+  do_check_false(d.isActive);
+  do_check_true(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_neq(t1, null);
+  do_check_true(t1.isActive);
+  do_check_false(t1.userDisabled);
+  do_check_eq(t1.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "theme1");
+
+  prepare_test({
+    "default@tests.mozilla.org": [
+      "onEnabling"
+    ],
+    "theme1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  t1.uninstall(true);
+  ensure_test_completed();
+
+  do_check_neq(d, null);
+  do_check_false(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_ENABLE);
+
+  do_check_true(t1.isActive);
+  do_check_false(t1.userDisabled);
+  do_check_true(hasFlag(t1.pendingOperations, AddonManager.PENDING_UNINSTALL));
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "theme1");
+
+  prepare_test({
+    "default@tests.mozilla.org": [
+      "onOperationCancelled"
+    ],
+    "theme1@tests.mozilla.org": [
+      "onOperationCancelled"
+    ]
+  });
+  t1.cancelUninstall();
+  ensure_test_completed();
+
+  do_check_neq(d, null);
+  do_check_false(d.isActive);
+  do_check_true(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_neq(t1, null);
+  do_check_true(t1.isActive);
+  do_check_false(t1.userDisabled);
+  do_check_eq(t1.pendingOperations, AddonManager.PENDING_NONE);
+
+  yield promiseRestartManager();
+
+  [ t1, d ] = yield promiseAddonsByIDs(["theme1@tests.mozilla.org",
+                                        "default@tests.mozilla.org"]);
+
+  do_check_neq(d, null);
+  do_check_false(d.isActive);
+  do_check_true(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_neq(t1, null);
+  do_check_true(t1.isActive);
+  do_check_false(t1.userDisabled);
+  do_check_eq(t1.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "theme1");
+
+  t1.uninstall();
+  yield promiseRestartManager();
+});
+
+//Tests that uninstalling a disabled theme offers the option to undo
+add_task(function* uninstallDisabledOffersUndo() {
+  writeInstallRDFForExtension(theme1, profileDir);
+
+  yield promiseRestartManager();
+
+  let [ t1, d ] = yield promiseAddonsByIDs(["theme1@tests.mozilla.org",
+                                            "default@tests.mozilla.org"]);
+
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_neq(t1, null);
+  do_check_false(t1.isActive);
+  do_check_true(t1.userDisabled);
+  do_check_eq(t1.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+
+  prepare_test({
+    "theme1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  t1.uninstall(true);
+  ensure_test_completed();
+
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_false(t1.isActive);
+  do_check_true(t1.userDisabled);
+  do_check_true(hasFlag(t1.pendingOperations, AddonManager.PENDING_UNINSTALL));
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+
+  yield promiseRestartManager();
+
+  [ t1, d ] = yield promiseAddonsByIDs(["theme1@tests.mozilla.org",
+                                        "default@tests.mozilla.org"]);
+
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(t1, null);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+});
+
+//Tests that uninstalling a disabled theme can be undone
+add_task(function* canUndoUninstallDisabled() {
+  writeInstallRDFForExtension(theme1, profileDir);
+
+  yield promiseRestartManager();
+
+  let [ t1, d ] = yield promiseAddonsByIDs(["theme1@tests.mozilla.org",
+                                            "default@tests.mozilla.org"]);
+
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_neq(t1, null);
+  do_check_false(t1.isActive);
+  do_check_true(t1.userDisabled);
+  do_check_eq(t1.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+
+  prepare_test({
+    "theme1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  t1.uninstall(true);
+  ensure_test_completed();
+
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_false(t1.isActive);
+  do_check_true(t1.userDisabled);
+  do_check_true(hasFlag(t1.pendingOperations, AddonManager.PENDING_UNINSTALL));
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+
+  prepare_test({
+    "theme1@tests.mozilla.org": [
+      "onOperationCancelled"
+    ]
+  });
+  t1.cancelUninstall();
+  ensure_test_completed();
+
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_neq(t1, null);
+  do_check_false(t1.isActive);
+  do_check_true(t1.userDisabled);
+  do_check_eq(t1.pendingOperations, AddonManager.PENDING_NONE);
+
+  yield promiseRestartManager();
+
+  [ t1, d ] = yield promiseAddonsByIDs(["theme1@tests.mozilla.org",
+                                        "default@tests.mozilla.org"]);
+
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_neq(t1, null);
+  do_check_false(t1.isActive);
+  do_check_true(t1.userDisabled);
+  do_check_eq(t1.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+
+  t1.uninstall();
+  yield promiseRestartManager();
+});
+
+//Tests that uninstalling an enabled lightweight theme offers the option to undo
+add_task(function* uninstallLWTOffersUndo() {
+  // skipped since lightweight themes don't support undoable uninstall yet
+  return;
+  LightweightThemeManager.currentTheme = dummyLWTheme("theme1");
+
+  let [ t1, d ] = yield promiseAddonsByIDs(["theme1@personas.mozilla.org",
+                                            "default@tests.mozilla.org"]);
+
+  do_check_neq(d, null);
+  do_check_false(d.isActive);
+  do_check_true(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_neq(t1, null);
+  do_check_true(t1.isActive);
+  do_check_false(t1.userDisabled);
+  do_check_eq(t1.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+
+  prepare_test({
+    "default@tests.mozilla.org": [
+      "onEnabling"
+    ],
+    "theme1@personas.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  t1.uninstall(true);
+  ensure_test_completed();
+
+  do_check_neq(d, null);
+  do_check_false(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_ENABLE);
+
+  do_check_true(t1.isActive);
+  do_check_false(t1.userDisabled);
+  do_check_true(hasFlag(t1.pendingOperations, AddonManager.PENDING_UNINSTALL));
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+
+  yield promiseRestartManager();
+
+  [ t1, d ] = yield promiseAddonsByIDs(["theme1@personas.mozilla.org",
+                                        "default@tests.mozilla.org"]);
+
+  do_check_neq(d, null);
+  do_check_true(d.isActive);
+  do_check_false(d.userDisabled);
+  do_check_eq(d.pendingOperations, AddonManager.PENDING_NONE);
+
+  do_check_eq(t1, null);
+
+  do_check_eq(Services.prefs.getCharPref(PREF_GENERAL_SKINS_SELECTEDSKIN), "classic/1.0");
+});

--- a/toolkit/mozapps/extensions/test/xpcshell/test_undouninstall.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_undouninstall.js
@@ -1,0 +1,792 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+// This verifies that forcing undo for uninstall works
+
+const APP_STARTUP                     = 1;
+const APP_SHUTDOWN                    = 2;
+const ADDON_ENABLE                    = 3;
+const ADDON_DISABLE                   = 4;
+const ADDON_INSTALL                   = 5;
+const ADDON_UNINSTALL                 = 6;
+const ADDON_UPGRADE                   = 7;
+const ADDON_DOWNGRADE                 = 8;
+
+const ID = "undouninstall1@tests.mozilla.org";
+const INCOMPAT_ID = "incompatible@tests.mozilla.org";
+
+var addon1 = {
+  id: "addon1@tests.mozilla.org",
+  version: "1.0",
+  name: "Test 1",
+  targetApplications: [{
+    id: "xpcshell@tests.mozilla.org",
+    minVersion: "1",
+    maxVersion: "1"
+  }]
+};
+
+
+const profileDir = gProfD.clone();
+profileDir.append("extensions");
+
+BootstrapMonitor.init();
+
+function getStartupReason(id) {
+  let info = BootstrapMonitor.started.get(id);
+  return info ? info.reason : undefined;
+}
+
+function getShutdownReason(id) {
+  let info = BootstrapMonitor.stopped.get(id);
+  return info ? info.reason : undefined;
+}
+
+function getInstallReason(id) {
+  let info = BootstrapMonitor.installed.get(id);
+  return info ? info.reason : undefined;
+}
+
+function getUninstallReason(id) {
+  let info = BootstrapMonitor.uninstalled.get(id);
+  return info ? info.reason : undefined;
+}
+
+function getStartupOldVersion(id) {
+  let info = BootstrapMonitor.started.get(id);
+  return info ? info.data.oldVersion : undefined;
+}
+
+function getShutdownNewVersion(id) {
+  let info = BootstrapMonitor.stopped.get(id);
+  return info ? info.data.newVersion : undefined;
+}
+
+function getInstallOldVersion(id) {
+  let info = BootstrapMonitor.installed.get(id);
+  return info ? info.data.oldVersion : undefined;
+}
+
+function getUninstallNewVersion(id) {
+  let info = BootstrapMonitor.uninstalled.get(id);
+  return info ? info.data.newVersion : undefined;
+}
+
+// Sets up the profile by installing an add-on.
+function run_test() {
+  createAppInfo("xpcshell@tests.mozilla.org", "XPCShell", "1", "1.9.2");
+
+  startupManager();
+  do_register_cleanup(promiseShutdownManager);
+
+  run_next_test();
+}
+
+add_task(function* installAddon() {
+  let olda1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_eq(olda1, null);
+
+  writeInstallRDFForExtension(addon1, profileDir);
+  yield promiseRestartManager();
+
+  let a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+  do_check_true(isExtensionInAddonsList(profileDir, a1.id));
+  do_check_eq(a1.pendingOperations, 0);
+  do_check_in_crash_annotation(addon1.id, addon1.version);
+});
+
+// Uninstalling an add-on should work.
+add_task(function* uninstallAddon() {
+  prepare_test({
+    "addon1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+
+  let a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_eq(a1.pendingOperations, 0);
+  do_check_neq(a1.operationsRequiringRestart &
+               AddonManager.OP_NEEDS_RESTART_UNINSTALL, 0);
+  a1.uninstall(true);
+  do_check_true(hasFlag(a1.pendingOperations, AddonManager.PENDING_UNINSTALL));
+  do_check_in_crash_annotation(addon1.id, addon1.version);
+
+  ensure_test_completed();
+
+  let list = yield promiseAddonsWithOperationsByTypes(null);
+
+  do_check_eq(list.length, 1);
+  do_check_eq(list[0].id, "addon1@tests.mozilla.org");
+
+  yield promiseRestartManager();
+
+  a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_eq(a1, null);
+  do_check_false(isExtensionInAddonsList(profileDir, "addon1@tests.mozilla.org"));
+  do_check_not_in_crash_annotation(addon1.id, addon1.version);
+
+  var dest = profileDir.clone();
+  dest.append(do_get_expected_addon_name("addon1@tests.mozilla.org"));
+  do_check_false(dest.exists());
+  writeInstallRDFForExtension(addon1, profileDir);
+  yield promiseRestartManager();
+});
+
+// Cancelling the uninstall should send onOperationCancelled
+add_task(function* cancelUninstall() {
+  prepare_test({
+    "addon1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+
+  let a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+  do_check_true(isExtensionInAddonsList(profileDir, a1.id));
+  do_check_eq(a1.pendingOperations, 0);
+  a1.uninstall(true);
+  do_check_true(hasFlag(a1.pendingOperations, AddonManager.PENDING_UNINSTALL));
+
+  ensure_test_completed();
+
+  prepare_test({
+    "addon1@tests.mozilla.org": [
+      "onOperationCancelled"
+    ]
+  });
+  a1.cancelUninstall();
+  do_check_eq(a1.pendingOperations, 0);
+
+  ensure_test_completed();
+  yield promiseRestartManager();
+
+  a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+  do_check_true(isExtensionInAddonsList(profileDir, a1.id));
+});
+
+// Uninstalling an item pending disable should still require a restart
+add_task(function* pendingDisableRequestRestart() {
+  let a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  prepare_test({
+    "addon1@tests.mozilla.org": [
+      "onDisabling"
+    ]
+  });
+  a1.userDisabled = true;
+  ensure_test_completed();
+
+  do_check_true(hasFlag(AddonManager.PENDING_DISABLE, a1.pendingOperations));
+  do_check_true(a1.isActive);
+
+  prepare_test({
+    "addon1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+
+  prepare_test({
+    "addon1@tests.mozilla.org": [
+      "onOperationCancelled"
+    ]
+  });
+  a1.cancelUninstall();
+  ensure_test_completed();
+  do_check_true(hasFlag(AddonManager.PENDING_DISABLE, a1.pendingOperations));
+
+  yield promiseRestartManager();
+});
+
+// Test that uninstalling an inactive item should still allow cancelling
+add_task(function* uninstallInactiveIsCancellable() {
+  let a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+  do_check_false(isExtensionInAddonsList(profileDir, a1.id));
+
+  prepare_test({
+    "addon1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+
+  prepare_test({
+    "addon1@tests.mozilla.org": [
+      "onOperationCancelled"
+    ]
+  });
+  a1.cancelUninstall();
+  ensure_test_completed();
+
+  yield promiseRestartManager();
+});
+
+//Test that an inactive item can be uninstalled
+add_task(function* uninstallInactive() {
+  let a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+  do_check_false(isExtensionInAddonsList(profileDir, a1.id));
+
+  prepare_test({
+    "addon1@tests.mozilla.org": [
+      [ "onUninstalling", false ],
+      "onUninstalled"
+    ]
+  });
+  a1.uninstall();
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("addon1@tests.mozilla.org");
+  do_check_eq(a1, null);
+});
+
+// Tests that an enabled restartless add-on can be uninstalled and goes away
+// when the uninstall is committed
+add_task(function* uninstallRestartless() {
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      ["onInstalling", false],
+      "onInstalled"
+    ]
+  }, [
+    "onNewInstall",
+    "onInstallStarted",
+    "onInstallEnded"
+  ]);
+  yield promiseInstallAllFiles([do_get_addon("test_undouninstall1")]);
+  ensure_test_completed();
+
+  let a1 = yield promiseAddonByID(ID);
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getInstallReason(ID), ADDON_INSTALL);
+  do_check_eq(getStartupReason(ID), ADDON_INSTALL);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID(ID);
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID);
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  do_check_eq(getShutdownReason(ID), ADDON_UNINSTALL);
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+  do_check_false(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  // complete the uinstall
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onUninstalled"
+    ]
+  });
+  a1.uninstall();
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID(ID);
+
+  do_check_eq(a1, null);
+  BootstrapMonitor.checkAddonNotStarted(ID);
+});
+
+//Tests that an enabled restartless add-on can be uninstalled and then cancelled
+add_task(function* cancelUninstallOfRestartless() {
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      ["onInstalling", false],
+      "onInstalled"
+    ]
+  }, [
+    "onNewInstall",
+    "onInstallStarted",
+    "onInstallEnded"
+  ]);
+  yield promiseInstallAllFiles([do_get_addon("test_undouninstall1")]);
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID(ID);
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getInstallReason(ID), ADDON_INSTALL);
+  do_check_eq(getStartupReason(ID), ADDON_INSTALL);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID);
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  do_check_eq(getShutdownReason(ID), ADDON_UNINSTALL);
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+  do_check_false(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onOperationCancelled"
+    ]
+  });
+  a1.cancelUninstall();
+  ensure_test_completed();
+
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getStartupReason(ID), ADDON_INSTALL);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  shutdownManager();
+
+  do_check_eq(getShutdownReason(ID), APP_SHUTDOWN);
+  do_check_eq(getShutdownNewVersion(ID), undefined);
+
+  startupManager(false);
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getStartupReason(ID), APP_STARTUP);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  a1.uninstall();
+});
+
+// Tests that reinstalling an enabled restartless add-on waiting to be
+// uninstalled aborts the uninstall and leaves the add-on enabled
+add_task(function* reinstallAddonAwaitingUninstall() {
+  yield promiseInstallAllFiles([do_get_addon("test_undouninstall1")]);
+
+  let a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getInstallReason(ID), ADDON_INSTALL);
+  do_check_eq(getStartupReason(ID), ADDON_INSTALL);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID);
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  do_check_eq(getShutdownReason(ID), ADDON_UNINSTALL);
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+  do_check_false(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      ["onInstalling", false],
+      "onInstalled"
+    ]
+  }, [
+    "onNewInstall",
+    "onInstallStarted",
+    "onInstallEnded"
+  ]);
+
+  yield promiseInstallAllFiles([do_get_addon("test_undouninstall1")]);
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  ensure_test_completed();
+
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getUninstallReason(ID), ADDON_DOWNGRADE);
+  do_check_eq(getInstallReason(ID), ADDON_DOWNGRADE);
+  do_check_eq(getStartupReason(ID), ADDON_DOWNGRADE);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  shutdownManager();
+
+  do_check_eq(getShutdownReason(ID), APP_SHUTDOWN);
+
+  startupManager(false);
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getStartupReason(ID), APP_STARTUP);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  a1.uninstall();
+});
+
+// Tests that a disabled restartless add-on can be uninstalled and goes away
+// when the uninstall is committed
+add_task(function* uninstallDisabledRestartless() {
+  yield promiseInstallAllFiles([do_get_addon("test_undouninstall1")]);
+
+  let a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getInstallReason(ID), ADDON_INSTALL);
+  do_check_eq(getStartupReason(ID), ADDON_INSTALL);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  a1.userDisabled = true;
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  do_check_eq(getShutdownReason(ID), ADDON_DISABLE);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  // commit the uninstall
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onUninstalled"
+    ]
+  });
+  a1.uninstall();
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_eq(a1, null);
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  BootstrapMonitor.checkAddonNotInstalled(ID);
+  do_check_eq(getUninstallReason(ID), ADDON_UNINSTALL);
+});
+
+//Tests that a disabled restartless add-on can be uninstalled and then cancelled
+add_task(function* cancelUninstallDisabledRestartless() {
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      ["onInstalling", false],
+      "onInstalled"
+    ]
+  }, [
+    "onNewInstall",
+    "onInstallStarted",
+    "onInstallEnded"
+  ]);
+  yield promiseInstallAllFiles([do_get_addon("test_undouninstall1")]);
+  ensure_test_completed();
+
+  let a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getInstallReason(ID), ADDON_INSTALL);
+  do_check_eq(getStartupReason(ID), ADDON_INSTALL);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      ["onDisabling", false],
+      "onDisabled"
+    ]
+  });
+  a1.userDisabled = true;
+  ensure_test_completed();
+
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  do_check_eq(getShutdownReason(ID), ADDON_DISABLE);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  BootstrapMonitor.checkAddonInstalled(ID);
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onOperationCancelled"
+    ]
+  });
+  a1.cancelUninstall();
+  ensure_test_completed();
+
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  BootstrapMonitor.checkAddonInstalled(ID);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  yield promiseRestartManager();
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  BootstrapMonitor.checkAddonInstalled(ID);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  a1.uninstall();
+});
+
+//Tests that reinstalling a disabled restartless add-on waiting to be
+//uninstalled aborts the uninstall and leaves the add-on disabled
+add_task(function* reinstallDisabledAddonAwaitingUninstall() {
+  yield promiseInstallAllFiles([do_get_addon("test_undouninstall1")]);
+
+  let a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getInstallReason(ID), ADDON_INSTALL);
+  do_check_eq(getStartupReason(ID), ADDON_INSTALL);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  a1.userDisabled = true;
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  do_check_eq(getShutdownReason(ID), ADDON_DISABLE);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonNotStarted(ID);
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      ["onInstalling", false],
+      "onInstalled"
+    ]
+  }, [
+    "onNewInstall",
+    "onInstallStarted",
+    "onInstallEnded"
+  ]);
+
+  yield promiseInstallAllFiles([do_get_addon("test_undouninstall1")]);
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  ensure_test_completed();
+
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonNotStarted(ID, "1.0");
+  do_check_eq(getUninstallReason(ID), ADDON_DOWNGRADE);
+  do_check_eq(getInstallReason(ID), ADDON_DOWNGRADE);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  yield promiseRestartManager();
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonNotStarted(ID, "1.0");
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_false(a1.isActive);
+  do_check_true(a1.userDisabled);
+
+  a1.uninstall();
+});
+
+
+// Test that uninstalling a temporary addon can be canceled
+add_task(function* cancelUninstallTemporary() {
+  yield AddonManager.installTemporaryAddon(do_get_addon("test_undouninstall1"));
+
+  let a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonInstalled(ID, "1.0");
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(getInstallReason(ID), ADDON_INSTALL);
+  do_check_eq(getStartupReason(ID), ADDON_ENABLE);
+  do_check_eq(a1.pendingOperations, AddonManager.PENDING_NONE);
+  do_check_true(a1.isActive);
+  do_check_false(a1.userDisabled);
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+  ensure_test_completed();
+
+  BootstrapMonitor.checkAddonNotStarted(ID, "1.0");
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+
+  prepare_test({
+    "undouninstall1@tests.mozilla.org": [
+      "onOperationCancelled"
+    ]
+  });
+  a1.cancelUninstall();
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID("undouninstall1@tests.mozilla.org");
+
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonStarted(ID, "1.0");
+  do_check_eq(a1.pendingOperations, 0);
+
+  yield promiseRestartManager();
+});
+
+// Tests that cancelling the uninstall of an incompatible restartless addon
+// does not start the addon
+add_task(function* cancelUninstallIncompatibleRestartless() {
+  yield promiseInstallAllFiles([do_get_addon("test_undoincompatible")]);
+
+  let a1 = yield promiseAddonByID(INCOMPAT_ID);
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonNotStarted(INCOMPAT_ID);
+  do_check_false(a1.isActive);
+
+  prepare_test({
+    "incompatible@tests.mozilla.org": [
+      "onUninstalling"
+    ]
+  });
+  a1.uninstall(true);
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID(INCOMPAT_ID);
+  do_check_neq(a1, null);
+  do_check_true(hasFlag(AddonManager.PENDING_UNINSTALL, a1.pendingOperations));
+  do_check_false(a1.isActive);
+
+  prepare_test({
+    "incompatible@tests.mozilla.org": [
+      "onOperationCancelled"
+    ]
+  });
+  a1.cancelUninstall();
+  ensure_test_completed();
+
+  a1 = yield promiseAddonByID(INCOMPAT_ID);
+  do_check_neq(a1, null);
+  BootstrapMonitor.checkAddonNotStarted(INCOMPAT_ID);
+  do_check_eq(a1.pendingOperations, 0);
+  do_check_false(a1.isActive);
+});

--- a/toolkit/mozapps/extensions/test/xpcshell/test_uninstall.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_uninstall.js
@@ -201,6 +201,7 @@ function run_test_4() {
       ]
     });
     a1.uninstall();
+    ensure_test_completed();
 
     check_test_4();
   });

--- a/toolkit/mozapps/extensions/test/xpcshell/xpcshell-shared.ini
+++ b/toolkit/mozapps/extensions/test/xpcshell/xpcshell-shared.ini
@@ -245,6 +245,8 @@ fail-if = os == "android"
 # Bug 676992: test consistently fails on Android
 fail-if = os == "android"
 [test_types.js]
+[test_undothemeuninstall.js]
+[test_undouninstall.js]
 [test_uninstall.js]
 [test_update.js]
 # Bug 676992: test consistently hangs on Android


### PR DESCRIPTION
Based on [bug 612168](https://bugzilla.mozilla.org/show_bug.cgi?id=612168). 

This fixes the issue that  restartless add-ons were never received the `ADDON_UNINSTALL` reason on uninstall, but `ADDON_DISABLE` (see [bug 620541](https://bugzilla.mozilla.org/show_bug.cgi?id=620541)).