### PR TITLE
Potential fix for missing locate_t on Mac OSX.

### DIFF
--- a/intl/icu/source/i18n/digitlst.cpp
+++ b/intl/icu/source/i18n/digitlst.cpp
@@ -61,7 +61,7 @@
 #endif
 
 #if U_USE_STRTOD_L
-# if U_HAVE_XLOCALE_H
+# if U_HAVE_XLOCALE_H || U_PLATFORM_IS_DARWIN_BASED
 #   include <xlocale.h>
 # else
 #   include <locale.h>


### PR DESCRIPTION
Tag #1459 

This needs verification before merging.