### PR TITLE
DOM - events - add support for the ondragexit attribute

### DIFF
--- a/dom/events/EventNameList.h
+++ b/dom/events/EventNameList.h
@@ -193,6 +193,10 @@ EVENT(dragenter,
       NS_DRAGDROP_ENTER,
       EventNameType_HTMLXUL,
       eDragEventClass)
+EVENT(dragexit,
+      NS_DRAGDROP_EXIT_SYNTH,
+      EventNameType_HTMLXUL,
+      eDragEventClass)
 EVENT(dragleave,
       NS_DRAGDROP_LEAVE_SYNTH,
       EventNameType_HTMLXUL,
@@ -738,10 +742,6 @@ NON_IDL_EVENT(commandupdate,
               NS_XUL_COMMAND_UPDATE,
               EventNameType_XUL,
               eBasicEventClass)
-NON_IDL_EVENT(dragexit,
-              NS_DRAGDROP_EXIT_SYNTH,
-              EventNameType_XUL,
-              eDragEventClass)
 NON_IDL_EVENT(dragdrop,
               NS_DRAGDROP_DRAGDROP,
               EventNameType_XUL,

--- a/dom/webidl/EventHandler.webidl
+++ b/dom/webidl/EventHandler.webidl
@@ -45,7 +45,7 @@ interface GlobalEventHandlers {
            attribute EventHandler ondrag;
            attribute EventHandler ondragend;
            attribute EventHandler ondragenter;
-           //(Not implemented)attribute EventHandler ondragexit;
+           attribute EventHandler ondragexit;
            attribute EventHandler ondragleave;
            attribute EventHandler ondragover;
            attribute EventHandler ondragstart;


### PR DESCRIPTION
Ad #1526 

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1284914

An example:
- `ondragexit` - in Browser Console: `dragexit1`
- `addEventListener("dragexit")` - in Browser Console: `dragexit2`
  - [drag.zip](https://github.com/MoonchildProductions/Pale-Moon/files/1523808/drag.zip)

---

I've created the new build (x32, Windows) and tested.
