### PR TITLE
Copy dylibs to the application bundle instead of symlinks.

### DIFF
--- a/palemoon/app/Makefile.in
+++ b/palemoon/app/Makefile.in
@@ -88,6 +88,9 @@ tools repackage:: $(PROGRAM)
 	sed -e 's/%MAC_APP_NAME%/$(MAC_APP_NAME)/' $(srcdir)/macbuild/Contents/Resources/English.lproj/InfoPlist.strings.in | iconv -f UTF-8 -t UTF-16 > '$(dist_dest)/Contents/Resources/$(AB).lproj/InfoPlist.strings'
 	rsync -a --exclude-from='$(srcdir)/macbuild/Contents/MacOS-files.in' $(DIST)/bin/ '$(dist_dest)/Contents/Resources'
 	rsync -a --include-from='$(srcdir)/macbuild/Contents/MacOS-files.in' --exclude '*' $(DIST)/bin/ '$(dist_dest)/Contents/MacOS'
+	# MacOS-files-copy.in is a list of files that should be copies rather
+	# than symlinks and placed in .app/Contents/MacOS.
+	rsync -aL --include-from='$(srcdir)/macbuild/Contents/MacOS-files-copy.in' --exclude '*' $(DIST)/bin/ '$(dist_dest)/Contents/MacOS'
 	$(RM) '$(dist_dest)/Contents/MacOS/$(PROGRAM)'
 	rsync -aL $(PROGRAM) '$(dist_dest)/Contents/MacOS'
 	cp -RL $(DIST)/branding/firefox.icns '$(dist_dest)/Contents/Resources/firefox.icns'

--- a/palemoon/app/macbuild/Contents/MacOS-files-copy.in
+++ b/palemoon/app/macbuild/Contents/MacOS-files-copy.in
@@ -1,0 +1,11 @@
+# Specifies files that should be copied (via deep copy, resolving symlinks)
+# from dist/bin to the .app/Contents/MacOS directory. Linking is preferred to
+# reduce disk I/O during builds, so just include dylibs which need to be in the
+# same directory as returned by dladdr(3).
+#
+# Some of these dylibs load other dylibs which are assumed to be siblings in
+# the same directory obtained from dladdr(3). With macOS 10.15, dladdr returns
+# absolute resolved paths which breaks this assumption if symlinks are used
+# because the symlink targets are in different directories. Hence the need for
+# them to be copied to the same directory.
+/*.dylib

--- a/palemoon/app/macbuild/Contents/MacOS-files.in
+++ b/palemoon/app/macbuild/Contents/MacOS-files.in
@@ -1,5 +1,4 @@
 /*.app/***
-/*.dylib
 /certutil
 /firefox-bin
 /gtest/***


### PR DESCRIPTION
This should resolve UXP Issue #1469 for local builds on Catalina.

https://drive.google.com/file/d/1iC-5RUQ9D4ayFTaPeqwcZ4ZIKl_VwuuR/view?usp=sharing
https://drive.google.com/file/d/1gaAkWGf-jQgA8nUlz9xvXGqbhJgYtRUA/view?usp=sharing

Builds on El Capitan and Catalina using this patch. 