### PR TITLE
Add 1.25x play speed to the html player context menu

### DIFF
--- a/palemoon/base/content/browser-context.inc
+++ b/palemoon/base/content/browser-context.inc
@@ -85,6 +85,12 @@
                     name="playbackrate"
                     checked="true"
                     oncommand="gContextMenu.mediaCommand('playbackRate', 1.0);"/>
+          <menuitem id="context-media-playbackrate-125x"
+                    label="&mediaPlaybackRate125x.label;"
+                    accesskey="&mediaPlaybackRate125x.accesskey;"
+                    type="radio"
+                    name="playbackrate"
+                    oncommand="gContextMenu.mediaCommand('playbackRate', 1.25);"/>
           <menuitem id="context-media-playbackrate-150x"
                     label="&mediaPlaybackRate150x.label;"
                     accesskey="&mediaPlaybackRate150x.accesskey;"

--- a/palemoon/base/content/nsContextMenu.js
+++ b/palemoon/base/content/nsContextMenu.js
@@ -393,6 +393,7 @@ nsContextMenu.prototype = {
     if (onMedia) {
       this.setItemAttr("context-media-playbackrate-050x", "checked", this.target.playbackRate == 0.5);
       this.setItemAttr("context-media-playbackrate-100x", "checked", this.target.playbackRate == 1.0);
+      this.setItemAttr("context-media-playbackrate-125x", "checked", this.target.playbackRate == 1.25);
       this.setItemAttr("context-media-playbackrate-150x", "checked", this.target.playbackRate == 1.5);
       this.setItemAttr("context-media-playbackrate-200x", "checked", this.target.playbackRate == 2.0);
       this.setItemAttr("context-media-loop", "checked", this.target.loop);
@@ -405,6 +406,7 @@ nsContextMenu.prototype = {
       this.setItemAttr("context-media-playbackrate", "disabled", hasError);
       this.setItemAttr("context-media-playbackrate-050x", "disabled", hasError);
       this.setItemAttr("context-media-playbackrate-100x", "disabled", hasError);
+      this.setItemAttr("context-media-playbackrate-125x", "disabled", hasError);
       this.setItemAttr("context-media-playbackrate-150x", "disabled", hasError);
       this.setItemAttr("context-media-playbackrate-200x", "disabled", hasError);
       this.setItemAttr("context-media-showcontrols", "disabled", hasError);

--- a/palemoon/locales/en-US/chrome/browser/browser.dtd
+++ b/palemoon/locales/en-US/chrome/browser/browser.dtd
@@ -423,6 +423,8 @@ items are mutually exclusive. -->
 <!ENTITY mediaPlaybackRate050x.accesskey "S">
 <!ENTITY mediaPlaybackRate100x.label "Normal Speed">
 <!ENTITY mediaPlaybackRate100x.accesskey "N">
+<!ENTITY mediaPlaybackRate125x.label "Increased Speed (1.25×)">
+<!ENTITY mediaPlaybackRate125x.accesskey "I">
 <!ENTITY mediaPlaybackRate150x.label "High Speed (1.5×)">
 <!ENTITY mediaPlaybackRate150x.accesskey "H">
 <!-- LOCALIZATION NOTE: "Ludicrous Speed" is a reference to the


### PR DESCRIPTION
This adds `1.25x` play speed option to the html player context menu, ~and also beautifies the names of the play speed menu items, as is done in Basilisk.~

Resolves #1730.