### PR TITLE
Allow hiding pinned tabs from various tab views

### DIFF
--- a/palemoon/app/profile/palemoon.js
+++ b/palemoon/app/profile/palemoon.js
@@ -468,6 +468,7 @@ pref("browser.tabs.showAudioPlayingIcon", true);
 pref("browser.tabs.delayHidingAudioPlayingIconMS", 3000);
 
 pref("browser.allTabs.previews", true);
+pref("browser.allTabs.hidePinnedTabs", false);
 pref("browser.ctrlTab.previews", true);
 pref("browser.ctrlTab.hidePinnedTabs", false);
 pref("browser.ctrlTab.recentlyUsedLimit", 7);

--- a/palemoon/app/profile/palemoon.js
+++ b/palemoon/app/profile/palemoon.js
@@ -469,6 +469,7 @@ pref("browser.tabs.delayHidingAudioPlayingIconMS", 3000);
 
 pref("browser.allTabs.previews", true);
 pref("browser.ctrlTab.previews", true);
+pref("browser.ctrlTab.hidePinnedTabs", false);
 pref("browser.ctrlTab.recentlyUsedLimit", 7);
 
 // By default, do not export HTML at shutdown.

--- a/palemoon/base/content/browser-tabPreviews.js
+++ b/palemoon/base/content/browser-tabPreviews.js
@@ -658,6 +658,15 @@ var allTabs = {
 
     this._currentFilter = this.filterField.value;
 
+    let hidePinnedTabs = gPrefService.getBoolPref("browser.allTabs.hidePinnedTabs");
+    if (hidePinnedTabs) {
+      let regularTabsList = Array.filter(this.previews, function (preview) !preview._tab.pinned);
+      // Show pinned tabs if we don't have any regular tabs
+      if (regularTabsList.length == 0) {
+        hidePinnedTabs = false;
+      }
+    }
+
     var filter = this._currentFilter.split(/\s+/g);
     this._visible = 0;
     Array.forEach(this.previews, function (preview) {
@@ -672,7 +681,7 @@ var allTabs = {
         for (let i = 0; i < filter.length; i++)
           matches += tabstring.includes(filter[i]);
       }
-      if (matches < filter.length || tab.hidden) {
+      if (matches < filter.length || tab.hidden || (hidePinnedTabs && tab.pinned)) {
         preview.hidden = true;
       }
       else {

--- a/palemoon/base/content/browser-tabPreviews.js
+++ b/palemoon/base/content/browser-tabPreviews.js
@@ -216,6 +216,15 @@ var ctrlTab = {
       }
     }
 
+    let hidePinnedTabs = gPrefService.getBoolPref("browser.ctrlTab.hidePinnedTabs");
+    if (hidePinnedTabs) {
+      regularTabsList = list.filter(function (tab) !tab.pinned);
+      // Don't hide pinned tabs if we only have 1 regular tab
+      if (regularTabsList.length > 1) {
+        list = regularTabsList;
+      }
+    }
+
     return this._tabList = list;
   },
 


### PR DESCRIPTION
This resolves #1722.

Contrary to the approach used in #362, this hides pinned tabs from the graphical all tabs pane by (ab)using the filter function. Hiding pinned tabs from the Ctrl-Tab graphical pane was achieved using Tobin's snippet.