### PR TITLE
HTML - details/summary - don't suppress the scroll bits of a non-open <details> that has the appropriate overflow styles.

### DIFF
--- a/dom/base/nsIContent.h
+++ b/dom/base/nsIContent.h
@@ -310,6 +310,18 @@ public:
            GetBindingParent();
   }
 
+  bool IsGeneratedContentContainerForBefore() const
+  {
+    return IsRootOfNativeAnonymousSubtree() &&
+           mNodeInfo->NameAtom() == nsGkAtoms::mozgeneratedcontentbefore;
+  }
+
+  bool IsGeneratedContentContainerForAfter() const
+  {
+    return IsRootOfNativeAnonymousSubtree() &&
+           mNodeInfo->NameAtom() == nsGkAtoms::mozgeneratedcontentafter;
+  }
+
   /**
    * Set attribute values. All attribute values are assumed to have a
    * canonical string representation that can be used for these

--- a/layout/base/crashtests/1297835.html
+++ b/layout/base/crashtests/1297835.html
@@ -1,0 +1,6 @@
+<body onload="document.documentElement.offsetWidth; document.querySelector('details').style.color = 'green'">
+  <details style="display: block; overflow: scroll;">
+    <summary>Some summary</summary>
+    The details
+  </details>
+</body>

--- a/layout/base/crashtests/crashtests.list
+++ b/layout/base/crashtests/crashtests.list
@@ -458,3 +458,4 @@ load 1061028.html
 load 1116104.html
 load 1107508-1.html
 load 1127198-1.html
+load 1297835.html

--- a/layout/base/nsCSSFrameConstructor.cpp
+++ b/layout/base/nsCSSFrameConstructor.cpp
@@ -5601,9 +5601,15 @@ nsCSSFrameConstructor::AddFrameConstructionItemsInternal(nsFrameConstructorState
   }
 
   // When constructing a child of a non-open <details>, create only the frame
-  // for the main <summary> element, and skip other elements.
+  // for the main <summary> element, and skip other elements.  This only applies
+  // to things that are not roots of native anonymous subtrees (except for
+  // ::before and ::after); we always want to create "internal" anonymous
+  // content.
   auto* details = HTMLDetailsElement::FromContentOrNull(parent);
-  if (details && !details->Open()) {
+  if (details && !details->Open() &&
+      (!aContent->IsRootOfNativeAnonymousSubtree() ||
+       aContent->IsGeneratedContentContainerForBefore() ||
+       aContent->IsGeneratedContentContainerForAfter())) {
     auto* summary = HTMLSummaryElement::FromContentOrNull(aContent);
     if (!summary || !summary->IsMainSummary()) {
       SetAsUndisplayedContent(aState, aItems, aContent, styleContext,

--- a/layout/reftests/details-summary/details-after.html
+++ b/layout/reftests/details-summary/details-after.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+<head>
+  <style>
+    details::after {
+      content: "This is the details.";
+      /* Match the margins and display of <p> */
+      display: block;
+      margin-block-start: 1em;
+      margin-block-end: 1em;
+    }
+  </style>
+</head>
+<html>
+  <body>
+    <details>
+      <summary>Summary</summary>
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/details-before.html
+++ b/layout/reftests/details-summary/details-before.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+<head>
+  <style>
+    details::before {
+      content: "This is the details.";
+      /* Match the margins and display of <p> */
+      display: block;
+      margin-block-start: 1em;
+      margin-block-end: 1em;
+    }
+  </style>
+</head>
+<html>
+  <body>
+    <details>
+      <summary>Summary</summary>
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/open-details-after.html
+++ b/layout/reftests/details-summary/open-details-after.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+<head>
+  <style>
+    details::after {
+      content: "This is the details.";
+      /* Match the margins and display of <p> */
+      display: block;
+      margin-block-start: 1em;
+      margin-block-end: 1em;
+    }
+  </style>
+</head>
+<html>
+  <body>
+    <details open>
+      <summary>Summary</summary>
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/open-details-before.html
+++ b/layout/reftests/details-summary/open-details-before.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+<head>
+  <style>
+    details::before {
+      content: "This is the details.";
+      /* Match the margins and display of <p> */
+      display: block;
+      margin-block-start: 1em;
+      margin-block-end: 1em;
+    }
+  </style>
+</head>
+<html>
+  <body>
+    <details open>
+      <summary>Summary</summary>
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/overflow-scroll-details-ref.html
+++ b/layout/reftests/details-summary/overflow-scroll-details-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  div#details {
+    background-color: orange;
+    overflow: scroll;
+    width: 300px;
+    height: 200px;
+  }
+  div#summary {
+    background-color: green;
+    width: 200px;
+    height: 100px;
+  }
+  </style>
+  <body>
+    <div id="details">
+      <div id="summary">Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+        enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+        aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit
+        in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+        officia deserunt mollit anim id est laborum.
+      </div>
+    </div>
+  </body>
+</html>

--- a/layout/reftests/details-summary/overflow-scroll-details.html
+++ b/layout/reftests/details-summary/overflow-scroll-details.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<!-- Any copyright is dedicated to the Public Domain.
+   - http://creativecommons.org/publicdomain/zero/1.0/ -->
+
+<html>
+  <style>
+  details {
+    background-color: orange;
+    overflow: scroll;
+    width: 300px;
+    height: 200px;
+  }
+  summary::-moz-list-bullet {
+    /* Hide the triangle for comparing with div in reftest. */
+    list-style-type: none;
+  }
+  summary {
+    background-color: green;
+    width: 200px;
+    height: 100px;
+  }
+  </style>
+  <body>
+    <details>
+      <summary>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+        eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+        minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+        ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+        sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </summary>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </details>
+  </body>
+</html>

--- a/layout/reftests/details-summary/reftest.list
+++ b/layout/reftests/details-summary/reftest.list
@@ -35,6 +35,7 @@
 # With 'overflow' property
 == overflow-hidden-open-details.html overflow-hidden-open-details-ref.html
 == overflow-auto-open-details.html overflow-auto-open-details-ref.html
+== overflow-scroll-details.html overflow-scroll-details-ref.html
 
 # With pagination property
 == details-page-break-after-1.html details-two-pages.html
@@ -88,3 +89,9 @@
 == key-enter-open-second-summary.html open-multiple-summary.html
 == key-enter-prevent-default.html single-summary.html
 == key-space-single-summary.html open-single-summary.html
+
+# Generated content bits
+== details-after.html single-summary.html
+== details-before.html single-summary.html
+== open-details-after.html open-single-summary.html
+== open-details-before.html open-single-summary.html

--- a/layout/style/nsTransitionManager.cpp
+++ b/layout/style/nsTransitionManager.cpp
@@ -162,9 +162,9 @@ nsTransitionManager::StyleContextChanged(dom::Element *aElement,
     }
 
     NS_ASSERTION((pseudoType == nsCSSPseudoElements::ePseudo_before &&
-                  aElement->Tag() == nsGkAtoms::mozgeneratedcontentbefore) ||
+                  aElement->IsGeneratedContentContainerForBefore()) ||
                  (pseudoType == nsCSSPseudoElements::ePseudo_after &&
-                  aElement->Tag() == nsGkAtoms::mozgeneratedcontentafter),
+                  aElement->IsGeneratedContentContainerForAfter()),
                  "Unexpected aElement coming through");
 
     // Else the element we want to use from now on is the element the


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/issues/1496#issuecomment-347458810

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1297835
https://bugzilla.mozilla.org/show_bug.cgi?id=1295852 (partially)

An example:
https://hg.mozilla.org/mozilla-central/file/75e8d28abce1/layout/reftests/details-summary/overflow-scroll-details.html

---

I've created the new build (x32, Windows) and tested.
