### PR TITLE
CSS - box-decoration-break:clone on block overflow container makes it draw a border

### DIFF
--- a/layout/base/nsCSSRendering.cpp
+++ b/layout/base/nsCSSRendering.cpp
@@ -739,10 +739,13 @@ nsCSSRendering::PaintBorderWithStyleBorder(nsPresContext* aPresContext,
   } else {
     MOZ_ASSERT(joinedBorderArea.IsEqualEdges(aBorderArea),
                "Should use aBorderArea for box-decoration-break:clone");
-    MOZ_ASSERT(aForFrame->GetSkipSides().IsEmpty(),
+    MOZ_ASSERT(aForFrame->GetSkipSides().IsEmpty() ||
+               IS_TRUE_OVERFLOW_CONTAINER(aForFrame),
                "Should not skip sides for box-decoration-break:clone except "
                "::first-letter/line continuations or other frame types that "
-               "don't have borders but those shouldn't reach this point.");
+               "don't have borders but those shouldn't reach this point. "
+               "Overflow containers do reach this point though.");
+    border.ApplySkipSides(aSkipSides);
   }
 
   // Convert to dev pixels.

--- a/layout/generic/nsFrame.cpp
+++ b/layout/generic/nsFrame.cpp
@@ -987,7 +987,8 @@ nsIFrame::Sides
 nsIFrame::GetSkipSides(const nsHTMLReflowState* aReflowState) const
 {
   if (MOZ_UNLIKELY(StyleBorder()->mBoxDecorationBreak ==
-                     NS_STYLE_BOX_DECORATION_BREAK_CLONE)) {
+                     NS_STYLE_BOX_DECORATION_BREAK_CLONE) &&
+      !(GetStateBits() & NS_FRAME_IS_OVERFLOW_CONTAINER)) {
     return Sides();
   }
 

--- a/layout/reftests/css-break/box-decoration-break-bug-1249913-ref.html
+++ b/layout/reftests/css-break/box-decoration-break-bug-1249913-ref.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+  <meta charset="utf-8">
+  <title>'box-decoration-break' with child overflow</title>
+  <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1249913">
+  <style type="text/css">
+body,html { color:black; background:white; font-size:16px; padding:0; margin:0; }
+
+p { height: 27px; width: 100px; margin:0; background:lime; }
+.border { border:3px solid black; }
+.outline { outline:3px solid brown; }
+.shadow { box-shadow: 2px 2px 0 0 blue; }
+
+.columns {
+     -moz-columns: 2;
+      -ms-columns: 2;
+  -webkit-columns: 2;
+          columns: 2;
+     -moz-column-fill: auto;
+      -ms-column-fill: auto;
+  -webkit-column-fill: auto;
+          column-fill: auto;
+  width:500px;
+  height:30px;
+  border:solid silver;
+  margin: 2px 0;
+}
+
+.columns div { height: 10px; }
+
+x { height: 27px; width: 100px; margin:0; background:lime; display:block; }
+y { height: 23px; width: 100px; margin:0; background:lime; display:block; }
+
+</style>
+</head>
+<body>
+
+<div class="columns"><div class="border"><p></p><y></y></div></div>
+<div class="columns"><div class="outline"><p style="height:30px"></p><y style="height:20px"></y></div></div>
+<div class="columns"><div class="shadow"><p style="height:30px"></p><y style="height:20px"></y></div></div>
+<div class="columns"><div class="border outline"><p></p><y></y></div></div>
+<div class="columns"><div class="border shadow"><p></p><y></y></div></div>
+
+<div class="columns"><div class="border"><x></x><y></y></div></div>
+<div class="columns"><div class="outline"><x></x><y></y></div></div>
+<div class="columns"><div class="shadow"><x></x><y></y></div></div>
+<div class="columns"><div class="border outline"><x></x><y></y></div></div>
+<div class="columns"><div class="border shadow"><x></x><y></y></div></div>
+
+</body>
+</html>

--- a/layout/reftests/css-break/box-decoration-break-bug-1249913.html
+++ b/layout/reftests/css-break/box-decoration-break-bug-1249913.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+  <meta charset="utf-8">
+  <title>'box-decoration-break' with child overflow</title>
+  <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1249913">
+  <link rel="help" href="https://drafts.csswg.org/css-break/#break-decoration">
+  <link rel="match" href="box-decoration-break-bug-1249913-ref.html">
+  <style type="text/css">
+body,html { color:black; background:white; font-size:16px; padding:0; margin:0; }
+
+p { height: 50px; width: 100px; margin:0; background:lime; }
+.clone { height: 10px; box-decoration-break:clone; }
+.border { border:3px solid black; }
+.outline { outline:3px solid brown; }
+.shadow { box-shadow: 2px 2px 0 0 blue; }
+
+.columns {
+     -moz-columns: 2;
+      -ms-columns: 2;
+  -webkit-columns: 2;
+          columns: 2;
+     -moz-column-fill: auto;
+      -ms-column-fill: auto;
+  -webkit-column-fill: auto;
+          column-fill: auto;
+  width:500px;
+  height:30px;
+  border:solid silver;
+  margin: 2px 0;
+}
+
+.columns div { height: 10px; }
+
+</style>
+</head>
+<body>
+
+<div class="columns"><div class="clone border"><p></p></div></div>
+<div class="columns"><div class="clone outline"><p></p></div></div>
+<div class="columns"><div class="clone shadow"><p></p></div></div>
+<div class="columns"><div class="clone border outline"><p></p></div></div>
+<div class="columns"><div class="clone border shadow"><p></p></div></div>
+
+<div class="columns"><div class="border"><p></p></div></div>
+<div class="columns"><div class="outline"><p></p></div></div>
+<div class="columns"><div class="shadow"><p></p></div></div>
+<div class="columns"><div class="border outline"><p></p></div></div>
+<div class="columns"><div class="border shadow"><p></p></div></div>
+
+</body>
+</html>

--- a/layout/reftests/css-break/reftest.list
+++ b/layout/reftests/css-break/reftest.list
@@ -7,3 +7,4 @@ random-if(!gtk2Widget) HTTP(..) == box-decoration-break-border-image.html box-de
 == box-decoration-break-block-border-padding.html box-decoration-break-block-border-padding-ref.html
 == box-decoration-break-block-margin.html box-decoration-break-block-margin-ref.html
 == box-decoration-break-first-letter.html box-decoration-break-first-letter-ref.html
+== box-decoration-break-bug-1249913.html box-decoration-break-bug-1249913-ref.html


### PR DESCRIPTION
Ad #1499

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1249913

---

I've created the new build (x32, Windows) and tested.
