### PR TITLE
HTML - input type="number" matches :-moz-read-only when it is not read only

### DIFF
--- a/dom/events/EventStateManager.cpp
+++ b/dom/events/EventStateManager.cpp
@@ -1433,7 +1433,7 @@ EventStateManager::FireContextClick()
       nsCOMPtr<nsIFormControl> formCtrl(do_QueryInterface(mGestureDownContent));
 
       if (formCtrl) {
-        allowedToDispatch = formCtrl->IsTextControl(false) ||
+        allowedToDispatch = formCtrl->IsTextOrNumberControl(/*aExcludePassword*/ false) ||
                             formCtrl->GetType() == NS_FORM_INPUT_FILE;
       }
       else if (tag == nsGkAtoms::applet ||

--- a/dom/html/nsGenericHTMLElement.cpp
+++ b/dom/html/nsGenericHTMLElement.cpp
@@ -2315,7 +2315,7 @@ nsGenericHTMLFormElement::IntrinsicState() const
 
   // Make the text controls read-write
   if (!state.HasState(NS_EVENT_STATE_MOZ_READWRITE) &&
-      IsTextControl(false)) {
+      IsTextOrNumberControl(/*aExcludePassword*/ false)) {
     bool roState = GetBoolAttr(nsGkAtoms::readonly);
 
     if (!roState) {

--- a/dom/html/nsIFormControl.h
+++ b/dom/html/nsIFormControl.h
@@ -175,7 +175,14 @@ public:
    * @param  aExcludePassword  to have NS_FORM_INPUT_PASSWORD returning false.
    * @return whether this is a text control.
    */
-  inline bool IsTextControl(bool aExcludePassword) const ;
+  inline bool IsTextControl(bool aExcludePassword) const;
+
+  /**
+   * Returns true if this is a text control or a number control.
+   * @param  aExcludePassword  to have NS_FORM_INPUT_PASSWORD returning false.
+   * @return true if this is a text control or a number control.
+   */
+  inline bool IsTextOrNumberControl(bool aExcludePassword) const;
 
   /**
    * Returns whether this is a single line text control.
@@ -232,6 +239,12 @@ nsIFormControl::IsTextControl(bool aExcludePassword) const
   uint32_t type = GetType();
   return type == NS_FORM_TEXTAREA ||
          IsSingleLineTextControl(aExcludePassword, type);
+}
+
+bool
+nsIFormControl::IsTextOrNumberControl(bool aExcludePassword) const
+{
+  return IsTextControl(aExcludePassword) || GetType() == NS_FORM_INPUT_NUMBER;
 }
 
 bool

--- a/layout/reftests/forms/input/number/pseudo-classes.html
+++ b/layout/reftests/forms/input/number/pseudo-classes.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+  <meta charset="utf-8">
+  <title>Test pseudo-classes on number controls</title>
+  <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1250315">
+  <link rel="help" href="https://drafts.csswg.org/selectors-4/#rw-pseudos">
+  <link rel="match" href="about:blank">
+  <style type="text/css">
+body,html { color:black; background:white; font-size:16px; padding:0; margin:0; }
+
+#t1:-moz-read-only { display:none; }
+#t1:-moz-read-write { display:block; }
+
+#t2:-moz-read-write { display:none; }
+#t2:-moz-read-only { display:block; }
+
+#t3:disabled { display:none; }
+#t3:enabled { display:block; }
+
+#t4:enabled { display:none; }
+#t4:disabled { display:block; }
+
+  </style>
+</head>
+<body>
+
+<input id=t1 type=number readonly>
+<input id=t2 type=number>
+<input id=t3 type=number disabled>
+<input id=t4 type=number>
+
+</body>
+</html>

--- a/layout/reftests/forms/input/number/reftest.list
+++ b/layout/reftests/forms/input/number/reftest.list
@@ -48,3 +48,4 @@ skip-if(B2G) needs-focus == focus-handling.html focus-handling-ref.html
 # bevel which gets slightly different antialiasing after invalidation):
 fuzzy(128,4) == number-reframe-anon-text-field.html number-reframe-anon-text-field-ref.html
 
+== pseudo-classes.html about:blank


### PR DESCRIPTION
Ad #1500

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1250315

---

I've created the new build (x32, Windows) and tested.
