### PR TITLE
Fix "help cmd" in the Developer Toolbar

### DIFF
--- a/toolkit/devtools/gcli/source/lib/gcli/commands/help.js
+++ b/toolkit/devtools/gcli/source/lib/gcli/commands/help.js
@@ -270,7 +270,7 @@ exports.items = [
           '  <div if="${command.isParent}">\n' +
           '    <p class="gcli-help-header">${l10n.subCommands}:</p>\n' +
           '    <ul class="gcli-help-${subcommands}">\n' +
-          '      <li if="${subcommands.length === 0}">${l10n.subcommandsNone}</li>\n' +
+          '      <li if="${subcommands.length === 0}">${l10n.subCommandsNone}</li>\n' +
           '      <li foreach="subcommand in ${subcommands}">\n' +
           '        ${subcommand.name}: ${subcommand.description}\n' +
           '        <span class="gcli-out-shortcut" data-command="help ${subcommand.name}"\n' +
@@ -316,7 +316,7 @@ exports.items = [
           '\n' +
           '<span if="${command.isParent}"># ${l10n.subCommands}:</span>\n' +
           '\n' +
-          '<span if="${subcommands.length === 0}">${l10n.subcommandsNone}</span>\n' +
+          '<span if="${subcommands.length === 0}">${l10n.subCommandsNone}</span>\n' +
           '<loop foreach="subcommand in ${subcommands}">* ${subcommand.name}: ${subcommand.description}\n' +
           '</loop>\n' +
           '</div>\n',

--- a/toolkit/locales/en-US/chrome/global/devtools/gcli.properties
+++ b/toolkit/locales/en-US/chrome/global/devtools/gcli.properties
@@ -141,9 +141,10 @@ helpManual=Provide help either on a specific command (if a search string is prov
 helpSearchDesc=Search string
 helpSearchManual3=search string to use in narrowing down the displayed commands. Regular expressions not supported.
 
-# LOCALIZATION NOTE: These strings are displayed in the help page for a
-# command in the console.
+# LOCALIZATION NOTE (helpManSynopsis, helpManDescription): These strings are
+# displayed in the help page for a command in the console.
 helpManSynopsis=Synopsis
+helpManDescription=Description
 
 # LOCALIZATION NOTE: This message is displayed in the help page if the command
 # has no parameters.
@@ -176,6 +177,10 @@ helpIntro=GCLI is an experiment to create a highly usable command line for web d
 # when the command in question has sub-commands, before a list of the matching
 # sub-commands.
 subCommands=Sub-Commands
+
+# LOCALIZATION NOTE: Text shown as part of the output of the 'help' command
+# when the command in question should have sub-commands but in fact has none.
+subCommandsNone=None
 
 # LOCALIZATION NOTE: This error message is displayed when the command line is
 # cannot find a match for the parse types.


### PR DESCRIPTION
This resolves #1608 → You add the label `Devtools`, please

---

You add the label `String Changes`, please.

---

I've created the new build (x32, Windows) and tested.
