### PR TITLE
Ensure we process FIN flags on all-padding final frames.

### DIFF
--- a/netwerk/protocol/http/Http2Session.cpp
+++ b/netwerk/protocol/http/Http2Session.cpp
@@ -2771,7 +2771,10 @@ Http2Session::WriteSegments(nsAHttpSegmentWriter *writer,
     LOG3(("Http2Session::WriteSegments %p trying to discard %d bytes of data",
           this, count));
 
-    if (!count) {
+    if (!count && mDownstreamState == DISCARDING_DATA_FRAME) {
+      // Only do this short-cirtuit if we're not discarding a pure padding
+      // frame, as we need to potentially handle the stream FIN in those cases.
+      // See bug 1381016 comment 36 for more details.
       ResetDownstreamState();
       ResumeRecv();
       return NS_BASE_STREAM_WOULD_BLOCK;


### PR DESCRIPTION
This should prevent http2 sessions freezing and resolve #1462.