### PR TITLE
Align XCTO: nosniff allowed script MIME types with the spec

### DIFF
--- a/dom/base/nsContentUtils.cpp
+++ b/dom/base/nsContentUtils.cpp
@@ -3438,20 +3438,6 @@ nsContentUtils::IsChildOfSameType(nsIDocument* aDoc)
   return sameTypeParent != nullptr;
 }
 
-bool 
-nsContentUtils::IsScriptType(const nsACString& aContentType)
-{
-  // NOTE: if you add a type here, add it to the CONTENTDLF_CATEGORIES
-  // define in nsContentDLF.h as well. 
-  return aContentType.EqualsLiteral(APPLICATION_JAVASCRIPT) ||
-         aContentType.EqualsLiteral(APPLICATION_XJAVASCRIPT) ||
-         aContentType.EqualsLiteral(TEXT_ECMASCRIPT) ||
-         aContentType.EqualsLiteral(APPLICATION_ECMASCRIPT) ||
-         aContentType.EqualsLiteral(TEXT_JAVASCRIPT) ||
-         aContentType.EqualsLiteral(APPLICATION_JSON) ||
-         aContentType.EqualsLiteral(TEXT_JSON);
-}
-
 bool
 nsContentUtils::IsPlainTextType(const nsACString& aContentType)
 {
@@ -3461,7 +3447,13 @@ nsContentUtils::IsPlainTextType(const nsACString& aContentType)
          aContentType.EqualsLiteral(TEXT_CSS) ||
          aContentType.EqualsLiteral(TEXT_CACHE_MANIFEST) ||
          aContentType.EqualsLiteral(TEXT_VTT) ||
-         IsScriptType(aContentType);
+         aContentType.EqualsLiteral(APPLICATION_JAVASCRIPT) ||
+         aContentType.EqualsLiteral(APPLICATION_XJAVASCRIPT) ||
+         aContentType.EqualsLiteral(TEXT_ECMASCRIPT) ||
+         aContentType.EqualsLiteral(APPLICATION_ECMASCRIPT) ||
+         aContentType.EqualsLiteral(TEXT_JAVASCRIPT) ||
+         aContentType.EqualsLiteral(APPLICATION_JSON) ||
+         aContentType.EqualsLiteral(TEXT_JSON);
 }
 
 bool

--- a/dom/base/nsContentUtils.h
+++ b/dom/base/nsContentUtils.h
@@ -876,11 +876,6 @@ public:
   static bool IsChildOfSameType(nsIDocument* aDoc);
 
   /**
-  '* Returns true if the content-type is any of the supported script types.
-   */
-  static bool IsScriptType(const nsACString& aContentType);
-
-  /**
   '* Returns true if the content-type will be rendered as plain-text.
    */
   static bool IsPlainTextType(const nsACString& aContentType);

--- a/netwerk/protocol/http/nsHttpChannel.cpp
+++ b/netwerk/protocol/http/nsHttpChannel.cpp
@@ -1385,7 +1385,7 @@ ProcessXCTO(nsHttpResponseHead* aResponseHead, nsILoadInfo* aLoadInfo)
     }
 
     if (aLoadInfo->GetContentPolicyType() == nsIContentPolicy::TYPE_SCRIPT) {
-        if (nsContentUtils::IsScriptType(contentType)) {
+        if (nsContentUtils::IsJavascriptMIMEType(NS_ConvertUTF8toUTF16(contentType))) {
             return NS_OK;
         }
         return NS_ERROR_CORRUPTED_CONTENT;


### PR DESCRIPTION
The changes were verified using http://w3c-test.org/fetch/nosniff/ with [the limitations](https://github.com/MoonchildProductions/Pale-Moon/issues/1343#issuecomment-328839415) imposed by current Pale Moon platform code:

* [importscripts](http://w3c-test.org/fetch/nosniff/importscripts.html) test expects `NetworkError` when the script is blocked because of `nosniff`, but our platform code always return `Error` in such cases (see [bug 1251369](https://bugzilla.mozilla.org/show_bug.cgi?id=1251369))
* [worker](http://w3c-test.org/fetch/nosniff/worker.html) test expects the script loader will not throw the exceptions when the script is blocked (see [bug 1288768](https://bugzilla.mozilla.org/show_bug.cgi?id=1288768))

This resolves #1660.