### PR TITLE
Improve copying from the location bar, stop encoding parentheses explicitly

### DIFF
--- a/palemoon/base/content/urlbarBindings.xml
+++ b/palemoon/base/content/urlbarBindings.xml
@@ -505,11 +505,16 @@
           let uriFixup = Cc["@mozilla.org/docshell/urifixup;1"].getService(Ci.nsIURIFixup);
 
           let uri;
-          try {
-            uri = uriFixup.createFixupURI(inputVal, Ci.nsIURIFixup.FIXUP_FLAG_NONE);
-          } catch (e) {}
-          if (!uri)
-            return selectedVal;
+          if (this.getAttribute("pageproxystate") == "valid") {
+            uri = gBrowser.currentURI;
+          } else {
+            // We're dealing with an autocompleted value, create a new URI from that.
+            try {
+              uri = uriFixup.createFixupURI(inputVal, Ci.nsIURIFixup.FIXUP_FLAG_NONE);
+            } catch (e) {}
+            if (!uri)
+              return selectedVal;
+          }
 
           // Only copy exposable URIs
           try {
@@ -521,8 +526,7 @@
             // ... but only if  isn't a javascript: or data: URI, since those
             // are hard to read when encoded
             if (!uri.schemeIs("javascript") && !uri.schemeIs("data")) {
-              // Parentheses are known to confuse third-party applications (bug 458565).
-              selectedVal = uri.spec.replace(/[()]/g, function (c) escape(c));
+              selectedVal = uri.spec;
             }
 
             return selectedVal;


### PR DESCRIPTION
Use the current page's original URI rather than creating a new one for copying from the location bar, stop encoding parentheses explicitly.

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=824887, resolves #1706.