### PR TITLE
Bug1299753

### DIFF
--- a/layout/base/nsCSSFrameConstructor.cpp
+++ b/layout/base/nsCSSFrameConstructor.cpp
@@ -3244,8 +3244,7 @@ nsCSSFrameConstructor::ConstructFieldSetFrame(nsFrameConstructorState& aState,
   }
 
   nsContainerFrame* blockFrame =
-    NS_NewBlockFrame(mPresShell, fieldsetContentStyle,
-                     NS_BLOCK_FLOAT_MGR | NS_BLOCK_MARGIN_ROOT);
+    NS_NewBlockFormattingContext(mPresShell, fieldsetContentStyle);
   InitAndRestoreFrame(aState, content,
     scrollFrame ? scrollFrame : fieldsetFrame, blockFrame);
 

--- a/layout/base/nsCSSFrameConstructor.cpp
+++ b/layout/base/nsCSSFrameConstructor.cpp
@@ -3308,51 +3308,42 @@ nsCSSFrameConstructor::ConstructDetailsFrame(nsFrameConstructorState& aState,
                                              const nsStyleDisplay* aStyleDisplay,
                                              nsFrameItems& aFrameItems)
 {
+  if (!aStyleDisplay->IsScrollableOverflow()) {
+    return ConstructNonScrollableBlockWithConstructor(aState, aItem, aParentFrame,
+                                                      aStyleDisplay, aFrameItems,
+                                                      NS_NewDetailsFrame);
+  }
+
   nsIContent* const content = aItem.mContent;
   nsStyleContext* const styleContext = aItem.mStyleContext;
   nsContainerFrame* geometricParent =
     aState.GetGeometricParent(aStyleDisplay, aParentFrame);
 
   nsContainerFrame* detailsFrame = NS_NewDetailsFrame(mPresShell, styleContext);
-  nsIFrame* frameToReturn = nullptr;
 
   // Build a scroll frame to wrap details frame if necessary.
-  if (aStyleDisplay->IsScrollableOverflow()) {
-    nsContainerFrame* scrollFrame = nullptr;
+  nsContainerFrame* scrollFrame = nullptr;
 
-    nsRefPtr<nsStyleContext> detailsStyle =
-      BeginBuildingScrollFrame(aState, content, styleContext, geometricParent ,
-                               nsCSSAnonBoxes::scrolledContent, false,
-                               scrollFrame);
+  RefPtr<nsStyleContext> detailsStyle =
+    BeginBuildingScrollFrame(aState, content, styleContext, geometricParent ,
+                             nsCSSAnonBoxes::scrolledContent, false,
+                             scrollFrame);
 
-    aState.AddChild(scrollFrame, aFrameItems, content, styleContext,
-                    aParentFrame);
+  aState.AddChild(scrollFrame, aFrameItems, content, styleContext,
+                  aParentFrame);
 
-    nsFrameItems scrollFrameItems;
-    ConstructBlock(aState, aStyleDisplay, content,
-                   scrollFrame, scrollFrame,
-                   detailsStyle, &detailsFrame, scrollFrameItems,
-                   aStyleDisplay->IsPositioned(scrollFrame) ?
-                     scrollFrame : nullptr,
-                   aItem.mPendingBinding);
+  nsFrameItems scrollFrameItems;
+  ConstructBlock(aState, aStyleDisplay, content, scrollFrame, scrollFrame,
+                 detailsStyle, &detailsFrame, scrollFrameItems,
+                 aStyleDisplay->IsPositioned(scrollFrame) ?
+                   scrollFrame : nullptr,
+                 aItem.mPendingBinding);
 
-    MOZ_ASSERT(scrollFrameItems.OnlyChild() == detailsFrame);
+  MOZ_ASSERT(scrollFrameItems.OnlyChild() == detailsFrame);
 
-    FinishBuildingScrollFrame(scrollFrame, detailsFrame);
+  FinishBuildingScrollFrame(scrollFrame, detailsFrame);
 
-    frameToReturn = scrollFrame;
-  } else {
-    ConstructBlock(aState, aStyleDisplay, content, geometricParent,
-                   aParentFrame, styleContext,
-                   &detailsFrame, aFrameItems,
-                   aStyleDisplay->IsPositioned(detailsFrame) ?
-                     detailsFrame : nullptr,
-                   aItem.mPendingBinding);
-
-    frameToReturn = detailsFrame;
-  }
-
-  return frameToReturn;
+  return scrollFrame;
 }
 
 static nsIFrame*
@@ -4349,10 +4340,9 @@ nsCSSFrameConstructor::FindXULLabelData(Element* aElement,
 static nsIFrame*
 NS_NewXULDescriptionFrame(nsIPresShell* aPresShell, nsStyleContext *aContext)
 {
-  // XXXbz do we really need to set those flags?  If the parent is not
-  // a block we'll get them anyway, and if it is, do we want them?
-  return NS_NewBlockFrame(aPresShell, aContext,
-                          NS_BLOCK_FLOAT_MGR | NS_BLOCK_MARGIN_ROOT);
+  // XXXbz do we really need to set up the block formatting context root? If the
+  // parent is not a block we'll get it anyway, and if it is, do we want it?
+  return NS_NewBlockFormattingContext(aPresShell, aContext);
 }
 
 /* static */
@@ -4788,6 +4778,20 @@ nsCSSFrameConstructor::ConstructNonScrollableBlock(nsFrameConstructorState& aSta
                                                    const nsStyleDisplay*    aDisplay,
                                                    nsFrameItems&            aFrameItems)
 {
+  return ConstructNonScrollableBlockWithConstructor(aState, aItem, aParentFrame,
+                                                    aDisplay, aFrameItems,
+                                                    NS_NewBlockFrame);
+}
+
+nsIFrame*
+nsCSSFrameConstructor::ConstructNonScrollableBlockWithConstructor(
+  nsFrameConstructorState& aState,
+  FrameConstructionItem& aItem,
+  nsContainerFrame* aParentFrame,
+  const nsStyleDisplay* aDisplay,
+  nsFrameItems& aFrameItems,
+  BlockFrameCreationFunc aConstructor)
+{
   nsStyleContext* const styleContext = aItem.mStyleContext;
 
   // We want a block formatting context root in paginated contexts for
@@ -4796,20 +4800,20 @@ nsCSSFrameConstructor::ConstructNonScrollableBlock(nsFrameConstructorState& aSta
   // we can check it later in nsFrame::ApplyPaginatedOverflowClipping.
   bool clipPaginatedOverflow =
     (aItem.mFCData->mBits & FCDATA_FORCED_NON_SCROLLABLE_BLOCK) != 0;
-  nsContainerFrame* newFrame;
+  nsFrameState flags = nsFrameState(0);
   if ((aDisplay->IsAbsolutelyPositionedStyle() ||
        aDisplay->IsFloatingStyle() ||
        NS_STYLE_DISPLAY_INLINE_BLOCK == aDisplay->mDisplay ||
        clipPaginatedOverflow) &&
       !aParentFrame->IsSVGText()) {
-    newFrame = NS_NewBlockFormattingContext(mPresShell, styleContext);
+    flags = NS_BLOCK_FLOAT_MGR | NS_BLOCK_MARGIN_ROOT;
     if (clipPaginatedOverflow) {
-      newFrame->AddStateBits(NS_BLOCK_CLIP_PAGINATED_OVERFLOW);
+      flags |= NS_BLOCK_CLIP_PAGINATED_OVERFLOW;
     }
-  } else {
-    newFrame = NS_NewBlockFrame(mPresShell, styleContext);
   }
 
+  nsContainerFrame* newFrame = aConstructor(mPresShell, styleContext);
+  newFrame->AddStateBits(flags);
   ConstructBlock(aState, aDisplay, aItem.mContent,
                  aState.GetGeometricParent(aDisplay, aParentFrame),
                  aParentFrame, styleContext, &newFrame,

--- a/layout/base/nsCSSFrameConstructor.cpp
+++ b/layout/base/nsCSSFrameConstructor.cpp
@@ -3314,36 +3314,10 @@ nsCSSFrameConstructor::ConstructDetailsFrame(nsFrameConstructorState& aState,
                                                       NS_NewDetailsFrame);
   }
 
-  nsIContent* const content = aItem.mContent;
-  nsStyleContext* const styleContext = aItem.mStyleContext;
-  nsContainerFrame* geometricParent =
-    aState.GetGeometricParent(aStyleDisplay, aParentFrame);
-
-  nsContainerFrame* detailsFrame = NS_NewDetailsFrame(mPresShell, styleContext);
-
   // Build a scroll frame to wrap details frame if necessary.
-  nsContainerFrame* scrollFrame = nullptr;
-
-  RefPtr<nsStyleContext> detailsStyle =
-    BeginBuildingScrollFrame(aState, content, styleContext, geometricParent ,
-                             nsCSSAnonBoxes::scrolledContent, false,
-                             scrollFrame);
-
-  aState.AddChild(scrollFrame, aFrameItems, content, styleContext,
-                  aParentFrame);
-
-  nsFrameItems scrollFrameItems;
-  ConstructBlock(aState, aStyleDisplay, content, scrollFrame, scrollFrame,
-                 detailsStyle, &detailsFrame, scrollFrameItems,
-                 aStyleDisplay->IsPositioned(scrollFrame) ?
-                   scrollFrame : nullptr,
-                 aItem.mPendingBinding);
-
-  MOZ_ASSERT(scrollFrameItems.OnlyChild() == detailsFrame);
-
-  FinishBuildingScrollFrame(scrollFrame, detailsFrame);
-
-  return scrollFrame;
+  return ConstructScrollableBlockWithConstructor(aState, aItem, aParentFrame,
+                                                 aStyleDisplay, aFrameItems,
+                                                 NS_NewDetailsFrame);
 }
 
 static nsIFrame*
@@ -4738,6 +4712,20 @@ nsCSSFrameConstructor::ConstructScrollableBlock(nsFrameConstructorState& aState,
                                                 const nsStyleDisplay*    aDisplay,
                                                 nsFrameItems&            aFrameItems)
 {
+  return ConstructScrollableBlockWithConstructor(aState, aItem, aParentFrame,
+                                                 aDisplay, aFrameItems,
+                                                 NS_NewBlockFormattingContext);
+}
+
+nsIFrame*
+nsCSSFrameConstructor::ConstructScrollableBlockWithConstructor(
+  nsFrameConstructorState& aState,
+  FrameConstructionItem& aItem,
+  nsContainerFrame* aParentFrame,
+  const nsStyleDisplay* aDisplay,
+  nsFrameItems& aFrameItems,
+  BlockFrameCreationFunc aConstructor)
+{
   nsIContent* const content = aItem.mContent;
   nsStyleContext* const styleContext = aItem.mStyleContext;
 
@@ -4750,8 +4738,7 @@ nsCSSFrameConstructor::ConstructScrollableBlock(nsFrameConstructorState& aState,
 
   // Create our block frame
   // pass a temporary stylecontext, the correct one will be set later
-  nsContainerFrame* scrolledFrame =
-    NS_NewBlockFormattingContext(mPresShell, styleContext);
+  nsContainerFrame* scrolledFrame = aConstructor(mPresShell, styleContext);
 
   // Make sure to AddChild before we call ConstructBlock so that we
   // end up before our descendants in fixed-pos lists as needed.
@@ -4764,8 +4751,8 @@ nsCSSFrameConstructor::ConstructScrollableBlock(nsFrameConstructorState& aState,
                  aDisplay->IsPositioned(newFrame) ? newFrame : nullptr,
                  aItem.mPendingBinding);
 
-  NS_ASSERTION(blockItem.FirstChild() == scrolledFrame,
-               "Scrollframe's frameItems should be exactly the scrolled frame");
+  MOZ_ASSERT(blockItem.OnlyChild() == scrolledFrame,
+             "Scrollframe's frameItems should be exactly the scrolled frame!");
   FinishBuildingScrollFrame(newFrame, scrolledFrame);
 
   return newFrame;

--- a/layout/base/nsCSSFrameConstructor.h
+++ b/layout/base/nsCSSFrameConstructor.h
@@ -1538,6 +1538,18 @@ private:
                                      nsFrameItems&            aFrameItems);
 
   /**
+   * Construct a scrollable block frame using the given block frame creation
+   * function.
+   */
+  nsIFrame* ConstructScrollableBlockWithConstructor(
+    nsFrameConstructorState& aState,
+    FrameConstructionItem& aItem,
+    nsContainerFrame* aParentFrame,
+    const nsStyleDisplay* aDisplay,
+    nsFrameItems& aFrameItems,
+    BlockFrameCreationFunc aConstructor);
+
+  /**
    * Construct a non-scrollable block frame
    */
   nsIFrame* ConstructNonScrollableBlock(nsFrameConstructorState& aState,

--- a/layout/base/nsCSSFrameConstructor.h
+++ b/layout/base/nsCSSFrameConstructor.h
@@ -571,6 +571,7 @@ private:
      @param nsStyleContext the style context to use for the frame. */
   typedef nsIFrame* (* FrameCreationFunc)(nsIPresShell*, nsStyleContext*);
   typedef nsContainerFrame* (* ContainerFrameCreationFunc)(nsIPresShell*, nsStyleContext*);
+  typedef nsBlockFrame* (* BlockFrameCreationFunc)(nsIPresShell*, nsStyleContext*);
 
   /* A function that can be used to get a FrameConstructionData.  Such
      a function is allowed to return null.
@@ -1544,6 +1545,18 @@ private:
                                         nsContainerFrame*        aParentFrame,
                                         const nsStyleDisplay*    aDisplay,
                                         nsFrameItems&            aFrameItems);
+
+  /**
+   * Construct a non-scrollable block frame using the given block frame creation
+   * function.
+   */
+  nsIFrame* ConstructNonScrollableBlockWithConstructor(
+    nsFrameConstructorState& aState,
+    FrameConstructionItem& aItem,
+    nsContainerFrame* aParentFrame,
+    const nsStyleDisplay* aDisplay,
+    nsFrameItems& aFrameItems,
+    BlockFrameCreationFunc aConstructor);
 
   /**
    * This adds FrameConstructionItem objects to aItemsToConstruct for the

--- a/layout/generic/DetailsFrame.cpp
+++ b/layout/generic/DetailsFrame.cpp
@@ -22,7 +22,7 @@ NS_QUERYFRAME_HEAD(DetailsFrame)
   NS_QUERYFRAME_ENTRY(nsIAnonymousContentCreator)
 NS_QUERYFRAME_TAIL_INHERITING(nsBlockFrame)
 
-DetailsFrame*
+nsBlockFrame*
 NS_NewDetailsFrame(nsIPresShell* aPresShell, nsStyleContext* aContext)
 {
   return new (aPresShell) DetailsFrame(aContext);

--- a/layout/generic/nsBlockFrame.cpp
+++ b/layout/generic/nsBlockFrame.cpp
@@ -299,11 +299,18 @@ NS_DECLARE_FRAME_PROPERTY(BlockEndEdgeOfChildrenProperty, nullptr)
 //----------------------------------------------------------------------
 
 nsBlockFrame*
-NS_NewBlockFrame(nsIPresShell* aPresShell, nsStyleContext* aContext, nsFrameState aFlags)
+NS_NewBlockFrame(nsIPresShell* aPresShell, nsStyleContext* aContext)
 {
-  nsBlockFrame* it = new (aPresShell) nsBlockFrame(aContext);
-  it->SetFlags(aFlags);
-  return it;
+  return new (aPresShell) nsBlockFrame(aContext);
+}
+
+nsBlockFrame*
+NS_NewBlockFormattingContext(nsIPresShell* aPresShell,
+                             nsStyleContext* aStyleContext)
+{
+  nsBlockFrame* blockFrame = NS_NewBlockFrame(aPresShell, aStyleContext);
+  blockFrame->AddStateBits(NS_BLOCK_FLOAT_MGR | NS_BLOCK_MARGIN_ROOT);
+  return blockFrame;
 }
 
 NS_IMPL_FRAMEARENA_HELPERS(nsBlockFrame)

--- a/layout/generic/nsBlockFrame.h
+++ b/layout/generic/nsBlockFrame.h
@@ -100,8 +100,7 @@ public:
   reverse_line_iterator rline(nsLineBox* aList) { return mLines.rbegin(aList); }
 
   friend nsBlockFrame* NS_NewBlockFrame(nsIPresShell* aPresShell,
-                                        nsStyleContext* aContext,
-                                        nsFrameState aFlags);
+                                        nsStyleContext* aContext);
 
   // nsQueryFrame
   NS_DECL_QUERYFRAME

--- a/layout/generic/nsHTMLParts.h
+++ b/layout/generic/nsHTMLParts.h
@@ -50,7 +50,7 @@ class nsTableColFrame;
 // Create a frame that supports "display: block" layout behavior
 class nsBlockFrame;
 nsBlockFrame*
-NS_NewBlockFrame(nsIPresShell* aPresShell, nsStyleContext* aContext, nsFrameState aFlags = nsFrameState(0));
+NS_NewBlockFrame(nsIPresShell* aPresShell, nsStyleContext* aContext);
 
 // Special Generated Content Node. It contains text taken from an
 // attribute of its *grandparent* content node. 
@@ -67,12 +67,8 @@ nsContainerFrame*
 NS_NewSelectsAreaFrame(nsIPresShell* aPresShell, nsStyleContext* aContext, nsFrameState aFlags);
 
 // Create a block formatting context blockframe
-inline nsBlockFrame* NS_NewBlockFormattingContext(nsIPresShell* aPresShell,
-                                                  nsStyleContext* aStyleContext)
-{
-  return NS_NewBlockFrame(aPresShell, aStyleContext,
-                          NS_BLOCK_FLOAT_MGR | NS_BLOCK_MARGIN_ROOT);
-}
+nsBlockFrame*
+NS_NewBlockFormattingContext(nsIPresShell* aPresShell, nsStyleContext* aStyleContext);
 
 nsIFrame*
 NS_NewBRFrame(nsIPresShell* aPresShell, nsStyleContext* aContext);
@@ -177,8 +173,7 @@ nsIFrame*
 NS_NewRangeFrame(nsIPresShell* aPresShell, nsStyleContext* aContext);
 nsIFrame*
 NS_NewNumberControlFrame(nsIPresShell* aPresShell, nsStyleContext* aContext);
-class DetailsFrame;
-DetailsFrame*
+nsBlockFrame*
 NS_NewDetailsFrame(nsIPresShell* aPresShell, nsStyleContext* aContext);
 class SummaryFrame;
 SummaryFrame*

--- a/layout/reftests/details-summary/float-left-and-float-details-ref.html
+++ b/layout/reftests/details-summary/float-left-and-float-details-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  div#details {
+    float: left;
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <div id="details">
+      <div id="summary">Summary</div>
+      <!-- No content due to closed details -->
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-left-and-float-details.html
+++ b/layout/reftests/details-summary/float-left-and-float-details.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  details {
+    float: left;
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <!-- This tall float block is necessary to reproduce the incorrect height of the details. -->
+    <div id="float"></div>
+    <details>
+      <summary>Summary</summary>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-left-and-float-open-details-ref.html
+++ b/layout/reftests/details-summary/float-left-and-float-open-details-ref.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  div#details {
+    float: left;
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <div id="details">
+      <div id="summary">Summary</div>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-left-and-float-open-details.html
+++ b/layout/reftests/details-summary/float-left-and-float-open-details.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  details {
+    float: left;
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <!-- This tall float block is necessary to reproduce the incorrect height of the details. -->
+    <div id="float"></div>
+    <details open>
+      <summary>Summary</summary>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-left-and-inflow-details-ref.html
+++ b/layout/reftests/details-summary/float-left-and-inflow-details-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  div#details {
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <div id="details">
+      <div id="summary">Summary</div>
+      <!-- No content due to closed details -->
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-left-and-inflow-details.html
+++ b/layout/reftests/details-summary/float-left-and-inflow-details.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  details {
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <details>
+      <summary>Summary</summary>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-left-and-inflow-open-details-ref.html
+++ b/layout/reftests/details-summary/float-left-and-inflow-open-details-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  div#details {
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <div id="details">
+      <div id="summary">Summary</div>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-left-and-inflow-open-details.html
+++ b/layout/reftests/details-summary/float-left-and-inflow-open-details.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  details {
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <details open>
+      <summary>Summary</summary>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-open-details-contains-float-left-ref.html
+++ b/layout/reftests/details-summary/float-open-details-contains-float-left-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 400px;
+    background-color: lightgreen;
+  }
+  div#details {
+    float: left;
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="details">
+      <div id="summary">Summary</div>
+      <div id="float"></div>
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-open-details-contains-float-left.html
+++ b/layout/reftests/details-summary/float-open-details-contains-float-left.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: left;
+    width: 200px;
+    height: 400px;
+    background-color: lightgreen;
+  }
+  details {
+    float: left;
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <details open>
+      <summary>Summary</summary>
+      <div id="float"></div>
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-open-details-contains-float-right-ref.html
+++ b/layout/reftests/details-summary/float-open-details-contains-float-right-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 400px;
+    background-color: lightgreen;
+  }
+  div#details {
+    float: right;
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="details">
+      <div id="summary">Summary</div>
+      <div id="float"></div>
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-open-details-contains-float-right.html
+++ b/layout/reftests/details-summary/float-open-details-contains-float-right.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 400px;
+    background-color: lightgreen;
+  }
+  details {
+    float: right;
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <details open>
+      <summary>Summary</summary>
+      <div id="float"></div>
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-right-and-float-details-ref.html
+++ b/layout/reftests/details-summary/float-right-and-float-details-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  div#details {
+    float: right;
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <div id="details">
+      <div id="summary">Summary</div>
+      <!-- No content due to closed details -->
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-right-and-float-details.html
+++ b/layout/reftests/details-summary/float-right-and-float-details.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  details {
+    float: right;
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <!-- This tall float block is necessary to reproduce the incorrect height of the details. -->
+    <div id="float"></div>
+    <details>
+      <summary>Summary</summary>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-right-and-float-open-details-ref.html
+++ b/layout/reftests/details-summary/float-right-and-float-open-details-ref.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  div#details {
+    float: right;
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <div id="details">
+      <div id="summary">Summary</div>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-right-and-float-open-details.html
+++ b/layout/reftests/details-summary/float-right-and-float-open-details.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  details {
+    float: right;
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <!-- This tall float block is necessary to reproduce the incorrect height of the details. -->
+    <div id="float"></div>
+    <details open>
+      <summary>Summary</summary>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-right-and-inflow-details-ref.html
+++ b/layout/reftests/details-summary/float-right-and-inflow-details-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  div#details {
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <div id="details">
+      <div id="summary">Summary</div>
+      <!-- No content due to closed details -->
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-right-and-inflow-details.html
+++ b/layout/reftests/details-summary/float-right-and-inflow-details.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  details {
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <details>
+      <summary>Summary</summary>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-right-and-inflow-open-details-ref.html
+++ b/layout/reftests/details-summary/float-right-and-inflow-open-details-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  div#details {
+    background-color: orange;
+  }
+  div#summary {
+    background-color: green;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <div id="details">
+      <div id="summary">Summary</div>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/float-right-and-inflow-open-details.html
+++ b/layout/reftests/details-summary/float-right-and-inflow-open-details.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  body {
+    width: 400px;
+  }
+  div#float {
+    float: right;
+    width: 200px;
+    height: 200px;
+    background-color: lightgreen;
+  }
+  details {
+    background-color: orange;
+  }
+  summary {
+    background-color: green;
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  </style>
+  <body>
+    <div id="float"></div>
+    <details open>
+      <summary>Summary</summary>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/reftest.list
+++ b/layout/reftests/details-summary/reftest.list
@@ -42,6 +42,18 @@ details-page-break-after-2.html details-two-pages.html
 details-page-break-before-1.html details-two-pages.html
 details-page-break-before-2.html details-two-pages.html
 
+# With 'float' property
+float-left-and-float-details.html float-left-and-float-details-ref.html
+float-left-and-inflow-details.html float-left-and-inflow-details-ref.html
+float-left-and-float-open-details.html float-left-and-float-open-details-ref.html
+float-left-and-inflow-open-details.html float-left-and-inflow-open-details-ref.html
+float-right-and-float-details.html float-right-and-float-details-ref.html
+float-right-and-inflow-details.html float-right-and-inflow-details-ref.html
+float-right-and-float-open-details.html float-right-and-float-open-details-ref.html
+float-right-and-inflow-open-details.html float-right-and-inflow-open-details-ref.html
+float-open-details-contains-float-left.html float-open-details-contains-float-left-ref.html
+float-open-details-contains-float-right.html float-open-details-contains-float-right-ref.html
+
 # Various properties on details or summary
 details-display-inline.html details-display-inline-ref.html
 details-percentage-height-children.html details-percentage-height-children-ref.html


### PR DESCRIPTION
Work to solve issues with `<details>` and `<summary>` if using CSS float on it.

In the case of floating these elements, a block frame needs to be created
(see specific in CSS 2.2), which this set of patches achieves.

nsCSSFrameConstructor::ConstructNonScrollableBlock() has logic to
determine whether to create a block formatting context for a block
frame. The function is refactored to make it reusable by
nsCSSFrameConstructor::ConstructDetailsFrame().

Also, made NS_NewBlockFrame() accept two arguments as other frame
factory functions so that it could be pointed by BlockFrameCreationFunc.
NS_NewBlockFormattingContext is changed accordingly.

The construction for a scrollable DetailsFrame has been revised similarly.