### PR TITLE
Collapse notification bar in fullscreen

### DIFF
--- a/browser/base/content/browser.css
+++ b/browser/base/content/browser.css
@@ -685,3 +685,9 @@ toolbarbutton[pmkit-button="true"] > .toolbarbutton-badge-container > .toolbarbu
   width: 16px;
   height: 16px;
 }
+
+/* Remove white bar at the bottom of the screen when watching HTML5 video in fullscreen on Windows */
+#main-window[inFullscreen] #global-notificationbox,
+#main-window[inFullscreen] #high-priority-global-notificationbox {
+  visibility: collapse;
+}

--- a/browser/base/content/browser.css
+++ b/browser/base/content/browser.css
@@ -686,7 +686,7 @@ toolbarbutton[pmkit-button="true"] > .toolbarbutton-badge-container > .toolbarbu
   height: 16px;
 }
 
-/* Remove white bar at the bottom of the screen when watching HTML5 video in fullscreen on Windows */
+/* Remove white bar at the bottom of the screen when watching HTML5 video in fullscreen */
 #main-window[inFullscreen] #global-notificationbox,
 #main-window[inFullscreen] #high-priority-global-notificationbox {
   visibility: collapse;


### PR DESCRIPTION
Remove white bar at the bottom of the screen when watching HTML5 video in fullscreen on Windows
See https://forum.palemoon.org/viewtopic.php?f=3&t=17707, https://bugzilla.mozilla.org/show_bug.cgi?id=1076626, and https://forum.palemoon.org/viewtopic.php?f=29&t=17918