### PR TITLE
DOM - Buttons - Events - calling focus() from a focus handler

### DIFF
--- a/dom/html/HTMLButtonElement.cpp
+++ b/dom/html/HTMLButtonElement.cpp
@@ -299,63 +299,6 @@ HTMLButtonElement::PostHandleEvent(EventChainPostVisitor& aVisitor)
         }
         break;// NS_KEY_PRESS
 
-      case NS_MOUSE_BUTTON_DOWN:
-        {
-          WidgetMouseEvent* mouseEvent = aVisitor.mEvent->AsMouseEvent();
-          if (mouseEvent->button == WidgetMouseEvent::eLeftButton) {
-            if (mouseEvent->mFlags.mIsTrusted) {
-              EventStateManager* esm =
-                aVisitor.mPresContext->EventStateManager();
-              EventStateManager::SetActiveManager(
-                static_cast<EventStateManager*>(esm), this);
-            }
-            nsIFocusManager* fm = nsFocusManager::GetFocusManager();
-            if (fm)
-              fm->SetFocus(this, nsIFocusManager::FLAG_BYMOUSE |
-                                 nsIFocusManager::FLAG_NOSCROLL);
-            mouseEvent->mFlags.mMultipleActionsPrevented = true;
-          } else if (mouseEvent->button == WidgetMouseEvent::eMiddleButton ||
-                     mouseEvent->button == WidgetMouseEvent::eRightButton) {
-            // cancel all of these events for buttons
-            //XXXsmaug What to do with these events? Why these should be cancelled?
-            if (aVisitor.mDOMEvent) {
-              aVisitor.mDOMEvent->StopPropagation();
-            }
-          }
-        }
-        break;
-
-      // cancel all of these events for buttons
-      //XXXsmaug What to do with these events? Why these should be cancelled?
-      case NS_MOUSE_BUTTON_UP:
-      case NS_MOUSE_DOUBLECLICK:
-        {
-          WidgetMouseEvent* mouseEvent = aVisitor.mEvent->AsMouseEvent();
-          if (aVisitor.mDOMEvent &&
-              (mouseEvent->button == WidgetMouseEvent::eMiddleButton ||
-               mouseEvent->button == WidgetMouseEvent::eRightButton)) {
-            aVisitor.mDOMEvent->StopPropagation();
-          }
-        }
-        break;
-
-      case NS_MOUSE_ENTER_SYNTH:
-        {
-          aVisitor.mPresContext->EventStateManager()->
-            SetContentState(this, NS_EVENT_STATE_HOVER);
-          aVisitor.mEventStatus = nsEventStatus_eConsumeNoDefault;
-        }
-        break;
-
-        // XXX this doesn't seem to do anything yet
-      case NS_MOUSE_EXIT_SYNTH:
-        {
-          aVisitor.mPresContext->EventStateManager()->
-            SetContentState(nullptr, NS_EVENT_STATE_HOVER);
-          aVisitor.mEventStatus = nsEventStatus_eConsumeNoDefault;
-        }
-        break;
-
       default:
         break;
     }

--- a/dom/html/test/mochitest.ini
+++ b/dom/html/test/mochitest.ini
@@ -457,6 +457,7 @@ skip-if = (toolkit == 'gonk' && debug) || e10s #debug-only failure
 [test_dl_attributes_reflection.html]
 [test_element_prototype.html]
 [test_embed_attributes_reflection.html]
+[test_focusshift_button.html]
 [test_formData.html]
 [test_formSubmission.html]
 skip-if = buildapp == 'b2g' || toolkit == 'android' || e10s #TIMED_OUT # b2g(NS_ERROR_FILE_TARGET_DOES_NOT_EXIST) b2g-debug(NS_ERROR_FILE_TARGET_DOES_NOT_EXIST) b2g-desktop(NS_ERROR_FILE_TARGET_DOES_NOT_EXIST)

--- a/dom/html/test/test_focusshift_button.html
+++ b/dom/html/test/test_focusshift_button.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Test for shifting focus while mouse clicking on button</title>
+  <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="text/javascript" src="/tests/SimpleTest/EventUtils.js"></script>
+  <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
+</head>
+<body>
+<p id="display"></p>
+<div id="content" style="display: none">
+
+</div>
+
+<script class="testbody" type="application/javascript;version=1.7">
+
+var result = "";
+
+SimpleTest.waitForExplicitFinish();
+SimpleTest.waitForFocus(function() {
+  synthesizeMouseAtCenter(document.getElementById("button"), { });
+  if (/Mac/.test(navigator.platform)) {
+    // Buttons don't focus when clicked on Mac.
+    is(result, "", "Focus button then input");
+  }
+  else {
+    is(result, "(focus button)(blur button)(focus input)", "Focus button then input");
+  }
+  SimpleTest.finish();
+});
+</script>
+
+
+<button id="button" onfocus="result += '(focus button)'; document.getElementById('input').focus()"
+                    onblur="result += '(blur button)'">Focus</button>
+<input id="input" value="Test" onfocus="result += '(focus input)'"
+                               onblur="result += '(blur input)'">
+
+</body>
+</html>

--- a/dom/tests/browser/browser_focus_steal_from_chrome.js
+++ b/dom/tests/browser/browser_focus_steal_from_chrome.js
@@ -40,19 +40,6 @@ function test() {
       tagName: "INPUT", methodName: "click event on the label element" },
   ];
 
-  if (navigator.platform.indexOf("Mac") == -1) {
-    // clicking buttons doesn't focus on mac, so skip this test
-    testingList.push(
-      { uri: "data:text/html,<body onload=\"setTimeout(function () {" +
-             "  var element = document.getElementById('target');" +
-             "  var event = document.createEvent('MouseEvent');" +
-             "  event.initMouseEvent('mousedown', true, true, window," +
-             "    0, 0, 0, 0, 0, false, false, false, false, 0, element);" +
-             "  element.dispatchEvent(event); }, 10);\">" +
-             "<button id='target'>button</button></body>",
-        tagName: "BUTTON", methodName: "mousedown event on the button element" });
-  }
-
   let testingIndex = -1;
   let canRetry;
   let callback;


### PR DESCRIPTION
Ad #1460

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1310403

---

__An example:__
https://jsfiddle.net/68rw9cL2/8/

__Actual results:__
1. The focus handler on the button gives the focus to the input
2. Then Pale Moon gives the focus again to the button
3. The input loses the focus

__Expected results:__
1. The focus handler on the button gives the focus to the input
2. The input keeps the focus

---

I've created the new build (x32, Windows) and tested.
