### PR TITLE
Fix vendor name in about dialog for unofficial builds.

### DIFF
--- a/palemoon/branding/unofficial/locales/en-US/brand.dtd
+++ b/palemoon/branding/unofficial/locales/en-US/brand.dtd
@@ -4,5 +4,5 @@
 
 <!ENTITY  brandShortName        "Browser">
 <!ENTITY  brandFullName         "Browser">
-<!ENTITY  vendorShortName       " ">
+<!ENTITY  vendorShortName       "somebody">
 <!ENTITY  trademarkInfo.part1   " ">


### PR DESCRIPTION
For some reason name is picked from `branding/unofficial/locales/en-US/brand.dtd` and not `branding/unofficial/locales/en-US/brand.properties` but both of them have `vendorShortName` defined.

How it looks currently:
<img width="812" alt="Screenshot 2020-09-17 at 6 16 08 PM" src="https://user-images.githubusercontent.com/29352104/93474871-91903d00-f915-11ea-9e4e-5ad5a7e8e1b8.png">

