### PR TITLE
Handle custom URLs and add "My home page" for the New Tab URL.

### DIFF
--- a/browser/components/preferences/preferences.xul
+++ b/browser/components/preferences/preferences.xul
@@ -55,7 +55,9 @@
             style="&prefWinMinSize.styleGNOME;"
 #endif
 #endif
-            onunload="if (typeof gSecurityPane != 'undefined') gSecurityPane.syncAddonSecurityLevel();">
+            onunload="if (typeof gSecurityPane != 'undefined') gSecurityPane.syncAddonSecurityLevel();"
+            ondialogaccept="if (typeof gTabsPane != 'undefined') gTabsPane.writeNewtabUrl();
+                            return true;">
 
     <script type="application/javascript" src="chrome://browser/content/utilityOverlay.js"/>
 

--- a/browser/components/preferences/tabs.xul
+++ b/browser/components/preferences/tabs.xul
@@ -16,9 +16,7 @@
          xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
   <prefpane id="paneTabs"
-#ifdef XP_WIN
             onpaneload="gTabsPane.init();"
-#endif
             helpTopic="prefs-tabs">
 
     <preferences id="tabsPreferences">
@@ -36,9 +34,10 @@
       <preference id="browser.tabs.insertRelatedAfterCurrent"  name="browser.tabs.insertRelatedAfterCurrent"  type="bool"/>
       <preference id="browser.search.context.loadInBackground" name="browser.search.context.loadInBackground" type="bool" inverted="true"/>
       <preference id="browser.tabs.closeWindowWithLastTab"     name="browser.tabs.closeWindowWithLastTab"     type="bool"/>
-      <preference id="browser.newtab.url"
-                  name="browser.newtab.url"
-                  type="string" />  
+      
+      <preference id="browser.newtab.url"    name="browser.newtab.url"    type="string"/>
+      <preference id="browser.newtab.myhome" name="browser.newtab.myhome" type="string"/>
+      <preference id="browser.newtab.choice" name="browser.newtab.choice" type="int"/>
     </preferences>
     
     <script type="application/javascript" src="chrome://browser/content/preferences/tabs.js"/>
@@ -80,11 +79,15 @@
                 preference="browser.tabs.closeWindowWithLastTab"/>
       <hbox align="center">
         <label value="&newtabPage.label;"/>
-        <menulist id="newtabPage" preference="browser.newtab.url">
+        <menulist 
+          id="newtabPage"
+          preference="browser.newtab.choice">
           <menupopup>
-            <menuitem label="&newtabPage.blank.label;"     value="about:logopage" id="newtabPageBlank"/>
-            <menuitem label="&newtabPage.home.label;"      value="https://start.palemoon.org/" id="newtabPageHome"/>
-            <menuitem label="&newtabPage.quickdial.label;" value="about:newtab" id="newtabPageQuickdial"/>
+            <menuitem label="&newtabPage.custom.label;"    value="0" id="newtabPageCustom" hidden="true" />
+            <menuitem label="&newtabPage.blank.label;"     value="1" />
+            <menuitem label="&newtabPage.home.label;"      value="2" />
+            <menuitem label="&newtabPage.myhome.label;"    value="3" />
+            <menuitem label="&newtabPage.quickdial.label;" value="4" />
           </menupopup>
         </menulist>
       </hbox>

--- a/browser/locales/en-US/chrome/browser/preferences/tabs.dtd
+++ b/browser/locales/en-US/chrome/browser/preferences/tabs.dtd
@@ -28,6 +28,8 @@
 <!ENTITY closeWindowWithLastTab.label       "Close the window when the last tab is closed">
 
 <!ENTITY newtabPage.label                   "When opening a new tab, show:">
+<!ENTITY newtabPage.custom.label            "A custom URL">
 <!ENTITY newtabPage.blank.label             "A blank page">
 <!ENTITY newtabPage.home.label              "The Pale Moon start page">
+<!ENTITY newtabPage.myhome.label            "My home page">
 <!ENTITY newtabPage.quickdial.label         "The Quickdial page">


### PR DESCRIPTION
Instead of dealing with the pref directly in the drop-down, we use an index value.

Upon loading the pref pane, we check against known values in `browser.newtab.url` and set the index accordingly. If no known value is found, the index will be set to `0` and `A custom URL` is shown (normally hidden in the drop-down) to indicate the user has manually set a custom URL for the New Tab page.

When the preferences dialog is closed with OK (accepted), the index value is read, and `browser.newtab.url` will be set to known values for the appropriate index value or remain unchanged in the case of `0`.

Special handling when the user chooses "my home page":
1. Read the browser's home page string
2. In case of multiple entries separated by pipes `|`, only the first URL will be used.
3. The sanitized value will be saved in `browser.newtab.myhome` to check against when determining the proper index.
4. The sanitized value will be saved in `browser.newtab.url`