### PR TITLE
Show the Status Line (e.g. "HTTP/2.0 200 OK") in raw headers (response)

### DIFF
--- a/toolkit/devtools/netmonitor/netmonitor-view.js
+++ b/toolkit/devtools/netmonitor/netmonitor-view.js
@@ -670,9 +670,15 @@ RequestsMenuView.prototype = Heritage.extend(WidgetMethods, {
     if (rawHeadersHidden) {
       let selected = this.selectedItem.attachment;
       let selectedRequestHeaders = selected.requestHeaders.headers;
+      // display Status-Line above other response headers
+      let selectedStatusLine = selected.httpVersion
+                               + " " + selected.status
+                               + " " + selected.statusText
+                               + "\n";
       let selectedResponseHeaders = selected.responseHeaders.headers;
       requestTextarea.value = writeHeaderText(selectedRequestHeaders);
-      responseTextare.value = writeHeaderText(selectedResponseHeaders);
+      responseTextare.value = selectedStatusLine
+                              + writeHeaderText(selectedResponseHeaders);
       $("#raw-headers").hidden = false;
     } else {
       requestTextarea.value = null;


### PR DESCRIPTION
This resolves #1602 (you add the label `Devtools`, please)

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1419401

I've created the new build (x32, Windows) and tested.
