### PR TITLE
Fix placement of Mac window controls in maximized private and lwtheme…

### DIFF
--- a/palemoon/themes/osx/browser.css
+++ b/palemoon/themes/osx/browser.css
@@ -96,10 +96,6 @@
     -moz-appearance: -moz-window-button-box;
 }
 
-#main-window[sizemode="maximized"] #titlebar-buttonbox {
-    -moz-appearance: -moz-window-button-box-maximized;
-}
-
 .titlebar-placeholder[type="appmenu-button"] {
     margin-left: 4px;
 }


### PR DESCRIPTION
… windows

Description of the issue on the forum:
https://forum.palemoon.org/viewtopic.php?f=41&t=23935&start=40#p186227
https://forum.palemoon.org/viewtopic.php?f=41&t=24052#p186678
This affects the caption buttons and, on older versions of OS X, the fullscreen arrows/button.
Before:
<img width="144" alt="Screenshot 2020-03-29 16 14 49" src="https://user-images.githubusercontent.com/11634417/77864025-2de54c80-71db-11ea-82ad-6a62b2efae33.png">
After:
<img width="145" alt="Screenshot 2020-03-29 16 18 56" src="https://user-images.githubusercontent.com/11634417/77864028-3047a680-71db-11ea-9a31-c862a6d561e5.png">