### PR TITLE
Make caret behind CJK char normal width by default

### DIFF
--- a/layout/base/nsCaret.cpp
+++ b/layout/base/nsCaret.cpp
@@ -117,6 +117,12 @@ IsBidiUI()
   return Preferences::GetBool("bidi.browser.ui");
 }
 
+static bool
+CjkThickCaret()
+{
+  return Preferences::GetBool("layout.cjkthickcaret");
+}
+
 nsCaret::nsCaret()
 : mOverrideOffset(0)
 , mIsBlinkOn(false)
@@ -188,7 +194,7 @@ nsCaret::ComputeMetrics(nsIFrame* aFrame, int32_t aOffset, nscoord aCaretHeight)
     nsPresContext::CSSPixelsToAppUnits(
         LookAndFeel::GetInt(LookAndFeel::eIntID_CaretWidth, 1));
 
-  if (DrawCJKCaret(aFrame, aOffset)) {
+  if (DrawCJKCaret(aFrame, aOffset) && CjkThickCaret()) {
     caretWidth += nsPresContext::CSSPixelsToAppUnits(1);
   }
   nscoord bidiIndicatorSize = nsPresContext::CSSPixelsToAppUnits(kMinBidiIndicatorPixels);

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4909,4 +4909,4 @@ pref("dom.secureelement.enabled", false);
 pref("plugins.rewrite_youtube_embeds", true);
 
 // Thick caret when behind CJK characters
-pref("layout.cjkthickcaret", false);
+pref("layout.cjkthickcaret", true);

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4907,3 +4907,6 @@ pref("dom.secureelement.enabled", false);
 
 // Turn rewriting of youtube embeds on/off
 pref("plugins.rewrite_youtube_embeds", true);
+
+// Thick caret when behind CJK characters
+pref("layout.cjkthickcaret", false);


### PR DESCRIPTION
Add a preference (layout.cjkthickcaret; false by default) for whether or not the caret should be thicker than normal when located behind a Chinese/Japanese/Korean character. Currently this is always the case.

This resolves #1555.