### PR TITLE
The profile - resetting (migration doesn't work)

### DIFF
--- a/browser/components/migration/ChromeProfileMigrator.js
+++ b/browser/components/migration/ChromeProfileMigrator.js
@@ -101,7 +101,7 @@ ChromeProfileMigrator.prototype.getResources =
   function Chrome_getResources(aProfile) {
     if (this._chromeUserDataFolder) {
       let profileFolder = this._chromeUserDataFolder.clone();
-      profileFolder.append(aProfile);
+      profileFolder.append(aProfile.id);
       if (profileFolder.exists()) {
         let possibleResources = [GetBookmarksResource(profileFolder),
                                  GetHistoryResource(profileFolder),
@@ -124,7 +124,7 @@ Object.defineProperty(ChromeProfileMigrator.prototype, "sourceProfiles", {
     if (!this._chromeUserDataFolder)
       return [];
 
-    let profiles;
+    let profiles = [];
     try {
       // Local State is a JSON file that contains profile info.
       let localState = this._chromeUserDataFolder.clone();
@@ -139,20 +139,30 @@ Object.defineProperty(ChromeProfileMigrator.prototype, "sourceProfiles", {
       let inputStream = NetUtil.readInputStreamToString(fstream, fstream.available(),
                                                         { charset: "UTF-8" });
       let info_cache = JSON.parse(inputStream).profile.info_cache;
-      if (info_cache)
-        profiles = Object.keys(info_cache);
+      for (let profileFolderName in info_cache) {
+        let profileFolder = this._chromeUserDataFolder.clone();
+        profileFolder.append(profileFolderName);
+        profiles.push({
+          id: profileFolderName,
+          name: info_cache[profileFolderName].name || profileFolderName,
+        });
+      }
     } catch (e) {
       Cu.reportError("Error detecting Chrome profiles: " + e);
       // If we weren't able to detect any profiles above, fallback to the Default profile.
       let defaultProfileFolder = this._chromeUserDataFolder.clone();
       defaultProfileFolder.append("Default");
-      if (defaultProfileFolder.exists())
-        profiles = ["Default"];
+      if (defaultProfileFolder.exists()) {
+        profiles = [{
+          id: "Default",
+          name: "Default",
+        }];
+      }
     }
 
     // Only list profiles from which any data can be imported
-    return this.__sourceProfiles = profiles.filter(function(profileName) {
-      let resources = this.getResources(profileName);
+    return this.__sourceProfiles = profiles.filter(function(profile) {
+      let resources = this.getResources(profile);
       return resources && resources.length > 0;
     }, this);
   }

--- a/browser/components/migration/FirefoxProfileMigrator.js
+++ b/browser/components/migration/FirefoxProfileMigrator.js
@@ -73,12 +73,12 @@ FirefoxProfileMigrator.prototype.getResources = function(aProfile) {
       let file = sourceProfileDir.clone();
       file.append(fileName);
 
-      // File resources are monolithic.  We don't make partial copies since
-      // they are not expected to work alone.
-      if (!file.exists())
-        return null;
-
-      files.push(file);
+      if (file.exists()) {
+        files.push(file);
+      }
+    }
+    if (!files.length) {
+      return null;
     }
     return {
       type: aMigrationType,
@@ -92,10 +92,10 @@ FirefoxProfileMigrator.prototype.getResources = function(aProfile) {
   };
 
   let types = MigrationUtils.resourceTypes;
-  let places = getFileResource(types.HISTORY, ["places.sqlite"]);
-  let cookies = getFileResource(types.COOKIES, ["cookies.sqlite"]);
+  let places = getFileResource(types.HISTORY, ["places.sqlite", "places.sqlite-wal"]);
+  let cookies = getFileResource(types.COOKIES, ["cookies.sqlite", "cookies.sqlite-wal"]);
   let passwords = getFileResource(types.PASSWORDS,
-                                  ["signons.sqlite", "key3.db"]);
+                                  ["signons.sqlite", "logins.json", "key3.db"]);
   let formData = getFileResource(types.FORMDATA, ["formhistory.sqlite"]);
   let bookmarksBackups = getFileResource(types.OTHERDATA,
     [PlacesBackups.profileRelativeFolderPath]);

--- a/browser/components/migration/content/migration.js
+++ b/browser/components/migration/content/migration.js
@@ -129,7 +129,10 @@ var MigrationWizard = {
 
     // check for more than one source profile
     var sourceProfiles = this._migrator.sourceProfiles;    
-    if (sourceProfiles && sourceProfiles.length > 1) {
+    if (this._skipImportSourcePage) {
+      this._wiz.currentPage.next = "homePageImport";
+    }
+    else if (sourceProfiles && sourceProfiles.length > 1) {
       this._wiz.currentPage.next = "selectProfile";
     }
     else {
@@ -141,7 +144,7 @@ var MigrationWizard = {
       if (sourceProfiles && sourceProfiles.length == 1)
         this._selectedProfile = sourceProfiles[0];
       else
-        this._selectedProfile = "";
+        this._selectedProfile = null;
     }
   },
   
@@ -161,28 +164,33 @@ var MigrationWizard = {
     // and we canceled the dialog.  When that happens, _migrator will be null.
     if (this._migrator) {
       var sourceProfiles = this._migrator.sourceProfiles;
-      for (var i = 0; i < sourceProfiles.length; ++i) {
+
+      for (let profile of sourceProfiles) {
         var item = document.createElement("radio");
-        item.id = sourceProfiles[i];
-        item.setAttribute("label", sourceProfiles[i]);
+        item.id = profile.id;
+        item.setAttribute("label", profile.name);
         profiles.appendChild(item);
       }
     }
     
-    profiles.selectedItem = this._selectedProfile ? document.getElementById(this._selectedProfile) : profiles.firstChild;
+    profiles.selectedItem = this._selectedProfile ? document.getElementById(this._selectedProfile.id) : profiles.firstChild;
   },
   
   onSelectProfilePageRewound: function ()
   {
     var profiles = document.getElementById("profiles");
-    this._selectedProfile = profiles.selectedItem.id;
+    this._selectedProfile = this._migrator.sourceProfiles.find(
+      profile => profile.id == profiles.selectedItem.id
+    ) || null;
   },
   
   onSelectProfilePageAdvanced: function ()
   {
     var profiles = document.getElementById("profiles");
-    this._selectedProfile = profiles.selectedItem.id;
-    
+    this._selectedProfile = this._migrator.sourceProfiles.find(
+      profile => profile.id == profiles.selectedItem.id
+    ) || null;
+
     // If we're automigrating or just doing bookmarks don't show the item selection page
     if (this._autoMigrate)
       this._wiz.currentPage.next = "homePageImport";

--- a/browser/components/migration/content/migration.xul
+++ b/browser/components/migration/content/migration.xul
@@ -32,6 +32,7 @@
     <description id="importBookmarks" control="importSourceGroup" hidden="true">&importFromBookmarks.label;</description>
 
     <radiogroup id="importSourceGroup" align="start">
+      <radio id="firefox"   label="&importFromFirefox.label;"   accesskey="&importFromFirefox.accesskey;"/>
 #ifdef XP_WIN
       <radio id="ie"        label="&importFromIE.label;"        accesskey="&importFromIE.accesskey;"/>
       <radio id="chrome"    label="&importFromChrome.label;"    accesskey="&importFromChrome.accesskey;"/>
@@ -42,7 +43,6 @@
 #elifdef XP_UNIX
       <radio id="chrome"    label="&importFromChrome.label;"    accesskey="&importFromChrome.accesskey;"/>
 #endif
-      <radio id="firefox"   label="&importFromFirefox.label;"   accesskey="&importFromFirefox.accesskey;"/>
       <radio id="nothing"   label="&importFromNothing.label;"   accesskey="&importFromNothing.accesskey;" hidden="true"/>
     </radiogroup>
     <label id="noSources" hidden="true">&noMigrationSources.label;</label>

--- a/browser/components/migration/nsIBrowserProfileMigrator.idl
+++ b/browser/components/migration/nsIBrowserProfileMigrator.idl
@@ -8,7 +8,7 @@
 interface nsIArray;
 interface nsIProfileStartup;
 
-[scriptable, uuid(44993E0E-74E8-4BEC-9D66-AD8156E0A274)]
+[scriptable, uuid(30e5a7ec-f71e-4f41-9dbd-7429c02132ec)]
 interface nsIBrowserProfileMigrator : nsISupports 
 {
   /**
@@ -29,7 +29,7 @@ interface nsIBrowserProfileMigrator : nsISupports
    * @param aStartup helper interface which is non-null if called during startup. 
    * @param aProfile profile to migrate from, if there is more than one.
    */
-  void migrate(in unsigned short aItems, in nsIProfileStartup aStartup, in wstring aProfile);
+  void migrate(in unsigned short aItems, in nsIProfileStartup aStartup, in jsval aProfile);
 
   /**
    * A bit field containing profile items that this migrator
@@ -40,7 +40,7 @@ interface nsIBrowserProfileMigrator : nsISupports
    * @return  bit field containing profile items (see above)
    * @note    a return value of 0 represents no items rather than ALL.
    */
-  unsigned short getMigrateData(in wstring aProfile, in boolean aDoingStartup);
+  unsigned short getMigrateData(in jsval aProfile, in boolean aDoingStartup);
 
   /** 
    * Whether or not there is any data that can be imported from this 

--- a/toolkit/modules/ResetProfile.jsm
+++ b/toolkit/modules/ResetProfile.jsm
@@ -8,8 +8,8 @@ this.EXPORTED_SYMBOLS = ["ResetProfile"];
 
 const {classes: Cc, interfaces: Ci, utils: Cu, results: Cr} = Components;
 
-//Hard-code MOZ_APP_NAME to firefox because of hard-coded type in migrator.
-#expand const MOZ_APP_NAME = "firefox";
+//For Pale Moon: Hard-code MOZ_APP_NAME to firefox because of hard-coded type in migrator.
+#expand const MOZ_APP_NAME = ("__MOZ_APP_NAME__" == "palemoon") ? "firefox" : "__MOZ_APP_NAME__";
 #expand const MOZ_BUILD_APP = "__MOZ_BUILD_APP__";
 
 Cu.import("resource://gre/modules/Services.jsm");

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -1879,17 +1879,19 @@ ShowProfileManager(nsIToolkitProfileService* aProfileSvc,
 }
 
 /**
- * Set the currently running profile as the default/selected one.
+ * Get the currently running profile using its root directory.
  *
+ * @param aProfileSvc         The profile service
  * @param aCurrentProfileRoot The root directory of the current profile.
- * @return an error if aCurrentProfileRoot is not found or the profile could not
- * be set as the default.
+ * @param aProfile            Out-param that returns the profile object.
+ * @return an error if aCurrentProfileRoot is not found
  */
 static nsresult
-SetCurrentProfileAsDefault(nsIToolkitProfileService* aProfileSvc,
-                           nsIFile* aCurrentProfileRoot)
+GetCurrentProfile(nsIToolkitProfileService* aProfileSvc,
+                  nsIFile* aCurrentProfileRoot,
+                  nsIToolkitProfile** aProfile)
 {
-  NS_ENSURE_ARG_POINTER(aProfileSvc);
+  NS_ENSURE_ARG_POINTER(aProfile);
 
   nsCOMPtr<nsISimpleEnumerator> profiles;
   nsresult rv = aProfileSvc->GetProfiles(getter_AddRefs(profiles));
@@ -1905,7 +1907,8 @@ SetCurrentProfileAsDefault(nsIToolkitProfileService* aProfileSvc,
     profile->GetRootDir(getter_AddRefs(profileRoot));
     profileRoot->Equals(aCurrentProfileRoot, &foundMatchingProfile);
     if (foundMatchingProfile) {
-      return aProfileSvc->SetSelectedProfile(profile);
+      profile.forget(aProfile);
+      return NS_OK;
     }
     rv = profiles->GetNext(getter_AddRefs(supports));
   }
@@ -3599,15 +3602,23 @@ XREMain::XRE_mainRun()
       nsresult backupCreated = ProfileResetCleanup(profileBeingReset);
       if (NS_FAILED(backupCreated)) NS_WARNING("Could not cleanup the profile that was reset");
 
-      // Set the new profile as the default after we're done cleaning up the old profile,
-      // iff that profile was already the default
-      if (profileWasSelected) {
-        // this is actually "broken" - see bug 1122124
-        rv = SetCurrentProfileAsDefault(mProfileSvc, mProfD);
-        if (NS_FAILED(rv)) NS_WARNING("Could not set current profile as the default");
+      nsCOMPtr<nsIToolkitProfile> newProfile;
+      rv = GetCurrentProfile(mProfileSvc, mProfD, getter_AddRefs(newProfile));
+      if (NS_SUCCEEDED(rv)) {
+        newProfile->SetName(gResetOldProfileName);
+        mProfileName.Assign(gResetOldProfileName);
+        // Set the new profile as the default after we're done cleaning up the old profile,
+        // iff that profile was already the default
+        if (profileWasSelected) {
+          rv = mProfileSvc->SetDefaultProfile(newProfile);
+          if (NS_FAILED(rv)) NS_WARNING("Could not set current profile as the default");
+        }
+      } else {
+        NS_WARNING("Could not find current profile to set as default / change name.");
       }
-      // Need to write out the fact that the profile has been removed and potentially
-      // that the selected/default profile changed.
+
+      // Need to write out the fact that the profile has been removed, the new profile
+      // renamed, and potentially that the selected/default profile changed.
       mProfileSvc->Flush();
     }
   }

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -3588,7 +3588,8 @@ XREMain::XRE_mainRun()
         if (gDoProfileReset) {
           // Automatically migrate from the current application if we just
           // reset the profile.
-          aKey = MOZ_APP_NAME;
+          //Hard-code MOZ_APP_NAME to firefox because of hard-coded type in migrator.
+          aKey = (MOZ_APP_NAME == "palemoon") ? "firefox" : MOZ_APP_NAME;
         }
         pm->Migrate(&mDirProvider, aKey, gResetOldProfileName);
       }


### PR DESCRIPTION
Ad #1480 

## 1) The first commit:

Follow up:
https://github.com/MoonchildProductions/Pale-Moon/commit/ae2cf6b18f152f0c02de41eecfc25f4abc2ae7f4
\+
https://github.com/MoonchildProductions/Pale-Moon/pull/1402

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=705927
https://bugzilla.mozilla.org/show_bug.cgi?id=1100118 (partially)


## 2) The second commit:

### 2a)

__Steps to reproduce:__

1. Open `Pale Moon` with profile manager (`-p`).
2. Create a profile.
3. Start with that profile.
4. Open `about:support`.
5. Click `Refresh Pale Moon`, and click through the dialogs that follow, restore your tabs when asked.
6. Exit Pale Moon.

__Actual results:__
The newly-created `default-...` profile is selected if you now start the profile manager (it's the default) and has the Default=1 annotation in profiles.ini

__Expected results:__
Neither of the above is actually the case.

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1122124

### 2b)

__Add migration data (`login.json`, `...sqlite-wal`):__

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1388611
https://bugzilla.mozilla.org/show_bug.cgi?id=1096787

---

You add the label `Verification Needed` (`Pale Moon` - tested, `Chrome` - __not tested__ currently), please.

---

I've created the new build (x32, Windows).
