### PR TITLE
Put the osx private browsing indicator in its own element

### DIFF
--- a/palemoon/base/content/browser.xul
+++ b/palemoon/base/content/browser.xul
@@ -348,6 +348,10 @@
         <toolbarbutton class="titlebar-button" id="titlebar-close" command="cmd_closeWindow"/>
       </hbox>
     </hbox>
+#ifdef XP_MACOSX
+    <spacer id="titlebar-spacer" flex="1"/>
+    <hbox class="private-browsing-indicator"/>
+#endif
   </hbox>
 </vbox>
 #endif
@@ -718,6 +722,10 @@
                        tooltiptext="&fullScreenClose.tooltip;"
                        oncommand="BrowserTryToCloseWindow();"/>
       </hbox>
+
+#ifdef XP_MACOSX
+      <hbox class="private-browsing-indicator"/>
+#endif
     </toolbar>
 
     <toolbarset id="customToolbars" context="toolbar-context-menu"/>
@@ -837,6 +845,10 @@
                      command="cmd_close"
                      label="&closeTab.label;"
                      tooltiptext="&closeTab.label;"/>
+
+#ifdef XP_MACOSX
+      <hbox class="private-browsing-indicator"/>
+#endif
 
 #ifdef CAN_DRAW_IN_TITLEBAR
       <hbox class="titlebar-placeholder" type="appmenu-button" ordinal="0"/>

--- a/palemoon/themes/osx/browser.css
+++ b/palemoon/themes/osx/browser.css
@@ -127,7 +127,7 @@
 
 /* ::::: titlebar ::::: */
 
-#main-window[sizemode="normal"]:not([privatebrowsingmode=temporary]) > #titlebar {
+#main-window[sizemode="normal"] > #titlebar {
   -moz-appearance: -moz-window-titlebar;
 }
 
@@ -2800,55 +2800,46 @@ toolbar[brighttext] #addonbar-closebutton {
 }
 
 #main-window[privatebrowsingmode=temporary] {
-  background-image: url("chrome://browser/skin/privatebrowsing-mask.png");
-  background-position: top right;
-  background-repeat: no-repeat;
   background-color: moz-mac-chrome-active;
 }
 
+.private-browsing-indicator {
+  background-image: url("chrome://browser/skin/privatebrowsing-mask.png");
+  background-repeat: no-repeat;
+  background-size: 100% auto;
+  width: 38px;
+  height: 20px;
+  margin-left: 4px;
+  margin-right: 4px;
+}
+
+#titlebar-secondary-buttonbox > .private-browsing-indicator {
+  position: relative;
+}
+
+/**
+ * There are three private-browsing-indicator hboxes, one in the titlebar,
+ * one in the nav-bar, and one in the TabsToolbar. If the private
+ * window isn't in fullscreen the one in the titlebar should show up
+ * and not the others. If it is in fullscreen then the one in the topmost
+ * toolbar should be the one to appear, and that depends on whether tabs
+ * are on top or not.
+ */
+#main-window:not([privatebrowsingmode=temporary]) .private-browsing-indicator,
+#main-window[privatebrowsingmode=temporary][inFullscreen] > #titlebar > #titlebar-content > #titlebar-secondary-buttonbox > .private-browsing-indicator,
+#main-window[privatebrowsingmode=temporary]:not([inFullscreen]) > #tab-view-deck > #browser-panel > #navigator-toolbox > #nav-bar > .private-browsing-indicator,
+#main-window[privatebrowsingmode=temporary]:not([inFullscreen]) > #tab-view-deck > #browser-panel > #navigator-toolbox > #TabsToolbar > .private-browsing-indicator,
+#main-window[privatebrowsingmode=temporary][inFullscreen] > #tab-view-deck > #browser-panel > #navigator-toolbox > #nav-bar[tabsontop=true] > .private-browsing-indicator,
+#main-window[privatebrowsingmode=temporary][inFullscreen] > #tab-view-deck > #browser-panel > #navigator-toolbox > #TabsToolbar[tabsontop=false] > .private-browsing-indicator {
+  display: none;
+}
+
 @media (min-resolution: 2dppx) {
-  #main-window[privatebrowsingmode=temporary] {
+  .private-browsing-indicator {
   background-image: url("chrome://browser/skin/privatebrowsing-mask@2x.png");
-  background-size: 38px;
   }
-}
-
-#main-window[privatebrowsingmode=temporary] {
-  background-position: top right 40px;
-}
-
-#main-window[privatebrowsingmode=temporary][inFullscreen] {
-  background-position: top right 10px;
-}
-
-#main-window[privatebrowsingmode=temporary]:-moz-locale-dir(rtl) {
-  background-position: top left 70px;
-}
-
-#main-window[privatebrowsingmode=temporary][inFullscreen]:-moz-locale-dir(rtl) {
-  background-position: top left 10px;
 }
 
 #main-window[privatebrowsingmode=temporary]:-moz-window-inactive {
   background-color: -moz-mac-chrome-inactive;
-}
-
-#main-window[privatebrowsingmode=temporary][inFullscreen] #nav-bar[tabsontop=false] {
-  padding-inline-end: 50px !important;
-}
-
-@media (-moz-mac-lion-theme) {
-  #main-window[privatebrowsingmode=temporary][inFullscreen] #TabsToolbar[tabsontop=true] {
-  padding-inline-end: 50px;
-  }
-}
-
-@media not all and (-moz-mac-lion-theme) {
-  #main-window[privatebrowsingmode=temporary] {
-  background-position: top right 10px;
-  }
-
-  #main-window[privatebrowsingmode=temporary][inFullscreen][tabsontop=true] #window-controls {
-  padding-inline-end: 50px;
-  }
 }


### PR DESCRIPTION
This also allows the titlebar of private browsing windows to use the normal titlebar appearance again, and shows the indicator in fullscreen.