### PR TITLE
Clicking on a notification should select the originating tab

### DIFF
--- a/browser/base/content/content.js
+++ b/browser/base/content/content.js
@@ -62,3 +62,7 @@ addMessageListener("Finder:Initialize", function () {
   let {RemoteFinderListener} = Cu.import("resource://gre/modules/RemoteFinder.jsm", {});
   new RemoteFinderListener(global);
 });
+
+addEventListener("DOMWebNotificationClicked", function(event) {
+  sendAsyncMessage("DOMWebNotificationClicked", {});
+}, false);

--- a/browser/base/content/tabbrowser.xml
+++ b/browser/base/content/tabbrowser.xml
@@ -2959,7 +2959,7 @@
                 tab.setAttribute("titlechanged", "true");
             }
             case "DOMWebNotificationClicked": {
-              let tab = this._getTabForBrowser(browser);
+              let tab = this.getTabForBrowser(browser);
               if (!tab)
                 return;
               this.selectedTab = tab;

--- a/browser/base/content/tabbrowser.xml
+++ b/browser/base/content/tabbrowser.xml
@@ -2950,13 +2950,22 @@
           let browser = aMessage.target;
 
           switch (aMessage.name) {
-            case "DOMTitleChanged":
+            case "DOMTitleChanged": {
               let tab = this.getTabForBrowser(browser);
               if (!tab)
                 return;
               let titleChanged = this.setTabTitle(tab);
               if (titleChanged && !tab.selected && !tab.hasAttribute("busy"))
                 tab.setAttribute("titlechanged", "true");
+            }
+            case "DOMWebNotificationClicked": {
+              let tab = this._getTabForBrowser(browser);
+              if (!tab)
+                return;
+              this.selectedTab = tab;
+              window.focus();
+              break;
+            }
           }
         ]]></body>
       </method>
@@ -3022,6 +3031,7 @@
             this._outerWindowIDBrowserMap.set(this.mCurrentBrowser.outerWindowID,
                                               this.mCurrentBrowser);
           }
+          messageManager.addMessageListener("DOMWebNotificationClicked", this);
         ]]>
       </constructor>
 

--- a/browser/base/content/tabbrowser.xml
+++ b/browser/base/content/tabbrowser.xml
@@ -2957,6 +2957,7 @@
               let titleChanged = this.setTabTitle(tab);
               if (titleChanged && !tab.selected && !tab.hasAttribute("busy"))
                 tab.setAttribute("titlechanged", "true");
+              break;
             }
             case "DOMWebNotificationClicked": {
               let tab = this.getTabForBrowser(browser);


### PR DESCRIPTION
This resolves #1641

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=853972
https://bugzilla.mozilla.org/show_bug.cgi?id=960997

I've created the new build (x32, Windows) and tested.

---

~~IMHO: I suggest adding `break;` after:~~
~~https://github.com/MoonchildProductions/Pale-Moon/pull/1642/files#diff-bbbe75ef0288f6a09e20ad8e169c8b16R2959~~
