### PR TITLE
[minor fix] Build - warnings

### DIFF
--- a/dom/base/nsGlobalWindow.cpp
+++ b/dom/base/nsGlobalWindow.cpp
@@ -5692,7 +5692,9 @@ int32_t
 nsGlobalWindow::GetScrollMinX(ErrorResult& aError)
 {
   MOZ_ASSERT(IsInnerWindow());
-  FORWARD_TO_OUTER_OR_THROW(GetScrollBoundaryOuter, (eSideLeft), aError, 0);
+  int32_t scrollMinX = 0;
+  FORWARD_TO_OUTER_OR_THROW(GetScrollBoundaryOuter, (eSideLeft), aError, scrollMinX);
+  return scrollMinX;
 }
 
 NS_IMETHODIMP
@@ -5709,7 +5711,9 @@ int32_t
 nsGlobalWindow::GetScrollMinY(ErrorResult& aError)
 {
   MOZ_ASSERT(IsInnerWindow());
-  FORWARD_TO_OUTER_OR_THROW(GetScrollBoundaryOuter, (eSideTop), aError, 0);
+  int32_t scrollMinY = 0;
+  FORWARD_TO_OUTER_OR_THROW(GetScrollBoundaryOuter, (eSideTop), aError, scrollMinY);
+  return scrollMinY;
 }
 
 NS_IMETHODIMP
@@ -5726,7 +5730,9 @@ int32_t
 nsGlobalWindow::GetScrollMaxX(ErrorResult& aError)
 {
   MOZ_ASSERT(IsInnerWindow());
-  FORWARD_TO_OUTER_OR_THROW(GetScrollBoundaryOuter, (eSideRight), aError, 0);
+  int32_t scrollMaxX = 0;
+  FORWARD_TO_OUTER_OR_THROW(GetScrollBoundaryOuter, (eSideRight), aError, scrollMaxX);
+  return scrollMaxX;
 }
 
 NS_IMETHODIMP
@@ -5743,7 +5749,9 @@ int32_t
 nsGlobalWindow::GetScrollMaxY(ErrorResult& aError)
 {
   MOZ_ASSERT(IsInnerWindow());
-  FORWARD_TO_OUTER_OR_THROW(GetScrollBoundaryOuter, (eSideBottom), aError, 0);
+  int32_t scrollMaxY = 0;
+  FORWARD_TO_OUTER_OR_THROW(GetScrollBoundaryOuter, (eSideBottom), aError, scrollMaxY);
+  return scrollMaxY;
 }
 
 NS_IMETHODIMP


### PR DESCRIPTION
Ad #1464 

Build - warnings:

```
    "[drive]:\\[path]\\dom\\base\\nsglobalwindow.cpp": {
      "hash": "4ff1292eb92f5a6bd9ada15acfbc242033b63cc3", 
      "warnings": [
        {
          "column": null, 
          "filename": "[drive]:\\[path]\\dom\\base\\nsglobalwindow.cpp", 
          "flag": "C4715", 
          "line": 5696, 
          "message": "'nsGlobalWindow::GetScrollMinX' : not all control paths return a value"
        }, 
        {
          "column": null, 
          "filename": "[drive]:\\[path]\\dom\\base\\nsglobalwindow.cpp", 
          "flag": "C4715", 
          "line": 5713, 
          "message": "'nsGlobalWindow::GetScrollMinY' : not all control paths return a value"
        }, 
        {
          "column": null, 
          "filename": "[drive]:\\[path]\\dom\\base\\nsglobalwindow.cpp", 
          "flag": "C4715", 
          "line": 5730, 
          "message": "'nsGlobalWindow::GetScrollMaxX' : not all control paths return a value"
        }, 
        {
          "column": null, 
          "filename": "[drive]:\\[path]\\dom\\base\\nsglobalwindow.cpp", 
          "flag": "C4715", 
          "line": 5747, 
          "message": "'nsGlobalWindow::GetScrollMaxY' : not all control paths return a value"
        }
      ]
    }, 
```

Follow up for #1362

---

I've created the new build (x32, Windows) and tested.
