### PR TITLE
Add pref to allow copying unescaped URL from the URL bar

### DIFF
--- a/palemoon/app/profile/palemoon.js
+++ b/palemoon/app/profile/palemoon.js
@@ -329,6 +329,10 @@ pref("browser.identity.display_punycode", 1);
 // Address bar RSS icon control, show by default
 pref("browser.urlbar.rss", true);
 
+// If changed to true, copying the entire URL from the location bar will put
+// the human readable (percent-decoded) URL on the clipboard.
+pref("browser.urlbar.decodeURLsOnCopy", false);
+
 pref("browser.altClickSave", true);
 
 // Enable logging downloads operations to the Error Console.

--- a/palemoon/base/content/urlbarBindings.xml
+++ b/palemoon/base/content/urlbarBindings.xml
@@ -521,19 +521,17 @@
             uri = uriFixup.createExposableURI(uri);
           } catch (ex) {}
 
-          // If the entire URL is selected, just use the actual loaded URI.
-          if (inputVal == selectedVal) {
-            // ... but only if  isn't a javascript: or data: URI, since those
-            // are hard to read when encoded
-            if (!uri.schemeIs("javascript") && !uri.schemeIs("data")) {
-              selectedVal = uri.spec;
-            }
-
-            return selectedVal;
+          // If the entire URL is selected, just use the actual loaded URI,
+          // unless we want a decoded URI, or it's a data: or javascript: URI,
+          // since those are hard to read when encoded.
+          if (inputVal == selectedVal &&
+              !uri.schemeIs("javascript") && !uri.schemeIs("data") &&
+              !Services.prefs.getBoolPref("browser.urlbar.decodeURLsOnCopy")) {
+            return uri.spec;
           }
 
-          // Just the beginning of the URL is selected, check for a trimmed
-          // value
+          // Just the beginning of the URL is selected, or we want a decoded
+          // url. First check for a trimmed value.
           let spec = uri.spec;
           let trimmedSpec = this.trimValue(spec);
           if (spec != trimmedSpec) {


### PR DESCRIPTION
This adds the `browser.urlbar.decodeURLsOnCopy` pref (`false` by default) to allow copying unescaped URL from the URL bar.

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1320061, resolves #1766.