### PR TITLE
Restore missing close icon on the undo prompt at the quick dial page

### DIFF
--- a/palemoon/themes/linux/newtab/newTab.css
+++ b/palemoon/themes/linux/newtab/newTab.css
@@ -17,11 +17,15 @@
 }
 
 #newtab-undo-close-button {
-  padding: 0;
-  border: none;
-  -moz-user-focus: normal;
+  background-image: -moz-image-rect(url("chrome://global/skin/icons/close.svg"), 0, 16, 16, 0);
+  background-position: center center;
+  background-repeat: no-repeat;
 }
 
-#newtab-undo-close-button > .toolbarbutton-icon {
-  margin: -4px;
+#newtab-undo-close-button:hover {
+  background-image: -moz-image-rect(url("chrome://global/skin/icons/close.svg"), 0, 32, 16, 16);
+}
+
+#newtab-undo-close-button:hover:active {
+  background-image: -moz-image-rect(url("chrome://global/skin/icons/close.svg"), 0, 48, 16, 32);
 }

--- a/palemoon/themes/osx/newtab/newTab.css
+++ b/palemoon/themes/osx/newtab/newTab.css
@@ -22,8 +22,15 @@
 }
 
 #newtab-undo-close-button {
-  -moz-appearance: none;
-  padding: 0;
-  border: none;
-  -moz-user-focus: normal;
+  background-image: -moz-image-rect(url("chrome://global/skin/icons/close.png"), 0, 16, 16, 0);
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+
+#newtab-undo-close-button:hover {
+  background-image: -moz-image-rect(url("chrome://global/skin/icons/close.png"), 0, 32, 16, 16);
+}
+
+#newtab-undo-close-button:hover:active {
+  background-image: -moz-image-rect(url("chrome://global/skin/icons/close.png"), 0, 48, 16, 32);
 }

--- a/palemoon/themes/shared/newtab/newTab.css.inc
+++ b/palemoon/themes/shared/newtab/newTab.css.inc
@@ -43,13 +43,14 @@ body {
   outline: 1px dotted;
 }
 
-
-#newtab-undo-close-button > .toolbarbutton-text {
-  display: none;
-}
-
-#newtab-undo-close-button:-moz-focusring {
-  outline: 1px dotted;
+#newtab-undo-close-button {
+  -moz-appearance: none;
+  padding: 0;
+  border: none;
+  width: 16px;
+  height: 16px;
+  float: right;
+  right: 0;
 }
 
 /* TOGGLE */

--- a/palemoon/themes/windows/newtab/newTab.css
+++ b/palemoon/themes/windows/newtab/newTab.css
@@ -22,8 +22,15 @@
 }
 
 #newtab-undo-close-button {
-  -moz-appearance: none;
-  padding: 0;
-  border: none;
-  -moz-user-focus: normal;
+  background-image: -moz-image-rect(url("chrome://global/skin/icons/close.svg"), 0, 16, 16, 0);
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+
+#newtab-undo-close-button:hover {
+  background-image: -moz-image-rect(url("chrome://global/skin/icons/close.svg"), 0, 32, 16, 16);
+}
+
+#newtab-undo-close-button:hover:active {
+  background-image: -moz-image-rect(url("chrome://global/skin/icons/close.svg"), 0, 48, 16, 32);
 }


### PR DESCRIPTION
This resolves #1826.

While this could've all been placed in the shared new tab style sheet, OSX does not include the SVG close icon used by the other platforms and has its own custom close icon. If desired, I could also do it the other way and include the SVG close icon on OSX.