### PR TITLE
Add Eyedropper to the app menu

### DIFF
--- a/browser/base/content/browser-appmenu.inc
+++ b/browser/base/content/browser-appmenu.inc
@@ -147,6 +147,8 @@
                     observes="devtoolsMenuBroadcaster_BrowserConsole"/>
           <menuitem id="appmenu_responsiveUI"
                     observes="devtoolsMenuBroadcaster_ResponsiveUI"/>
+          <menuitem id="appmenu_eyedropper"
+                    observes="devtoolsMenuBroadcaster_Eyedropper"/>
           <menuitem id="appmenu_scratchpad"
                     observes="devtoolsMenuBroadcaster_Scratchpad"/>
 #endif


### PR DESCRIPTION
This resolves #1588 (you add the label `Devtools`, please)

Follow up https://github.com/MoonchildProductions/Pale-Moon/commit/d9b38083d568ad1cc6c3697c0af8ca7604744f23#diff-245f392704a166ee94ee8dcc7f57dca0R554

---

Maybe (I don't know): You add the label `Theme changes`, please.

---

I've created the new build (x32, Windows) and tested.
