### PR TITLE
Implement Symbol.species

### DIFF
--- a/js/src/builtin/Map.js
+++ b/js/src/builtin/Map.js
@@ -32,3 +32,9 @@ function MapForEach(callbackfn, thisArg = undefined) {
         callFunction(callbackfn, thisArg, entry[1], entry[0], M);
     }
 }
+
+// ES6 final draft 23.1.2.2.
+function MapSpecies() {
+    // Step 1.
+    return this;
+}

--- a/js/src/builtin/MapObject.cpp
+++ b/js/src/builtin/MapObject.cpp
@@ -1043,9 +1043,15 @@ const JSFunctionSpec MapObject::methods[] = {
     JS_FS_END
 };
 
+const JSPropertySpec MapObject::staticProperties[] = {
+    JS_SELF_HOSTED_SYM_GET(species, "MapSpecies", 0),
+    JS_PS_END
+};
+
 static JSObject*
 InitClass(JSContext* cx, Handle<GlobalObject*> global, const Class* clasp, JSProtoKey key, Native construct,
-          const JSPropertySpec* properties, const JSFunctionSpec* methods)
+          const JSPropertySpec* properties, const JSFunctionSpec* methods,
+          const JSPropertySpec* staticProperties)
 {
     RootedNativeObject proto(cx, global->createBlankPrototype(cx, clasp));
     if (!proto)
@@ -1054,6 +1060,7 @@ InitClass(JSContext* cx, Handle<GlobalObject*> global, const Class* clasp, JSPro
 
     Rooted<JSFunction*> ctor(cx, global->createConstructor(cx, construct, ClassName(key, cx), 1));
     if (!ctor ||
+        !JS_DefineProperties(cx, ctor, staticProperties) ||
         !LinkConstructorAndPrototype(cx, ctor, proto) ||
         !DefinePropertiesAndFunctions(cx, proto, properties, methods) ||
         !GlobalObject::initBuiltinConstructor(cx, global, key, ctor, proto))
@@ -1068,7 +1075,8 @@ MapObject::initClass(JSContext* cx, JSObject* obj)
 {
     Rooted<GlobalObject*> global(cx, &obj->as<GlobalObject>());
     RootedObject proto(cx,
-        InitClass(cx, global, &class_, JSProto_Map, construct, properties, methods));
+        InitClass(cx, global, &class_, JSProto_Map, construct, properties, methods,
+                  staticProperties));
     if (proto) {
         // Define the "entries" method.
         JSFunction* fun = JS_DefineFunction(cx, proto, "entries", entries, 0, 0);
@@ -1770,12 +1778,18 @@ const JSFunctionSpec SetObject::methods[] = {
     JS_FS_END
 };
 
+const JSPropertySpec SetObject::staticProperties[] = {
+    JS_SELF_HOSTED_SYM_GET(species, "SetSpecies", 0),
+    JS_PS_END
+};
+
 JSObject*
 SetObject::initClass(JSContext* cx, JSObject* obj)
 {
     Rooted<GlobalObject*> global(cx, &obj->as<GlobalObject>());
     RootedObject proto(cx,
-        InitClass(cx, global, &class_, JSProto_Set, construct, properties, methods));
+        InitClass(cx, global, &class_, JSProto_Set, construct, properties, methods,
+                  staticProperties));
     if (proto) {
         // Define the "values" method.
         JSFunction* fun = JS_DefineFunction(cx, proto, "values", values, 0, 0);

--- a/js/src/builtin/MapObject.h
+++ b/js/src/builtin/MapObject.h
@@ -108,6 +108,7 @@ class MapObject : public NativeObject {
   private:
     static const JSPropertySpec properties[];
     static const JSFunctionSpec methods[];
+    static const JSPropertySpec staticProperties[];
     ValueMap* getData() { return static_cast<ValueMap*>(getPrivate()); }
     static ValueMap & extract(HandleObject o);
     static ValueMap & extract(CallReceiver call);
@@ -153,6 +154,7 @@ class SetObject : public NativeObject {
   private:
     static const JSPropertySpec properties[];
     static const JSFunctionSpec methods[];
+    static const JSPropertySpec staticProperties[];
     ValueSet* getData() { return static_cast<ValueSet*>(getPrivate()); }
     static ValueSet & extract(CallReceiver call);
     static void mark(JSTracer* trc, JSObject* obj);

--- a/js/src/builtin/Set.js
+++ b/js/src/builtin/Set.js
@@ -32,3 +32,9 @@ function SetForEach(callbackfn, thisArg = undefined) {
         callFunction(callbackfn, thisArg, value, value, S);
     }
 }
+
+// ES6 final draft 23.2.2.2.
+function SetSpecies() {
+    // Step 1.
+    return this;
+}

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -4211,6 +4211,7 @@ GetSymbolDescription(HandleSymbol symbol);
 /* Well-known symbols. */
 #define JS_FOR_EACH_WELL_KNOWN_SYMBOL(macro) \
     macro(iterator) \
+    macro(species) \
     macro(unscopables)
 
 enum class SymbolCode : uint32_t {

--- a/js/src/jsapi.h
+++ b/js/src/jsapi.h
@@ -2193,6 +2193,11 @@ inline int CheckIsStrictPropertyOp(JSStrictPropertyOp op);
      { nullptr, JS_CAST_STRING_TO(getterName, const JSJitInfo*) },  \
      { nullptr, JS_CAST_STRING_TO(setterName, const JSJitInfo*) } }
 #define JS_PS_END { nullptr, 0, JSNATIVE_WRAPPER(nullptr), JSNATIVE_WRAPPER(nullptr) }
+#define JS_SELF_HOSTED_SYM_GET(symbol, getterName, flags) \
+    {reinterpret_cast<const char*>(uint32_t(::JS::SymbolCode::symbol) + 1), \
+     uint8_t(JS_CHECK_ACCESSOR_FLAGS(flags) | JSPROP_SHARED | JSPROP_GETTER), \
+     { { nullptr, JS_CAST_STRING_TO(getterName, const JSJitInfo*) } }, \
+     JSNATIVE_WRAPPER(nullptr) }
 
 /*
  * To define a native function, set call to a JSNativeWrapper. To define a

--- a/js/src/vm/CommonPropertyNames.h
+++ b/js/src/vm/CommonPropertyNames.h
@@ -239,6 +239,7 @@
     /* Well-known atom names must be continuous and ordered, matching \
      * enum JS::SymbolCode in jsapi.h. */ \
     macro(iterator, iterator, "iterator") \
+    macro(species, species, "species") \
     macro(unscopables, unscopables, "unscopables") \
     /* Same goes for the descriptions of the well-known symbols. */ \
     macro(Symbol_create, Symbol_create, "Symbol.create") \
@@ -246,6 +247,7 @@
     macro(Symbol_isConcatSpreadable, Symbol_isConcatSpreadable, "Symbol.isConcatSpreadable") \
     macro(Symbol_isRegExp, Symbol_isRegExp, "Symbol.isRegExp") \
     macro(Symbol_iterator, Symbol_iterator, "Symbol.iterator") \
+    macro(Symbol_species,  Symbol_species,  "Symbol.species") \
     macro(Symbol_toPrimitive, Symbol_toPrimitive, "Symbol.toPrimitive") \
     macro(Symbol_unscopables, Symbol_unscopables, "Symbol.unscopables") \
 

--- a/js/src/vm/GlobalObject.cpp
+++ b/js/src/vm/GlobalObject.cpp
@@ -383,6 +383,14 @@ GlobalObject::initSelfHostingBuiltins(JSContext* cx, Handle<GlobalObject*> globa
         return false;
     }
 
+    RootedValue std_species(cx);
+    std_species.setSymbol(cx->wellKnownSymbols().get(JS::SymbolCode::species));
+    if (!JS_DefineProperty(cx, global, "std_species", std_species,
+                           JSPROP_PERMANENT | JSPROP_READONLY))
+    {
+        return false;
+    }
+
     return InitBareBuiltinCtor(cx, global, JSProto_Array) &&
            InitBareBuiltinCtor(cx, global, JSProto_TypedArray) &&
            InitBareBuiltinCtor(cx, global, JSProto_Uint8Array) &&


### PR DESCRIPTION
This resolves #1565

An example (for Scratchpad):
``` javascript
function assertEq(a, b) {
  console.log("assertEq: ", (a === b));
}

for (var C of [Map, Set]) {
  assertEq(C[Symbol.species], C);
}

for (C of [Map, Set]) {
  var desc = Object.getOwnPropertyDescriptor(C, Symbol.species);
  // ["configurable", "enumerable", "get", "set"]
  console.log(JSON.stringify(Object.keys(desc).sort()));
  assertEq(desc.set, undefined);
  assertEq(desc.enumerable, false);
  assertEq(desc.configurable, true);
  assertEq(desc.get.apply(null), null);
  assertEq(desc.get.apply(undefined), undefined);
  assertEq(desc.get.apply(42), 42);
}
```

Expected results:
`"assertEq: " true` (2x - Map, Set - `for (var C of [Map, Set])`)
`"["configurable","enumerable","get","set"]"` (Map - `for (C of [Map, Set]) {`)
`"assertEq: " true` (6x - Map - `for (C of [Map, Set]) {`)
`"["configurable","enumerable","get","set"]"` (Set - `for (C of [Map, Set]) {`)
`"assertEq: " true` (6x - Set - `for (C of [Map, Set]) {`)

---

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1131043

---

I've created the new build (x32, Windows) and tested.
