### PR TITLE
Add global menubar support for GTK

### DIFF
--- a/palemoon/base/content/browser-menubar.inc
+++ b/palemoon/base/content/browser-menubar.inc
@@ -5,7 +5,11 @@
 
        <menubar id="main-menubar"
                 onpopupshowing="if (event.target.parentNode.parentNode == this &amp;&amp;
+#ifdef MOZ_WIDGET_GTK
+                                    document.documentElement.getAttribute('shellshowingmenubar') != 'true')
+#else
                                     !('@mozilla.org/widget/nativemenuservice;1' in Cc))
+#endif
                                   this.setAttribute('openedwithkey',
                                                     event.target.parentNode.openedWithKey);"
                 style="border:0px;padding:0px;margin:0px;-moz-appearance:none">

--- a/palemoon/base/content/browser.css
+++ b/palemoon/base/content/browser.css
@@ -226,6 +226,10 @@ splitmenu {
 #appmenu-toolbar-button > .toolbarbutton-text {
   display: -moz-box;
 }
+
+window[shellshowingmenubar="true"] #appmenu-toolbar-button {
+  display: none;
+}
 %endif
 
 #appmenu_offlineModeRecovery:not([checked=true]) {

--- a/palemoon/base/content/browser.js
+++ b/palemoon/base/content/browser.js
@@ -4600,6 +4600,12 @@ function onViewToolbarsPopupShowing(aEvent, aInsertPoint) {
   toolbarNodes.push(document.getElementById("addon-bar"));
 
   for (let toolbar of toolbarNodes) {
+#ifdef MOZ_WIDGET_GTK
+    if (toolbar.id == "toolbar-menubar" &&
+        document.documentElement.getAttribute("shellshowingmenubar") == "true") {
+      continue;
+    }
+#endif
     let toolbarName = toolbar.getAttribute("toolbarname");
     if (toolbarName) {
       let menuItem = document.createElement("menuitem");

--- a/palemoon/components/places/content/places.xul
+++ b/palemoon/components/places/content/places.xul
@@ -154,7 +154,11 @@
         <toolbarbutton type="menu" class="tabbable"
               onpopupshowing="document.getElementById('placeContent').focus()"
 #else
+#ifdef MOZ_WIDGET_GTK
+      <menubar id="placesMenu" _moz-menubarkeeplocal="true">
+#else
       <menubar id="placesMenu">
+#endif
         <menu accesskey="&organize.accesskey;" class="menu-iconic"
 #endif
               id="organizeButton" label="&organize.label;"


### PR DESCRIPTION
Tag MoonchildProductions/UXP#1578

This ensures the menubar toggle is not enabled when the global menubar is enabled, and also makes sure the Places toolbar is not exported as that should not be treated as a traditional menubar. In this configuration the `appmenu-toolbar-button` is not required so is removed when the global menubar is enabled, in the same way as it is removed when the application menubar is enabled.