### PR TITLE
Improve some button labels in preferences

### DIFF
--- a/browser/components/preferences/cookies.js
+++ b/browser/components/preferences/cookies.js
@@ -5,6 +5,8 @@
 
 const nsICookie = Components.interfaces.nsICookie;
 
+Components.utils.import("resource://gre/modules/PluralForm.jsm");
+
 var gCookiesWindow = {
   _cm               : Components.classes["@mozilla.org/cookiemanager;1"]
                                 .getService(Components.interfaces.nsICookieManager),
@@ -23,6 +25,11 @@ var gCookiesWindow = {
 
     this._bundle = document.getElementById("bundlePreferences");
     this._tree = document.getElementById("cookiesList");
+
+    let removeAllCookies = document.getElementById("removeAllCookies");
+    removeAllCookies.setAttribute("accesskey", this._bundle.getString("removeAllCookies.accesskey"));
+    let removeSelectedCookies = document.getElementById("removeSelectedCookies");
+    removeSelectedCookies.setAttribute("accesskey", this._bundle.getString("removeSelectedCookies.accesskey"));
 
     this._populateList(true);
 
@@ -551,12 +558,12 @@ var gCookiesWindow = {
     if (item && seln.count == 1 && item.container && item.open)
       selectedCookieCount += 2;
 
-    var removeCookie = document.getElementById("removeCookie");
-    var removeCookies = document.getElementById("removeCookies");
-    removeCookie.parentNode.selectedPanel =
-      selectedCookieCount == 1 ? removeCookie : removeCookies;
+    let buttonLabel = this._bundle.getString("removeSelectedCookies.label");
+    let removeSelectedCookies = document.getElementById("removeSelectedCookies");
+    removeSelectedCookies.label = PluralForm.get(selectedCookieCount, buttonLabel)
+                                            .replace("#1", selectedCookieCount);
 
-    removeCookie.disabled = removeCookies.disabled = !(seln.count > 0);
+    removeSelectedCookies.disabled = !(seln.count > 0);
   },
 
   performDeletion: function gCookiesWindow_performDeletion(deleteItems) {
@@ -860,7 +867,17 @@ var gCookiesWindow = {
   },
 
   _updateRemoveAllButton: function gCookiesWindow__updateRemoveAllButton() {
-    document.getElementById("removeAllCookies").disabled = this._view._rowCount == 0;
+    let removeAllCookies = document.getElementById("removeAllCookies");
+    removeAllCookies.disabled = this._view._rowCount == 0;
+
+    let labelStringID = "removeAllCookies.label";
+    let accessKeyStringID = "removeAllCookies.accesskey";
+    if (this._view._filtered) {
+      labelStringID = "removeAllShownCookies.label";
+      accessKeyStringID = "removeAllShownCookies.accesskey";
+    }
+    removeAllCookies.setAttribute("label", this._bundle.getString(labelStringID));
+    removeAllCookies.setAttribute("accesskey", this._bundle.getString(accessKeyStringID));
   },
 
   filter: function () {

--- a/browser/components/preferences/cookies.xul
+++ b/browser/components/preferences/cookies.xul
@@ -91,16 +91,9 @@
   </vbox>
   <hbox align="end">
     <hbox class="actionButtons" flex="1">
-      <deck oncommand="gCookiesWindow.deleteCookie();">
-        <button id="removeCookie" disabled="true" icon="remove"
-                label="&button.removecookie.label;"
-                accesskey="&button.removecookie.accesskey;"/>
-        <button id="removeCookies" disabled="true" icon="remove"
-                label="&button.removecookies.label;"
-                accesskey="&button.removecookie.accesskey;"/>
-      </deck>
+      <button id="removeSelectedCookies" disabled="true" icon="clear"
+              oncommand="gCookiesWindow.deleteCookie();"/>
       <button id="removeAllCookies" disabled="true" icon="clear"
-              label="&button.removeallcookies.label;" accesskey="&button.removeallcookies.accesskey;"
               oncommand="gCookiesWindow.deleteAllCookies();"/>
       <spacer flex="1"/>
 #ifndef XP_MACOSX

--- a/browser/locales/en-US/chrome/browser/preferences/cookies.dtd
+++ b/browser/locales/en-US/chrome/browser/preferences/cookies.dtd
@@ -7,11 +7,6 @@
 <!ENTITY     cookiesonsystem.label          "The following cookies are stored on your computer:">
 <!ENTITY     cookiename.label               "Cookie Name">
 <!ENTITY     cookiedomain.label             "Site"> 
-<!ENTITY     button.removecookies.label     "Remove Cookies">
-<!ENTITY     button.removecookie.label      "Remove Cookie">
-<!ENTITY     button.removecookie.accesskey  "R">
-<!ENTITY     button.removeallcookies.label  "Remove All Cookies">
-<!ENTITY     button.removeallcookies.accesskey "A">
 
 <!ENTITY     props.name.label               "Name:">
 <!ENTITY     props.value.label              "Content:">

--- a/browser/locales/en-US/chrome/browser/preferences/preferences.properties
+++ b/browser/locales/en-US/chrome/browser/preferences/preferences.properties
@@ -93,6 +93,27 @@ noCookieSelected=<no cookie selected>
 cookiesAll=The following cookies are stored on your computer:
 cookiesFiltered=The following cookies match your search:
 
+# LOCALIZATION NOTE (removeAllCookies, removeAllShownCookies):
+# removeAllCookies and removeAllShownCookies are both used on the same one button,
+# never displayed together and can share the same accesskey.
+# When only partial cookies are shown as a result of keyword search,
+# removeAllShownCookies is displayed as button label.
+# removeAllCookies is displayed when no keyword search and all cookies are shown.
+removeAllCookies.label=Remove All
+removeAllCookies.accesskey=A
+removeAllShownCookies.label=Remove All Shown
+removeAllShownCookies.accesskey=A
+
+# LOCALIZATION NOTE (removeSelectedCookies):
+# Semicolon-separated list of plural forms. See:
+# http://developer.mozilla.org/en/docs/Localization_and_Plurals
+# If you need to display the number of selected elements in your language,
+# you can use #1 in your localization as a placeholder for the number.
+# For example this is the English string with numbers:
+# removeSelectedCookied=Remove #1 Selected;Remove #1 Selected
+removeSelectedCookies.label=Remove Selected;Remove Selected
+removeSelectedCookies.accesskey=R
+
 #### Offline apps
 offlineAppRemoveTitle=Remove offline website data
 offlineAppRemovePrompt=After removing this data, %S will not be available offline.  Are you sure you want to remove this offline website?

--- a/toolkit/components/passwordmgr/content/passwordManager.js
+++ b/toolkit/components/passwordmgr/content/passwordManager.js
@@ -14,9 +14,15 @@ var dateAndTimeFormatter = new Intl.DateTimeFormat(undefined,
 
 function SignonsStartup() {
   kSignonBundle = document.getElementById("signonBundle");
-  document.getElementById("togglePasswords").label = kSignonBundle.getString("showPasswords");
-  document.getElementById("togglePasswords").accessKey = kSignonBundle.getString("showPasswordsAccessKey");
-  document.getElementById("signonsIntro").textContent = kSignonBundle.getString("loginsSpielAll");
+  var toggleButton = document.getElementById("togglePasswords");
+  var introButton = document.getElementById("signonsIntro");
+  var removeAllButton = document.getElementById("removeAllSignons");
+
+  toggleButton.label = kSignonBundle.getString("showPasswords");
+  toggleButton.accesskey = kSignonBundle.getString("showPasswordsAccessKey");
+  introButton.textContent = kSignonBundle.getString("loginsSpielAll");
+  removeAllButton.setAttribute("label", kSignonBundle.getString("removeAll.label"));
+  removeAllButton.setAttribute("accesskey", kSignonBundle.getString("removeAll.accesskey"));
 
   let treecols = document.getElementsByTagName("treecols")[0];
   treecols.addEventListener("click", HandleTreeColumnClick.bind(null, SignonColumnSort));
@@ -274,6 +280,9 @@ function SignonClearFilter() {
   signonsTreeView._lastSelectedRanges = [];
 
   document.getElementById("signonsIntro").textContent = kSignonBundle.getString("loginsSpielAll");
+  var removeAllButton = document.getElementById("removeAllSignons");
+  removeAllButton.setAttribute("label", kSignonBundle.getString("removeAll.label"));
+  removeAllButton.setAttribute("accesskey", kSignonBundle.getString("removeAll.accesskey"));
 }
 
 function FocusFilterBox() {
@@ -344,6 +353,9 @@ function _filterPasswords()
     signonsTreeView.selection.select(0);
 
   document.getElementById("signonsIntro").textContent = kSignonBundle.getString("loginsSpielFiltered");
+  var removeAllButton = document.getElementById("removeAllSignons");
+  removeAllButton.setAttribute("label", kSignonBundle.getString("removeAllShown.label"));
+  removeAllButton.setAttribute("accesskey", kSignonBundle.getString("removeAllShown.accesskey"));
 }
 
 function CopyPassword() {

--- a/toolkit/components/passwordmgr/content/passwordManager.xul
+++ b/toolkit/components/passwordmgr/content/passwordManager.xul
@@ -99,7 +99,6 @@
               label="&remove.label;" accesskey="&remove.accesskey;"
               oncommand="DeleteSignon();"/>
       <button id="removeAllSignons" icon="clear"
-              label="&removeall.label;" accesskey="&removeall.accesskey;"
               oncommand="DeleteAllSignons();"/>
       <spacer flex="1"/>
       <button id="togglePasswords"

--- a/toolkit/locales/en-US/chrome/passwordmgr/passwordManager.dtd
+++ b/toolkit/locales/en-US/chrome/passwordmgr/passwordManager.dtd
@@ -19,8 +19,6 @@
 
 <!ENTITY      remove.label                    "Remove">
 <!ENTITY      remove.accesskey                "R">
-<!ENTITY      removeall.label                 "Remove All">
-<!ENTITY      removeall.accesskey             "A">
 
 <!ENTITY      filter.label                    "Search:">
 <!ENTITY      filter.accesskey                "S">

--- a/toolkit/locales/en-US/chrome/passwordmgr/passwordmgr.properties
+++ b/toolkit/locales/en-US/chrome/passwordmgr/passwordmgr.properties
@@ -40,3 +40,14 @@ removeAllPasswordsPrompt=Are you sure you wish to remove all passwords?
 removeAllPasswordsTitle=Remove all passwords
 loginsSpielAll=Passwords for the following sites are stored on your computer:
 loginsSpielFiltered=The following passwords match your search:
+
+# LOCALIZATION NOTE (removeAll, removeAllShown):
+# removeAll and removeAllShown are both used on the same one button,
+# never displayed together and can share the same accesskey.
+# When only partial sites are shown as a result of keyword search,
+# removeAllShown is displayed as button label.
+# removeAll is displayed when no keyword search and all sites are shown.
+removeAll.label=Remove All
+removeAll.accesskey=A
+removeAllShown.label=Remove All Shown
+removeAllShown.accesskey=A


### PR DESCRIPTION
This takes care of button labels for handling cookies and passwords.
This resolves #1325 

This does not address "site data settings" as I could not figure out how to invoke site data settings window from Pale Moon UI. Neither could I find it in the codebase.