### PR TITLE
Make the Mac bottom tab bar blend better

### DIFF
--- a/palemoon/themes/osx/browser.css
+++ b/palemoon/themes/osx/browser.css
@@ -94,11 +94,15 @@
 
 /* Blend the topmost toolbar with the titlebar */
 #main-window[tabsontop=false]:not([privatebrowsingmode=temporary]) #nav-bar:not(:-moz-lwtheme),
+#main-window[tabsontop=false]:not([privatebrowsingmode=temporary]) #PersonalToolbar[collapsed=true]
+ ~ #TabsToolbar:not(:-moz-lwtheme),
 #main-window[tabsontop=true]:not([privatebrowsingmode=temporary]) #TabsToolbar:not(:-moz-lwtheme) {
   -moz-appearance: toolbar;
 }
 
 #main-window[tabsontop=false][privatebrowsingmode=temporary] #nav-bar:not(:-moz-lwtheme),
+#main-window[tabsontop=false][privatebrowsingmode=temporary] #PersonalToolbar[collapsed=true]
+ ~ #TabsToolbar:not(:-moz-lwtheme),
 #main-window[tabsontop=true][privatebrowsingmode=temporary] #TabsToolbar:not(:-moz-lwtheme) {
   background-color: transparent;
 }


### PR DESCRIPTION
Tag #1751 

As per discussion in the above, this makes the tab bar (in tabs on bottom mode) blend better with the titlebar, when the bookmarks toolbar is not enabled.

Normal mode:
![Normal](https://i.imgur.com/5BgZyiM.png)

Private mode:
![Private](https://i.imgur.com/lOVCj3z.png)