### PR TITLE
Synchronously read the session file if the session need to be restored at startup

### DIFF
--- a/browser/components/sessionstore/nsSessionStartup.js
+++ b/browser/components/sessionstore/nsSessionStartup.js
@@ -77,9 +77,14 @@ SessionStartup.prototype = {
       return;
     }
 
-    _SessionFile.read().then(
-      this._onSessionFileRead.bind(this)
-    );
+    if (Services.prefs.getBoolPref("browser.sessionstore.resume_session_once") ||
+        Services.prefs.getIntPref("browser.startup.page") == 3) {
+      this._ensureInitialized();
+    } else {
+      _SessionFile.read().then(
+        this._onSessionFileRead.bind(this)
+      );
+    }
   },
 
   // Wrap a string as a nsISupports


### PR DESCRIPTION
This resolves #1310 and reduces the overall startup time.

With this patch applied in my test environment with ~25 tabs, the sessionRestored event fires after ~3300 ms instead of ~4000 ms.