### PR TITLE
Show private indicator on OS X if no MOZ_CAN_DRAW_IN_TITLEBAR

### DIFF
--- a/palemoon/themes/osx/browser.css
+++ b/palemoon/themes/osx/browser.css
@@ -2862,4 +2862,12 @@ toolbar[brighttext] #addonbar-closebutton {
   padding-inline-end: 50px;
   }
 }
+%else
+#main-window[privatebrowsingmode=temporary] #TabsToolbar::before {
+  display: -moz-box;
+  content: "";
+  background: url("chrome://browser/skin/privatebrowsing-dark.png") center no-repeat;
+  width: 30px;
+  color: inherit;
+}
 %endif


### PR DESCRIPTION
Follow-up to #1778, this ensures that a private browsing indicator is present.

![Tabs on bottom](https://i.imgur.com/OQvrDrK.png)

![Tabs on top](https://i.imgur.com/Gt8ecY0.png)