### PR TITLE
HTML - details/summary - correct the universal selector for summary to include all namespaces (tests)

### DIFF
--- a/layout/reftests/details-summary/details-in-ol-ref.html
+++ b/layout/reftests/details-summary/details-in-ol-ref.html
@@ -18,6 +18,14 @@
                 <li>Second item in summary</li>
               </ol>
             </div>
+            <svg>
+              <foreignObject width="300" height="300">
+                <ol>
+                  <li>First item in foreignObject</li>
+                  <li>Second item in foreignObject</li>
+                </ol>
+              </foreignObject>
+            </svg>
           </summary>
           <p>This is the details.</p>
           <li>First item in details</li>

--- a/layout/reftests/details-summary/details-in-ol.html
+++ b/layout/reftests/details-summary/details-in-ol.html
@@ -25,6 +25,14 @@
                 <li>Second item in summary</li>
               </ol>
             </div>
+            <svg>
+              <foreignObject width="300" height="300">
+                <ol>
+                  <li>First item in foreignObject</li>
+                  <li>Second item in foreignObject</li>
+                </ol>
+              </foreignObject>
+            </svg>
           </summary>
           <p>This is the details.</p>
           <!-- Although html spec does not allow <li> inside <details>, we


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/issues/1496#issuecomment-347458810

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1264533 (partially)

---

I've created the new build (x32, Windows) and tested.
