### PR TITLE
Padlock Improvements

### DIFF
--- a/palemoon/base/content/padlock.js
+++ b/palemoon/base/content/padlock.js
@@ -84,7 +84,9 @@ var padlock_PadLock =
             } else if (aCipher.indexOf("_SHA") > -1) {
               level = "low";
             }
-          } else if (aCipher.indexOf("_DES_EDE3_") > -1) {
+          } else if (aCipher == "TLS_RSA_WITH_3DES_EDE_CBC_SHA") {
+            level = "low";
+          } else if (aCipher == "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA") {
             level = "low";
           }
         }

--- a/palemoon/base/content/padlock.js
+++ b/palemoon/base/content/padlock.js
@@ -100,7 +100,7 @@ var padlock_PadLock =
         highlight_urlbar = false;
       }
     } catch(ex) {}
-        
+
     let ub = document.getElementById("urlbar");
     if (ub) {
       // Only call if URL bar is present.
@@ -116,15 +116,15 @@ var padlock_PadLock =
       padlock_PadLock.setPadlockLevel("padlock-ib-left", level);
       padlock_PadLock.setPadlockLevel("padlock-ub-right", level);
     } catch(e) {}
-    
+
     padlock_PadLock.setPadlockLevel("padlock-sb", level);
     padlock_PadLock.setPadlockLevel("padlock-tab", level);
   },
-  
+
   setPadlockLevel: function(item, level) {
     let secbut = document.getElementById(item);
     var sectooltip = "";
-    
+
     if (level) {
       secbut.setAttribute("level", level);
       secbut.hidden = false;
@@ -170,12 +170,12 @@ var padlock_PadLock =
     }
     secbut.setAttribute("tooltiptext", sectooltip);
   },
-  
+
   prefbranch : null,
-  
+
   onLoad: function() {
     gBrowser.addProgressListener(padlock_PadLock);
-    
+
     var prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
     padlock_PadLock.prefbranch = prefService.getBranch("browser.padlock.");
     padlock_PadLock.prefbranch.QueryInterface(Components.interfaces.nsIPrefBranch2);
@@ -262,7 +262,7 @@ var padlock_PadLock =
       document.getElementById("padlock-ib-left").setAttribute("padshow", padshow);
       document.getElementById("padlock-ub-right").setAttribute("padshow", padshow);
     } catch(e) {}
-    
+
     document.getElementById("padlock-sb").setAttribute("padshow", padshow);
     document.getElementById("padlock-tab").setAttribute("padshow", padshow);
 
@@ -271,7 +271,7 @@ var padlock_PadLock =
       document.getElementById("padlock-ib-left").setAttribute("padstyle", padstyle);
       document.getElementById("padlock-ub-right").setAttribute("padstyle", padstyle);
     } catch(e) {}
-    
+
     document.getElementById("padlock-sb").setAttribute("padstyle", padstyle);
     document.getElementById("padlock-tab").setAttribute("padstyle", padstyle);
 

--- a/palemoon/base/content/padlock.js
+++ b/palemoon/base/content/padlock.js
@@ -34,22 +34,22 @@ var padlock_PadLock =
         highlight_urlbar = true;
         break;
       case wpl.STATE_IS_SECURE:
-      case wpl.STATE_IS_SECURE |
+      case wpl.STATE_IS_BROKEN |
            wpl.STATE_LOADED_MIXED_DISPLAY_CONTENT:
         level = "high";
         highlight_urlbar = true;
         break;
-      case wpl.STATE_IS_SECURE |
+      case wpl.STATE_IS_BROKEN |
            wpl.STATE_LOADED_MIXED_ACTIVE_CONTENT:
         level = "low";
         highlight_urlbar = true;
         break;
-      case wpl.STATE_IS_SECURE | wpl.STATE_IDENTITY_EV_TOPLEVEL |
+      case wpl.STATE_IS_BROKEN | wpl.STATE_IDENTITY_EV_TOPLEVEL |
            wpl.STATE_LOADED_MIXED_ACTIVE_CONTENT |
            wpl.STATE_LOADED_MIXED_DISPLAY_CONTENT:
-      case wpl.STATE_IS_SECURE | wpl.STATE_IDENTITY_EV_TOPLEVEL |
+      case wpl.STATE_IS_BROKEN | wpl.STATE_IDENTITY_EV_TOPLEVEL |
            wpl.STATE_LOADED_MIXED_ACTIVE_CONTENT:
-      case wpl.STATE_IS_SECURE | wpl.STATE_IDENTITY_EV_TOPLEVEL |
+      case wpl.STATE_IS_BROKEN | wpl.STATE_IDENTITY_EV_TOPLEVEL |
            wpl.STATE_LOADED_MIXED_DISPLAY_CONTENT:
       case wpl.STATE_IS_BROKEN:
         level = "broken";

--- a/palemoon/base/content/padlock.js
+++ b/palemoon/base/content/padlock.js
@@ -84,11 +84,7 @@ var padlock_PadLock =
             } else if (aCipher.indexOf("_SHA") > -1) {
               level = "low";
             }
-          } else if (aCipher.indexOf("TLS_DHE_RSA_WITH_AES") > -1) {
-            level = "low";
-          } else if (aCipher.indexOf("TLS_RSA_WITH_AES_128_") > -1) {
-            level = "low";
-          } else if (aCipher.indexOf("_3DES_") > -1) {
+          } else if (aCipher.indexOf("_DES_EDE3_") > -1) {
             level = "low";
           }
         }

--- a/palemoon/base/content/padlock.js
+++ b/palemoon/base/content/padlock.js
@@ -84,9 +84,7 @@ var padlock_PadLock =
             } else if (aCipher.indexOf("_SHA") > -1) {
               level = "low";
             }
-          } else if (aCipher == "TLS_RSA_WITH_3DES_EDE_CBC_SHA") {
-            level = "low";
-          } else if (aCipher == "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA") {
+          } else if (aCipher.indexOf("_3DES_") > -1) {
             level = "low";
           }
         }

--- a/palemoon/base/content/padlock.js
+++ b/palemoon/base/content/padlock.js
@@ -132,19 +132,38 @@ var padlock_PadLock =
       secbut.hidden = true;
       secbut.removeAttribute("level");
     }
-    
+
+    let s_ev = "Extended Validated";
+    let s_hi = "Secure";
+    let s_lo = "Weak security";
+    let s_no = "Not secure";
+    let gLocale = document.getElementById("bundle_browser");
+    if(!!gLocale) {
+      let n_ev = gLocale.getString("identity.padlock.ev");
+      if(n_ev != null)
+        s_ev = n_ev;
+      let n_hi = gLocale.getString("identity.padlock.high");
+      if(n_hi != null)
+        s_hi = n_hi;
+      let n_lo = gLocale.getString("identity.padlock.low");
+      if(n_lo != null)
+        s_lo = n_lo;
+      let n_no = gLocale.getString("identity.padlock.broken");
+      if(n_no != null)
+        s_no = n_no;
+    }
     switch (level) {
       case "ev":
-        sectooltip = "Extended Validated";
+        sectooltip = s_ev;
         break;
       case "high":
-        sectooltip = "Secure";
+        sectooltip = s_hi;
         break;
       case "low":
-        sectooltip = "Weak security";
+        sectooltip = s_lo;
         break;
       case "broken":
-        sectooltip = "Not secure";
+        sectooltip = s_no;
         break;
       default:
         sectooltip = "";

--- a/palemoon/locales/en-US/chrome/browser/browser.properties
+++ b/palemoon/locales/en-US/chrome/browser/browser.properties
@@ -280,6 +280,11 @@ identity.mixed_content=Your connection to this site is only partially encrypted,
 
 identity.unknown.tooltip=This website does not supply identity information.
 
+identity.padlock.ev=Extended Validated
+identity.padlock.high=Secure
+identity.padlock.low=Weak security
+identity.padlock.broken=Not secure
+
 identity.ownerUnknown2=(unknown)
 
 # Edit Bookmark UI


### PR DESCRIPTION
It's time to ignore STATE_SECURE_{HIGH,MED,LOW} from UXP, as they're essentially depricated.

This draft includes the following changes:
- Stricter checks for mixed content in EV situations and active mixed content in secure situations.
- **SSL 3** marked as `Broken`
- **TLS 1.0** and **1.1** marked as `Low` (Gotta wonder, should we bring `Medium` back just for 1.1?)
- **EXPORT** ciphers marked as `Broken`
- **RC2** ciphers marked as `Broken`
- **RC4 + MD5** ciphers marked as `Broken`
- **RC4 + SHA** ciphers marked as `Low`
- **3DES** ciphers marked as `Low`

Note that the detection method for ciphers just uses `indexOf()` on the cipherSuite value, rather than specifically checking for each specific value. This could potentially lead to issues in certain cases.

Resolves #1717 (or heads toward a resolution).