### PR TITLE
HTML - details/summary - localize the description of default summary

### DIFF
--- a/dom/locales/en-US/chrome/layout/HtmlForm.properties
+++ b/dom/locales/en-US/chrome/layout/HtmlForm.properties
@@ -36,3 +36,7 @@ ColorPicker=Choose a color
 # minus 20 and will always be a number equal to or greater than 2. So the
 # singular case will never be used.
 AndNMoreFiles=and one more;and #1 more
+# LOCALIZATION NOTE (DefaultSummary): this string is shown on a <details> when
+# it has no direct <summary> child. Google Chrome should already have this
+# string translated.
+DefaultSummary=Details

--- a/layout/generic/DetailsFrame.cpp
+++ b/layout/generic/DetailsFrame.cpp
@@ -107,9 +107,11 @@ DetailsFrame::CreateAnonymousContent(nsTArray<ContentInfo>& aElements)
                                  nsIDOMNode::ELEMENT_NODE);
   mDefaultSummary = new HTMLSummaryElement(nodeInfo);
 
-  // TODO: Need to localize this "Details" string in bug 1225752.
+  nsXPIDLString defaultSummaryText;
+  nsContentUtils::GetLocalizedString(nsContentUtils::eFORMS_PROPERTIES,
+                                     "DefaultSummary", defaultSummaryText);
   nsRefPtr<nsTextNode> description = new nsTextNode(nodeInfoManager);
-  description->SetText(NS_LITERAL_STRING("Details"), false);
+  description->SetText(defaultSummaryText, false);
   mDefaultSummary->AppendChildTo(description, false);
 
   aElements.AppendElement(mDefaultSummary);


### PR DESCRIPTION
Ad #1496

Localize the description of default summary

An example:
```
<details></details>
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1225752

---

You add the label `String changes`, please.

---

I've created the new build (x32, Windows) and tested.

