### PR TITLE
Fix broken page style menu selection for alternative style sheets

### DIFF
--- a/palemoon/base/content/browser.js
+++ b/palemoon/base/content/browser.js
@@ -5637,7 +5637,7 @@ var gPageStyleMenu = {
   _stylesheetInFrame: function(frame, title) {
     return Array.some(frame.document.styleSheets,
                       function(stylesheet) {
-                        stylesheet.title == title
+                        return stylesheet.title == title;
                       });
   },
 


### PR DESCRIPTION
This resolves #1824.

Missing `return` in anonymous function which checks if the given style sheet title is present in the document's style sheet array.