### PR TITLE
Change nsIDocumentLoaderFactory and nsIURIContentListener to take MIME types as an XPCOM string, not a char*

### DIFF
--- a/docshell/base/nsDSURIContentListener.cpp
+++ b/docshell/base/nsDSURIContentListener.cpp
@@ -87,7 +87,7 @@ nsDSURIContentListener::OnStartURIOpen(nsIURI* aURI, bool* aAbortOpen)
 }
 
 NS_IMETHODIMP
-nsDSURIContentListener::DoContent(const char* aContentType,
+nsDSURIContentListener::DoContent(const nsACString& aContentType,
                                   bool aIsContentPreferred,
                                   nsIRequest* aRequest,
                                   nsIStreamListener** aContentHandler,
@@ -131,7 +131,7 @@ nsDSURIContentListener::DoContent(const char* aContentType,
   }
 
   bool reuseCV = baseChannel && baseChannel == mExistingJPEGRequest &&
-                 nsDependentCString(aContentType).EqualsLiteral("image/jpeg");
+                 aContentType.EqualsLiteral("image/jpeg");
 
   if (mExistingJPEGStreamListener && reuseCV) {
     nsRefPtr<nsIStreamListener> copy(mExistingJPEGStreamListener);

--- a/docshell/base/nsDocShell.cpp
+++ b/docshell/base/nsDocShell.cpp
@@ -8000,7 +8000,7 @@ nsDocShell::CreateAboutBlankContentViewer(nsIPrincipal* aPrincipal,
   mFiredUnloadEvent = false;
 
   nsCOMPtr<nsIDocumentLoaderFactory> docFactory =
-    nsContentUtils::FindInternalContentViewer("text/html");
+    nsContentUtils::FindInternalContentViewer(NS_LITERAL_CSTRING("text/html"));
 
   if (docFactory) {
     nsCOMPtr<nsIPrincipal> principal;
@@ -8962,7 +8962,7 @@ nsDocShell::RestoreFromHistory()
 }
 
 nsresult
-nsDocShell::CreateContentViewer(const char* aContentType,
+nsDocShell::CreateContentViewer(const nsACString& aContentType,
                                 nsIRequest* aRequest,
                                 nsIStreamListener** aContentHandler)
 {
@@ -9158,7 +9158,7 @@ nsDocShell::CreateContentViewer(const char* aContentType,
 }
 
 nsresult
-nsDocShell::NewContentViewerObj(const char* aContentType,
+nsDocShell::NewContentViewerObj(const nsACString& aContentType,
                                 nsIRequest* aRequest, nsILoadGroup* aLoadGroup,
                                 nsIStreamListener** aContentHandler,
                                 nsIContentViewer** aViewer)

--- a/docshell/base/nsDocShell.h
+++ b/docshell/base/nsDocShell.h
@@ -292,10 +292,10 @@ protected:
   nsresult CreateAboutBlankContentViewer(nsIPrincipal* aPrincipal,
                                          nsIURI* aBaseURI,
                                          bool aTryToSaveOldPresentation = true);
-  nsresult CreateContentViewer(const char* aContentType,
+  nsresult CreateContentViewer(const nsACString& aContentType,
                                nsIRequest* aRequest,
                                nsIStreamListener** aContentHandler);
-  nsresult NewContentViewerObj(const char* aContentType,
+  nsresult NewContentViewerObj(const nsACString& aContentType,
                                nsIRequest* aRequest, nsILoadGroup* aLoadGroup,
                                nsIStreamListener** aContentHandler,
                                nsIContentViewer** aViewer);

--- a/docshell/base/nsIDocumentLoaderFactory.idl
+++ b/docshell/base/nsIDocumentLoaderFactory.idl
@@ -22,12 +22,12 @@ interface nsIPrincipal;
  * The component is a service, so use GetService, not CreateInstance to get it.
  */
 
-[scriptable, uuid(70905274-8494-4e39-b011-d559adde3733)]
+[scriptable, uuid(e795239e-9d3c-47c4-b063-9e600fb3b287)]
 interface nsIDocumentLoaderFactory : nsISupports {
     nsIContentViewer createInstance(in string aCommand,
                               in nsIChannel aChannel,
                               in nsILoadGroup aLoadGroup,
-                              in string aContentType, 
+                              in ACString aContentType, 
                               in nsIDocShell aContainer,
                               in nsISupports aExtraInfo,
                               out nsIStreamListener aDocListenerResult);

--- a/docshell/base/nsWebNavigationInfo.cpp
+++ b/docshell/base/nsWebNavigationInfo.cpp
@@ -89,7 +89,7 @@ nsWebNavigationInfo::IsTypeSupportedInternal(const nsCString& aType,
   nsContentUtils::ContentViewerType vtype = nsContentUtils::TYPE_UNSUPPORTED;
 
   nsCOMPtr<nsIDocumentLoaderFactory> docLoaderFactory =
-    nsContentUtils::FindInternalContentViewer(aType.get(), &vtype);
+    nsContentUtils::FindInternalContentViewer(aType, &vtype);
 
   switch (vtype) {
     case nsContentUtils::TYPE_UNSUPPORTED:

--- a/dom/base/nsContentUtils.cpp
+++ b/dom/base/nsContentUtils.cpp
@@ -6463,7 +6463,7 @@ nsContentUtils::AllowXULXBLForPrincipal(nsIPrincipal* aPrincipal)
 }
 
 already_AddRefed<nsIDocumentLoaderFactory>
-nsContentUtils::FindInternalContentViewer(const char* aType,
+nsContentUtils::FindInternalContentViewer(const nsACString& aType,
                                           ContentViewerType* aLoaderType)
 {
   if (aLoaderType) {
@@ -6478,7 +6478,9 @@ nsContentUtils::FindInternalContentViewer(const char* aType,
   nsCOMPtr<nsIDocumentLoaderFactory> docFactory;
 
   nsXPIDLCString contractID;
-  nsresult rv = catMan->GetCategoryEntry("Goanna-Content-Viewers", aType, getter_Copies(contractID));
+  nsresult rv = catMan->GetCategoryEntry("Goanna-Content-Viewers",
+                                         PromiseFlatCString(aType).get(),
+                                         getter_Copies(contractID));
   if (NS_SUCCEEDED(rv)) {
     docFactory = do_GetService(contractID);
     if (docFactory && aLoaderType) {
@@ -6492,7 +6494,7 @@ nsContentUtils::FindInternalContentViewer(const char* aType,
     return docFactory.forget();
   }
 
-  if (DecoderTraits::IsSupportedInVideoDocument(nsDependentCString(aType))) {
+  if (DecoderTraits::IsSupportedInVideoDocument(aType)) {
     docFactory = do_GetService("@mozilla.org/content/document-loader-factory;1");
     if (docFactory && aLoaderType) {
       *aLoaderType = TYPE_CONTENT;

--- a/dom/base/nsContentUtils.h
+++ b/dom/base/nsContentUtils.h
@@ -2065,7 +2065,7 @@ public:
   };
 
   static already_AddRefed<nsIDocumentLoaderFactory>
-  FindInternalContentViewer(const char* aType,
+  FindInternalContentViewer(const nsACString& aType,
                             ContentViewerType* aLoaderType = nullptr);
 
   /**

--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -1227,7 +1227,7 @@ nsExternalResourceMap::PendingLoad::SetupViewer(nsIRequest* aRequest,
   nsCOMPtr<nsIContentViewer> viewer;
   nsCOMPtr<nsIStreamListener> listener;
   rv = docLoaderFactory->CreateInstance("external-resource", chan, newLoadGroup,
-                                        type.get(), nullptr, nullptr,
+                                        type, nullptr, nullptr,
                                         getter_AddRefs(listener),
                                         getter_AddRefs(viewer));
   NS_ENSURE_SUCCESS(rv, rv);

--- a/image/src/SVGDocumentWrapper.cpp
+++ b/image/src/SVGDocumentWrapper.cpp
@@ -320,7 +320,8 @@ SVGDocumentWrapper::SetupViewer(nsIRequest* aRequest,
   nsCOMPtr<nsIStreamListener> listener;
   rv = docLoaderFactory->CreateInstance("external-resource", chan,
                                         newLoadGroup,
-                                        IMAGE_SVG_XML, nullptr, nullptr,
+                                        NS_LITERAL_CSTRING(IMAGE_SVG_XML),
+                                        nullptr, nullptr,
                                         getter_AddRefs(listener),
                                         getter_AddRefs(viewer));
   NS_ENSURE_SUCCESS(rv, rv);

--- a/layout/build/nsContentDLF.cpp
+++ b/layout/build/nsContentDLF.cpp
@@ -133,16 +133,14 @@ NS_IMETHODIMP
 nsContentDLF::CreateInstance(const char* aCommand,
                              nsIChannel* aChannel,
                              nsILoadGroup* aLoadGroup,
-                             const char* aContentType, 
+                             const nsACString& aContentType,
                              nsIDocShell* aContainer,
                              nsISupports* aExtraInfo,
                              nsIStreamListener** aDocListener,
                              nsIContentViewer** aDocViewer)
 {
-  // Declare "type" here.  This is because although the variable itself only
-  // needs limited scope, we need to use the raw string memory -- as returned
-  // by "type.get()" farther down in the function.
-  nsAutoCString type;
+  // Make a copy of aContentType, because we're possibly going to change it.
+  nsAutoCString contentType(aContentType);
 
   // Are we viewing source?
   nsCOMPtr<nsIViewSourceChannel> viewSourceChannel = do_QueryInterface(aChannel);
@@ -154,6 +152,7 @@ nsContentDLF::CreateInstance(const char* aCommand,
     // view-source channel normally returns.  Get the actual content
     // type of the data.  If it's known, use it; otherwise use
     // text/plain.
+    nsAutoCString type;
     viewSourceChannel->GetOriginalContentType(type);
     bool knownType = false;
     int32_t typeIndex;
@@ -187,18 +186,18 @@ nsContentDLF::CreateInstance(const char* aCommand,
     } else if (IsImageContentType(type.get())) {
       // If it's an image, we want to display it the same way we normally would.
       // Also note the lifetime of "type" allows us to safely use "get()" here.
-      aContentType = type.get();
+      contentType = type;
     } else {
       viewSourceChannel->SetContentType(NS_LITERAL_CSTRING(TEXT_PLAIN));
     }
-  } else if (0 == PL_strcmp(VIEWSOURCE_CONTENT_TYPE, aContentType)) {
+  } else if (aContentType.EqualsLiteral(VIEWSOURCE_CONTENT_TYPE)) {
     aChannel->SetContentType(NS_LITERAL_CSTRING(TEXT_PLAIN));
-    aContentType = TEXT_PLAIN;
+    contentType = TEXT_PLAIN;
   }
   // Try html
   int typeIndex=0;
   while(gHTMLTypes[typeIndex]) {
-    if (0 == PL_strcmp(gHTMLTypes[typeIndex++], aContentType)) {
+    if (contentType.EqualsASCII(gHTMLTypes[typeIndex++])) {
       return CreateDocument(aCommand, 
                             aChannel, aLoadGroup,
                             aContainer, kHTMLDocumentCID,
@@ -209,7 +208,7 @@ nsContentDLF::CreateInstance(const char* aCommand,
   // Try XML
   typeIndex = 0;
   while(gXMLTypes[typeIndex]) {
-    if (0== PL_strcmp(gXMLTypes[typeIndex++], aContentType)) {
+    if (contentType.EqualsASCII(gXMLTypes[typeIndex++])) {
       return CreateDocument(aCommand, 
                             aChannel, aLoadGroup,
                             aContainer, kXMLDocumentCID,
@@ -220,7 +219,7 @@ nsContentDLF::CreateInstance(const char* aCommand,
   // Try SVG
   typeIndex = 0;
   while(gSVGTypes[typeIndex]) {
-    if (!PL_strcmp(gSVGTypes[typeIndex++], aContentType)) {
+    if (contentType.EqualsASCII(gSVGTypes[typeIndex++])) {
       return CreateDocument(aCommand,
                             aChannel, aLoadGroup,
                             aContainer, kSVGDocumentCID,
@@ -231,19 +230,17 @@ nsContentDLF::CreateInstance(const char* aCommand,
   // Try XUL
   typeIndex = 0;
   while (gXULTypes[typeIndex]) {
-    if (0 == PL_strcmp(gXULTypes[typeIndex++], aContentType)) {
+    if (contentType.EqualsASCII(gXULTypes[typeIndex++])) {
       if (!MayUseXULXBL(aChannel)) {
         return NS_ERROR_REMOTE_XUL;
       }
 
-      return CreateXULDocument(aCommand,
-                               aChannel, aLoadGroup,
-                               aContentType, aContainer,
+      return CreateXULDocument(aCommand, aChannel, aLoadGroup, aContainer,
                                aExtraInfo, aDocListener, aDocViewer);
     }
   }
 
-  if (mozilla::DecoderTraits::ShouldHandleMediaType(aContentType)) {
+  if (mozilla::DecoderTraits::ShouldHandleMediaType(contentType.get())) {
     return CreateDocument(aCommand, 
                           aChannel, aLoadGroup,
                           aContainer, kVideoDocumentCID,
@@ -251,7 +248,7 @@ nsContentDLF::CreateInstance(const char* aCommand,
   }  
 
   // Try image types
-  if (IsImageContentType(aContentType)) {
+  if (IsImageContentType(contentType.get())) {
     return CreateDocument(aCommand, 
                           aChannel, aLoadGroup,
                           aContainer, kImageDocumentCID,
@@ -261,7 +258,7 @@ nsContentDLF::CreateInstance(const char* aCommand,
   nsCOMPtr<nsIPluginHost> pluginHostCOM(do_GetService(MOZ_PLUGIN_HOST_CONTRACTID));
   nsPluginHost *pluginHost = static_cast<nsPluginHost*>(pluginHostCOM.get());
   if(pluginHost &&
-     pluginHost->PluginExistsForType(aContentType)) {
+     pluginHost->PluginExistsForType(contentType.get())) {
     return CreateDocument(aCommand,
                           aChannel, aLoadGroup,
                           aContainer, kPluginDocumentCID,
@@ -414,7 +411,6 @@ nsresult
 nsContentDLF::CreateXULDocument(const char* aCommand,
                                 nsIChannel* aChannel,
                                 nsILoadGroup* aLoadGroup,
-                                const char* aContentType,
                                 nsIDocShell* aContainer,
                                 nsISupports* aExtraInfo,
                                 nsIStreamListener** aDocListener,

--- a/layout/build/nsContentDLF.h
+++ b/layout/build/nsContentDLF.h
@@ -43,7 +43,6 @@ public:
   nsresult CreateXULDocument(const char* aCommand,
                              nsIChannel* aChannel,
                              nsILoadGroup* aLoadGroup,
-                             const char* aContentType,
                              nsIDocShell* aContainer,
                              nsISupports* aExtraInfo,
                              nsIStreamListener** aDocListener,

--- a/security/manager/ssl/src/PSMContentListener.cpp
+++ b/security/manager/ssl/src/PSMContentListener.cpp
@@ -264,7 +264,7 @@ PSMContentListener::CanHandleContent(const char * aContentType,
 }
 
 NS_IMETHODIMP
-PSMContentListener::DoContent(const char * aContentType,
+PSMContentListener::DoContent(const nsACString & aContentType,
                                bool aIsContentPreferred,
                                nsIRequest * aRequest,
                                nsIStreamListener ** aContentHandler,
@@ -272,7 +272,7 @@ PSMContentListener::DoContent(const char * aContentType,
 {
   PSMContentDownloader *downLoader;
   uint32_t type;
-  type = getPSMContentType(aContentType);
+  type = getPSMContentType(PromiseFlatCString(aContentType).get());
   PR_LOG(gPIPNSSLog, PR_LOG_DEBUG, ("PSMContentListener::DoContent\n"));
   if (type != PSMContentDownloader::UNKNOWN_TYPE) {
     downLoader = new PSMContentDownloader(type);

--- a/uriloader/base/nsIURIContentListener.idl
+++ b/uriloader/base/nsIURIContentListener.idl
@@ -16,7 +16,7 @@ interface nsIURI;
  * a nsIURIContentListener for each of its content windows with the uri
  * dispatcher service. 
  */
-[scriptable, uuid(94928AB3-8B63-11d3-989D-001083010E9B)]
+[scriptable, uuid(10a28f38-32e8-4c63-8aa1-12eaaebc369a)]
 interface nsIURIContentListener : nsISupports
 {
  /**
@@ -52,7 +52,7 @@ interface nsIURIContentListener : nsISupports
   *                             continue handling the load and call the
   *                             returned streamlistener's methods. 
   */
-  boolean doContent(in string aContentType,
+  boolean doContent(in ACString aContentType,
                     in boolean aIsContentPreferred,
                     in nsIRequest aRequest,
                     out nsIStreamListener aContentHandler);

--- a/uriloader/base/nsURILoader.cpp
+++ b/uriloader/base/nsURILoader.cpp
@@ -723,7 +723,7 @@ nsDocumentOpenInfo::TryContentListener(nsIURIContentListener* aListener,
   
   bool abort = false;
   bool isPreferred = (mFlags & nsIURILoader::IS_CONTENT_PREFERRED) != 0;
-  nsresult rv = aListener->DoContent(mContentType.get(),
+  nsresult rv = aListener->DoContent(mContentType,
                                      isPreferred,
                                      aChannel,
                                      getter_AddRefs(m_targetStreamListener),

--- a/xpfe/components/directory/nsDirectoryViewer.cpp
+++ b/xpfe/components/directory/nsDirectoryViewer.cpp
@@ -1263,7 +1263,7 @@ NS_IMETHODIMP
 nsDirectoryViewerFactory::CreateInstance(const char *aCommand,
                                          nsIChannel* aChannel,
                                          nsILoadGroup* aLoadGroup,
-                                         const char* aContentType, 
+                                         const nsACString& aContentType,
                                          nsIDocShell* aContainer,
                                          nsISupports* aExtraInfo,
                                          nsIStreamListener** aDocListenerResult,
@@ -1271,7 +1271,8 @@ nsDirectoryViewerFactory::CreateInstance(const char *aCommand,
 {
   nsresult rv;
 
-  bool viewSource = aContentType && strstr(aContentType, "view-source");
+  bool viewSource = FindInReadable(NS_LITERAL_CSTRING("view-source"),
+                                   aContentType);
 
   if (!viewSource &&
       Preferences::GetInt("network.dir.format", FORMAT_XUL) == FORMAT_XUL) {
@@ -1309,7 +1310,8 @@ nsDirectoryViewerFactory::CreateInstance(const char *aCommand,
     if (NS_FAILED(rv)) return rv;
     
     nsCOMPtr<nsIStreamListener> listener;
-    rv = factory->CreateInstance(aCommand, channel, aLoadGroup, "application/vnd.mozilla.xul+xml",
+    rv = factory->CreateInstance(aCommand, channel, aLoadGroup,
+                                 NS_LITERAL_CSTRING("application/vnd.mozilla.xul+xml"),
                                  aContainer, aExtraInfo, getter_AddRefs(listener),
                                  aDocViewerResult);
     if (NS_FAILED(rv)) return rv;
@@ -1357,11 +1359,13 @@ nsDirectoryViewerFactory::CreateInstance(const char *aCommand,
   nsCOMPtr<nsIStreamListener> listener;
 
   if (viewSource) {
-    rv = factory->CreateInstance("view-source", aChannel, aLoadGroup, "text/html; x-view-type=view-source",
+    rv = factory->CreateInstance("view-source", aChannel, aLoadGroup,
+                                 NS_LITERAL_CSTRING("text/html; x-view-type=view-source"),
                                  aContainer, aExtraInfo, getter_AddRefs(listener),
                                  aDocViewerResult);
   } else {
-    rv = factory->CreateInstance("view", aChannel, aLoadGroup, "text/html",
+    rv = factory->CreateInstance("view", aChannel, aLoadGroup,
+                                 NS_LITERAL_CSTRING("text/html"),
                                  aContainer, aExtraInfo, getter_AddRefs(listener),
                                  aDocViewerResult);
   }


### PR DESCRIPTION
This increases overall code consistency and is a prerequisite for adding `text/json` and `text/vtt` to the known MIME types (PR will follow), which is a prerequisite for #1343.

Based on [bug 1136388](https://bugzilla.mozilla.org/show_bug.cgi?id=1136388).

Clobber is required (?) for IDL changes (not included in PR).